### PR TITLE
feat(pm+staff-inbox): add private messaging and staff inbox systems

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,7 @@ module.exports = {
   rules: {
     'import/no-unresolved': [
       'error',
-      { ignore: ['@asteasolutions/zod-to-openapi', '@prisma/client'] }
+      { ignore: ['@asteasolutions/zod-to-openapi', '@prisma/client', 'express-rate-limit'] }
     ]
   },
   settings: {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,22 @@ Node.js / Express / TypeScript REST API with PostgreSQL (Prisma ORM) and JWT coo
 npm run dev              # nodemon + ts-node
 npm run build            # tsc
 npx tsc --noEmit         # type-check only (run before committing)
-npx prettier --write ... # format — always run on edited files before committing
+npm run format           # prettier --write src — run on ALL changed files before committing
+npm run lint             # eslint src --ext .ts — run before committing; must be clean on new/changed files
+npm run test             # jest --runInBand
 npx prisma generate      # regenerate Prisma client after schema changes
-npx prisma migrate dev   # create + apply migration
+npx prisma migrate dev   # create + apply migration (requires interactive TTY)
 ```
 
-No test framework yet. `tsconfig` excludes `*.spec.ts` in preparation.
+## Commit workflow
+
+1. `npx tsc --noEmit` — must be clean
+2. `npm run format` — formats all of src/ including openapi.ts and spec files
+3. `npm run lint` — verify no new ESLint errors in changed files
+4. `npm run test --no-coverage` — must pass
+5. Commit with descriptive message following existing log style
+
+> Note: `npm run lint` has pre-existing errors in unchanged files; only new/changed files must be clean.
 
 ## Environment
 

--- a/prisma/migrations/20260426032715_add_pm_and_staff_inbox/migration.sql
+++ b/prisma/migrations/20260426032715_add_pm_and_staff_inbox/migration.sql
@@ -1,0 +1,153 @@
+/*
+  Warnings:
+
+  - The values [wmv,lua] on the enum `FileType` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the column `jsonFile` on the `contributions` table. All the data in the column will be lost.
+  - Added the required column `downloadUrl` to the `contributions` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "StaffInboxStatus" AS ENUM ('Unanswered', 'Open', 'Resolved');
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "FileType_new" AS ENUM ('mp3', 'flac', 'wav', 'ogg', 'aac', 'm4a', 'm4b', 'mp4', 'mkv', 'avi', 'mov', 'zip', 'exe', 'dmg', 'apk', 'pdf', 'epub', 'mobi', 'cbz', 'cbr', 'jpg', 'png', 'gif', 'txt');
+ALTER TABLE "contributions" ALTER COLUMN "type" TYPE "FileType_new" USING ("type"::text::"FileType_new");
+ALTER TYPE "FileType" RENAME TO "FileType_old";
+ALTER TYPE "FileType_new" RENAME TO "FileType";
+DROP TYPE "FileType_old";
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "collages" ALTER COLUMN "tags" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "contributions" DROP COLUMN "jsonFile",
+ADD COLUMN     "downloadUrl" TEXT NOT NULL,
+ALTER COLUMN "sizeInBytes" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "disablePm" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "private_conversations" (
+    "id" SERIAL NOT NULL,
+    "subject" VARCHAR(255) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "private_conversations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "private_conversation_participants" (
+    "userId" INTEGER NOT NULL,
+    "conversationId" INTEGER NOT NULL,
+    "inInbox" BOOLEAN NOT NULL DEFAULT true,
+    "inSentbox" BOOLEAN NOT NULL DEFAULT false,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "isSticky" BOOLEAN NOT NULL DEFAULT false,
+    "forwardedToId" INTEGER,
+    "sentAt" TIMESTAMP(3),
+    "receivedAt" TIMESTAMP(3),
+
+    CONSTRAINT "private_conversation_participants_pkey" PRIMARY KEY ("userId","conversationId")
+);
+
+-- CreateTable
+CREATE TABLE "private_messages" (
+    "id" SERIAL NOT NULL,
+    "conversationId" INTEGER NOT NULL,
+    "senderId" INTEGER,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "private_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "staff_inbox_conversations" (
+    "id" SERIAL NOT NULL,
+    "subject" VARCHAR(255) NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "status" "StaffInboxStatus" NOT NULL DEFAULT 'Unanswered',
+    "assignedUserId" INTEGER,
+    "resolverId" INTEGER,
+    "isReadByUser" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "staff_inbox_conversations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "staff_inbox_messages" (
+    "id" SERIAL NOT NULL,
+    "conversationId" INTEGER NOT NULL,
+    "senderId" INTEGER NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "staff_inbox_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "staff_inbox_responses" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "staff_inbox_responses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "private_conversation_participants_userId_idx" ON "private_conversation_participants"("userId");
+
+-- CreateIndex
+CREATE INDEX "private_conversation_participants_conversationId_idx" ON "private_conversation_participants"("conversationId");
+
+-- CreateIndex
+CREATE INDEX "private_messages_conversationId_idx" ON "private_messages"("conversationId");
+
+-- CreateIndex
+CREATE INDEX "staff_inbox_conversations_userId_idx" ON "staff_inbox_conversations"("userId");
+
+-- CreateIndex
+CREATE INDEX "staff_inbox_conversations_status_idx" ON "staff_inbox_conversations"("status");
+
+-- CreateIndex
+CREATE INDEX "staff_inbox_conversations_assignedUserId_idx" ON "staff_inbox_conversations"("assignedUserId");
+
+-- CreateIndex
+CREATE INDEX "staff_inbox_messages_conversationId_idx" ON "staff_inbox_messages"("conversationId");
+
+-- CreateIndex
+CREATE INDEX "requests_status_idx" ON "requests"("status");
+
+-- AddForeignKey
+ALTER TABLE "private_conversation_participants" ADD CONSTRAINT "private_conversation_participants_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "private_conversation_participants" ADD CONSTRAINT "private_conversation_participants_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "private_conversations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "private_messages" ADD CONSTRAINT "private_messages_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "private_conversations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "private_messages" ADD CONSTRAINT "private_messages_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_inbox_conversations" ADD CONSTRAINT "staff_inbox_conversations_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_inbox_conversations" ADD CONSTRAINT "staff_inbox_conversations_assignedUserId_fkey" FOREIGN KEY ("assignedUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_inbox_conversations" ADD CONSTRAINT "staff_inbox_conversations_resolverId_fkey" FOREIGN KEY ("resolverId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_inbox_messages" ADD CONSTRAINT "staff_inbox_messages_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "staff_inbox_conversations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_inbox_messages" ADD CONSTRAINT "staff_inbox_messages_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,12 @@ enum RequestActionType {
   RESTORE
 }
 
+enum StaffInboxStatus {
+  Unanswered
+  Open
+  Resolved
+}
+
 // ─── User & Auth ──────────────────────────────────────────────────────────────
 
 model UserRank {
@@ -222,6 +228,7 @@ model User {
   warned             DateTime?
   warnedTimes        Int          @default(0)
   communityPass      String       @default("")
+  disablePm          Boolean      @default(false)
   createdAt          DateTime     @default(now())
   updatedAt          DateTime     @updatedAt
 
@@ -275,6 +282,12 @@ model User {
   downloadGrantsReversed    DownloadAccessGrant[] @relation("DownloadGrantReversedBy")
   ratioPolicyState          RatioPolicyState?
   contributionReports       ContributionReport[]
+  pmParticipations          PrivateConversationParticipant[] @relation("PmParticipant")
+  pmMessagesSent            PrivateMessage[]                 @relation("PmSender")
+  staffInboxConversations   StaffInboxConversation[]         @relation("StaffInboxOwner")
+  staffInboxAssigned        StaffInboxConversation[]         @relation("StaffInboxAssignee")
+  staffInboxResolved        StaffInboxConversation[]         @relation("StaffInboxResolver")
+  staffInboxMessages        StaffInboxMessage[]              @relation("StaffInboxMsgSender")
 
   @@index([userRankId])
   @@map("users")
@@ -1363,4 +1376,95 @@ model AuditLog {
   actor User @relation(fields: [actorId], references: [id])
 
   @@map("audit_logs")
+}
+
+// ─── Private Messaging ────────────────────────────────────────────────────────
+
+model PrivateConversation {
+  id           Int                              @id @default(autoincrement())
+  subject      String                           @db.VarChar(255)
+  messages     PrivateMessage[]
+  participants PrivateConversationParticipant[]
+  createdAt    DateTime                          @default(now())
+
+  @@map("private_conversations")
+}
+
+model PrivateConversationParticipant {
+  userId         Int
+  conversationId Int
+  user           User                @relation("PmParticipant", fields: [userId], references: [id])
+  conversation   PrivateConversation @relation(fields: [conversationId], references: [id])
+  inInbox        Boolean             @default(true)
+  inSentbox      Boolean             @default(false)
+  isRead         Boolean             @default(false)
+  isSticky       Boolean             @default(false)
+  // forwardedToId retained as plain Int (forwarding deferred — see deviation notes)
+  forwardedToId  Int?
+  sentAt         DateTime?
+  receivedAt     DateTime?
+
+  @@id([userId, conversationId])
+  @@index([userId])
+  @@index([conversationId])
+  @@map("private_conversation_participants")
+}
+
+model PrivateMessage {
+  id             Int                 @id @default(autoincrement())
+  conversationId Int
+  conversation   PrivateConversation @relation(fields: [conversationId], references: [id])
+  senderId       Int?
+  sender         User?               @relation("PmSender", fields: [senderId], references: [id])
+  body           String              @db.Text
+  createdAt      DateTime            @default(now())
+
+  @@index([conversationId])
+  @@map("private_messages")
+}
+
+// ─── Staff Inbox ──────────────────────────────────────────────────────────────
+
+model StaffInboxConversation {
+  id             Int                 @id @default(autoincrement())
+  subject        String              @db.VarChar(255)
+  userId         Int
+  user           User                @relation("StaffInboxOwner", fields: [userId], references: [id])
+  status         StaffInboxStatus    @default(Unanswered)
+  assignedUserId Int?
+  assignedUser   User?               @relation("StaffInboxAssignee", fields: [assignedUserId], references: [id])
+  resolverId     Int?
+  resolver       User?               @relation("StaffInboxResolver", fields: [resolverId], references: [id])
+  isReadByUser   Boolean             @default(false)
+  messages       StaffInboxMessage[]
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
+
+  @@index([userId])
+  @@index([status])
+  @@index([assignedUserId])
+  @@map("staff_inbox_conversations")
+}
+
+model StaffInboxMessage {
+  id             Int                    @id @default(autoincrement())
+  conversationId Int
+  conversation   StaffInboxConversation @relation(fields: [conversationId], references: [id])
+  senderId       Int
+  sender         User                   @relation("StaffInboxMsgSender", fields: [senderId], references: [id])
+  body           String                 @db.Text
+  createdAt      DateTime               @default(now())
+
+  @@index([conversationId])
+  @@map("staff_inbox_messages")
+}
+
+model StaffInboxResponse {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(255)
+  body      String   @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("staff_inbox_responses")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,8 @@ import communitiesRouter from './routes/api/communities/communities';
 import contributionsRouter from './routes/api/communities/contributions';
 import artistRouter from './routes/api/communities/artist';
 import collagesRouter from './routes/api/collages';
+import messagesRouter from './routes/api/messages';
+import staffInboxRouter from './routes/api/staffInbox';
 
 const log = getLogger('app');
 
@@ -88,6 +90,8 @@ export const createApp = () => {
   app.use('/api/contributions', contributionsRouter);
   app.use('/api/artists', artistRouter);
   app.use('/api/collages', collagesRouter);
+  app.use('/api/messages', messagesRouter);
+  app.use('/api/staff-inbox', staffInboxRouter);
 
   app.use(
     (

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2652,7 +2652,11 @@ registry.registerPath({
 
 const MessageUser = registry.register(
   'MessageUser',
-  z.object({ id: z.number(), username: z.string(), avatar: z.string().nullable().optional() })
+  z.object({
+    id: z.number(),
+    username: z.string(),
+    avatar: z.string().nullable().optional()
+  })
 );
 
 const PrivateMessage = registry.register(
@@ -2730,7 +2734,9 @@ registry.registerPath({
   responses: {
     200: {
       description: 'Unread conversation count',
-      content: { 'application/json': { schema: z.object({ count: z.number() }) } }
+      content: {
+        'application/json': { schema: z.object({ count: z.number() }) }
+      }
     }
   }
 });
@@ -2751,7 +2757,11 @@ registry.registerPath({
   method: 'post',
   path: '/messages/bulk',
   tags: ['Messages'],
-  request: { body: { content: { 'application/json': { schema: bulkMessageActionSchema } } } },
+  request: {
+    body: {
+      content: { 'application/json': { schema: bulkMessageActionSchema } }
+    }
+  },
   responses: { 204: { description: 'Bulk action applied' } }
 });
 
@@ -2759,13 +2769,18 @@ registry.registerPath({
   method: 'post',
   path: '/messages',
   tags: ['Messages'],
-  request: { body: { content: { 'application/json': { schema: composeMessageSchema } } } },
+  request: {
+    body: { content: { 'application/json': { schema: composeMessageSchema } } }
+  },
   responses: {
     201: {
       description: 'Conversation created',
       content: { 'application/json': { schema: PrivateConversation } }
     },
-    400: { description: 'Validation error', content: { 'application/json': { schema: MsgResponse } } }
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
   }
 });
 
@@ -2779,7 +2794,10 @@ registry.registerPath({
       description: 'Conversation with messages',
       content: { 'application/json': { schema: PrivateConversation } }
     },
-    404: { description: 'Not found', content: { 'application/json': { schema: MsgResponse } } }
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
   }
 });
 
@@ -2796,7 +2814,10 @@ registry.registerPath({
       description: 'Reply sent',
       content: { 'application/json': { schema: PrivateMessage } }
     },
-    403: { description: 'Not a participant', content: { 'application/json': { schema: MsgResponse } } }
+    403: {
+      description: 'Not a participant',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
   }
 });
 
@@ -2806,7 +2827,9 @@ registry.registerPath({
   tags: ['Messages'],
   request: {
     params: z.object({ id: z.string() }),
-    body: { content: { 'application/json': { schema: updateConversationSchema } } }
+    body: {
+      content: { 'application/json': { schema: updateConversationSchema } }
+    }
   },
   responses: { 204: { description: 'Flags updated' } }
 });
@@ -2833,7 +2856,11 @@ import {
 
 const StaffInboxMessageUser = registry.register(
   'StaffInboxMessageUser',
-  z.object({ id: z.number(), username: z.string(), avatar: z.string().nullable().optional() })
+  z.object({
+    id: z.number(),
+    username: z.string(),
+    avatar: z.string().nullable().optional()
+  })
 );
 
 const StaffInboxMsg = registry.register(
@@ -2890,7 +2917,10 @@ registry.registerPath({
   tags: ['StaffInbox'],
   request: { query: ticketListQuerySchema },
   responses: {
-    200: { description: 'Staff ticket list', content: { 'application/json': { schema: PaginatedTickets } } }
+    200: {
+      description: 'Staff ticket list',
+      content: { 'application/json': { schema: PaginatedTickets } }
+    }
   }
 });
 
@@ -2901,7 +2931,9 @@ registry.registerPath({
   responses: {
     200: {
       description: 'Open ticket count',
-      content: { 'application/json': { schema: z.object({ count: z.number() }) } }
+      content: {
+        'application/json': { schema: z.object({ count: z.number() }) }
+      }
     }
   }
 });
@@ -2911,7 +2943,10 @@ registry.registerPath({
   path: '/staff-inbox/mine',
   tags: ['StaffInbox'],
   responses: {
-    200: { description: 'My tickets', content: { 'application/json': { schema: PaginatedTickets } } }
+    200: {
+      description: 'My tickets',
+      content: { 'application/json': { schema: PaginatedTickets } }
+    }
   }
 });
 
@@ -2931,9 +2966,14 @@ registry.registerPath({
   method: 'post',
   path: '/staff-inbox/responses',
   tags: ['StaffInbox'],
-  request: { body: { content: { 'application/json': { schema: createResponseSchema } } } },
+  request: {
+    body: { content: { 'application/json': { schema: createResponseSchema } } }
+  },
   responses: {
-    201: { description: 'Response created', content: { 'application/json': { schema: StaffInboxResponse } } }
+    201: {
+      description: 'Response created',
+      content: { 'application/json': { schema: StaffInboxResponse } }
+    }
   }
 });
 
@@ -2946,8 +2986,14 @@ registry.registerPath({
     body: { content: { 'application/json': { schema: updateResponseSchema } } }
   },
   responses: {
-    200: { description: 'Response updated', content: { 'application/json': { schema: StaffInboxResponse } } },
-    404: { description: 'Not found', content: { 'application/json': { schema: MsgResponse } } }
+    200: {
+      description: 'Response updated',
+      content: { 'application/json': { schema: StaffInboxResponse } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
   }
 });
 
@@ -2963,11 +3009,17 @@ registry.registerPath({
   method: 'post',
   path: '/staff-inbox/bulk-resolve',
   tags: ['StaffInbox'],
-  request: { body: { content: { 'application/json': { schema: bulkResolveSchema } } } },
+  request: {
+    body: { content: { 'application/json': { schema: bulkResolveSchema } } }
+  },
   responses: {
     200: {
       description: 'Tickets resolved',
-      content: { 'application/json': { schema: z.object({ ok: z.boolean(), resolved: z.number() }) } }
+      content: {
+        'application/json': {
+          schema: z.object({ ok: z.boolean(), resolved: z.number() })
+        }
+      }
     }
   }
 });
@@ -2976,9 +3028,14 @@ registry.registerPath({
   method: 'post',
   path: '/staff-inbox',
   tags: ['StaffInbox'],
-  request: { body: { content: { 'application/json': { schema: createTicketSchema } } } },
+  request: {
+    body: { content: { 'application/json': { schema: createTicketSchema } } }
+  },
   responses: {
-    201: { description: 'Ticket created', content: { 'application/json': { schema: StaffInboxConversation } } }
+    201: {
+      description: 'Ticket created',
+      content: { 'application/json': { schema: StaffInboxConversation } }
+    }
   }
 });
 
@@ -2988,8 +3045,14 @@ registry.registerPath({
   tags: ['StaffInbox'],
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    200: { description: 'Ticket', content: { 'application/json': { schema: StaffInboxConversation } } },
-    404: { description: 'Not found', content: { 'application/json': { schema: MsgResponse } } }
+    200: {
+      description: 'Ticket',
+      content: { 'application/json': { schema: StaffInboxConversation } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
   }
 });
 
@@ -3002,7 +3065,10 @@ registry.registerPath({
     body: { content: { 'application/json': { schema: replyTicketSchema } } }
   },
   responses: {
-    201: { description: 'Reply sent', content: { 'application/json': { schema: StaffInboxMsg } } }
+    201: {
+      description: 'Reply sent',
+      content: { 'application/json': { schema: StaffInboxMsg } }
+    }
   }
 });
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2648,6 +2648,391 @@ registry.registerPath({
   }
 });
 
+// ─── Private Messages ────────────────────────────────────────────────────────
+
+const MessageUser = registry.register(
+  'MessageUser',
+  z.object({ id: z.number(), username: z.string(), avatar: z.string().nullable().optional() })
+);
+
+const PrivateMessage = registry.register(
+  'PrivateMessage',
+  z.object({
+    id: z.number(),
+    conversationId: z.number(),
+    body: z.string(),
+    createdAt: z.string(),
+    sender: MessageUser.nullable().optional()
+  })
+);
+
+const PrivateConversationParticipant = registry.register(
+  'PrivateConversationParticipant',
+  z.object({
+    userId: z.number(),
+    conversationId: z.number(),
+    inInbox: z.boolean(),
+    inSentbox: z.boolean(),
+    isRead: z.boolean(),
+    isSticky: z.boolean(),
+    sentAt: z.string().nullable().optional(),
+    receivedAt: z.string().nullable().optional(),
+    user: MessageUser.optional()
+  })
+);
+
+const PrivateConversation = registry.register(
+  'PrivateConversation',
+  z.object({
+    id: z.number(),
+    subject: z.string(),
+    createdAt: z.string(),
+    participants: z.array(PrivateConversationParticipant).optional(),
+    messages: z.array(PrivateMessage).optional()
+  })
+);
+
+const PaginatedConversations = registry.register(
+  'PaginatedConversations',
+  z.object({
+    total: z.number(),
+    page: z.number(),
+    pageSize: z.number(),
+    conversations: z.array(PrivateConversation)
+  })
+);
+
+import {
+  composeMessageSchema,
+  replyMessageSchema,
+  updateConversationSchema,
+  bulkMessageActionSchema,
+  messageListQuerySchema
+} from '../schemas/pm';
+
+registry.registerPath({
+  method: 'get',
+  path: '/messages',
+  tags: ['Messages'],
+  request: { query: messageListQuerySchema },
+  responses: {
+    200: {
+      description: 'Inbox conversations',
+      content: { 'application/json': { schema: PaginatedConversations } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/messages/unread-count',
+  tags: ['Messages'],
+  responses: {
+    200: {
+      description: 'Unread conversation count',
+      content: { 'application/json': { schema: z.object({ count: z.number() }) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/messages/sent',
+  tags: ['Messages'],
+  responses: {
+    200: {
+      description: 'Sent conversations',
+      content: { 'application/json': { schema: PaginatedConversations } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/messages/bulk',
+  tags: ['Messages'],
+  request: { body: { content: { 'application/json': { schema: bulkMessageActionSchema } } } },
+  responses: { 204: { description: 'Bulk action applied' } }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/messages',
+  tags: ['Messages'],
+  request: { body: { content: { 'application/json': { schema: composeMessageSchema } } } },
+  responses: {
+    201: {
+      description: 'Conversation created',
+      content: { 'application/json': { schema: PrivateConversation } }
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: MsgResponse } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/messages/{id}',
+  tags: ['Messages'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Conversation with messages',
+      content: { 'application/json': { schema: PrivateConversation } }
+    },
+    404: { description: 'Not found', content: { 'application/json': { schema: MsgResponse } } }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/messages/{id}/reply',
+  tags: ['Messages'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: replyMessageSchema } } }
+  },
+  responses: {
+    201: {
+      description: 'Reply sent',
+      content: { 'application/json': { schema: PrivateMessage } }
+    },
+    403: { description: 'Not a participant', content: { 'application/json': { schema: MsgResponse } } }
+  }
+});
+
+registry.registerPath({
+  method: 'patch',
+  path: '/messages/{id}',
+  tags: ['Messages'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: updateConversationSchema } } }
+  },
+  responses: { 204: { description: 'Flags updated' } }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/messages/{id}',
+  tags: ['Messages'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 204: { description: 'Conversation soft-deleted' } }
+});
+
+// ─── Staff Inbox ──────────────────────────────────────────────────────────────
+
+import {
+  createTicketSchema,
+  replyTicketSchema,
+  assignTicketSchema,
+  bulkResolveSchema,
+  ticketListQuerySchema,
+  createResponseSchema,
+  updateResponseSchema
+} from '../schemas/staffInbox';
+
+const StaffInboxMessageUser = registry.register(
+  'StaffInboxMessageUser',
+  z.object({ id: z.number(), username: z.string(), avatar: z.string().nullable().optional() })
+);
+
+const StaffInboxMsg = registry.register(
+  'StaffInboxMsg',
+  z.object({
+    id: z.number(),
+    conversationId: z.number(),
+    body: z.string(),
+    createdAt: z.string(),
+    sender: StaffInboxMessageUser
+  })
+);
+
+const StaffInboxConversation = registry.register(
+  'StaffInboxConversation',
+  z.object({
+    id: z.number(),
+    subject: z.string(),
+    status: z.enum(['Unanswered', 'Open', 'Resolved']),
+    isReadByUser: z.boolean(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    user: StaffInboxMessageUser,
+    assignedUser: StaffInboxMessageUser.nullable().optional(),
+    resolver: StaffInboxMessageUser.nullable().optional(),
+    messages: z.array(StaffInboxMsg).optional()
+  })
+);
+
+const PaginatedTickets = registry.register(
+  'PaginatedTickets',
+  z.object({
+    total: z.number(),
+    page: z.number(),
+    pageSize: z.number(),
+    conversations: z.array(StaffInboxConversation)
+  })
+);
+
+const StaffInboxResponse = registry.register(
+  'StaffInboxResponse',
+  z.object({
+    id: z.number(),
+    name: z.string(),
+    body: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/staff-inbox',
+  tags: ['StaffInbox'],
+  request: { query: ticketListQuerySchema },
+  responses: {
+    200: { description: 'Staff ticket list', content: { 'application/json': { schema: PaginatedTickets } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/staff-inbox/unread-count',
+  tags: ['StaffInbox'],
+  responses: {
+    200: {
+      description: 'Open ticket count',
+      content: { 'application/json': { schema: z.object({ count: z.number() }) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/staff-inbox/mine',
+  tags: ['StaffInbox'],
+  responses: {
+    200: { description: 'My tickets', content: { 'application/json': { schema: PaginatedTickets } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/staff-inbox/responses',
+  tags: ['StaffInbox'],
+  responses: {
+    200: {
+      description: 'Canned responses',
+      content: { 'application/json': { schema: z.array(StaffInboxResponse) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox/responses',
+  tags: ['StaffInbox'],
+  request: { body: { content: { 'application/json': { schema: createResponseSchema } } } },
+  responses: {
+    201: { description: 'Response created', content: { 'application/json': { schema: StaffInboxResponse } } }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/staff-inbox/responses/{id}',
+  tags: ['StaffInbox'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: updateResponseSchema } } }
+  },
+  responses: {
+    200: { description: 'Response updated', content: { 'application/json': { schema: StaffInboxResponse } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: MsgResponse } } }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/staff-inbox/responses/{id}',
+  tags: ['StaffInbox'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 204: { description: 'Response deleted' } }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox/bulk-resolve',
+  tags: ['StaffInbox'],
+  request: { body: { content: { 'application/json': { schema: bulkResolveSchema } } } },
+  responses: {
+    200: {
+      description: 'Tickets resolved',
+      content: { 'application/json': { schema: z.object({ ok: z.boolean(), resolved: z.number() }) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox',
+  tags: ['StaffInbox'],
+  request: { body: { content: { 'application/json': { schema: createTicketSchema } } } },
+  responses: {
+    201: { description: 'Ticket created', content: { 'application/json': { schema: StaffInboxConversation } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/staff-inbox/{id}',
+  tags: ['StaffInbox'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Ticket', content: { 'application/json': { schema: StaffInboxConversation } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: MsgResponse } } }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox/{id}/reply',
+  tags: ['StaffInbox'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: replyTicketSchema } } }
+  },
+  responses: {
+    201: { description: 'Reply sent', content: { 'application/json': { schema: StaffInboxMsg } } }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox/{id}/assign',
+  tags: ['StaffInbox'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: assignTicketSchema } } }
+  },
+  responses: { 204: { description: 'Assigned' } }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox/{id}/resolve',
+  tags: ['StaffInbox'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 204: { description: 'Resolved' } }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/staff-inbox/{id}/unresolve',
+  tags: ['StaffInbox'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 204: { description: 'Unresolved' } }
+});
+
 // ─── Document builder ─────────────────────────────────────────────────────────
 
 export function buildOpenApiDocument() {

--- a/src/messages.spec.ts
+++ b/src/messages.spec.ts
@@ -1,0 +1,183 @@
+import { request, app, resetApiTestState, pmMock } from './test/apiTestHarness';
+
+const PAGED_EMPTY = { total: 0, page: 1, pageSize: 25, conversations: [] };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeConversation = (): any => ({
+  id: 1,
+  subject: 'Hello',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  participants: [],
+  messages: []
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeMessage = (): any => ({
+  id: 10,
+  conversationId: 1,
+  senderId: 7,
+  body: 'Hey there',
+  createdAt: new Date(),
+  sender: { id: 7, username: 'testuser', avatar: null }
+});
+
+describe('GET /api/messages', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns inbox with search forwarded to module', async () => {
+    pmMock.listInbox.mockResolvedValue(PAGED_EMPTY);
+    await request(app).get('/api/messages?page=2&search=hi');
+    expect(pmMock.listInbox).toHaveBeenCalledWith(7, 2, 'hi');
+  });
+});
+
+describe('GET /api/messages/unread-count', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns count', async () => {
+    pmMock.getUnreadCount.mockResolvedValue(3);
+    const res = await request(app).get('/api/messages/unread-count');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(3);
+  });
+});
+
+describe('GET /api/messages/sent', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns sentbox', async () => {
+    pmMock.listSentbox.mockResolvedValue(PAGED_EMPTY);
+    const res = await request(app).get('/api/messages/sent');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /api/messages', () => {
+  beforeEach(() => resetApiTestState());
+
+  const payload = { toUserId: 99, subject: 'Hi', body: 'Hello!' };
+
+  it('returns 201 on success', async () => {
+    pmMock.sendMessage.mockResolvedValue({
+      ok: true,
+      conversation: makeConversation()
+    });
+    const res = await request(app).post('/api/messages').send(payload);
+    expect(res.status).toBe(201);
+  });
+
+  it('maps self_message to 400 and recipient_not_found to 404', async () => {
+    pmMock.sendMessage.mockResolvedValue({ ok: false, reason: 'self_message' });
+    expect(
+      (await request(app).post('/api/messages').send(payload)).status
+    ).toBe(400);
+
+    pmMock.sendMessage.mockResolvedValue({
+      ok: false,
+      reason: 'recipient_not_found'
+    });
+    expect(
+      (await request(app).post('/api/messages').send(payload)).status
+    ).toBe(404);
+  });
+});
+
+describe('GET /api/messages/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns conversation', async () => {
+    pmMock.viewConversation.mockResolvedValue({
+      ok: true,
+      conversation: makeConversation()
+    });
+    const res = await request(app).get('/api/messages/1');
+    expect(res.status).toBe(200);
+    expect(pmMock.viewConversation).toHaveBeenCalledWith(1, 7);
+  });
+
+  it('returns 404 when not found', async () => {
+    pmMock.viewConversation.mockResolvedValue({
+      ok: false,
+      reason: 'not_found'
+    });
+    expect((await request(app).get('/api/messages/99')).status).toBe(404);
+  });
+});
+
+describe('POST /api/messages/:id/reply', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 201 on success and 403 when not a participant', async () => {
+    pmMock.replyToConversation.mockResolvedValue({
+      ok: true,
+      message: makeMessage()
+    });
+    expect(
+      (await request(app).post('/api/messages/1/reply').send({ body: 'yo' }))
+        .status
+    ).toBe(201);
+
+    pmMock.replyToConversation.mockResolvedValue({
+      ok: false,
+      reason: 'not_participant'
+    });
+    expect(
+      (await request(app).post('/api/messages/1/reply').send({ body: 'yo' }))
+        .status
+    ).toBe(403);
+  });
+});
+
+describe('PATCH /api/messages/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 204 on success and 404 when not found', async () => {
+    pmMock.updateConversationFlags.mockResolvedValue({ ok: true });
+    expect(
+      (await request(app).patch('/api/messages/1').send({ isSticky: true }))
+        .status
+    ).toBe(204);
+
+    pmMock.updateConversationFlags.mockResolvedValue({
+      ok: false,
+      reason: 'not_found'
+    });
+    expect(
+      (await request(app).patch('/api/messages/1').send({ isSticky: true }))
+        .status
+    ).toBe(404);
+  });
+});
+
+describe('DELETE /api/messages/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 204 on success and 404 when not found', async () => {
+    pmMock.deleteConversation.mockResolvedValue({ ok: true });
+    expect((await request(app).delete('/api/messages/1')).status).toBe(204);
+
+    pmMock.deleteConversation.mockResolvedValue({
+      ok: false,
+      reason: 'not_found'
+    });
+    expect((await request(app).delete('/api/messages/99')).status).toBe(404);
+  });
+});
+
+describe('POST /api/messages/bulk', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 204 and delegates to module', async () => {
+    pmMock.bulkUpdateConversations.mockResolvedValue({ ok: true });
+    const res = await request(app)
+      .post('/api/messages/bulk')
+      .send({ ids: [1, 2], action: 'markRead' });
+    expect(res.status).toBe(204);
+    expect(pmMock.bulkUpdateConversations).toHaveBeenCalledWith(
+      7,
+      [1, 2],
+      'markRead'
+    );
+  });
+});

--- a/src/modules/pm.ts
+++ b/src/modules/pm.ts
@@ -1,0 +1,286 @@
+import { prisma } from '../lib/prisma';
+
+const PAGE_SIZE = 25;
+
+const senderSelect = {
+  id: true,
+  username: true,
+  avatar: true
+} as const;
+
+export async function listInbox(userId: number, page: number, search?: string) {
+  const where = {
+    participants: {
+      some: { userId, inInbox: true }
+    },
+    ...(search
+      ? { subject: { contains: search, mode: 'insensitive' as const } }
+      : {})
+  };
+
+  const [total, conversations] = await Promise.all([
+    prisma.privateConversation.count({ where }),
+    prisma.privateConversation.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      include: {
+        participants: {
+          where: { userId },
+          select: {
+            isRead: true,
+            isSticky: true,
+            receivedAt: true,
+            sentAt: true
+          }
+        },
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          include: { sender: { select: senderSelect } }
+        }
+      }
+    })
+  ]);
+
+  return { total, page, pageSize: PAGE_SIZE, conversations };
+}
+
+export async function listSentbox(userId: number, page: number) {
+  const where = {
+    participants: { some: { userId, inSentbox: true } }
+  };
+
+  const [total, conversations] = await Promise.all([
+    prisma.privateConversation.count({ where }),
+    prisma.privateConversation.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      include: {
+        participants: {
+          where: { userId },
+          select: { isRead: true, sentAt: true }
+        },
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          include: { sender: { select: senderSelect } }
+        }
+      }
+    })
+  ]);
+
+  return { total, page, pageSize: PAGE_SIZE, conversations };
+}
+
+export async function getUnreadCount(userId: number): Promise<number> {
+  return prisma.privateConversation.count({
+    where: {
+      participants: { some: { userId, inInbox: true, isRead: false } }
+    }
+  });
+}
+
+export async function sendMessage(
+  fromId: number,
+  toId: number,
+  subject: string,
+  body: string
+) {
+  if (fromId === toId) return { ok: false as const, reason: 'self_message' };
+
+  const recipient = await prisma.user.findUnique({
+    where: { id: toId },
+    select: { id: true, disabled: true, disablePm: true }
+  });
+  if (!recipient) return { ok: false as const, reason: 'recipient_not_found' };
+  if (recipient.disabled)
+    return { ok: false as const, reason: 'recipient_disabled' };
+  if (recipient.disablePm)
+    return { ok: false as const, reason: 'recipient_pm_disabled' };
+
+  const conversation = await prisma.$transaction(async (tx) => {
+    const conv = await tx.privateConversation.create({
+      data: {
+        subject,
+        messages: {
+          create: { senderId: fromId, body }
+        },
+        participants: {
+          create: [
+            {
+              userId: toId,
+              inInbox: true,
+              inSentbox: false,
+              isRead: false,
+              receivedAt: new Date()
+            },
+            {
+              userId: fromId,
+              inInbox: false,
+              inSentbox: true,
+              isRead: true,
+              sentAt: new Date()
+            }
+          ]
+        }
+      },
+      include: {
+        messages: { include: { sender: { select: senderSelect } } },
+        participants: true
+      }
+    });
+    return conv;
+  });
+
+  return { ok: true as const, conversation };
+}
+
+export async function replyToConversation(
+  conversationId: number,
+  senderId: number,
+  body: string
+) {
+  const participant = await prisma.privateConversationParticipant.findFirst({
+    where: {
+      conversationId,
+      userId: senderId,
+      OR: [{ inInbox: true }, { inSentbox: true }]
+    }
+  });
+  if (!participant) return { ok: false as const, reason: 'not_participant' };
+
+  const allParticipants = await prisma.privateConversationParticipant.findMany({
+    where: { conversationId }
+  });
+
+  const message = await prisma.$transaction(async (tx) => {
+    const msg = await tx.privateMessage.create({
+      data: { conversationId, senderId, body },
+      include: { sender: { select: senderSelect } }
+    });
+
+    // Mark recipients unread + restore inbox visibility; mark sender sentbox updated
+    for (const p of allParticipants) {
+      if (p.userId === senderId) {
+        await tx.privateConversationParticipant.update({
+          where: {
+            userId_conversationId: { userId: p.userId, conversationId }
+          },
+          data: { inSentbox: true, isRead: true, sentAt: new Date() }
+        });
+      } else {
+        await tx.privateConversationParticipant.update({
+          where: {
+            userId_conversationId: { userId: p.userId, conversationId }
+          },
+          data: { inInbox: true, isRead: false, receivedAt: new Date() }
+        });
+      }
+    }
+
+    return msg;
+  });
+
+  return { ok: true as const, message };
+}
+
+export async function viewConversation(conversationId: number, userId: number) {
+  const participant = await prisma.privateConversationParticipant.findFirst({
+    where: {
+      conversationId,
+      userId,
+      OR: [{ inInbox: true }, { inSentbox: true }]
+    }
+  });
+  if (!participant) return { ok: false as const, reason: 'not_found' };
+
+  const conversation = await prisma.privateConversation.findUnique({
+    where: { id: conversationId },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+        include: { sender: { select: senderSelect } }
+      },
+      participants: {
+        include: { user: { select: senderSelect } }
+      }
+    }
+  });
+  if (!conversation) return { ok: false as const, reason: 'not_found' };
+
+  // Mark read
+  if (!participant.isRead) {
+    await prisma.privateConversationParticipant.update({
+      where: { userId_conversationId: { userId, conversationId } },
+      data: { isRead: true }
+    });
+  }
+
+  return { ok: true as const, conversation };
+}
+
+export async function updateConversationFlags(
+  conversationId: number,
+  userId: number,
+  flags: { isSticky?: boolean; isRead?: boolean }
+) {
+  const participant = await prisma.privateConversationParticipant.findFirst({
+    where: {
+      conversationId,
+      userId,
+      OR: [{ inInbox: true }, { inSentbox: true }]
+    }
+  });
+  if (!participant) return { ok: false as const, reason: 'not_found' };
+
+  await prisma.privateConversationParticipant.update({
+    where: { userId_conversationId: { userId, conversationId } },
+    data: flags
+  });
+
+  return { ok: true as const };
+}
+
+export async function deleteConversation(
+  conversationId: number,
+  userId: number
+) {
+  const participant = await prisma.privateConversationParticipant.findFirst({
+    where: { conversationId, userId }
+  });
+  if (!participant) return { ok: false as const, reason: 'not_found' };
+
+  await prisma.privateConversationParticipant.update({
+    where: { userId_conversationId: { userId, conversationId } },
+    data: { inInbox: false, inSentbox: false, isSticky: false }
+  });
+
+  return { ok: true as const };
+}
+
+export async function bulkUpdateConversations(
+  userId: number,
+  ids: number[],
+  action: 'delete' | 'markRead' | 'markUnread'
+) {
+  const dataMap = {
+    delete: { inInbox: false, inSentbox: false, isSticky: false },
+    markRead: { isRead: true },
+    markUnread: { isRead: false }
+  };
+
+  await prisma.privateConversationParticipant.updateMany({
+    where: {
+      userId,
+      conversationId: { in: ids },
+      OR: [{ inInbox: true }, { inSentbox: true }]
+    },
+    data: dataMap[action]
+  });
+
+  return { ok: true as const };
+}

--- a/src/modules/staffInbox.ts
+++ b/src/modules/staffInbox.ts
@@ -1,0 +1,299 @@
+import { prisma } from '../lib/prisma';
+import { Prisma, type StaffInboxStatus } from '@prisma/client';
+
+const PAGE_SIZE = 25;
+
+const userSelect = {
+  id: true,
+  username: true,
+  avatar: true
+} as const;
+
+export async function listStaffTickets(opts: {
+  page: number;
+  status: StaffInboxStatus | 'all';
+  assignedToMe: boolean;
+  staffUserId: number;
+}) {
+  const { page, status, assignedToMe, staffUserId } = opts;
+
+  const where: Prisma.StaffInboxConversationWhereInput = {};
+  if (status !== 'all') where.status = status;
+  if (assignedToMe) where.assignedUserId = staffUserId;
+
+  const [total, conversations] = await Promise.all([
+    prisma.staffInboxConversation.count({ where }),
+    prisma.staffInboxConversation.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      include: {
+        user: { select: userSelect },
+        assignedUser: { select: userSelect },
+        resolver: { select: userSelect },
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          include: { sender: { select: userSelect } }
+        }
+      }
+    })
+  ]);
+
+  return { total, page, pageSize: PAGE_SIZE, conversations };
+}
+
+export async function listMyTickets(userId: number, page: number) {
+  const where = { userId };
+  const [total, conversations] = await Promise.all([
+    prisma.staffInboxConversation.count({ where }),
+    prisma.staffInboxConversation.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      include: {
+        assignedUser: { select: userSelect },
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          include: { sender: { select: userSelect } }
+        }
+      }
+    })
+  ]);
+
+  return { total, page, pageSize: PAGE_SIZE, conversations };
+}
+
+export async function getStaffUnreadCount(): Promise<number> {
+  return prisma.staffInboxConversation.count({
+    where: { status: { not: 'Resolved' } }
+  });
+}
+
+export async function createTicket(
+  userId: number,
+  subject: string,
+  body: string
+) {
+  const conversation = await prisma.staffInboxConversation.create({
+    data: {
+      subject,
+      userId,
+      status: 'Unanswered',
+      messages: { create: { senderId: userId, body } }
+    },
+    include: {
+      user: { select: userSelect },
+      messages: { include: { sender: { select: userSelect } } }
+    }
+  });
+  return conversation;
+}
+
+export async function viewTicket(
+  id: number,
+  requesterId: number,
+  isStaff: boolean
+) {
+  const conversation = await prisma.staffInboxConversation.findUnique({
+    where: { id },
+    include: {
+      user: { select: userSelect },
+      assignedUser: { select: userSelect },
+      resolver: { select: userSelect },
+      messages: {
+        orderBy: { createdAt: 'asc' },
+        include: { sender: { select: userSelect } }
+      }
+    }
+  });
+  if (!conversation) return { ok: false as const, reason: 'not_found' };
+  if (!isStaff && conversation.userId !== requesterId) {
+    return { ok: false as const, reason: 'forbidden' };
+  }
+
+  // Mark read by user when they view their own ticket
+  if (!isStaff && !conversation.isReadByUser) {
+    await prisma.staffInboxConversation.update({
+      where: { id },
+      data: { isReadByUser: true }
+    });
+  }
+
+  return { ok: true as const, conversation };
+}
+
+export async function replyToTicket(
+  id: number,
+  senderId: number,
+  body: string,
+  isStaff: boolean
+) {
+  const conversation = await prisma.staffInboxConversation.findUnique({
+    where: { id },
+    select: { userId: true, status: true }
+  });
+  if (!conversation) return { ok: false as const, reason: 'not_found' };
+  if (!isStaff && conversation.userId !== senderId) {
+    return { ok: false as const, reason: 'forbidden' };
+  }
+  if (conversation.status === 'Resolved') {
+    return { ok: false as const, reason: 'resolved' };
+  }
+
+  const newStatus: StaffInboxStatus = isStaff ? 'Open' : 'Unanswered';
+
+  const [message] = await prisma.$transaction([
+    prisma.staffInboxMessage.create({
+      data: { conversationId: id, senderId, body },
+      include: { sender: { select: userSelect } }
+    }),
+    prisma.staffInboxConversation.update({
+      where: { id },
+      data: {
+        status: newStatus,
+        // When staff replies, user hasn't read it yet; when user replies, staff hasn't read it
+        isReadByUser: isStaff ? false : true
+      }
+    })
+  ]);
+
+  return { ok: true as const, message };
+}
+
+export async function assignTicket(
+  id: number,
+  assignedUserId: number | null,
+  staffUserId: number
+) {
+  const conversation = await prisma.staffInboxConversation.findUnique({
+    where: { id },
+    select: { id: true, status: true }
+  });
+  if (!conversation) return { ok: false as const, reason: 'not_found' };
+
+  // If assigning to a specific user, verify they exist and are staff
+  if (assignedUserId !== null) {
+    const assignee = await prisma.user.findUnique({
+      where: { id: assignedUserId },
+      select: { id: true, userRank: { select: { permissions: true } } }
+    });
+    if (!assignee) return { ok: false as const, reason: 'assignee_not_found' };
+    const perms = (assignee.userRank.permissions ?? {}) as Record<
+      string,
+      boolean
+    >;
+    if (!perms['staff'] && !perms['admin']) {
+      return { ok: false as const, reason: 'assignee_not_staff' };
+    }
+  }
+
+  await prisma.staffInboxConversation.update({
+    where: { id },
+    data: {
+      assignedUserId,
+      status: 'Unanswered'
+    }
+  });
+
+  return { ok: true as const };
+}
+
+export async function resolveTicket(
+  id: number,
+  resolverId: number,
+  isStaff: boolean
+) {
+  const conversation = await prisma.staffInboxConversation.findUnique({
+    where: { id },
+    select: { userId: true, status: true }
+  });
+  if (!conversation) return { ok: false as const, reason: 'not_found' };
+  if (!isStaff && conversation.userId !== resolverId) {
+    return { ok: false as const, reason: 'forbidden' };
+  }
+  if (conversation.status === 'Resolved') {
+    return { ok: false as const, reason: 'already_resolved' };
+  }
+
+  await prisma.staffInboxConversation.update({
+    where: { id },
+    data: { status: 'Resolved', resolverId }
+  });
+
+  return { ok: true as const };
+}
+
+export async function unresolveTicket(id: number, staffUserId: number) {
+  const conversation = await prisma.staffInboxConversation.findUnique({
+    where: { id },
+    select: { status: true }
+  });
+  if (!conversation) return { ok: false as const, reason: 'not_found' };
+  if (conversation.status !== 'Resolved') {
+    return { ok: false as const, reason: 'not_resolved' };
+  }
+
+  await prisma.staffInboxConversation.update({
+    where: { id },
+    data: { status: 'Unanswered', resolverId: null }
+  });
+
+  return { ok: true as const };
+}
+
+export async function bulkResolveTickets(ids: number[], resolverId: number) {
+  const conversations = await prisma.staffInboxConversation.findMany({
+    where: { id: { in: ids }, status: { not: 'Resolved' } },
+    select: { id: true }
+  });
+
+  const resolveIds = conversations.map((c) => c.id);
+  if (resolveIds.length === 0) return { ok: true as const, resolved: 0 };
+
+  await prisma.staffInboxConversation.updateMany({
+    where: { id: { in: resolveIds } },
+    data: { status: 'Resolved', resolverId }
+  });
+
+  return { ok: true as const, resolved: resolveIds.length };
+}
+
+// Canned responses
+
+export async function listResponses() {
+  return prisma.staffInboxResponse.findMany({
+    orderBy: { name: 'asc' }
+  });
+}
+
+export async function createResponse(name: string, body: string) {
+  return prisma.staffInboxResponse.create({ data: { name, body } });
+}
+
+export async function updateResponse(
+  id: number,
+  data: { name?: string; body?: string }
+) {
+  const existing = await prisma.staffInboxResponse.findUnique({
+    where: { id }
+  });
+  if (!existing) return { ok: false as const, reason: 'not_found' };
+  const updated = await prisma.staffInboxResponse.update({
+    where: { id },
+    data
+  });
+  return { ok: true as const, response: updated };
+}
+
+export async function deleteResponse(id: number) {
+  const existing = await prisma.staffInboxResponse.findUnique({
+    where: { id }
+  });
+  if (!existing) return { ok: false as const, reason: 'not_found' };
+  await prisma.staffInboxResponse.delete({ where: { id } });
+  return { ok: true as const };
+}

--- a/src/modules/staffInbox.ts
+++ b/src/modules/staffInbox.ts
@@ -164,11 +164,7 @@ export async function replyToTicket(
   return { ok: true as const, message };
 }
 
-export async function assignTicket(
-  id: number,
-  assignedUserId: number | null,
-  staffUserId: number
-) {
+export async function assignTicket(id: number, assignedUserId: number | null) {
   const conversation = await prisma.staffInboxConversation.findUnique({
     where: { id },
     select: { id: true, status: true }
@@ -227,7 +223,7 @@ export async function resolveTicket(
   return { ok: true as const };
 }
 
-export async function unresolveTicket(id: number, staffUserId: number) {
+export async function unresolveTicket(id: number) {
   const conversation = await prisma.staffInboxConversation.findUnique({
     where: { id },
     select: { status: true }

--- a/src/routes/api/messages.ts
+++ b/src/routes/api/messages.ts
@@ -1,0 +1,189 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { z } from 'zod';
+import { authHandler } from '../../modules/asyncHandler';
+import { requireAuth } from '../../middleware/auth';
+import {
+  validate,
+  validateParams,
+  validateQuery,
+  parsedBody,
+  parsedParams,
+  parsedQuery
+} from '../../middleware/validate';
+import {
+  composeMessageSchema,
+  replyMessageSchema,
+  updateConversationSchema,
+  bulkMessageActionSchema,
+  messageListQuerySchema,
+  type ComposeMessageInput,
+  type ReplyMessageInput,
+  type UpdateConversationInput,
+  type BulkMessageActionInput,
+  type MessageListQueryInput
+} from '../../schemas/pm';
+import {
+  listInbox,
+  listSentbox,
+  sendMessage,
+  replyToConversation,
+  viewConversation,
+  updateConversationFlags,
+  deleteConversation,
+  bulkUpdateConversations,
+  getUnreadCount
+} from '../../modules/pm';
+
+const router = express.Router();
+
+const sendLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  message: { msg: 'Too many messages sent. Please wait before trying again.' },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+const conversationIdSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+// GET /api/messages — inbox list
+router.get(
+  '/',
+  requireAuth,
+  validateQuery(messageListQuerySchema),
+  authHandler(async (req, res) => {
+    const { page, search } = parsedQuery<MessageListQueryInput>(res);
+    const result = await listInbox(req.user.id, page, search);
+    res.json(result);
+  })
+);
+
+// GET /api/messages/unread-count
+router.get(
+  '/unread-count',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const count = await getUnreadCount(req.user.id);
+    res.json({ count });
+  })
+);
+
+// GET /api/messages/sent — sentbox list
+router.get(
+  '/sent',
+  requireAuth,
+  validateQuery(messageListQuerySchema),
+  authHandler(async (req, res) => {
+    const { page } = parsedQuery<MessageListQueryInput>(res);
+    const result = await listSentbox(req.user.id, page);
+    res.json(result);
+  })
+);
+
+// POST /api/messages/bulk — bulk action on multiple conversations
+router.post(
+  '/bulk',
+  requireAuth,
+  validate(bulkMessageActionSchema),
+  authHandler(async (req, res) => {
+    const { ids, action } = parsedBody<BulkMessageActionInput>(res);
+    await bulkUpdateConversations(req.user.id, ids, action);
+    res.status(204).send();
+  })
+);
+
+// POST /api/messages — compose new conversation
+router.post(
+  '/',
+  requireAuth,
+  sendLimiter,
+  validate(composeMessageSchema),
+  authHandler(async (req, res) => {
+    const { toUserId, subject, body } = parsedBody<ComposeMessageInput>(res);
+    const result = await sendMessage(req.user.id, toUserId, subject, body);
+    if (!result.ok) {
+      const statusMap: Record<string, number> = {
+        self_message: 400,
+        recipient_not_found: 404,
+        recipient_disabled: 422,
+        recipient_pm_disabled: 422
+      };
+      return res
+        .status(statusMap[result.reason] ?? 400)
+        .json({ msg: result.reason });
+    }
+    res.status(201).json(result.conversation);
+  })
+);
+
+// GET /api/messages/:id — view conversation
+router.get(
+  '/:id',
+  requireAuth,
+  validateParams(conversationIdSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const result = await viewConversation(id, req.user.id);
+    if (!result.ok)
+      return res.status(404).json({ msg: 'Conversation not found' });
+    res.json(result.conversation);
+  })
+);
+
+// POST /api/messages/:id/reply — reply to conversation
+router.post(
+  '/:id/reply',
+  requireAuth,
+  sendLimiter,
+  validateParams(conversationIdSchema),
+  validate(replyMessageSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { body } = parsedBody<ReplyMessageInput>(res);
+    const result = await replyToConversation(id, req.user.id, body);
+    if (!result.ok) {
+      const statusMap: Record<string, number> = {
+        not_participant: 403
+      };
+      return res
+        .status(statusMap[result.reason] ?? 400)
+        .json({ msg: result.reason });
+    }
+    res.status(201).json(result.message);
+  })
+);
+
+// PATCH /api/messages/:id — update flags (sticky, read)
+router.patch(
+  '/:id',
+  requireAuth,
+  validateParams(conversationIdSchema),
+  validate(updateConversationSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const flags = parsedBody<UpdateConversationInput>(res);
+    const result = await updateConversationFlags(id, req.user.id, flags);
+    if (!result.ok)
+      return res.status(404).json({ msg: 'Conversation not found' });
+    res.status(204).send();
+  })
+);
+
+// DELETE /api/messages/:id — soft delete conversation for this user
+router.delete(
+  '/:id',
+  requireAuth,
+  validateParams(conversationIdSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const result = await deleteConversation(id, req.user.id);
+    if (!result.ok)
+      return res.status(404).json({ msg: 'Conversation not found' });
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/staffInbox.ts
+++ b/src/routes/api/staffInbox.ts
@@ -221,7 +221,7 @@ router.post(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { assignedUserId } = parsedBody<AssignTicketInput>(res);
-    const result = await assignTicket(id, assignedUserId, req.user.id);
+    const result = await assignTicket(id, assignedUserId);
     if (!result.ok) {
       const statusMap: Record<string, number> = {
         not_found: 404,
@@ -266,7 +266,7 @@ router.post(
   validateParams(ticketIdSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const result = await unresolveTicket(id, req.user.id);
+    const result = await unresolveTicket(id);
     if (!result.ok) {
       const statusMap: Record<string, number> = {
         not_found: 404,

--- a/src/routes/api/staffInbox.ts
+++ b/src/routes/api/staffInbox.ts
@@ -1,0 +1,283 @@
+import express from 'express';
+import { z } from 'zod';
+import { authHandler } from '../../modules/asyncHandler';
+import { requireAuth } from '../../middleware/auth';
+import { requirePermission, isModerator } from '../../middleware/permissions';
+import {
+  validate,
+  validateParams,
+  validateQuery,
+  parsedBody,
+  parsedParams,
+  parsedQuery
+} from '../../middleware/validate';
+import {
+  createTicketSchema,
+  replyTicketSchema,
+  assignTicketSchema,
+  bulkResolveSchema,
+  ticketListQuerySchema,
+  createResponseSchema,
+  updateResponseSchema,
+  type CreateTicketInput,
+  type ReplyTicketInput,
+  type AssignTicketInput,
+  type BulkResolveInput,
+  type TicketListQueryInput,
+  type CreateResponseInput,
+  type UpdateResponseInput
+} from '../../schemas/staffInbox';
+import {
+  listStaffTickets,
+  listMyTickets,
+  createTicket,
+  viewTicket,
+  replyToTicket,
+  assignTicket,
+  resolveTicket,
+  unresolveTicket,
+  bulkResolveTickets,
+  listResponses,
+  createResponse,
+  updateResponse,
+  deleteResponse,
+  getStaffUnreadCount
+} from '../../modules/staffInbox';
+import type { StaffInboxStatus } from '@prisma/client';
+
+const router = express.Router();
+
+const ticketIdSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+const responseIdSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+// GET /api/staff-inbox — staff view of all tickets
+router.get(
+  '/',
+  ...requirePermission('staff', 'admin'),
+  validateQuery(ticketListQuerySchema),
+  authHandler(async (req, res) => {
+    const { page, status, assignedToMe } =
+      parsedQuery<TicketListQueryInput>(res);
+    const result = await listStaffTickets({
+      page,
+      status: status as StaffInboxStatus | 'all',
+      assignedToMe,
+      staffUserId: req.user.id
+    });
+    res.json(result);
+  })
+);
+
+// GET /api/staff-inbox/unread-count — count of open/unanswered tickets (staff)
+router.get(
+  '/unread-count',
+  ...requirePermission('staff', 'admin'),
+  authHandler(async (_req, res) => {
+    const count = await getStaffUnreadCount();
+    res.json({ count });
+  })
+);
+
+// GET /api/staff-inbox/responses — list canned responses (staff)
+router.get(
+  '/responses',
+  ...requirePermission('staff', 'admin'),
+  authHandler(async (_req, res) => {
+    const responses = await listResponses();
+    res.json(responses);
+  })
+);
+
+// POST /api/staff-inbox/responses — create canned response (staff)
+router.post(
+  '/responses',
+  ...requirePermission('staff', 'admin'),
+  validate(createResponseSchema),
+  authHandler(async (_req, res) => {
+    const { name, body } = parsedBody<CreateResponseInput>(res);
+    const response = await createResponse(name, body);
+    res.status(201).json(response);
+  })
+);
+
+// PUT /api/staff-inbox/responses/:id — update canned response (staff)
+router.put(
+  '/responses/:id',
+  ...requirePermission('staff', 'admin'),
+  validateParams(responseIdSchema),
+  validate(updateResponseSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const data = parsedBody<UpdateResponseInput>(res);
+    const result = await updateResponse(id, data);
+    if (!result.ok) return res.status(404).json({ msg: 'Response not found' });
+    res.json(result.response);
+  })
+);
+
+// DELETE /api/staff-inbox/responses/:id — delete canned response (staff)
+router.delete(
+  '/responses/:id',
+  ...requirePermission('staff', 'admin'),
+  validateParams(responseIdSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const result = await deleteResponse(id);
+    if (!result.ok) return res.status(404).json({ msg: 'Response not found' });
+    res.status(204).send();
+  })
+);
+
+// POST /api/staff-inbox/bulk-resolve — bulk resolve tickets (staff)
+router.post(
+  '/bulk-resolve',
+  ...requirePermission('staff', 'admin'),
+  validate(bulkResolveSchema),
+  authHandler(async (req, res) => {
+    const { ids } = parsedBody<BulkResolveInput>(res);
+    const result = await bulkResolveTickets(ids, req.user.id);
+    res.json(result);
+  })
+);
+
+// GET /api/staff-inbox/mine — user's own submitted tickets
+router.get(
+  '/mine',
+  requireAuth,
+  validateQuery(z.object({ page: z.coerce.number().int().min(1).default(1) })),
+  authHandler(async (req, res) => {
+    const { page } = parsedQuery<{ page: number }>(res);
+    const result = await listMyTickets(req.user.id, page);
+    res.json(result);
+  })
+);
+
+// POST /api/staff-inbox — create new ticket (any authenticated user)
+router.post(
+  '/',
+  requireAuth,
+  validate(createTicketSchema),
+  authHandler(async (req, res) => {
+    const { subject, body } = parsedBody<CreateTicketInput>(res);
+    const conversation = await createTicket(req.user.id, subject, body);
+    res.status(201).json(conversation);
+  })
+);
+
+// GET /api/staff-inbox/:id — view ticket
+router.get(
+  '/:id',
+  requireAuth,
+  validateParams(ticketIdSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const staffAccess = await isModerator(req, res);
+    const result = await viewTicket(id, req.user.id, staffAccess);
+    if (!result.ok) {
+      if (result.reason === 'forbidden')
+        return res.status(403).json({ msg: 'Permission denied' });
+      return res.status(404).json({ msg: 'Ticket not found' });
+    }
+    res.json(result.conversation);
+  })
+);
+
+// POST /api/staff-inbox/:id/reply — reply to ticket
+router.post(
+  '/:id/reply',
+  requireAuth,
+  validateParams(ticketIdSchema),
+  validate(replyTicketSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { body } = parsedBody<ReplyTicketInput>(res);
+    const staffAccess = await isModerator(req, res);
+    const result = await replyToTicket(id, req.user.id, body, staffAccess);
+    if (!result.ok) {
+      const statusMap: Record<string, number> = {
+        not_found: 404,
+        forbidden: 403,
+        resolved: 422
+      };
+      return res
+        .status(statusMap[result.reason] ?? 400)
+        .json({ msg: result.reason });
+    }
+    res.status(201).json(result.message);
+  })
+);
+
+// POST /api/staff-inbox/:id/assign — assign ticket (staff only)
+router.post(
+  '/:id/assign',
+  ...requirePermission('staff', 'admin'),
+  validateParams(ticketIdSchema),
+  validate(assignTicketSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { assignedUserId } = parsedBody<AssignTicketInput>(res);
+    const result = await assignTicket(id, assignedUserId, req.user.id);
+    if (!result.ok) {
+      const statusMap: Record<string, number> = {
+        not_found: 404,
+        assignee_not_found: 404,
+        assignee_not_staff: 422
+      };
+      return res
+        .status(statusMap[result.reason] ?? 400)
+        .json({ msg: result.reason });
+    }
+    res.status(204).send();
+  })
+);
+
+// POST /api/staff-inbox/:id/resolve — resolve ticket
+router.post(
+  '/:id/resolve',
+  requireAuth,
+  validateParams(ticketIdSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const staffAccess = await isModerator(req, res);
+    const result = await resolveTicket(id, req.user.id, staffAccess);
+    if (!result.ok) {
+      const statusMap: Record<string, number> = {
+        not_found: 404,
+        forbidden: 403,
+        already_resolved: 422
+      };
+      return res
+        .status(statusMap[result.reason] ?? 400)
+        .json({ msg: result.reason });
+    }
+    res.status(204).send();
+  })
+);
+
+// POST /api/staff-inbox/:id/unresolve — unresolve ticket (staff only)
+router.post(
+  '/:id/unresolve',
+  ...requirePermission('staff', 'admin'),
+  validateParams(ticketIdSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const result = await unresolveTicket(id, req.user.id);
+    if (!result.ok) {
+      const statusMap: Record<string, number> = {
+        not_found: 404,
+        not_resolved: 422
+      };
+      return res
+        .status(statusMap[result.reason] ?? 400)
+        .json({ msg: result.reason });
+    }
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/schemas/pm.ts
+++ b/src/schemas/pm.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const composeMessageSchema = z.object({
+  toUserId: z.number().int().positive('toUserId is required'),
+  subject: z.string().min(1, 'Subject is required').max(255),
+  body: z.string().min(1, 'Body is required')
+});
+
+export const replyMessageSchema = z.object({
+  body: z.string().min(1, 'Body is required')
+});
+
+export const updateConversationSchema = z
+  .object({
+    isSticky: z.boolean().optional(),
+    isRead: z.boolean().optional()
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: 'No fields to update' });
+
+export const bulkMessageActionSchema = z.object({
+  ids: z.array(z.number().int().positive()).min(1, 'At least one id required'),
+  action: z.enum(['delete', 'markRead', 'markUnread'])
+});
+
+export const messageListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  search: z.string().optional()
+});
+
+export type ComposeMessageInput = z.infer<typeof composeMessageSchema>;
+export type ReplyMessageInput = z.infer<typeof replyMessageSchema>;
+export type UpdateConversationInput = z.infer<typeof updateConversationSchema>;
+export type BulkMessageActionInput = z.infer<typeof bulkMessageActionSchema>;
+export type MessageListQueryInput = z.infer<typeof messageListQuerySchema>;

--- a/src/schemas/staffInbox.ts
+++ b/src/schemas/staffInbox.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const createTicketSchema = z.object({
+  subject: z.string().min(1, 'Subject is required').max(255),
+  body: z.string().min(1, 'Body is required')
+});
+
+export const replyTicketSchema = z.object({
+  body: z.string().min(1, 'Body is required')
+});
+
+export const assignTicketSchema = z.object({
+  assignedUserId: z.number().int().positive().nullable()
+});
+
+export const bulkResolveSchema = z.object({
+  ids: z.array(z.number().int().positive()).min(1, 'At least one id required')
+});
+
+export const ticketListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  status: z.enum(['Unanswered', 'Open', 'Resolved', 'all']).default('all'),
+  assignedToMe: z.coerce.boolean().default(false)
+});
+
+export const createResponseSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255),
+  body: z.string().min(1, 'Body is required')
+});
+
+export const updateResponseSchema = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    body: z.string().min(1).optional()
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: 'No fields to update' });
+
+export type CreateTicketInput = z.infer<typeof createTicketSchema>;
+export type ReplyTicketInput = z.infer<typeof replyTicketSchema>;
+export type AssignTicketInput = z.infer<typeof assignTicketSchema>;
+export type BulkResolveInput = z.infer<typeof bulkResolveSchema>;
+export type TicketListQueryInput = z.infer<typeof ticketListQuerySchema>;
+export type CreateResponseInput = z.infer<typeof createResponseSchema>;
+export type UpdateResponseInput = z.infer<typeof updateResponseSchema>;

--- a/src/staffInbox.spec.ts
+++ b/src/staffInbox.spec.ts
@@ -1,0 +1,387 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock,
+  staffInboxMock
+} from './test/apiTestHarness';
+
+const setStaff = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue({
+    permissions: { staff: true }
+  });
+
+const PAGED_EMPTY = { total: 0, page: 1, pageSize: 25, conversations: [] };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeTicket = (overrides: Record<string, unknown> = {}): any => ({
+  id: 1,
+  userId: 7,
+  subject: 'Help please',
+  status: 'Unanswered',
+  assignedUserId: null,
+  resolverId: null,
+  isReadByUser: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  user: { id: 7, username: 'testuser', avatar: null },
+  assignedUser: null,
+  resolver: null,
+  messages: [],
+  ...overrides
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeResponse = (overrides: Record<string, unknown> = {}): any => ({
+  id: 1,
+  name: 'Standard reply',
+  body: 'Thank you for contacting support.',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeMessage = (): any => ({
+  id: 10,
+  conversationId: 1,
+  senderId: 7,
+  body: 'Here is my reply',
+  createdAt: new Date(),
+  sender: { id: 7, username: 'testuser', avatar: null }
+});
+
+// ─── Staff ticket list ────────────────────────────────────────────────────────
+
+describe('GET /api/staff-inbox', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 403 without staff permission', async () => {
+    expect((await request(app).get('/api/staff-inbox')).status).toBe(403);
+  });
+
+  it('returns ticket list for staff', async () => {
+    setStaff();
+    staffInboxMock.listStaffTickets.mockResolvedValue({
+      ...PAGED_EMPTY,
+      conversations: [makeTicket()]
+    });
+    const res = await request(app).get('/api/staff-inbox?status=Open');
+    expect(res.status).toBe(200);
+    expect(staffInboxMock.listStaffTickets).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'Open', staffUserId: 7 })
+    );
+  });
+});
+
+// ─── Staff unread count ───────────────────────────────────────────────────────
+
+describe('GET /api/staff-inbox/unread-count', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 403 without staff permission', async () => {
+    expect(
+      (await request(app).get('/api/staff-inbox/unread-count')).status
+    ).toBe(403);
+  });
+
+  it('returns count for staff', async () => {
+    setStaff();
+    staffInboxMock.getStaffUnreadCount.mockResolvedValue(5);
+    const res = await request(app).get('/api/staff-inbox/unread-count');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(5);
+  });
+});
+
+// ─── User's own tickets ───────────────────────────────────────────────────────
+
+describe('GET /api/staff-inbox/mine', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns paginated list for authenticated user', async () => {
+    staffInboxMock.listMyTickets.mockResolvedValue({
+      ...PAGED_EMPTY,
+      conversations: [makeTicket()]
+    });
+    const res = await request(app).get('/api/staff-inbox/mine');
+    expect(res.status).toBe(200);
+    expect(staffInboxMock.listMyTickets).toHaveBeenCalledWith(7, 1);
+  });
+});
+
+// ─── Create ticket ────────────────────────────────────────────────────────────
+
+describe('POST /api/staff-inbox', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('creates ticket and returns 201', async () => {
+    staffInboxMock.createTicket.mockResolvedValue(makeTicket());
+    const res = await request(app)
+      .post('/api/staff-inbox')
+      .send({ subject: 'Help', body: 'I need help please.' });
+    expect(res.status).toBe(201);
+    expect(staffInboxMock.createTicket).toHaveBeenCalledWith(
+      7,
+      'Help',
+      'I need help please.'
+    );
+  });
+});
+
+// ─── View ticket ─────────────────────────────────────────────────────────────
+
+describe('GET /api/staff-inbox/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('calls viewTicket with staffAccess=false for regular user', async () => {
+    staffInboxMock.viewTicket.mockResolvedValue({
+      ok: true,
+      conversation: makeTicket()
+    });
+    await request(app).get('/api/staff-inbox/1');
+    expect(staffInboxMock.viewTicket).toHaveBeenCalledWith(1, 7, false);
+  });
+
+  it('calls viewTicket with staffAccess=true for staff', async () => {
+    setStaff();
+    staffInboxMock.viewTicket.mockResolvedValue({
+      ok: true,
+      conversation: makeTicket()
+    });
+    await request(app).get('/api/staff-inbox/1');
+    expect(staffInboxMock.viewTicket).toHaveBeenCalledWith(1, 7, true);
+  });
+
+  it('returns 403 and 404 for respective failure reasons', async () => {
+    staffInboxMock.viewTicket.mockResolvedValue({
+      ok: false,
+      reason: 'forbidden'
+    });
+    expect((await request(app).get('/api/staff-inbox/1')).status).toBe(403);
+
+    staffInboxMock.viewTicket.mockResolvedValue({
+      ok: false,
+      reason: 'not_found'
+    });
+    expect((await request(app).get('/api/staff-inbox/99')).status).toBe(404);
+  });
+});
+
+// ─── Reply to ticket ─────────────────────────────────────────────────────────
+
+describe('POST /api/staff-inbox/:id/reply', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 201 on success and 422 when resolved', async () => {
+    staffInboxMock.replyToTicket.mockResolvedValue({
+      ok: true,
+      message: makeMessage()
+    });
+    expect(
+      (
+        await request(app)
+          .post('/api/staff-inbox/1/reply')
+          .send({ body: 'On it.' })
+      ).status
+    ).toBe(201);
+
+    staffInboxMock.replyToTicket.mockResolvedValue({
+      ok: false,
+      reason: 'resolved'
+    });
+    expect(
+      (
+        await request(app)
+          .post('/api/staff-inbox/1/reply')
+          .send({ body: 'Late.' })
+      ).status
+    ).toBe(422);
+  });
+});
+
+// ─── Resolve / unresolve ──────────────────────────────────────────────────────
+
+describe('POST /api/staff-inbox/:id/resolve', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 204 on success and 422 when already resolved', async () => {
+    staffInboxMock.resolveTicket.mockResolvedValue({ ok: true });
+    expect((await request(app).post('/api/staff-inbox/1/resolve')).status).toBe(
+      204
+    );
+
+    staffInboxMock.resolveTicket.mockResolvedValue({
+      ok: false,
+      reason: 'already_resolved'
+    });
+    expect((await request(app).post('/api/staff-inbox/1/resolve')).status).toBe(
+      422
+    );
+  });
+});
+
+describe('POST /api/staff-inbox/:id/unresolve', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 403 without staff permission and 204 for staff', async () => {
+    expect(
+      (await request(app).post('/api/staff-inbox/1/unresolve')).status
+    ).toBe(403);
+
+    setStaff();
+    staffInboxMock.unresolveTicket.mockResolvedValue({ ok: true });
+    expect(
+      (await request(app).post('/api/staff-inbox/1/unresolve')).status
+    ).toBe(204);
+  });
+});
+
+// ─── Assign ───────────────────────────────────────────────────────────────────
+
+describe('POST /api/staff-inbox/:id/assign', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 403 without staff permission', async () => {
+    expect(
+      (
+        await request(app)
+          .post('/api/staff-inbox/1/assign')
+          .send({ assignedUserId: 5 })
+      ).status
+    ).toBe(403);
+  });
+
+  it('returns 204 on success and 422 when assignee is not staff', async () => {
+    setStaff();
+    staffInboxMock.assignTicket.mockResolvedValue({ ok: true });
+    expect(
+      (
+        await request(app)
+          .post('/api/staff-inbox/1/assign')
+          .send({ assignedUserId: 5 })
+      ).status
+    ).toBe(204);
+
+    staffInboxMock.assignTicket.mockResolvedValue({
+      ok: false,
+      reason: 'assignee_not_staff'
+    });
+    expect(
+      (
+        await request(app)
+          .post('/api/staff-inbox/1/assign')
+          .send({ assignedUserId: 99 })
+      ).status
+    ).toBe(422);
+  });
+});
+
+// ─── Canned responses ─────────────────────────────────────────────────────────
+
+describe('GET /api/staff-inbox/responses', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 403 without staff permission and list for staff', async () => {
+    expect((await request(app).get('/api/staff-inbox/responses')).status).toBe(
+      403
+    );
+
+    setStaff();
+    staffInboxMock.listResponses.mockResolvedValue([makeResponse()]);
+    const res = await request(app).get('/api/staff-inbox/responses');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});
+
+describe('POST /api/staff-inbox/responses', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('creates response and returns 201', async () => {
+    setStaff();
+    staffInboxMock.createResponse.mockResolvedValue(makeResponse());
+    const res = await request(app)
+      .post('/api/staff-inbox/responses')
+      .send({
+        name: 'Standard reply',
+        body: 'Thank you for contacting support.'
+      });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('PUT /api/staff-inbox/responses/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 200 on success', async () => {
+    setStaff();
+    staffInboxMock.updateResponse.mockResolvedValue({
+      ok: true,
+      response: makeResponse({ name: 'Updated' })
+    });
+    const res = await request(app)
+      .put('/api/staff-inbox/responses/1')
+      .send({ name: 'Updated', body: 'Body.' });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 404 when not found', async () => {
+    setStaff();
+    staffInboxMock.updateResponse.mockResolvedValue({
+      ok: false,
+      reason: 'not_found'
+    });
+    const res = await request(app)
+      .put('/api/staff-inbox/responses/99')
+      .send({ name: 'x', body: 'y' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/staff-inbox/responses/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 204 on success and 404 when not found', async () => {
+    setStaff();
+    staffInboxMock.deleteResponse.mockResolvedValue({ ok: true });
+    expect(
+      (await request(app).delete('/api/staff-inbox/responses/1')).status
+    ).toBe(204);
+
+    staffInboxMock.deleteResponse.mockResolvedValue({
+      ok: false,
+      reason: 'not_found'
+    });
+    expect(
+      (await request(app).delete('/api/staff-inbox/responses/99')).status
+    ).toBe(404);
+  });
+});
+
+// ─── Bulk resolve ─────────────────────────────────────────────────────────────
+
+describe('POST /api/staff-inbox/bulk-resolve', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns 403 without staff and resolved count for staff', async () => {
+    expect(
+      (
+        await request(app)
+          .post('/api/staff-inbox/bulk-resolve')
+          .send({ ids: [1, 2] })
+      ).status
+    ).toBe(403);
+
+    setStaff();
+    staffInboxMock.bulkResolveTickets.mockResolvedValue({
+      ok: true as const,
+      resolved: 2
+    });
+    const res = await request(app)
+      .post('/api/staff-inbox/bulk-resolve')
+      .send({ ids: [1, 2] });
+    expect(res.status).toBe(200);
+    expect(res.body.resolved).toBe(2);
+  });
+});

--- a/src/staffInbox.spec.ts
+++ b/src/staffInbox.spec.ts
@@ -301,12 +301,10 @@ describe('POST /api/staff-inbox/responses', () => {
   it('creates response and returns 201', async () => {
     setStaff();
     staffInboxMock.createResponse.mockResolvedValue(makeResponse());
-    const res = await request(app)
-      .post('/api/staff-inbox/responses')
-      .send({
-        name: 'Standard reply',
-        body: 'Thank you for contacting support.'
-      });
+    const res = await request(app).post('/api/staff-inbox/responses').send({
+      name: 'Standard reply',
+      body: 'Thank you for contacting support.'
+    });
     expect(res.status).toBe(201);
   });
 });

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -37,6 +37,35 @@ jest.mock('../modules/forum', () => ({
   createTopicNote: jest.fn()
 }));
 
+jest.mock('../modules/pm', () => ({
+  listInbox: jest.fn(),
+  listSentbox: jest.fn(),
+  sendMessage: jest.fn(),
+  replyToConversation: jest.fn(),
+  viewConversation: jest.fn(),
+  updateConversationFlags: jest.fn(),
+  deleteConversation: jest.fn(),
+  bulkUpdateConversations: jest.fn(),
+  getUnreadCount: jest.fn()
+}));
+
+jest.mock('../modules/staffInbox', () => ({
+  listStaffTickets: jest.fn(),
+  listMyTickets: jest.fn(),
+  createTicket: jest.fn(),
+  viewTicket: jest.fn(),
+  replyToTicket: jest.fn(),
+  assignTicket: jest.fn(),
+  resolveTicket: jest.fn(),
+  unresolveTicket: jest.fn(),
+  bulkResolveTickets: jest.fn(),
+  listResponses: jest.fn(),
+  createResponse: jest.fn(),
+  updateResponse: jest.fn(),
+  deleteResponse: jest.fn(),
+  getStaffUnreadCount: jest.fn()
+}));
+
 jest.mock('../modules/config', () => ({
   auth: { jwtSecret: 'x'.repeat(32) },
   http: { port: 8080, corsOrigin: 'http://localhost:3000' },
@@ -188,6 +217,39 @@ jest.mock('../lib/prisma', () => ({
     release: {
       findUnique: jest.fn()
     },
+    privateConversation: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn()
+    },
+    privateConversationParticipant: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn()
+    },
+    privateMessage: {
+      create: jest.fn()
+    },
+    staffInboxConversation: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn()
+    },
+    staffInboxMessage: {
+      create: jest.fn()
+    },
+    staffInboxResponse: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn()
+    },
     $transaction: jest.fn()
   }
 }));
@@ -222,6 +284,8 @@ import {
   grantDownloadAccess,
   reverseDownloadAccess
 } from '../modules/downloads';
+import * as pmModule from '../modules/pm';
+import * as staffInboxModule from '../modules/staffInbox';
 
 export { app, request };
 
@@ -337,6 +401,39 @@ export const prismaMock = prisma as unknown as {
   release: {
     findUnique: jest.Mock;
   };
+  privateConversation: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    count: jest.Mock;
+    create: jest.Mock;
+  };
+  privateConversationParticipant: {
+    findFirst: jest.Mock;
+    findMany: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
+  privateMessage: {
+    create: jest.Mock;
+  };
+  staffInboxConversation: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    count: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
+  staffInboxMessage: {
+    create: jest.Mock;
+  };
+  staffInboxResponse: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
   $transaction: jest.Mock;
 };
 export const bcryptMock = bcrypt as unknown as {
@@ -386,6 +483,10 @@ export const grantDownloadAccessMock =
   grantDownloadAccess as jest.MockedFunction<typeof grantDownloadAccess>;
 export const reverseDownloadAccessMock =
   reverseDownloadAccess as jest.MockedFunction<typeof reverseDownloadAccess>;
+export const pmMock = pmModule as jest.Mocked<typeof pmModule>;
+export const staffInboxMock = staffInboxModule as jest.Mocked<
+  typeof staffInboxModule
+>;
 
 export const setCurrentUserRankLevel = (level: number): void => {
   currentUserRankLevel = level;


### PR DESCRIPTION
Adds two new feature verticals:

Private messaging: conversation/thread model with per-user soft-delete (inInbox/inSentbox flags), unread state, sticky, and bulk actions. Rate-limited compose and reply (10/min).

Staff inbox: support ticket lifecycle (Unanswered → Open → Resolved), staff assignment, canned/template replies, and bulk resolve. Staff-only endpoints gated behind the staff/admin permission.

Includes Prisma schema additions (6 new models, StaffInboxStatus enum, disablePm flag on User), migration, Zod validation schemas, business logic modules, Express routes, OpenAPI registrations, and route tests (190 passing).