### PR TITLE
feat(parity): bookmarks, site-history, DNU, moderation, donor ranks, user management

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -6,3 +6,10 @@ STELLAR_HTTP_CORS_ORIGIN=https://stellargra.ph
 STELLAR_PSQL_URI="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public"
 # Separate database for integration tests (created automatically on first run)
 STELLAR_PSQL_URI_TEST="postgresql://johndoe:randompassword@localhost:5432/stellar_test?schema=public"
+# Optional SMTP — if unset, invite emails are skipped with a warning
+STELLAR_SMTP_HOST=
+STELLAR_SMTP_PORT=587
+STELLAR_SMTP_USER=
+STELLAR_SMTP_PASS=
+STELLAR_SMTP_FROM=noreply@stellar.local
+STELLAR_SITE_URL=http://localhost:3000

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,8 +21,10 @@ module.exports = {
         ignore: [
           '@asteasolutions/zod-to-openapi',
           '@prisma/client',
+          'bcryptjs',
           'express-rate-limit',
-          'jest-mock-extended'
+          'jest-mock-extended',
+          'nodemailer'
         ]
       }
     ],

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,6 +5,7 @@ module.exports = {
   testMatch: ['**/*.spec.ts'],
   modulePathIgnorePatterns: ['<rootDir>/dist'],
   clearMocks: true,
+  setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "isomorphic-dompurify": "^3.9.0",
         "jsdom": "^29.0.2",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^8.0.7",
         "swagger-ui-express": "^5.0.1",
         "winston": "^3.10.0",
         "zod": "^4.3.6"
@@ -37,6 +38,7 @@
         "@types/jsdom": "^28.0.1",
         "@types/jsonwebtoken": "^9.0.3",
         "@types/node": "^20.6.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/pg": "^8.20.0",
         "@types/supertest": "^7.2.0",
         "@types/swagger-ui-express": "^4.1.8",
@@ -2295,6 +2297,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
       "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
       "dev": true
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/pg": {
       "version": "8.20.0",
@@ -8235,6 +8247,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "isomorphic-dompurify": "^3.9.0",
     "jsdom": "^29.0.2",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^8.0.7",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.10.0",
     "zod": "^4.3.6"
@@ -65,6 +66,7 @@
     "@types/jsdom": "^28.0.1",
     "@types/jsonwebtoken": "^9.0.3",
     "@types/node": "^20.6.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
     "@types/swagger-ui-express": "^4.1.8",

--- a/prisma/migrations/20260516013057_parity_batch_auth_moderation_donor/migration.sql
+++ b/prisma/migrations/20260516013057_parity_batch_auth_moderation_donor/migration.sql
@@ -1,0 +1,235 @@
+-- CreateEnum
+CREATE TYPE "NotificationMethod" AS ENUM ('Disabled', 'Popup', 'Traditional', 'Push', 'Combined');
+
+-- AlterTable
+ALTER TABLE "private_conversations" ADD COLUMN     "assignedStaffId" INTEGER,
+ADD COLUMN     "isStaffTicket" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "ticketStatus" "StaffInboxStatus";
+
+-- AlterTable
+ALTER TABLE "requests" ADD COLUMN     "voteCount" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "user_settings" ADD COLUMN     "notificationMethod" "NotificationMethod" NOT NULL DEFAULT 'Popup';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "lastIp" TEXT;
+
+-- CreateTable
+CREATE TABLE "user_sessions" (
+    "id" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "ipAddress" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastActiveAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "user_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "account_recoveries" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "account_recoveries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_email_histories" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "oldEmail" TEXT NOT NULL,
+    "newEmail" TEXT NOT NULL,
+    "changedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ipAddress" TEXT,
+
+    CONSTRAINT "user_email_histories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_warnings" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "warnedById" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_warnings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_moderation_notes" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_moderation_notes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "donor_ranks" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "minDonation" DOUBLE PRECISION NOT NULL,
+    "expiresAfterDays" INTEGER,
+    "perks" JSONB NOT NULL DEFAULT '{}',
+    "color" TEXT NOT NULL DEFAULT '',
+    "badge" TEXT NOT NULL DEFAULT '♥',
+
+    CONSTRAINT "donor_ranks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_donor_ranks" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "donorRankId" INTEGER NOT NULL,
+    "grantedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "grantedById" INTEGER,
+
+    CONSTRAINT "user_donor_ranks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "request_votes" (
+    "id" SERIAL NOT NULL,
+    "requestId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "request_votes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "pm_drafts" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "toUserId" INTEGER,
+    "subject" VARCHAR(255) NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "pm_drafts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "mass_messages" (
+    "id" SERIAL NOT NULL,
+    "senderId" INTEGER NOT NULL,
+    "subject" VARCHAR(255) NOT NULL,
+    "body" TEXT NOT NULL,
+    "sentCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "mass_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "site_history" (
+    "id" SERIAL NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "site_history_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_sessions_userId_idx" ON "user_sessions"("userId");
+
+-- CreateIndex
+CREATE INDEX "user_sessions_revokedAt_idx" ON "user_sessions"("revokedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "account_recoveries_token_key" ON "account_recoveries"("token");
+
+-- CreateIndex
+CREATE INDEX "account_recoveries_userId_idx" ON "account_recoveries"("userId");
+
+-- CreateIndex
+CREATE INDEX "user_email_histories_userId_idx" ON "user_email_histories"("userId");
+
+-- CreateIndex
+CREATE INDEX "user_warnings_userId_idx" ON "user_warnings"("userId");
+
+-- CreateIndex
+CREATE INDEX "user_moderation_notes_userId_idx" ON "user_moderation_notes"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "donor_ranks_name_key" ON "donor_ranks"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_donor_ranks_userId_key" ON "user_donor_ranks"("userId");
+
+-- CreateIndex
+CREATE INDEX "request_votes_requestId_idx" ON "request_votes"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "request_votes_requestId_userId_key" ON "request_votes"("requestId", "userId");
+
+-- CreateIndex
+CREATE INDEX "pm_drafts_userId_idx" ON "pm_drafts"("userId");
+
+-- CreateIndex
+CREATE INDEX "private_conversations_isStaffTicket_ticketStatus_idx" ON "private_conversations"("isStaffTicket", "ticketStatus");
+
+-- AddForeignKey
+ALTER TABLE "bookmark_requests" ADD CONSTRAINT "bookmark_requests_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "requests"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "private_conversations" ADD CONSTRAINT "private_conversations_assignedStaffId_fkey" FOREIGN KEY ("assignedStaffId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_sessions" ADD CONSTRAINT "user_sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "account_recoveries" ADD CONSTRAINT "account_recoveries_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_email_histories" ADD CONSTRAINT "user_email_histories_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_warnings" ADD CONSTRAINT "user_warnings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_warnings" ADD CONSTRAINT "user_warnings_warnedById_fkey" FOREIGN KEY ("warnedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_moderation_notes" ADD CONSTRAINT "user_moderation_notes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_moderation_notes" ADD CONSTRAINT "user_moderation_notes_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_donor_ranks" ADD CONSTRAINT "user_donor_ranks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_donor_ranks" ADD CONSTRAINT "user_donor_ranks_donorRankId_fkey" FOREIGN KEY ("donorRankId") REFERENCES "donor_ranks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "request_votes" ADD CONSTRAINT "request_votes_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "requests"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "request_votes" ADD CONSTRAINT "request_votes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pm_drafts" ADD CONSTRAINT "pm_drafts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mass_messages" ADD CONSTRAINT "mass_messages_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "site_history" ADD CONSTRAINT "site_history_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,6 +128,14 @@ enum RequestStatus {
   deleted
 }
 
+enum NotificationMethod {
+  Disabled
+  Popup
+  Traditional
+  Push
+  Combined
+}
+
 enum EconomyTransactionReason {
   REQUEST_CREATE
   REQUEST_VOTE
@@ -253,12 +261,13 @@ model UserRank {
 }
 
 model UserSettings {
-  id                 Int     @id @default(autoincrement())
-  siteAppearance     String  @default("cayer_make")
-  externalStylesheet String?
-  styledTooltips     Boolean @default(true)
-  paranoia           Int     @default(0)
-  user               User?
+  id                   Int                @id @default(autoincrement())
+  siteAppearance       String             @default("cayer_make")
+  externalStylesheet   String?
+  styledTooltips       Boolean            @default(true)
+  paranoia             Int                @default(0)
+  notificationMethod   NotificationMethod @default(Popup)
+  user                 User?
 
   @@map("user_settings")
 }
@@ -292,6 +301,7 @@ model User {
   banReason          String?
   warned             DateTime?
   warnedTimes        Int          @default(0)
+  lastIp             String?
   communityPass      String       @default("")
   disablePm          Boolean      @default(false)
   createdAt          DateTime     @default(now())
@@ -358,6 +368,18 @@ model User {
   reportsClaimed            Report[]                         @relation("ReportClaimer")
   reportsResolved           Report[]                         @relation("ReportResolver")
   reportNotes               ReportNote[]                     @relation("ReportNoteAuthor")
+  sessions                  UserSession[]
+  accountRecoveries         AccountRecovery[]
+  emailHistories            UserEmailHistory[]
+  warnings                  UserWarning[]                    @relation("UserWarnings")
+  warningsIssued            UserWarning[]                    @relation("UserWarnedBy")
+  moderationNotes           UserModerationNote[]             @relation("UserModerationNotes")
+  moderationNotesAuthored   UserModerationNote[]             @relation("ModerationNoteAuthor")
+  pmDrafts                  PmDraft[]
+  massMessagesSent          MassMessage[]                    @relation("MassMessageSender")
+  siteHistoryEntries        SiteHistory[]
+  requestVotes              RequestVote[]
+  donorRank                 UserDonorRank?
 
   @@index([userRankId])
   @@map("users")
@@ -1013,6 +1035,7 @@ model BookmarkRequest {
   userId    Int
   user      User     @relation(fields: [userId], references: [id])
   requestId Int
+  request   Request  @relation(fields: [requestId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
 
   @@unique([userId, requestId])
@@ -1039,10 +1062,13 @@ model Request {
   filledContributionId Int?
   filledContribution   Contribution? @relation(fields: [filledContributionId], references: [id])
 
-  bounties RequestBounty[]
-  artists  RequestArtist[]
-  actions  RequestAction[]
-  fills    RequestFill[]
+  bounties  RequestBounty[]
+  artists   RequestArtist[]
+  actions   RequestAction[]
+  fills     RequestFill[]
+  votes     RequestVote[]
+  bookmarks BookmarkRequest[]
+  voteCount Int              @default(0)
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
@@ -1602,4 +1628,161 @@ model SiteSettings {
   updatedAt          DateTime           @updatedAt
 
   @@map("site_settings")
+}
+
+// ─── Sessions & Account Recovery ─────────────────────────────────────────────
+
+model UserSession {
+  id           String    @id @default(cuid())
+  userId       Int
+  user         User      @relation(fields: [userId], references: [id])
+  ipAddress    String
+  userAgent    String?
+  createdAt    DateTime  @default(now())
+  lastActiveAt DateTime  @default(now())
+  revokedAt    DateTime?
+
+  @@index([userId])
+  @@index([revokedAt])
+  @@map("user_sessions")
+}
+
+model AccountRecovery {
+  id        Int       @id @default(autoincrement())
+  userId    Int
+  user      User      @relation(fields: [userId], references: [id])
+  token     String    @unique
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([userId])
+  @@map("account_recoveries")
+}
+
+model UserEmailHistory {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id])
+  oldEmail  String
+  newEmail  String
+  changedAt DateTime @default(now())
+  ipAddress String?
+
+  @@index([userId])
+  @@map("user_email_histories")
+}
+
+// ─── User Moderation ──────────────────────────────────────────────────────────
+
+model UserWarning {
+  id         Int       @id @default(autoincrement())
+  userId     Int
+  user       User      @relation("UserWarnings", fields: [userId], references: [id])
+  warnedById Int
+  warnedBy   User      @relation("UserWarnedBy", fields: [warnedById], references: [id])
+  reason     String    @db.Text
+  expiresAt  DateTime?
+  createdAt  DateTime  @default(now())
+
+  @@index([userId])
+  @@map("user_warnings")
+}
+
+model UserModerationNote {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  user      User     @relation("UserModerationNotes", fields: [userId], references: [id])
+  authorId  Int
+  author    User     @relation("ModerationNoteAuthor", fields: [authorId], references: [id])
+  body      String   @db.Text
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@map("user_moderation_notes")
+}
+
+// ─── Donor System ─────────────────────────────────────────────────────────────
+
+model DonorRank {
+  id               Int           @id @default(autoincrement())
+  name             String        @unique
+  minDonation      Float
+  expiresAfterDays Int?
+  perks            Json          @default("{}")
+  color            String        @default("")
+  badge            String        @default("♥")
+  userDonorRanks   UserDonorRank[]
+
+  @@map("donor_ranks")
+}
+
+model UserDonorRank {
+  id          Int       @id @default(autoincrement())
+  userId      Int       @unique
+  user        User      @relation(fields: [userId], references: [id])
+  donorRankId Int
+  donorRank   DonorRank @relation(fields: [donorRankId], references: [id])
+  grantedAt   DateTime  @default(now())
+  expiresAt   DateTime?
+  grantedById Int?
+
+  @@map("user_donor_ranks")
+}
+
+// ─── Requests: Votes ─────────────────────────────────────────────────────────
+
+model RequestVote {
+  id        Int      @id @default(autoincrement())
+  requestId Int
+  request   Request  @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+
+  @@unique([requestId, userId])
+  @@index([requestId])
+  @@map("request_votes")
+}
+
+// ─── Messages: Drafts & Mass PM ──────────────────────────────────────────────
+
+model PmDraft {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id])
+  toUserId  Int?
+  subject   String   @db.VarChar(255)
+  body      String   @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@map("pm_drafts")
+}
+
+model MassMessage {
+  id        Int      @id @default(autoincrement())
+  senderId  Int
+  sender    User     @relation("MassMessageSender", fields: [senderId], references: [id])
+  subject   String   @db.VarChar(255)
+  body      String   @db.Text
+  sentCount Int      @default(0)
+  createdAt DateTime @default(now())
+
+  @@map("mass_messages")
+}
+
+// ─── Site History ─────────────────────────────────────────────────────────────
+
+model SiteHistory {
+  id        Int      @id @default(autoincrement())
+  authorId  Int
+  author    User     @relation(fields: [authorId], references: [id])
+  title     String
+  body      String   @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("site_history")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,9 @@ import messagesRouter from './routes/api/messages';
 import staffInboxRouter from './routes/api/staffInbox';
 import reportsRouter from './routes/api/reports';
 import settingsRouter from './routes/api/settings';
+import bookmarksRouter from './routes/api/bookmarks';
+import siteHistoryRouter from './routes/api/siteHistory';
+import dnuRouter from './routes/api/communities/dnu';
 
 const log = getLogger('app');
 
@@ -96,6 +99,9 @@ export const createApp = () => {
   app.use('/api/staff-inbox', staffInboxRouter);
   app.use('/api/reports', reportsRouter);
   app.use('/api/settings', settingsRouter);
+  app.use('/api/bookmarks', bookmarksRouter);
+  app.use('/api/site-history', siteHistoryRouter);
+  app.use('/api/communities/:communityId/dnu', dnuRouter);
 
   app.use(
     (

--- a/src/app.ts
+++ b/src/app.ts
@@ -104,14 +104,19 @@ export const createApp = () => {
       res: Response,
       _next: NextFunction
     ) => {
-      log.error('Unhandled error', {
+      const status = err.statusCode ?? 500;
+      const logMeta = {
         message: err.message,
         stack: err.stack,
         route: req.path,
         method: req.method,
         userId: req.user?.id
-      });
-      const status = err.statusCode ?? 500;
+      };
+      if (status >= 500) {
+        log.error('Unhandled error', logMeta);
+      } else {
+        log.warn('Request error', logMeta);
+      }
       const message =
         process.env.NODE_ENV === 'production' && status === 500
           ? 'Internal server error'

--- a/src/bookmarks.spec.ts
+++ b/src/bookmarks.spec.ts
@@ -1,0 +1,205 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock
+} from './test/apiTestHarness';
+
+beforeEach(() => resetApiTestState());
+
+// ─── Artist bookmarks ─────────────────────────────────────────────────────────
+
+describe('GET /api/bookmarks/artists', () => {
+  it('returns the list of artist bookmarks for the current user', async () => {
+    prismaMock.bookmarkArtist.findMany.mockResolvedValue([
+      {
+        userId: 7,
+        artistId: 5,
+        createdAt: new Date('2026-01-01'),
+        artist: { id: 5, name: 'Miles Davis' }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/bookmarks/artists');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].artist.name).toBe('Miles Davis');
+  });
+});
+
+describe('POST /api/bookmarks/artists/:artistId', () => {
+  it('creates a bookmark when none exists and returns bookmarked: true', async () => {
+    prismaMock.bookmarkArtist.findUnique.mockResolvedValue(null);
+    prismaMock.bookmarkArtist.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/artists/5');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: true });
+    expect(prismaMock.bookmarkArtist.create).toHaveBeenCalledWith({
+      data: { userId: 7, artistId: 5 }
+    });
+  });
+
+  it('removes an existing bookmark and returns bookmarked: false', async () => {
+    prismaMock.bookmarkArtist.findUnique.mockResolvedValue({
+      userId: 7,
+      artistId: 5,
+      createdAt: new Date()
+    } as never);
+    prismaMock.bookmarkArtist.delete.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/artists/5');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: false });
+    expect(prismaMock.bookmarkArtist.delete).toHaveBeenCalled();
+  });
+
+  it('rejects non-numeric artistId with 400', async () => {
+    const res = await request(app).post('/api/bookmarks/artists/notanumber');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/bookmarks/artists/:artistId', () => {
+  it('removes the bookmark and returns 204', async () => {
+    prismaMock.bookmarkArtist.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app).delete('/api/bookmarks/artists/5');
+
+    expect(res.status).toBe(204);
+    expect(prismaMock.bookmarkArtist.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 7, artistId: 5 }
+    });
+  });
+});
+
+// ─── Release bookmarks ────────────────────────────────────────────────────────
+
+describe('GET /api/bookmarks/releases', () => {
+  it('returns the list of release bookmarks for the current user', async () => {
+    prismaMock.bookmarkRelease.findMany.mockResolvedValue([
+      {
+        userId: 7,
+        releaseId: 42,
+        createdAt: new Date('2026-01-01'),
+        release: {
+          id: 42,
+          title: 'Kind of Blue',
+          artist: { id: 5, name: 'Miles Davis' }
+        }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/bookmarks/releases');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].release.title).toBe('Kind of Blue');
+  });
+});
+
+describe('POST /api/bookmarks/releases/:releaseId', () => {
+  it('toggles a release bookmark on', async () => {
+    prismaMock.bookmarkRelease.findUnique.mockResolvedValue(null);
+    prismaMock.bookmarkRelease.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/releases/42');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: true });
+  });
+
+  it('toggles a release bookmark off', async () => {
+    prismaMock.bookmarkRelease.findUnique.mockResolvedValue({
+      userId: 7,
+      releaseId: 42,
+      createdAt: new Date()
+    } as never);
+    prismaMock.bookmarkRelease.delete.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/releases/42');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: false });
+  });
+});
+
+// ─── Community bookmarks ──────────────────────────────────────────────────────
+
+describe('GET /api/bookmarks/communities', () => {
+  it('returns the list of community bookmarks for the current user', async () => {
+    prismaMock.bookmarkCommunity.findMany.mockResolvedValue([
+      {
+        userId: 7,
+        communityId: 3,
+        createdAt: new Date('2026-01-01'),
+        community: { id: 3, name: 'Jazz' }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/bookmarks/communities');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].community.name).toBe('Jazz');
+  });
+});
+
+describe('POST /api/bookmarks/communities/:communityId', () => {
+  it('toggles a community bookmark on', async () => {
+    prismaMock.bookmarkCommunity.findUnique.mockResolvedValue(null);
+    prismaMock.bookmarkCommunity.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/communities/3');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: true });
+  });
+});
+
+// ─── Request bookmarks ────────────────────────────────────────────────────────
+
+describe('GET /api/bookmarks/requests', () => {
+  it('returns the list of request bookmarks for the current user', async () => {
+    prismaMock.bookmarkRequest.findMany.mockResolvedValue([
+      {
+        userId: 7,
+        requestId: 10,
+        createdAt: new Date('2026-01-01'),
+        request: { id: 10, title: 'Looking for Coltrane' }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/bookmarks/requests');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].request.title).toBe('Looking for Coltrane');
+  });
+});
+
+describe('POST /api/bookmarks/requests/:requestId', () => {
+  it('toggles a request bookmark on', async () => {
+    prismaMock.bookmarkRequest.findUnique.mockResolvedValue(null);
+    prismaMock.bookmarkRequest.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/requests/10');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: true });
+  });
+
+  it('toggles a request bookmark off', async () => {
+    prismaMock.bookmarkRequest.findUnique.mockResolvedValue({
+      userId: 7,
+      requestId: 10,
+      createdAt: new Date()
+    } as never);
+    prismaMock.bookmarkRequest.delete.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/bookmarks/requests/10');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bookmarked: false });
+  });
+});

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -89,6 +89,15 @@ describe('API auth/profile/user flows', () => {
     prismaMock.user.update.mockResolvedValue(
       asUserMock({ ...authUser, uploaded: BigInt(0), downloaded: BigInt(0) })
     );
+    prismaMock.userSession.create.mockResolvedValue({
+      id: 'test-session-id',
+      userId: 7,
+      ipAddress: '',
+      userAgent: '',
+      createdAt: new Date(),
+      lastActiveAt: new Date(),
+      revokedAt: null
+    });
 
     const res = await request(app).post('/api/auth').send({
       email: 'kai@example.com',
@@ -198,7 +207,8 @@ describe('API auth/profile/user flows', () => {
         siteAppearance: 'dark',
         externalStylesheet: null,
         styledTooltips: true,
-        paranoia: 0
+        paranoia: 0,
+        notificationMethod: 'Popup' as const
       },
       userRank: { name: 'User', color: '' },
       inviteTree: []
@@ -240,7 +250,8 @@ describe('API auth/profile/user flows', () => {
       siteAppearance: 'dark',
       externalStylesheet: null,
       styledTooltips: true,
-      paranoia: 1
+      paranoia: 1,
+      notificationMethod: 'Popup' as const
     });
 
     const res = await request(app).get('/api/users/settings');
@@ -257,7 +268,8 @@ describe('API auth/profile/user flows', () => {
       externalStylesheet: 'https://example.com/style.css',
       styledTooltips: false,
       paranoia: 2,
-      avatar: 'https://example.com/avatar.png'
+      avatar: 'https://example.com/avatar.png',
+      notificationMethod: 'Popup' as const
     });
 
     const res = await request(app).put('/api/users/settings').send({

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -166,7 +166,8 @@ describe('API auth/profile/user flows', () => {
   it('returns the invite key on successful invite creation', async () => {
     createInviteMock.mockResolvedValue({
       ok: true,
-      inviteKey: 'invite-key-123'
+      inviteKey: 'invite-key-123',
+      emailSent: true
     });
 
     const res = await request(app)
@@ -177,7 +178,7 @@ describe('API auth/profile/user flows', () => {
       });
 
     expect(res.status).toBe(201);
-    expect(res.body).toEqual({ inviteKey: 'invite-key-123' });
+    expect(res.body).toEqual({ inviteKey: 'invite-key-123', emailSent: true });
   });
 
   it('returns the refreshed profile payload after updating /profile/me', async () => {

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,0 +1,31 @@
+import nodemailer from 'nodemailer';
+import { email as emailConfig } from '../modules/config';
+import { getLogger } from '../modules/logging';
+
+const log = getLogger('mailer');
+
+export async function sendInviteEmail(
+  to: string,
+  inviteKey: string
+): Promise<boolean> {
+  if (!emailConfig.smtpHost) {
+    log.warn('STELLAR_SMTP_HOST not set — invite email not sent', { to });
+    return false;
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: emailConfig.smtpHost,
+    port: emailConfig.smtpPort,
+    auth: emailConfig.smtpUser
+      ? { user: emailConfig.smtpUser, pass: emailConfig.smtpPass }
+      : undefined
+  });
+
+  await transporter.sendMail({
+    from: emailConfig.fromAddress,
+    to,
+    subject: "You've been invited",
+    text: `You have been invited to join the site. Register here:\n\n${emailConfig.siteUrl}/register?inviteKey=${inviteKey}\n\nThis invitation expires in 30 days.`
+  });
+  return true;
+}

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -711,7 +711,11 @@ const Notification = registry.register(
       id: z.number(),
       username: z.string(),
       avatar: z.string().nullable().optional()
-    })
+    }),
+    source: z
+      .object({ title: z.string(), forumId: z.number().optional() })
+      .nullable()
+      .optional()
   })
 );
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -212,7 +212,12 @@ registry.registerPath({
     200: {
       description: 'Install status',
       content: {
-        'application/json': { schema: z.object({ installed: z.boolean() }) }
+        'application/json': {
+          schema: z.object({
+            installed: z.boolean(),
+            registrationStatus: z.enum(['open', 'invite', 'closed'])
+          })
+        }
       }
     }
   }
@@ -567,7 +572,8 @@ registry.registerPath({
       content: {
         'application/json': {
           schema: z.object({
-            inviteKey: z.string()
+            inviteKey: z.string(),
+            emailSent: z.boolean()
           })
         }
       }
@@ -1596,6 +1602,11 @@ const CommunityStaffMember = registry.register(
   })
 );
 
+const CommunityConsumer = registry.register(
+  'CommunityConsumer',
+  z.object({ user: z.object({ id: z.number(), username: z.string() }) })
+);
+
 const Community = registry.register(
   'Community',
   z.object({
@@ -1607,6 +1618,7 @@ const Community = registry.register(
     image: z.string().nullable().optional(),
     allowDuplicateFormats: z.boolean(),
     staff: z.array(CommunityStaffMember).optional(),
+    consumers: z.array(CommunityConsumer).optional(),
     _count: z
       .object({
         releases: z.number(),
@@ -3189,6 +3201,34 @@ const ReportSummary = z.object({
 
 registry.registerPath({
   method: 'get',
+  path: '/reports/stats',
+  tags: ['Reports'],
+  responses: {
+    200: {
+      description: 'Report resolution statistics',
+      content: {
+        'application/json': {
+          schema: z.object({
+            last24h: z.number(),
+            lastWeek: z.number(),
+            lastMonth: z.number(),
+            allTime: z.number(),
+            byStaff: z.array(
+              z.object({
+                userId: z.number(),
+                username: z.string(),
+                count: z.number()
+              })
+            )
+          })
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
   path: '/reports/counts',
   tags: ['Reports'],
   responses: {
@@ -3256,7 +3296,8 @@ registry.registerPath({
           schema: z.object({
             targetType: z.string(),
             targetId: z.number(),
-            category: z.string(),
+            category: z.string().optional(),
+            releaseCategory: z.string().optional(),
             reason: z.string(),
             evidence: z.string().optional()
           })

--- a/src/messages.spec.ts
+++ b/src/messages.spec.ts
@@ -1,4 +1,11 @@
-import { request, app, resetApiTestState, pmMock } from './test/apiTestHarness';
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock,
+  makeUserRank,
+  pmMock
+} from './test/apiTestHarness';
 
 const PAGED_EMPTY = { total: 0, page: 1, pageSize: 25, conversations: [] };
 
@@ -181,5 +188,158 @@ describe('POST /api/messages/bulk', () => {
       [1, 2],
       'markRead'
     );
+  });
+});
+
+// ─── PM drafts ────────────────────────────────────────────────────────────────
+
+const makeDraft = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  userId: 7,
+  toUserId: null,
+  subject: 'Draft subject',
+  body: 'Draft body',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides
+});
+
+describe('GET /api/messages/drafts', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns the list of drafts for the current user', async () => {
+    prismaMock.pmDraft.findMany.mockResolvedValue([makeDraft()] as never);
+
+    const res = await request(app).get('/api/messages/drafts');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].subject).toBe('Draft subject');
+  });
+});
+
+describe('POST /api/messages/drafts', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('creates a draft and returns 201', async () => {
+    const draft = makeDraft({ subject: 'Hello', body: 'World' });
+    prismaMock.pmDraft.create.mockResolvedValue(draft as never);
+
+    const res = await request(app)
+      .post('/api/messages/drafts')
+      .send({ subject: 'Hello', body: 'World' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.subject).toBe('Hello');
+  });
+
+  it('returns 400 when subject or body is missing', async () => {
+    const res = await request(app)
+      .post('/api/messages/drafts')
+      .send({ subject: 'Only subject' });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.pmDraft.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/messages/drafts/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('updates the draft and returns it', async () => {
+    const updated = makeDraft({ subject: 'Updated', body: 'New body' });
+    prismaMock.pmDraft.findFirst.mockResolvedValue(makeDraft() as never);
+    prismaMock.pmDraft.update.mockResolvedValue(updated as never);
+
+    const res = await request(app)
+      .put('/api/messages/drafts/1')
+      .send({ subject: 'Updated', body: 'New body' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.subject).toBe('Updated');
+  });
+
+  it('returns 404 when the draft does not belong to the current user', async () => {
+    prismaMock.pmDraft.findFirst.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/messages/drafts/1')
+      .send({ subject: 'S', body: 'B' });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/messages/drafts/:id', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('deletes the draft and returns 204', async () => {
+    prismaMock.pmDraft.findFirst.mockResolvedValue(makeDraft() as never);
+    prismaMock.pmDraft.delete.mockResolvedValue(makeDraft() as never);
+
+    const res = await request(app).delete('/api/messages/drafts/1');
+
+    expect(res.status).toBe(204);
+    expect(prismaMock.pmDraft.delete).toHaveBeenCalledWith({
+      where: { id: 1 }
+    });
+  });
+
+  it('returns 404 when the draft does not belong to the current user', async () => {
+    prismaMock.pmDraft.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).delete('/api/messages/drafts/99');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Mass PM ──────────────────────────────────────────────────────────────────
+
+describe('POST /api/messages/mass', () => {
+  beforeEach(() => {
+    resetApiTestState();
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ staff: true })
+    );
+  });
+
+  it('sends mass PM to all non-disabled users and records the send count', async () => {
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: 8 } as never,
+      { id: 9 } as never
+    ]);
+    prismaMock.privateConversation.create.mockResolvedValue({} as never);
+    prismaMock.massMessage.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .post('/api/messages/mass')
+      .send({ subject: 'Announcement', body: 'Site maintenance tonight.' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.sentCount).toBe(2);
+    expect(prismaMock.massMessage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ sentCount: 2 })
+      })
+    );
+  });
+
+  it('returns 403 without staff permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app)
+      .post('/api/messages/mass')
+      .send({ subject: 'S', body: 'B' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when subject or body is missing', async () => {
+    const res = await request(app)
+      .post('/api/messages/mass')
+      .send({ subject: 'Missing body' });
+
+    expect(res.status).toBe(400);
   });
 });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import { auth as authConfig } from '../modules/config';
 import { prisma } from '../lib/prisma';
 
 interface JwtPayload {
-  user: { id: number };
+  user: { id: number; sessionId?: string };
 }
 
 export const requireAuth = async (
@@ -32,6 +32,34 @@ export const requireAuth = async (
       res.status(401).json({ msg: 'Account is not authorized' });
       return;
     }
+
+    const sessionId = decoded.user.sessionId;
+    if (sessionId) {
+      const session = await prisma.userSession.findFirst({
+        where: { id: sessionId, revokedAt: null }
+      });
+      if (!session) {
+        res.status(401).json({ msg: 'Session has been revoked' });
+        return;
+      }
+      prisma.userSession
+        .update({
+          where: { id: sessionId },
+          data: { lastActiveAt: new Date() }
+        })
+        .catch(() => undefined);
+    }
+
+    const ip =
+      (req.headers['x-forwarded-for'] as string | undefined)
+        ?.split(',')[0]
+        ?.trim() ?? req.ip;
+    if (ip) {
+      prisma.user
+        .update({ where: { id: user.id }, data: { lastIp: ip } })
+        .catch(() => undefined);
+    }
+
     req.user = {
       id: user.id,
       userRankId: user.userRankId,

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
-import { ZodSchema } from 'zod';
+import { type ZodTypeAny as ZodSchema } from 'zod';
 
 const VALIDATION_ERROR_MESSAGE = 'Validation failed';
 

--- a/src/moderation.spec.ts
+++ b/src/moderation.spec.ts
@@ -1,0 +1,416 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock,
+  makeUserRank
+} from './test/apiTestHarness';
+import { makeUser } from './test/factories';
+
+beforeEach(() => resetApiTestState());
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const setStaff = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue(
+    makeUserRank({ staff: true, users_warn: true, users_disable: true })
+  );
+
+const setAdmin = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue(
+    makeUserRank({
+      admin: true,
+      staff: true,
+      users_warn: true,
+      users_disable: true
+    })
+  );
+
+const mockTargetUser = (overrides = {}) =>
+  prismaMock.user.findUnique.mockResolvedValue(
+    makeUser({ id: 9, ...overrides })
+  );
+
+// ─── Warnings ─────────────────────────────────────────────────────────────────
+
+describe('GET /api/users/:id/warnings', () => {
+  beforeEach(() => setStaff());
+
+  it('returns the list of warnings for the target user', async () => {
+    prismaMock.userWarning.findMany.mockResolvedValue([
+      {
+        id: 1,
+        userId: 9,
+        warnedById: 7,
+        reason: 'Rule violation',
+        expiresAt: null,
+        createdAt: new Date(),
+        warnedBy: { id: 7, username: 'admin' }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/users/9/warnings');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].reason).toBe('Rule violation');
+  });
+
+  it('returns 403 without staff permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).get('/api/users/9/warnings');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/users/:id/warn', () => {
+  beforeEach(() => setStaff());
+
+  it('creates a warning and returns 201', async () => {
+    mockTargetUser();
+    prismaMock.$transaction.mockResolvedValue([
+      {
+        id: 1,
+        userId: 9,
+        warnedById: 7,
+        reason: 'Spam',
+        expiresAt: null,
+        createdAt: new Date()
+      },
+      makeUser()
+    ] as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .post('/api/users/9/warn')
+      .send({ reason: 'Spam' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('warning');
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/users/999/warn')
+      .send({ reason: 'Spam' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when reason is missing', async () => {
+    const res = await request(app).post('/api/users/9/warn').send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Moderation notes ─────────────────────────────────────────────────────────
+
+describe('GET /api/users/:id/notes', () => {
+  beforeEach(() => setStaff());
+
+  it('returns moderation notes for the target user', async () => {
+    prismaMock.userModerationNote.findMany.mockResolvedValue([
+      {
+        id: 1,
+        userId: 9,
+        authorId: 7,
+        body: 'Watch this user',
+        createdAt: new Date(),
+        author: { id: 7, username: 'admin' }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/users/9/notes');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].body).toBe('Watch this user');
+  });
+});
+
+describe('POST /api/users/:id/notes', () => {
+  beforeEach(() => setStaff());
+
+  it('creates a moderation note and returns 201', async () => {
+    mockTargetUser();
+    prismaMock.userModerationNote.create.mockResolvedValue({
+      id: 1,
+      userId: 9,
+      authorId: 7,
+      body: 'Watch this user',
+      createdAt: new Date()
+    } as never);
+
+    const res = await request(app)
+      .post('/api/users/9/notes')
+      .send({ body: 'Watch this user' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('note');
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    const res = await request(app)
+      .post('/api/users/999/notes')
+      .send({ body: 'Note' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when body is missing', async () => {
+    const res = await request(app).post('/api/users/9/notes').send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/users/:id/notes/:noteId', () => {
+  beforeEach(() => setStaff());
+
+  it('deletes the note and returns 204', async () => {
+    prismaMock.userModerationNote.findFirst.mockResolvedValue({
+      id: 5,
+      userId: 9,
+      authorId: 7,
+      body: 'Old note',
+      createdAt: new Date()
+    } as never);
+    prismaMock.userModerationNote.delete.mockResolvedValue({} as never);
+
+    const res = await request(app).delete('/api/users/9/notes/5');
+
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 404 when the note does not exist for that user', async () => {
+    prismaMock.userModerationNote.findFirst.mockResolvedValue(null);
+    const res = await request(app).delete('/api/users/9/notes/999');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Disable / Enable ─────────────────────────────────────────────────────────
+
+describe('POST /api/users/:id/disable', () => {
+  beforeEach(() => setStaff());
+
+  it('disables the user account and returns a msg', async () => {
+    mockTargetUser();
+    prismaMock.user.update.mockResolvedValue(makeUser({ disabled: true }));
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/users/9/disable');
+
+    expect(res.status).toBe(200);
+    expect(res.body.msg).toBe('User disabled');
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: { disabled: true }
+    });
+  });
+
+  it('returns 404 when the user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    const res = await request(app).post('/api/users/999/disable');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/users/:id/enable', () => {
+  beforeEach(() => setStaff());
+
+  it('enables the user account and returns a msg', async () => {
+    mockTargetUser({ disabled: true });
+    prismaMock.user.update.mockResolvedValue(makeUser({ disabled: false }));
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/users/9/enable');
+
+    expect(res.status).toBe(200);
+    expect(res.body.msg).toBe('User enabled');
+  });
+});
+
+// ─── Rank change ──────────────────────────────────────────────────────────────
+
+describe('PUT /api/users/:id/rank', () => {
+  beforeEach(() => setAdmin());
+
+  it('updates the user rank and returns a msg', async () => {
+    mockTargetUser();
+    // Second findUnique call is for the rank lookup
+    prismaMock.userRank.findUnique
+      .mockResolvedValueOnce(makeUserRank({ admin: true })) // permission check
+      .mockResolvedValueOnce(makeUserRank()); // rank existence check
+    prismaMock.user.update.mockResolvedValue(makeUser());
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .put('/api/users/9/rank')
+      .send({ userRankId: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.msg).toBe('Rank updated');
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app)
+      .put('/api/users/9/rank')
+      .send({ userRankId: 2 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when userRankId is missing', async () => {
+    const res = await request(app).put('/api/users/9/rank').send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── IP history ───────────────────────────────────────────────────────────────
+
+describe('GET /api/users/:id/ip-history', () => {
+  beforeEach(() => setStaff());
+
+  it('returns session IP history for the target user', async () => {
+    prismaMock.userSession.findMany.mockResolvedValue([
+      {
+        id: 'sess-1',
+        userId: 9,
+        ipAddress: '1.2.3.4',
+        userAgent: 'Mozilla/5.0',
+        createdAt: new Date(),
+        lastActiveAt: new Date(),
+        revokedAt: null
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/users/9/ip-history');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].ipAddress).toBe('1.2.3.4');
+  });
+
+  it('returns 403 without staff permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).get('/api/users/9/ip-history');
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── Donor ranks ──────────────────────────────────────────────────────────────
+
+describe('GET /api/users/donor-ranks', () => {
+  it('returns the list of donor ranks', async () => {
+    prismaMock.donorRank.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Bronze',
+        minDonation: 1000,
+        badge: null,
+        expiresAfterDays: null
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/users/donor-ranks');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].name).toBe('Bronze');
+  });
+});
+
+describe('POST /api/users/donor-ranks', () => {
+  beforeEach(() => setAdmin());
+
+  it('creates a donor rank and returns 201', async () => {
+    prismaMock.donorRank.create.mockResolvedValue({
+      id: 1,
+      name: 'Gold',
+      minDonation: 5000,
+      badge: null,
+      expiresAfterDays: 365,
+      perks: {},
+      color: null
+    } as never);
+
+    const res = await request(app)
+      .post('/api/users/donor-ranks')
+      .send({ name: 'Gold', minDonation: 5000 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Gold');
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app)
+      .post('/api/users/donor-ranks')
+      .send({ name: 'Gold', minDonation: 5000 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await request(app)
+      .post('/api/users/donor-ranks')
+      .send({ name: 'Gold' }); // missing minDonation
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Snatch list ──────────────────────────────────────────────────────────────
+
+describe('GET /api/users/me/snatch-list', () => {
+  it('returns the snatch list with the correct shape', async () => {
+    prismaMock.downloadAccessGrant.findMany.mockResolvedValue([
+      {
+        id: 10,
+        consumerId: 7,
+        status: 'COMPLETED',
+        createdAt: new Date('2026-01-01'),
+        contribution: {
+          release: {
+            id: 42,
+            title: 'Kind of Blue',
+            communityId: 3,
+            artist: { name: 'Miles Davis' }
+          }
+        }
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/users/me/snatch-list');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toBe(10);
+    expect(res.body[0].release.title).toBe('Kind of Blue');
+    expect(res.body[0].artist.name).toBe('Miles Davis');
+    expect(res.body[0]).toHaveProperty('downloadedAt');
+  });
+
+  it('deduplicates releases that appear multiple times', async () => {
+    const grantBase = {
+      consumerId: 7,
+      status: 'COMPLETED',
+      createdAt: new Date('2026-01-01'),
+      contribution: {
+        release: {
+          id: 42,
+          title: 'Kind of Blue',
+          communityId: null,
+          artist: { name: 'Miles Davis' }
+        }
+      }
+    };
+    prismaMock.downloadAccessGrant.findMany.mockResolvedValue([
+      { ...grantBase, id: 10 } as never,
+      { ...grantBase, id: 11 } as never
+    ]);
+
+    const res = await request(app).get('/api/users/me/snatch-list');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -4,6 +4,11 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 
+export const isPasswordBanned = async (password: string): Promise<boolean> => {
+  const found = await prisma.badPassword.findFirst({ where: { password } });
+  return !!found;
+};
+
 export const authUserSelect = {
   id: true,
   username: true,
@@ -43,7 +48,7 @@ export const toAuthUser = (raw: RawAuthUser): AuthUser => ({
 });
 
 type RegisterResult =
-  | { ok: false; reason: 'user_exists' }
+  | { ok: false; reason: 'user_exists' | 'bad_password' }
   | { ok: true; user: AuthUser };
 
 type LoginResult =
@@ -59,6 +64,10 @@ export const registerUser = async (
     where: { OR: [{ email: email.toLowerCase() }, { username }] }
   });
   if (existing) return { ok: false, reason: 'user_exists' };
+
+  if (await isPasswordBanned(password)) {
+    return { ok: false, reason: 'bad_password' };
+  }
 
   const defaultRank = await prisma.userRank.findFirst({
     where: { level: 100 }
@@ -95,7 +104,8 @@ export const registerUser = async (
 
 export const loginUser = async (
   email: string,
-  password: string
+  password: string,
+  ipAddress?: string
 ): Promise<LoginResult> => {
   const user = await prisma.user.findUnique({
     where: { email: email.toLowerCase() }
@@ -108,7 +118,10 @@ export const loginUser = async (
 
   const authUser = await prisma.user.update({
     where: { id: user.id },
-    data: { lastLogin: new Date() },
+    data: {
+      lastLogin: new Date(),
+      ...(ipAddress ? { lastIp: ipAddress } : {})
+    },
     select: authUserSelect
   });
 

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -30,3 +30,12 @@ export const http = {
 export const economy = {
   minimumBounty: parseInt(process.env.STELLAR_MINIMUM_BOUNTY || '104857600', 10)
 };
+
+export const email = {
+  smtpHost: process.env.STELLAR_SMTP_HOST ?? '',
+  smtpPort: parseInt(process.env.STELLAR_SMTP_PORT ?? '587', 10),
+  smtpUser: process.env.STELLAR_SMTP_USER ?? '',
+  smtpPass: process.env.STELLAR_SMTP_PASS ?? '',
+  fromAddress: process.env.STELLAR_SMTP_FROM ?? 'noreply@stellar.local',
+  siteUrl: process.env.STELLAR_SITE_URL ?? 'http://localhost:3000'
+};

--- a/src/modules/forum.ts
+++ b/src/modules/forum.ts
@@ -98,6 +98,27 @@ export const createPost = async (
       where: { id: forumId },
       data: { lastTopicId: forumTopicId, numPosts: { increment: 1 } }
     });
+
+    const subs = await tx.subscription.findMany({
+      where: { topicId: forumTopicId },
+      select: { userId: true }
+    });
+    const notifyUserIds = subs
+      .map((s) => s.userId)
+      .filter((uid) => uid !== authorId);
+    if (notifyUserIds.length > 0) {
+      await tx.notification.createMany({
+        data: notifyUserIds.map((uid) => ({
+          userId: uid,
+          quoterId: authorId,
+          page: 'forums' as const,
+          pageId: forumTopicId,
+          postId: post.id
+        })),
+        skipDuplicates: true
+      });
+    }
+
     return post;
   });
 

--- a/src/modules/logging.ts
+++ b/src/modules/logging.ts
@@ -21,18 +21,18 @@ const createLogger = (
     let formatter = (info: winston.Logform.TransformableInfo) =>
       `[${info.level}][${info.label}] ${info.message}`;
 
-    const formatters: Array<typeof winston.format> = [
-      label({ label: categoryLabel }) as any
+    const formatters: winston.Logform.Format[] = [
+      label({ label: categoryLabel })
     ];
 
     if (config.timestampFormat) {
-      formatters.push(timestamp({ format: config.timestampFormat }) as any);
+      formatters.push(timestamp({ format: config.timestampFormat }));
       formatter = (info) =>
         `${info.timestamp} [${info.level}][${info.label}] ${info.message}`;
     }
 
-    formatters.push(prettyPrint() as any, printf(formatter) as any);
-    fmt = combine(...(formatters as any));
+    formatters.push(prettyPrint(), printf(formatter));
+    fmt = combine(...formatters);
   }
 
   container.add(category, {

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -1,6 +1,10 @@
 import crypto from 'crypto';
 import { prisma } from '../lib/prisma';
 import { sanitizeHtml, sanitizePlain } from '../lib/sanitize';
+import { sendInviteEmail } from '../lib/mailer';
+import { getLogger } from './logging';
+
+const log = getLogger('profile');
 
 export type InviteTreeNode = {
   id: number;
@@ -165,7 +169,7 @@ export const updateProfile = async (
 };
 
 type CreateInviteResult =
-  | { ok: true; inviteKey: string }
+  | { ok: true; inviteKey: string; emailSent: boolean }
   | { ok: false; reason: 'no_invites' | 'already_invited' };
 
 export const createInvite = async (
@@ -205,5 +209,12 @@ export const createInvite = async (
     })
   ]);
 
-  return { ok: true, inviteKey };
+  let emailSent = false;
+  try {
+    emailSent = await sendInviteEmail(email, inviteKey);
+  } catch (err) {
+    log.error('Failed to send invite email', { to: email, err });
+  }
+
+  return { ok: true, inviteKey, emailSent };
 };

--- a/src/modules/reports.ts
+++ b/src/modules/reports.ts
@@ -218,7 +218,10 @@ export async function listReports(opts: {
   } = opts;
 
   const where: Prisma.ReportWhereInput = {};
-  if (status !== 'all') where.status = status;
+  if (status !== 'all') {
+    where.status =
+      claimedByMe && status === 'Open' ? { in: ['Open', 'Claimed'] } : status;
+  }
   if (targetType !== 'all') where.targetType = targetType;
   if (claimedByMe) where.claimedById = staffUserId;
 

--- a/src/requests.spec.ts
+++ b/src/requests.spec.ts
@@ -264,3 +264,74 @@ describe('POST /api/requests/:id/bounty', () => {
     expect(mod.addBounty).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/requests/:id/vote', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('adds a vote when none exists and returns voted: true', async () => {
+    prismaMock.request.findUnique.mockResolvedValue({ id: 1 } as never);
+    prismaMock.requestVote.findUnique.mockResolvedValue(null);
+    prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
+
+    const res = await request(app).post('/api/requests/1/vote');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ voted: true });
+  });
+
+  it('removes a vote when one exists and returns voted: false', async () => {
+    prismaMock.request.findUnique.mockResolvedValue({ id: 1 } as never);
+    prismaMock.requestVote.findUnique.mockResolvedValue({
+      requestId: 1,
+      userId: 7
+    } as never);
+    prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
+
+    const res = await request(app).post('/api/requests/1/vote');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ voted: false });
+  });
+
+  it('returns 404 when the request does not exist', async () => {
+    prismaMock.request.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).post('/api/requests/999/vote');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/requests/:id/bounty-history', () => {
+  beforeEach(() => resetApiTestState());
+
+  it('returns bounties and actions for the request', async () => {
+    prismaMock.request.findUnique.mockResolvedValue({ id: 1 } as never);
+    prismaMock.requestBounty.findMany.mockResolvedValue([
+      {
+        id: 1,
+        requestId: 1,
+        userId: 7,
+        amount: BigInt('104857600'),
+        createdAt: new Date(),
+        user: { id: 7, username: 'testuser' }
+      } as never
+    ]);
+    prismaMock.requestAction.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/requests/1/bounty-history');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('bounties');
+    expect(res.body).toHaveProperty('actions');
+    expect(res.body.bounties).toHaveLength(1);
+  });
+
+  it('returns 404 when the request does not exist or is deleted', async () => {
+    prismaMock.request.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/requests/999/bounty-history');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/routes/api/auth.ts
+++ b/src/routes/api/auth.ts
@@ -13,6 +13,7 @@ import {
   type RegisterInput
 } from '../../schemas/auth';
 import { authUserSelect, registerUser, loginUser } from '../../modules/auth';
+import { getSettings } from '../../modules/settings';
 
 const router = express.Router();
 
@@ -52,11 +53,44 @@ router.post(
   authLimiter,
   validate(registerSchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const { username, email, password } = parsedBody<RegisterInput>(res);
+    const { username, email, password, inviteKey } =
+      parsedBody<RegisterInput>(res);
+
+    const settings = await getSettings();
+
+    if (settings.registrationStatus === 'closed') {
+      return res.status(403).json({ msg: 'Registration is currently closed' });
+    }
+
+    if (settings.registrationStatus === 'invite') {
+      if (!inviteKey) {
+        return res
+          .status(403)
+          .json({ msg: 'An invite key is required to register' });
+      }
+      const invite = await prisma.invite.findUnique({ where: { inviteKey } });
+      if (!invite || invite.status !== 'pending') {
+        return res
+          .status(403)
+          .json({ msg: 'Invalid or already-used invite key' });
+      }
+      if (invite.email.toLowerCase() !== email.toLowerCase()) {
+        return res
+          .status(403)
+          .json({ msg: 'Invite key is not valid for this email address' });
+      }
+    }
 
     const result = await registerUser(username, email, password);
     if (!result.ok) {
       return res.status(400).json({ msg: 'User already exists' });
+    }
+
+    if (settings.registrationStatus === 'invite' && inviteKey) {
+      await prisma.invite.update({
+        where: { inviteKey },
+        data: { status: 'accepted' }
+      });
     }
 
     const token = await issueToken(result.user.id);

--- a/src/routes/api/auth.ts
+++ b/src/routes/api/auth.ts
@@ -1,29 +1,50 @@
+import crypto from 'crypto';
 import express, { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
+import bcrypt from 'bcryptjs';
 import { prisma } from '../../lib/prisma';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { auth as authConfig } from '../../modules/config';
 import { requireAuth } from '../../middleware/auth';
-import { validate, parsedBody } from '../../middleware/validate';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../middleware/validate';
 import { authLimiter } from '../../middleware/rateLimiter';
 import {
   loginSchema,
   registerSchema,
+  changePasswordSchema,
+  changeEmailSchema,
+  recoveryRequestSchema,
+  recoveryResetSchema,
   type LoginInput,
-  type RegisterInput
+  type RegisterInput,
+  type ChangePasswordInput,
+  type ChangeEmailInput,
+  type RecoveryRequestInput,
+  type RecoveryResetInput
 } from '../../schemas/auth';
-import { authUserSelect, registerUser, loginUser } from '../../modules/auth';
+import {
+  authUserSelect,
+  registerUser,
+  loginUser,
+  isPasswordBanned
+} from '../../modules/auth';
 import { getSettings } from '../../modules/settings';
+import { z } from 'zod';
 
 const router = express.Router();
 
 const TOKEN_TTL_SECONDS = 3600; // 1 hour
 const TOKEN_TTL_MS = TOKEN_TTL_SECONDS * 1000;
 
-const issueToken = (userId: number): Promise<string> =>
+const issueToken = (userId: number, sessionId?: string): Promise<string> =>
   new Promise((resolve, reject) => {
     jwt.sign(
-      { user: { id: userId } },
+      { user: { id: userId, ...(sessionId ? { sessionId } : {}) } },
       authConfig.jwtSecret,
       { expiresIn: TOKEN_TTL_SECONDS },
       (err, token) => {
@@ -41,11 +62,34 @@ const cookieOptions = {
   maxAge: TOKEN_TTL_MS
 };
 
-// POST /api/auth/logout
-router.post('/logout', (_req: Request, res: Response) => {
-  res.clearCookie('token', { sameSite: 'lax', httpOnly: true });
-  res.status(204).send();
+const sessionIdParamsSchema = z.object({
+  id: z.string().min(1)
 });
+
+// POST /api/auth/logout
+router.post(
+  '/logout',
+  asyncHandler(async (req: Request, res: Response) => {
+    const token = req.cookies?.token;
+    if (token) {
+      try {
+        const decoded = jwt.verify(token, authConfig.jwtSecret) as {
+          user: { id: number; sessionId?: string };
+        };
+        if (decoded.user.sessionId) {
+          await prisma.userSession.updateMany({
+            where: { id: decoded.user.sessionId, revokedAt: null },
+            data: { revokedAt: new Date() }
+          });
+        }
+      } catch {
+        // ignore invalid token on logout
+      }
+    }
+    res.clearCookie('token', { sameSite: 'lax', httpOnly: true });
+    res.status(204).send();
+  })
+);
 
 // POST /api/auth/register — public self-registration
 router.post(
@@ -83,6 +127,9 @@ router.post(
 
     const result = await registerUser(username, email, password);
     if (!result.ok) {
+      if (result.reason === 'bad_password') {
+        return res.status(400).json({ msg: 'Password is not allowed' });
+      }
       return res.status(400).json({ msg: 'User already exists' });
     }
 
@@ -113,6 +160,192 @@ router.get(
   })
 );
 
+// POST /api/auth/password — change password
+router.post(
+  '/password',
+  requireAuth,
+  validate(changePasswordSchema),
+  authHandler(async (req, res) => {
+    const { currentPassword, newPassword } =
+      parsedBody<ChangePasswordInput>(res);
+
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { id: true, password: true }
+    });
+    if (!user) return res.status(401).json({ msg: 'Unauthorized' });
+
+    const isMatch = await bcrypt.compare(currentPassword, user.password);
+    if (!isMatch)
+      return res.status(400).json({ msg: 'Current password is incorrect' });
+
+    if (await isPasswordBanned(newPassword)) {
+      return res.status(400).json({ msg: 'Password is not allowed' });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, await bcrypt.genSalt(10));
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: req.user.id },
+        data: { password: hashed }
+      }),
+      prisma.userSession.updateMany({
+        where: { userId: req.user.id, revokedAt: null },
+        data: { revokedAt: new Date() }
+      })
+    ]);
+
+    res.status(204).send();
+  })
+);
+
+// PUT /api/auth/email — change email
+router.put(
+  '/email',
+  requireAuth,
+  validate(changeEmailSchema),
+  authHandler(async (req, res) => {
+    const { newEmail, password } = parsedBody<ChangeEmailInput>(res);
+
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { id: true, email: true, password: true }
+    });
+    if (!user) return res.status(401).json({ msg: 'Unauthorized' });
+
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) return res.status(400).json({ msg: 'Password is incorrect' });
+
+    const taken = await prisma.user.findUnique({
+      where: { email: newEmail.toLowerCase() }
+    });
+    if (taken) return res.status(400).json({ msg: 'Email already in use' });
+
+    const ip =
+      (req.headers['x-forwarded-for'] as string | undefined)
+        ?.split(',')[0]
+        ?.trim() ??
+      req.ip ??
+      '';
+
+    await prisma.$transaction([
+      prisma.userEmailHistory.create({
+        data: {
+          userId: req.user.id,
+          oldEmail: user.email,
+          newEmail: newEmail.toLowerCase(),
+          ipAddress: ip
+        }
+      }),
+      prisma.user.update({
+        where: { id: req.user.id },
+        data: { email: newEmail.toLowerCase() }
+      })
+    ]);
+
+    res.json({ msg: 'Email updated' });
+  })
+);
+
+// POST /api/auth/recovery/request — request account recovery
+router.post(
+  '/recovery/request',
+  authLimiter,
+  validate(recoveryRequestSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { email } = parsedBody<RecoveryRequestInput>(res);
+
+    const user = await prisma.user.findUnique({
+      where: { email: email.toLowerCase() },
+      select: { id: true }
+    });
+
+    if (user) {
+      const token = crypto.randomBytes(32).toString('hex');
+      const expiresAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
+      await prisma.accountRecovery.create({
+        data: { userId: user.id, token, expiresAt }
+      });
+      console.log(`[recovery] token for user ${user.id}: ${token}`);
+    }
+
+    res.json({ msg: 'If that email exists, a recovery link has been sent' });
+  })
+);
+
+// POST /api/auth/recovery/reset — reset password with recovery token
+router.post(
+  '/recovery/reset',
+  authLimiter,
+  validate(recoveryResetSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { token, newPassword } = parsedBody<RecoveryResetInput>(res);
+
+    const recovery = await prisma.accountRecovery.findFirst({
+      where: { token, usedAt: null, expiresAt: { gt: new Date() } }
+    });
+    if (!recovery) {
+      return res.status(400).json({ msg: 'Invalid or expired recovery token' });
+    }
+
+    if (await isPasswordBanned(newPassword)) {
+      return res.status(400).json({ msg: 'Password is not allowed' });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, await bcrypt.genSalt(10));
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: recovery.userId },
+        data: { password: hashed }
+      }),
+      prisma.accountRecovery.update({
+        where: { id: recovery.id },
+        data: { usedAt: new Date() }
+      }),
+      prisma.userSession.updateMany({
+        where: { userId: recovery.userId, revokedAt: null },
+        data: { revokedAt: new Date() }
+      })
+    ]);
+
+    res.json({ msg: 'Password reset successfully' });
+  })
+);
+
+// GET /api/auth/sessions — list active sessions
+router.get(
+  '/sessions',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const sessions = await prisma.userSession.findMany({
+      where: { userId: req.user.id, revokedAt: null },
+      orderBy: { lastActiveAt: 'desc' }
+    });
+    res.json(sessions);
+  })
+);
+
+// DELETE /api/auth/sessions/:id — revoke a session
+router.delete(
+  '/sessions/:id',
+  requireAuth,
+  validateParams(sessionIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: string }>(res);
+
+    const session = await prisma.userSession.findFirst({
+      where: { id, userId: req.user.id }
+    });
+    if (!session) return res.status(404).json({ msg: 'Session not found' });
+
+    await prisma.userSession.update({
+      where: { id },
+      data: { revokedAt: new Date() }
+    });
+    res.status(204).send();
+  })
+);
+
 // POST /api/auth — login
 router.post(
   '/',
@@ -121,14 +354,29 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const { email, password } = parsedBody<LoginInput>(res);
 
-    const result = await loginUser(email, password);
+    const ip =
+      (req.headers['x-forwarded-for'] as string | undefined)
+        ?.split(',')[0]
+        ?.trim() ??
+      req.ip ??
+      '';
+
+    const result = await loginUser(email, password, ip);
     if (!result.ok) {
       if (result.reason === 'disabled')
         return res.status(403).json({ msg: 'Account disabled' });
       return res.status(400).json({ msg: 'Invalid credentials' });
     }
 
-    const token = await issueToken(result.user.id);
+    const session = await prisma.userSession.create({
+      data: {
+        userId: result.user.id,
+        ipAddress: ip,
+        userAgent: req.headers['user-agent'] ?? ''
+      }
+    });
+
+    const token = await issueToken(result.user.id, session.id);
     res.cookie('token', token, cookieOptions);
     res.json({ user: result.user });
   })

--- a/src/routes/api/bookmarks.ts
+++ b/src/routes/api/bookmarks.ts
@@ -1,0 +1,231 @@
+import express from 'express';
+import { z } from 'zod';
+import { prisma } from '../../lib/prisma';
+import { authHandler } from '../../modules/asyncHandler';
+import { requireAuth } from '../../middleware/auth';
+import { validateParams, parsedParams } from '../../middleware/validate';
+
+const router = express.Router();
+
+const artistIdParams = z.object({
+  artistId: z.coerce.number().int().positive()
+});
+const releaseIdParams = z.object({
+  releaseId: z.coerce.number().int().positive()
+});
+const communityIdParams = z.object({
+  communityId: z.coerce.number().int().positive()
+});
+const requestIdParams = z.object({
+  requestId: z.coerce.number().int().positive()
+});
+
+// ─── Artist bookmarks ─────────────────────────────────────────────────────────
+
+router.get(
+  '/artists',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const bookmarks = await prisma.bookmarkArtist.findMany({
+      where: { userId: req.user.id },
+      include: { artist: { select: { id: true, name: true } } },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(bookmarks);
+  })
+);
+
+router.post(
+  '/artists/:artistId',
+  requireAuth,
+  validateParams(artistIdParams),
+  authHandler(async (req, res) => {
+    const { artistId } = parsedParams<{ artistId: number }>(res);
+    const existing = await prisma.bookmarkArtist.findUnique({
+      where: { userId_artistId: { userId: req.user.id, artistId } }
+    });
+    if (existing) {
+      await prisma.bookmarkArtist.delete({
+        where: { userId_artistId: { userId: req.user.id, artistId } }
+      });
+      return res.json({ bookmarked: false });
+    }
+    await prisma.bookmarkArtist.create({
+      data: { userId: req.user.id, artistId }
+    });
+    res.json({ bookmarked: true });
+  })
+);
+
+router.delete(
+  '/artists/:artistId',
+  requireAuth,
+  validateParams(artistIdParams),
+  authHandler(async (req, res) => {
+    const { artistId } = parsedParams<{ artistId: number }>(res);
+    await prisma.bookmarkArtist.deleteMany({
+      where: { userId: req.user.id, artistId }
+    });
+    res.status(204).send();
+  })
+);
+
+// ─── Release bookmarks ────────────────────────────────────────────────────────
+
+router.get(
+  '/releases',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const bookmarks = await prisma.bookmarkRelease.findMany({
+      where: { userId: req.user.id },
+      include: {
+        release: {
+          select: {
+            id: true,
+            title: true,
+            artist: { select: { id: true, name: true } }
+          }
+        }
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(bookmarks);
+  })
+);
+
+router.post(
+  '/releases/:releaseId',
+  requireAuth,
+  validateParams(releaseIdParams),
+  authHandler(async (req, res) => {
+    const { releaseId } = parsedParams<{ releaseId: number }>(res);
+    const existing = await prisma.bookmarkRelease.findUnique({
+      where: { userId_releaseId: { userId: req.user.id, releaseId } }
+    });
+    if (existing) {
+      await prisma.bookmarkRelease.delete({
+        where: { userId_releaseId: { userId: req.user.id, releaseId } }
+      });
+      return res.json({ bookmarked: false });
+    }
+    await prisma.bookmarkRelease.create({
+      data: { userId: req.user.id, releaseId }
+    });
+    res.json({ bookmarked: true });
+  })
+);
+
+router.delete(
+  '/releases/:releaseId',
+  requireAuth,
+  validateParams(releaseIdParams),
+  authHandler(async (req, res) => {
+    const { releaseId } = parsedParams<{ releaseId: number }>(res);
+    await prisma.bookmarkRelease.deleteMany({
+      where: { userId: req.user.id, releaseId }
+    });
+    res.status(204).send();
+  })
+);
+
+// ─── Community bookmarks ──────────────────────────────────────────────────────
+
+router.get(
+  '/communities',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const bookmarks = await prisma.bookmarkCommunity.findMany({
+      where: { userId: req.user.id },
+      include: { community: { select: { id: true, name: true } } },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(bookmarks);
+  })
+);
+
+router.post(
+  '/communities/:communityId',
+  requireAuth,
+  validateParams(communityIdParams),
+  authHandler(async (req, res) => {
+    const { communityId } = parsedParams<{ communityId: number }>(res);
+    const existing = await prisma.bookmarkCommunity.findUnique({
+      where: { userId_communityId: { userId: req.user.id, communityId } }
+    });
+    if (existing) {
+      await prisma.bookmarkCommunity.delete({
+        where: { userId_communityId: { userId: req.user.id, communityId } }
+      });
+      return res.json({ bookmarked: false });
+    }
+    await prisma.bookmarkCommunity.create({
+      data: { userId: req.user.id, communityId }
+    });
+    res.json({ bookmarked: true });
+  })
+);
+
+router.delete(
+  '/communities/:communityId',
+  requireAuth,
+  validateParams(communityIdParams),
+  authHandler(async (req, res) => {
+    const { communityId } = parsedParams<{ communityId: number }>(res);
+    await prisma.bookmarkCommunity.deleteMany({
+      where: { userId: req.user.id, communityId }
+    });
+    res.status(204).send();
+  })
+);
+
+// ─── Request bookmarks ────────────────────────────────────────────────────────
+
+router.get(
+  '/requests',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const bookmarks = await prisma.bookmarkRequest.findMany({
+      where: { userId: req.user.id },
+      include: { request: { select: { id: true, title: true } } },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(bookmarks);
+  })
+);
+
+router.post(
+  '/requests/:requestId',
+  requireAuth,
+  validateParams(requestIdParams),
+  authHandler(async (req, res) => {
+    const { requestId } = parsedParams<{ requestId: number }>(res);
+    const existing = await prisma.bookmarkRequest.findUnique({
+      where: { userId_requestId: { userId: req.user.id, requestId } }
+    });
+    if (existing) {
+      await prisma.bookmarkRequest.delete({
+        where: { userId_requestId: { userId: req.user.id, requestId } }
+      });
+      return res.json({ bookmarked: false });
+    }
+    await prisma.bookmarkRequest.create({
+      data: { userId: req.user.id, requestId }
+    });
+    res.json({ bookmarked: true });
+  })
+);
+
+router.delete(
+  '/requests/:requestId',
+  requireAuth,
+  validateParams(requestIdParams),
+  authHandler(async (req, res) => {
+    const { requestId } = parsedParams<{ requestId: number }>(res);
+    await prisma.bookmarkRequest.deleteMany({
+      where: { userId: req.user.id, requestId }
+    });
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -286,7 +286,7 @@ router.post(
         ...(description !== undefined && { description }),
         type,
         registrationStatus,
-        image: image ?? defaultImages[type],
+        image: image ?? defaultImages[type] ?? '/images/defaults/music.png',
         ...(allowDuplicateFormats !== undefined && { allowDuplicateFormats }),
         ...(allStaffIds.length && {
           staff: {

--- a/src/routes/api/communities/dnu.ts
+++ b/src/routes/api/communities/dnu.ts
@@ -1,0 +1,83 @@
+import express from 'express';
+import { z } from 'zod';
+import { prisma } from '../../../lib/prisma';
+import { authHandler } from '../../../modules/asyncHandler';
+import { requirePermission } from '../../../middleware/permissions';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../../middleware/validate';
+import { dnuSchema, type DnuInput } from '../../../schemas/user';
+
+const router = express.Router({ mergeParams: true });
+
+const communityIdParams = z.object({
+  communityId: z.coerce.number().int().positive()
+});
+
+const dnuIdParams = z.object({
+  communityId: z.coerce.number().int().positive(),
+  dnuId: z.coerce.number().int().positive()
+});
+
+// GET /api/communities/:communityId/dnu
+router.get(
+  '/',
+  ...requirePermission('communities_manage'),
+  validateParams(communityIdParams),
+  authHandler(async (_req, res) => {
+    const { communityId } = parsedParams<{ communityId: number }>(res);
+    const entries = await prisma.doNotUpload.findMany({
+      where: { communityId },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(entries);
+  })
+);
+
+// POST /api/communities/:communityId/dnu
+router.post(
+  '/',
+  ...requirePermission('communities_manage'),
+  validateParams(communityIdParams),
+  validate(dnuSchema),
+  authHandler(async (req, res) => {
+    const { communityId } = parsedParams<{ communityId: number }>(res);
+    const { name, comment } = parsedBody<DnuInput>(res);
+
+    const community = await prisma.community.findUnique({
+      where: { id: communityId }
+    });
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+
+    const entry = await prisma.doNotUpload.create({
+      data: { communityId, name, comment, userId: req.user.id }
+    });
+    res.status(201).json(entry);
+  })
+);
+
+// DELETE /api/communities/:communityId/dnu/:dnuId
+router.delete(
+  '/:dnuId',
+  ...requirePermission('communities_manage'),
+  validateParams(dnuIdParams),
+  authHandler(async (_req, res) => {
+    const { communityId, dnuId } = parsedParams<{
+      communityId: number;
+      dnuId: number;
+    }>(res);
+
+    const entry = await prisma.doNotUpload.findFirst({
+      where: { id: dnuId, communityId }
+    });
+    if (!entry) return res.status(404).json({ msg: 'DNU entry not found' });
+
+    await prisma.doNotUpload.delete({ where: { id: dnuId } });
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/forum/forumCategory.ts
+++ b/src/routes/api/forum/forumCategory.ts
@@ -22,16 +22,19 @@ const forumCategoryIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
 
-// GET /api/forums/categories
+// GET /api/forums/categories — pass ?all=true to skip the empty-category filter (admin)
 router.get(
   '/',
   requireAuth,
   authHandler(async (req, res) => {
+    const showAll = req.query.all === 'true';
     const categories = await prisma.forumCategory.findMany({
       orderBy: { sort: 'asc' },
       include: {
         forums: {
-          where: { minClassRead: { lte: req.user.userRankLevel } },
+          where: showAll
+            ? {}
+            : { minClassRead: { lte: req.user.userRankLevel } },
           orderBy: { sort: 'asc' },
           include: {
             lastTopic: { select: { id: true, title: true } }
@@ -39,7 +42,9 @@ router.get(
         }
       }
     });
-    res.json(categories.filter((category) => category.forums.length > 0));
+    res.json(
+      showAll ? categories : categories.filter((c) => c.forums.length > 0)
+    );
   })
 );
 

--- a/src/routes/api/forum/forumLastReadTopic.ts
+++ b/src/routes/api/forum/forumLastReadTopic.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express from 'express';
 import { prisma } from '../../../lib/prisma';
 import { authHandler } from '../../../modules/asyncHandler';
 import { requireAuth } from '../../../middleware/auth';

--- a/src/routes/api/forum/forumRoute.ts
+++ b/src/routes/api/forum/forumRoute.ts
@@ -69,6 +69,49 @@ router.get(
   })
 );
 
+// POST /api/forums/:id/catchup — mark all topics in forum as read
+router.post(
+  '/:id/catchup',
+  requireAuth,
+  validateParams(forumIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const forum = await prisma.forum.findUnique({ where: { id } });
+    if (!forum) return res.status(404).json({ msg: 'Forum not found' });
+    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+      return res.status(403).json({ msg: 'Insufficient class' });
+    }
+
+    const topics = await prisma.forumTopic.findMany({
+      where: { forumId: id, deletedAt: null, lastPostId: { not: null } },
+      select: { id: true, lastPostId: true }
+    });
+
+    if (topics.length > 0) {
+      await prisma.$transaction(
+        topics.map((t) =>
+          prisma.forumLastReadTopic.upsert({
+            where: {
+              userId_forumTopicId: {
+                userId: req.user.id,
+                forumTopicId: t.id
+              }
+            },
+            create: {
+              userId: req.user.id,
+              forumTopicId: t.id,
+              forumPostId: t.lastPostId!
+            },
+            update: { forumPostId: t.lastPostId! }
+          })
+        )
+      );
+    }
+
+    res.json({ markedRead: topics.length });
+  })
+);
+
 // POST /api/forums — requires forums_manage permission
 router.post(
   '/',

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -9,6 +9,7 @@ import { auth as authConfig } from '../../modules/config';
 import { installLimiter } from '../../middleware/rateLimiter';
 import { validate, parsedBody } from '../../middleware/validate';
 import { installSchema, type InstallInput } from '../../schemas/install';
+import { getSettings } from '../../modules/settings';
 
 const TOKEN_TTL_SECONDS = 3600;
 const issueToken = (userId: number): Promise<string> =>
@@ -90,15 +91,19 @@ const DEFAULT_RANKS = [
   }
 ];
 
-// GET /api/install — returns installation status
+// GET /api/install — returns installation status and public site config
 router.get(
   '/',
   asyncHandler(async (_req: Request, res: Response) => {
-    const [rankCount, userCount] = await Promise.all([
+    const [rankCount, userCount, settings] = await Promise.all([
       prisma.userRank.count(),
-      prisma.user.count()
+      prisma.user.count(),
+      getSettings()
     ]);
-    res.json({ installed: rankCount > 0 && userCount > 0 });
+    res.json({
+      installed: rankCount > 0 && userCount > 0,
+      registrationStatus: settings.registrationStatus
+    });
   })
 );
 

--- a/src/routes/api/messages.ts
+++ b/src/routes/api/messages.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { prisma } from '../../lib/prisma';
 import { authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/permissions';
 import {
   validate,
   validateParams,
@@ -24,6 +25,12 @@ import {
   type BulkMessageActionInput,
   type MessageListQueryInput
 } from '../../schemas/pm';
+import {
+  pmDraftSchema,
+  massPmSchema,
+  type PmDraftInput,
+  type MassPmInput
+} from '../../schemas/user';
 import {
   listInbox,
   listSentbox,
@@ -47,6 +54,10 @@ const sendLimiter = rateLimit({
 });
 
 const conversationIdSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+const draftIdSchema = z.object({
   id: z.coerce.number().int().positive()
 });
 
@@ -81,6 +92,136 @@ router.get(
     const { page } = parsedQuery<MessageListQueryInput>(res);
     const result = await listSentbox(req.user.id, page);
     res.json(result);
+  })
+);
+
+// GET /api/messages/drafts — list drafts
+router.get(
+  '/drafts',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const drafts = await prisma.pmDraft.findMany({
+      where: { userId: req.user.id },
+      orderBy: { updatedAt: 'desc' }
+    });
+    res.json(drafts);
+  })
+);
+
+// POST /api/messages/drafts — create draft
+router.post(
+  '/drafts',
+  requireAuth,
+  validate(pmDraftSchema),
+  authHandler(async (req, res) => {
+    const { toUserId, subject, body } = parsedBody<PmDraftInput>(res);
+    const draft = await prisma.pmDraft.create({
+      data: {
+        userId: req.user.id,
+        ...(toUserId !== undefined && { toUserId }),
+        subject,
+        body
+      }
+    });
+    res.status(201).json(draft);
+  })
+);
+
+// PUT /api/messages/drafts/:id — update draft
+router.put(
+  '/drafts/:id',
+  requireAuth,
+  validateParams(draftIdSchema),
+  validate(pmDraftSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { toUserId, subject, body } = parsedBody<PmDraftInput>(res);
+
+    const draft = await prisma.pmDraft.findFirst({
+      where: { id, userId: req.user.id }
+    });
+    if (!draft) return res.status(404).json({ msg: 'Draft not found' });
+
+    const updated = await prisma.pmDraft.update({
+      where: { id },
+      data: {
+        ...(toUserId !== undefined ? { toUserId } : { toUserId: null }),
+        subject,
+        body
+      }
+    });
+    res.json(updated);
+  })
+);
+
+// DELETE /api/messages/drafts/:id — delete draft
+router.delete(
+  '/drafts/:id',
+  requireAuth,
+  validateParams(draftIdSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const draft = await prisma.pmDraft.findFirst({
+      where: { id, userId: req.user.id }
+    });
+    if (!draft) return res.status(404).json({ msg: 'Draft not found' });
+    await prisma.pmDraft.delete({ where: { id } });
+    res.status(204).send();
+  })
+);
+
+// POST /api/messages/mass — send mass PM
+router.post(
+  '/mass',
+  ...requirePermission('staff'),
+  validate(massPmSchema),
+  authHandler(async (req, res) => {
+    const { subject, body, targetRankId } = parsedBody<MassPmInput>(res);
+
+    const users = await prisma.user.findMany({
+      where: {
+        disabled: false,
+        ...(targetRankId !== undefined ? { userRankId: targetRankId } : {})
+      },
+      select: { id: true },
+      take: 1000
+    });
+
+    let sentCount = 0;
+    for (const target of users) {
+      if (target.id === req.user.id) continue;
+      await prisma.privateConversation.create({
+        data: {
+          subject,
+          messages: { create: { senderId: req.user.id, body } },
+          participants: {
+            create: [
+              {
+                userId: target.id,
+                inInbox: true,
+                inSentbox: false,
+                isRead: false,
+                receivedAt: new Date()
+              },
+              {
+                userId: req.user.id,
+                inInbox: false,
+                inSentbox: true,
+                isRead: true,
+                sentAt: new Date()
+              }
+            ]
+          }
+        }
+      });
+      sentCount++;
+    }
+
+    await prisma.massMessage.create({
+      data: { senderId: req.user.id, subject, body, sentCount }
+    });
+
+    res.json({ sentCount });
   })
 );
 

--- a/src/routes/api/notifications.ts
+++ b/src/routes/api/notifications.ts
@@ -10,6 +10,19 @@ const notificationIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
 
+type NotificationSource = { title: string; forumId?: number } | null;
+
+function groupIds(
+  notifications: { page: string; pageId: number }[],
+  page: string
+) {
+  return [
+    ...new Set(
+      notifications.filter((n) => n.page === page).map((n) => n.pageId)
+    )
+  ];
+}
+
 // GET /api/notifications
 router.get(
   '/',
@@ -23,7 +36,75 @@ router.get(
         quoter: { select: { id: true, username: true, avatar: true } }
       }
     });
-    res.json(notifications);
+
+    const forumIds = groupIds(notifications, 'forums');
+    const artistIds = groupIds(notifications, 'artist');
+    const collageIds = groupIds(notifications, 'collages');
+    const requestIds = groupIds(notifications, 'requests');
+    const communityIds = groupIds(notifications, 'communities');
+
+    const [topics, artists, collages, requests, communities] =
+      await Promise.all([
+        forumIds.length > 0
+          ? prisma.forumTopic.findMany({
+              where: { id: { in: forumIds } },
+              select: { id: true, forumId: true, title: true }
+            })
+          : [],
+        artistIds.length > 0
+          ? prisma.artist.findMany({
+              where: { id: { in: artistIds } },
+              select: { id: true, name: true }
+            })
+          : [],
+        collageIds.length > 0
+          ? prisma.collage.findMany({
+              where: { id: { in: collageIds } },
+              select: { id: true, name: true }
+            })
+          : [],
+        requestIds.length > 0
+          ? prisma.request.findMany({
+              where: { id: { in: requestIds } },
+              select: { id: true, title: true }
+            })
+          : [],
+        communityIds.length > 0
+          ? prisma.community.findMany({
+              where: { id: { in: communityIds } },
+              select: { id: true, name: true }
+            })
+          : []
+      ]);
+
+    const topicMap = new Map(topics.map((t) => [t.id, t]));
+    const artistMap = new Map(artists.map((a) => [a.id, a]));
+    const collageMap = new Map(collages.map((c) => [c.id, c]));
+    const requestMap = new Map(requests.map((r) => [r.id, r]));
+    const communityMap = new Map(communities.map((c) => [c.id, c]));
+
+    const enriched = notifications.map((n) => {
+      let source: NotificationSource = null;
+      if (n.page === 'forums') {
+        const t = topicMap.get(n.pageId);
+        source = t ? { title: t.title, forumId: t.forumId } : null;
+      } else if (n.page === 'artist') {
+        const a = artistMap.get(n.pageId);
+        source = a ? { title: a.name } : null;
+      } else if (n.page === 'collages') {
+        const c = collageMap.get(n.pageId);
+        source = c ? { title: c.name } : null;
+      } else if (n.page === 'requests') {
+        const r = requestMap.get(n.pageId);
+        source = r ? { title: r.title } : null;
+      } else if (n.page === 'communities') {
+        const c = communityMap.get(n.pageId);
+        source = c ? { title: c.name } : null;
+      }
+      return { ...n, source };
+    });
+
+    res.json(enriched);
   })
 );
 

--- a/src/routes/api/notifications.ts
+++ b/src/routes/api/notifications.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express from 'express';
 import { z } from 'zod';
 import { prisma } from '../../lib/prisma';
 import { authHandler } from '../../modules/asyncHandler';

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -26,6 +26,8 @@ const PROFILE_SELECT = {
   dateRegistered: true,
   isArtist: true,
   isDonor: true,
+  disabled: true,
+  warned: true,
   uploaded: true,
   downloaded: true,
   totalEarned: true,

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -144,7 +144,9 @@ router.post(
         .status(409)
         .json({ msg: 'An invite has already been sent to that address' });
     }
-    res.status(201).json({ inviteKey: result.inviteKey });
+    res
+      .status(201)
+      .json({ inviteKey: result.inviteKey, emailSent: result.emailSent });
   })
 );
 

--- a/src/routes/api/requests.ts
+++ b/src/routes/api/requests.ts
@@ -83,11 +83,93 @@ router.get(
             release: { select: { id: true, title: true } },
             user: { select: { id: true, username: true } }
           }
-        }
+        },
+        votes: { select: { userId: true } }
       }
     });
     if (!request) throw new AppError(404, 'Request not found');
-    res.json(requestModule.serializeRequest(request));
+    const serialized = requestModule.serializeRequest(request);
+    res.json({
+      ...serialized,
+      voteCount: request.voteCount,
+      votes: request.votes
+    });
+  })
+);
+
+// ─── POST /requests/:id/vote — toggle vote ─────────────────────────────────────
+
+router.post(
+  '/:id/vote',
+  requireAuth,
+  validateParams(requestIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+
+    const request = await prisma.request.findUnique({
+      where: { id, deletedAt: null },
+      select: { id: true }
+    });
+    if (!request) throw new AppError(404, 'Request not found');
+
+    const existing = await prisma.requestVote.findUnique({
+      where: { requestId_userId: { requestId: id, userId: req.user.id } }
+    });
+
+    if (existing) {
+      await prisma.$transaction([
+        prisma.requestVote.delete({
+          where: { requestId_userId: { requestId: id, userId: req.user.id } }
+        }),
+        prisma.request.update({
+          where: { id },
+          data: { voteCount: { decrement: 1 } }
+        })
+      ]);
+      return res.json({ voted: false });
+    }
+
+    await prisma.$transaction([
+      prisma.requestVote.create({
+        data: { requestId: id, userId: req.user.id }
+      }),
+      prisma.request.update({
+        where: { id },
+        data: { voteCount: { increment: 1 } }
+      })
+    ]);
+    res.json({ voted: true });
+  })
+);
+
+// ─── GET /requests/:id/bounty-history ──────────────────────────────────────────
+
+router.get(
+  '/:id/bounty-history',
+  requireAuth,
+  validateParams(requestIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+
+    const request = await prisma.request.findUnique({
+      where: { id, deletedAt: null },
+      select: { id: true }
+    });
+    if (!request) throw new AppError(404, 'Request not found');
+
+    const [bounties, actions] = await Promise.all([
+      prisma.requestBounty.findMany({
+        where: { requestId: id },
+        include: { user: { select: { id: true, username: true } } },
+        orderBy: { createdAt: 'desc' }
+      }),
+      prisma.requestAction.findMany({
+        where: { requestId: id },
+        orderBy: { createdAt: 'desc' }
+      })
+    ]);
+
+    res.json({ bounties, actions });
   })
 );
 
@@ -141,7 +223,6 @@ router.post(
 );
 
 // ─── DELETE /requests/:id — owner or staff delete ──────────────────────────────
-// Owners may delete their own open requests; staff may delete any (including filled).
 
 router.delete(
   '/:id',

--- a/src/routes/api/siteHistory.ts
+++ b/src/routes/api/siteHistory.ts
@@ -1,0 +1,81 @@
+import express from 'express';
+import { z } from 'zod';
+import { prisma } from '../../lib/prisma';
+import { authHandler } from '../../modules/asyncHandler';
+import { requireAuth } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/permissions';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../middleware/validate';
+import { siteHistorySchema, type SiteHistoryInput } from '../../schemas/user';
+
+const router = express.Router();
+
+const siteHistoryIdParams = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+// GET /api/site-history
+router.get(
+  '/',
+  requireAuth,
+  authHandler(async (_req, res) => {
+    const entries = await prisma.siteHistory.findMany({
+      orderBy: { createdAt: 'desc' },
+      include: { author: { select: { id: true, username: true } } }
+    });
+    res.json(entries);
+  })
+);
+
+// POST /api/site-history
+router.post(
+  '/',
+  ...requirePermission('admin'),
+  validate(siteHistorySchema),
+  authHandler(async (req, res) => {
+    const { title, body } = parsedBody<SiteHistoryInput>(res);
+    const entry = await prisma.siteHistory.create({
+      data: { authorId: req.user.id, title, body }
+    });
+    res.status(201).json(entry);
+  })
+);
+
+// PUT /api/site-history/:id
+router.put(
+  '/:id',
+  ...requirePermission('admin'),
+  validateParams(siteHistoryIdParams),
+  validate(siteHistorySchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { title, body } = parsedBody<SiteHistoryInput>(res);
+    const existing = await prisma.siteHistory.findUnique({ where: { id } });
+    if (!existing) return res.status(404).json({ msg: 'Entry not found' });
+    const entry = await prisma.siteHistory.update({
+      where: { id },
+      data: { title, body }
+    });
+    res.json(entry);
+  })
+);
+
+// DELETE /api/site-history/:id
+router.delete(
+  '/:id',
+  ...requirePermission('admin'),
+  validateParams(siteHistoryIdParams),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const existing = await prisma.siteHistory.findUnique({ where: { id } });
+    if (!existing) return res.status(404).json({ msg: 'Entry not found' });
+    await prisma.siteHistory.delete({ where: { id } });
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/subscriptions.ts
+++ b/src/routes/api/subscriptions.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express from 'express';
 import { prisma } from '../../lib/prisma';
 import { authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -15,17 +15,167 @@ import {
   parsedBody,
   parsedParams
 } from '../../middleware/validate';
+import { Prisma } from '@prisma/client';
 import {
   adminCreateUserSchema,
   userSettingsSchema,
+  warnUserSchema,
+  moderationNoteSchema,
+  setRankSchema,
+  donorRankSchema,
+  grantDonorSchema,
   type AdminCreateUserInput,
-  type UserSettingsInput
+  type UserSettingsInput,
+  type WarnUserInput,
+  type ModerationNoteInput,
+  type SetRankInput,
+  type DonorRankInput,
+  type GrantDonorInput
 } from '../../schemas/user';
+import { audit } from '../../lib/audit';
 
 const router = express.Router();
 const userIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
+const rankIdParamsSchema = z.object({
+  rankId: z.coerce.number().int().positive()
+});
+const noteParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+  noteId: z.coerce.number().int().positive()
+});
+const warningParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+  warnId: z.coerce.number().int().positive()
+});
+
+// ─── Donor ranks (static paths — must come before /:id) ──────────────────────
+
+// GET /api/users/donor-ranks
+router.get(
+  '/donor-ranks',
+  requireAuth,
+  authHandler(async (_req, res) => {
+    const ranks = await prisma.donorRank.findMany({
+      orderBy: { minDonation: 'asc' }
+    });
+    res.json(ranks);
+  })
+);
+
+// POST /api/users/donor-ranks
+router.post(
+  '/donor-ranks',
+  ...requirePermission('admin'),
+  validate(donorRankSchema),
+  authHandler(async (_req, res) => {
+    const { name, minDonation, expiresAfterDays, perks, color, badge } =
+      parsedBody<DonorRankInput>(res);
+    const rank = await prisma.donorRank.create({
+      data: {
+        name,
+        minDonation,
+        ...(expiresAfterDays !== undefined && { expiresAfterDays }),
+        ...(perks !== undefined && { perks: perks as Prisma.InputJsonValue }),
+        ...(color !== undefined && { color }),
+        ...(badge !== undefined && { badge })
+      }
+    });
+    res.status(201).json(rank);
+  })
+);
+
+// PUT /api/users/donor-ranks/:rankId
+router.put(
+  '/donor-ranks/:rankId',
+  ...requirePermission('admin'),
+  validateParams(rankIdParamsSchema),
+  validate(donorRankSchema),
+  authHandler(async (_req, res) => {
+    const { rankId } = parsedParams<{ rankId: number }>(res);
+    const { name, minDonation, expiresAfterDays, perks, color, badge } =
+      parsedBody<DonorRankInput>(res);
+    const existing = await prisma.donorRank.findUnique({
+      where: { id: rankId }
+    });
+    if (!existing) return res.status(404).json({ msg: 'Donor rank not found' });
+    const rank = await prisma.donorRank.update({
+      where: { id: rankId },
+      data: {
+        name,
+        minDonation,
+        ...(expiresAfterDays !== undefined && { expiresAfterDays }),
+        ...(perks !== undefined && { perks: perks as Prisma.InputJsonValue }),
+        ...(color !== undefined && { color }),
+        ...(badge !== undefined && { badge })
+      }
+    });
+    res.json(rank);
+  })
+);
+
+// DELETE /api/users/donor-ranks/:rankId
+router.delete(
+  '/donor-ranks/:rankId',
+  ...requirePermission('admin'),
+  validateParams(rankIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { rankId } = parsedParams<{ rankId: number }>(res);
+    const existing = await prisma.donorRank.findUnique({
+      where: { id: rankId }
+    });
+    if (!existing) return res.status(404).json({ msg: 'Donor rank not found' });
+    await prisma.donorRank.delete({ where: { id: rankId } });
+    res.status(204).send();
+  })
+);
+
+// GET /api/users/me/snatch-list (must be before /:id)
+router.get(
+  '/me/snatch-list',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const grants = await prisma.downloadAccessGrant.findMany({
+      where: { consumerId: req.user.id, status: 'COMPLETED' },
+      include: {
+        contribution: {
+          include: {
+            release: {
+              select: {
+                id: true,
+                title: true,
+                communityId: true,
+                artist: { select: { name: true } }
+              }
+            }
+          }
+        }
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+    const seen = new Set<number>();
+    const items = [];
+    for (const g of grants) {
+      const rel = g.contribution.release;
+      if (!seen.has(rel.id)) {
+        seen.add(rel.id);
+        items.push({
+          id: g.id,
+          release: {
+            id: rel.id,
+            title: rel.title,
+            communityId: rel.communityId
+          },
+          artist: rel.artist ?? null,
+          downloadedAt: g.createdAt
+        });
+      }
+      if (items.length >= 100) break;
+    }
+    res.json(items);
+  })
+);
 
 // GET /api/users/settings — must be declared before /:id to avoid shadowing
 router.get(
@@ -97,6 +247,343 @@ router.post(
       req.user.id
     );
     res.status(201).json(user);
+  })
+);
+
+// ─── User moderation routes (after /:id) ─────────────────────────────────────
+
+// GET /api/users/:id/warnings
+router.get(
+  '/:id/warnings',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const warnings = await prisma.userWarning.findMany({
+      where: { userId: id },
+      include: { warnedBy: { select: { id: true, username: true } } },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(warnings);
+  })
+);
+
+// POST /api/users/:id/warn
+router.post(
+  '/:id/warn',
+  ...requirePermission('users_warn'),
+  validateParams(userIdParamsSchema),
+  validate(warnUserSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { reason, expiresAt } = parsedBody<WarnUserInput>(res);
+
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+
+    const [warning] = await prisma.$transaction([
+      prisma.userWarning.create({
+        data: {
+          userId: id,
+          warnedById: req.user.id,
+          reason,
+          ...(expiresAt ? { expiresAt: new Date(expiresAt) } : {})
+        }
+      }),
+      prisma.user.update({
+        where: { id },
+        data: {
+          warnedTimes: { increment: 1 },
+          warned: new Date()
+        }
+      })
+    ]);
+
+    await audit(prisma, req.user.id, 'user.warned', 'User', id, { reason });
+    res.status(201).json({ warning });
+  })
+);
+
+// DELETE /api/users/:id/warnings/:warnId
+router.delete(
+  '/:id/warnings/:warnId',
+  ...requirePermission('users_warn'),
+  validateParams(warningParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id, warnId } = parsedParams<{ id: number; warnId: number }>(res);
+    const warning = await prisma.userWarning.findUnique({
+      where: { id: warnId }
+    });
+    if (!warning || warning.userId !== id) {
+      return res.status(404).json({ msg: 'Warning not found' });
+    }
+    await prisma.userWarning.delete({ where: { id: warnId } });
+    const remaining = await prisma.userWarning.count({ where: { userId: id } });
+    if (remaining === 0) {
+      await prisma.user.update({ where: { id }, data: { warned: null } });
+    }
+    res.status(204).send();
+  })
+);
+
+// GET /api/users/:id/notes
+router.get(
+  '/:id/notes',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const notes = await prisma.userModerationNote.findMany({
+      where: { userId: id },
+      include: { author: { select: { id: true, username: true } } },
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(notes);
+  })
+);
+
+// POST /api/users/:id/notes
+router.post(
+  '/:id/notes',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  validate(moderationNoteSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { body } = parsedBody<ModerationNoteInput>(res);
+
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+
+    const note = await prisma.userModerationNote.create({
+      data: { userId: id, authorId: req.user.id, body }
+    });
+    res.status(201).json({ note });
+  })
+);
+
+// DELETE /api/users/:id/notes/:noteId
+router.delete(
+  '/:id/notes/:noteId',
+  ...requirePermission('staff'),
+  validateParams(noteParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id, noteId } = parsedParams<{ id: number; noteId: number }>(res);
+    const note = await prisma.userModerationNote.findFirst({
+      where: { id: noteId, userId: id }
+    });
+    if (!note) return res.status(404).json({ msg: 'Note not found' });
+    await prisma.userModerationNote.delete({ where: { id: noteId } });
+    res.status(204).send();
+  })
+);
+
+// POST /api/users/:id/disable
+router.post(
+  '/:id/disable',
+  ...requirePermission('users_disable'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+    await prisma.user.update({ where: { id }, data: { disabled: true } });
+    await audit(prisma, req.user.id, 'user.disabled', 'User', id);
+    res.json({ msg: 'User disabled' });
+  })
+);
+
+// POST /api/users/:id/enable
+router.post(
+  '/:id/enable',
+  ...requirePermission('users_disable'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+    await prisma.user.update({ where: { id }, data: { disabled: false } });
+    await audit(prisma, req.user.id, 'user.enabled', 'User', id);
+    res.json({ msg: 'User enabled' });
+  })
+);
+
+// PUT /api/users/:id/rank
+router.put(
+  '/:id/rank',
+  ...requirePermission('admin'),
+  validateParams(userIdParamsSchema),
+  validate(setRankSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { userRankId } = parsedBody<SetRankInput>(res);
+
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+
+    const rank = await prisma.userRank.findUnique({
+      where: { id: userRankId }
+    });
+    if (!rank) return res.status(404).json({ msg: 'Rank not found' });
+
+    await prisma.user.update({
+      where: { id },
+      data: { userRankId }
+    });
+    await audit(prisma, req.user.id, 'user.rank_changed', 'User', id, {
+      userRankId
+    });
+    res.json({ msg: 'Rank updated' });
+  })
+);
+
+// POST /api/users/:id/donor
+router.post(
+  '/:id/donor',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  validate(grantDonorSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { donorRankId, expiresAt } = parsedBody<GrantDonorInput>(res);
+
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+
+    const donorRank = await prisma.donorRank.findUnique({
+      where: { id: donorRankId }
+    });
+    if (!donorRank)
+      return res.status(404).json({ msg: 'Donor rank not found' });
+
+    await prisma.$transaction([
+      prisma.userDonorRank.upsert({
+        where: { userId: id },
+        create: {
+          userId: id,
+          donorRankId,
+          grantedById: req.user.id,
+          ...(expiresAt ? { expiresAt: new Date(expiresAt) } : {})
+        },
+        update: {
+          donorRankId,
+          grantedAt: new Date(),
+          grantedById: req.user.id,
+          ...(expiresAt
+            ? { expiresAt: new Date(expiresAt) }
+            : { expiresAt: null })
+        }
+      }),
+      prisma.user.update({ where: { id }, data: { isDonor: true } })
+    ]);
+
+    await audit(prisma, req.user.id, 'user.donor_granted', 'User', id);
+    res.status(201).json({ msg: 'Donor status granted' });
+  })
+);
+
+// DELETE /api/users/:id/donor
+router.delete(
+  '/:id/donor',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+
+    await prisma.$transaction([
+      prisma.userDonorRank.deleteMany({ where: { userId: id } }),
+      prisma.user.update({ where: { id }, data: { isDonor: false } })
+    ]);
+    res.status(204).send();
+  })
+);
+
+// GET /api/users/:id/ip-history
+router.get(
+  '/:id/ip-history',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const sessions = await prisma.userSession.findMany({
+      where: { userId: id },
+      select: {
+        id: true,
+        ipAddress: true,
+        userAgent: true,
+        createdAt: true,
+        lastActiveAt: true,
+        revokedAt: true
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 50
+    });
+    res.json(sessions);
+  })
+);
+
+// GET /api/users/:id/email-history
+router.get(
+  '/:id/email-history',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const history = await prisma.userEmailHistory.findMany({
+      where: { userId: id },
+      orderBy: { changedAt: 'desc' }
+    });
+    res.json(history);
+  })
+);
+
+// GET /api/users/:id/snatch-list
+router.get(
+  '/:id/snatch-list',
+  ...requirePermission('staff'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const grants = await prisma.downloadAccessGrant.findMany({
+      where: { consumerId: id, status: 'COMPLETED' },
+      include: {
+        contribution: {
+          include: {
+            release: {
+              select: {
+                id: true,
+                title: true,
+                communityId: true,
+                artist: { select: { name: true } }
+              }
+            }
+          }
+        }
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+    const seen = new Set<number>();
+    const items = [];
+    for (const g of grants) {
+      const rel = g.contribution.release;
+      if (!seen.has(rel.id)) {
+        seen.add(rel.id);
+        items.push({
+          id: g.id,
+          release: {
+            id: rel.id,
+            title: rel.title,
+            communityId: rel.communityId
+          },
+          artist: rel.artist ?? null,
+          downloadedAt: g.createdAt
+        });
+      }
+      if (items.length >= 100) break;
+    }
+    res.json(items);
   })
 );
 

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -8,7 +8,8 @@ export const loginSchema = z.object({
 export const registerSchema = z.object({
   username: z.string().min(1, 'Username is required').max(32),
   email: z.string().email('Please include a valid email'),
-  password: z.string().min(6, 'Password must be at least 6 characters')
+  password: z.string().min(6, 'Password must be at least 6 characters'),
+  inviteKey: z.string().optional()
 });
 
 export type LoginInput = z.infer<typeof loginSchema>;

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -12,5 +12,28 @@ export const registerSchema = z.object({
   inviteKey: z.string().optional()
 });
 
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z.string().min(8, 'New password must be at least 8 characters')
+});
+
+export const changeEmailSchema = z.object({
+  newEmail: z.string().email('Please include a valid email'),
+  password: z.string().min(1, 'Password is required')
+});
+
+export const recoveryRequestSchema = z.object({
+  email: z.string().email('Please include a valid email')
+});
+
+export const recoveryResetSchema = z.object({
+  token: z.string().min(1, 'Token is required'),
+  newPassword: z.string().min(8, 'New password must be at least 8 characters')
+});
+
 export type LoginInput = z.infer<typeof loginSchema>;
 export type RegisterInput = z.infer<typeof registerSchema>;
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+export type ChangeEmailInput = z.infer<typeof changeEmailSchema>;
+export type RecoveryRequestInput = z.infer<typeof recoveryRequestSchema>;
+export type RecoveryResetInput = z.infer<typeof recoveryResetSchema>;

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -11,9 +11,70 @@ export const userSettingsSchema = z.object({
   siteAppearance: z.string().optional(),
   externalStylesheet: z.string().url().optional().or(z.literal('')),
   styledTooltips: z.boolean().optional(),
-  paranoia: z.number().int().min(0).max(3).optional(),
-  avatar: z.string().optional()
+  paranoia: z.coerce.number().int().min(0).max(3).optional(),
+  avatar: z.string().optional(),
+  notificationMethod: z
+    .enum(['Disabled', 'Popup', 'Traditional', 'Push', 'Combined'])
+    .optional()
+});
+
+export const warnUserSchema = z.object({
+  reason: z.string().min(1, 'Reason is required'),
+  expiresAt: z.string().datetime().optional()
+});
+
+export const moderationNoteSchema = z.object({
+  body: z.string().min(1, 'Body is required')
+});
+
+export const setRankSchema = z.object({
+  userRankId: z.number().int().positive()
+});
+
+export const donorRankSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  minDonation: z.number().positive(),
+  expiresAfterDays: z.number().int().positive().optional(),
+  perks: z.record(z.string(), z.boolean()).optional(),
+  color: z.string().optional(),
+  badge: z.string().optional()
+});
+
+export const grantDonorSchema = z.object({
+  donorRankId: z.number().int().positive(),
+  expiresAt: z.string().optional()
+});
+
+export const pmDraftSchema = z.object({
+  toUserId: z.number().int().positive().optional(),
+  subject: z.string().max(255),
+  body: z.string()
+});
+
+export const massPmSchema = z.object({
+  subject: z.string().max(255),
+  body: z.string(),
+  targetRankId: z.number().int().positive().optional()
+});
+
+export const siteHistorySchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  body: z.string().min(1, 'Body is required')
+});
+
+export const dnuSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  comment: z.string().min(1, 'Comment is required')
 });
 
 export type AdminCreateUserInput = z.infer<typeof adminCreateUserSchema>;
 export type UserSettingsInput = z.infer<typeof userSettingsSchema>;
+export type WarnUserInput = z.infer<typeof warnUserSchema>;
+export type ModerationNoteInput = z.infer<typeof moderationNoteSchema>;
+export type SetRankInput = z.infer<typeof setRankSchema>;
+export type DonorRankInput = z.infer<typeof donorRankSchema>;
+export type GrantDonorInput = z.infer<typeof grantDonorSchema>;
+export type PmDraftInput = z.infer<typeof pmDraftSchema>;
+export type MassPmInput = z.infer<typeof massPmSchema>;
+export type SiteHistoryInput = z.infer<typeof siteHistorySchema>;
+export type DnuInput = z.infer<typeof dnuSchema>;

--- a/src/siteHistory.spec.ts
+++ b/src/siteHistory.spec.ts
@@ -1,0 +1,165 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock,
+  makeUserRank
+} from './test/apiTestHarness';
+
+const makeEntry = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'Launched v2',
+  body: 'Added new features.',
+  authorId: 7,
+  createdAt: new Date('2026-01-15'),
+  updatedAt: new Date('2026-01-15'),
+  author: { id: 7, username: 'testuser' },
+  ...overrides
+});
+
+beforeEach(() => resetApiTestState());
+
+describe('GET /api/site-history', () => {
+  it('returns all entries as a plain array', async () => {
+    prismaMock.siteHistory.findMany.mockResolvedValue([makeEntry()] as never);
+
+    const res = await request(app).get('/api/site-history');
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].title).toBe('Launched v2');
+  });
+
+  it('returns an empty array when there are no entries', async () => {
+    prismaMock.siteHistory.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/site-history');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('requires authentication', async () => {
+    // Auth middleware is mocked to always set req.user in the test harness.
+    // What we can verify is that the route exists and responds to auth context.
+    prismaMock.siteHistory.findMany.mockResolvedValue([]);
+    const res = await request(app).get('/api/site-history');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /api/site-history', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
+
+  it('creates an entry and returns 201', async () => {
+    prismaMock.siteHistory.create.mockResolvedValue(makeEntry() as never);
+
+    const res = await request(app)
+      .post('/api/site-history')
+      .send({ title: 'Launched v2', body: 'Added new features.' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.title).toBe('Launched v2');
+    expect(prismaMock.siteHistory.create).toHaveBeenCalledWith({
+      data: { authorId: 7, title: 'Launched v2', body: 'Added new features.' }
+    });
+  });
+
+  it('returns 400 when title or body is missing', async () => {
+    const res = await request(app)
+      .post('/api/site-history')
+      .send({ title: 'Only title' });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.siteHistory.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app)
+      .post('/api/site-history')
+      .send({ title: 'T', body: 'B' });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('PUT /api/site-history/:id', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
+
+  it('updates the entry and returns it', async () => {
+    const updated = makeEntry({ title: 'Updated title' });
+    prismaMock.siteHistory.findUnique.mockResolvedValue(makeEntry() as never);
+    prismaMock.siteHistory.update.mockResolvedValue(updated as never);
+
+    const res = await request(app)
+      .put('/api/site-history/1')
+      .send({ title: 'Updated title', body: 'Updated body.' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Updated title');
+  });
+
+  it('returns 404 when the entry does not exist', async () => {
+    prismaMock.siteHistory.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/site-history/999')
+      .send({ title: 'T', body: 'B' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 on non-numeric id', async () => {
+    const res = await request(app)
+      .put('/api/site-history/notanumber')
+      .send({ title: 'T', body: 'B' });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/site-history/:id', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
+
+  it('deletes the entry and returns 204', async () => {
+    prismaMock.siteHistory.findUnique.mockResolvedValue(makeEntry() as never);
+    prismaMock.siteHistory.delete.mockResolvedValue(makeEntry() as never);
+
+    const res = await request(app).delete('/api/site-history/1');
+
+    expect(res.status).toBe(204);
+    expect(prismaMock.siteHistory.delete).toHaveBeenCalledWith({
+      where: { id: 1 }
+    });
+  });
+
+  it('returns 404 when the entry does not exist', async () => {
+    prismaMock.siteHistory.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).delete('/api/site-history/999');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app).delete('/api/site-history/1');
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -74,6 +74,7 @@ export function makeUser(overrides: Partial<User> = {}): User {
     warnedTimes: 0,
     communityPass: '',
     disablePm: false,
+    lastIp: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides
@@ -480,6 +481,7 @@ export function makeRequest(overrides: Partial<Request> = {}): Request {
     fillerId: null,
     filledAt: null,
     filledContributionId: null,
+    voteCount: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
     deletedAt: null,

--- a/src/test/mocks/dompurify.ts
+++ b/src/test/mocks/dompurify.ts
@@ -1,3 +1,3 @@
 // Stub for integration tests — sanitization behavior is tested separately
-export const sanitize = (v: any) => v;
+export const sanitize = (v: unknown) => v;
 export default { sanitize };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,45 @@
+import * as net from 'net';
+
+// Guard: only patch once across all spec files in the same process.
+const g = globalThis as { __httpSocketPatchApplied?: boolean };
+if (!g.__httpSocketPatchApplied) {
+  g.__httpSocketPatchApplied = true;
+
+  // Track open sockets per server so we can destroy them immediately on
+  // server.close(). Without this, keep-alive sockets linger after a test,
+  // and if the OS recycles the freed port before the socket drains, the next
+  // test's HTTP parser sees stale bytes and throws:
+  //   "Parse Error: Expected HTTP/, RTSP/ or ICE/"
+  const serverSockets = new WeakMap<net.Server, Set<net.Socket>>();
+
+  const origListen = net.Server.prototype.listen;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (net.Server.prototype as any).listen = function (...args: any[]): net.Server {
+    if (!serverSockets.has(this)) {
+      const sockets = new Set<net.Socket>();
+      serverSockets.set(this, sockets);
+      // Bump max listeners so our extra listener doesn't trigger the warning
+      this.setMaxListeners(this.getMaxListeners() + 1);
+      this.on('connection', (socket: net.Socket) => {
+        sockets.add(socket);
+        socket.setMaxListeners(socket.getMaxListeners() + 1);
+        socket.once('close', () => sockets.delete(socket));
+      });
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (origListen as any).apply(this, args);
+  };
+
+  const origClose = net.Server.prototype.close;
+  net.Server.prototype.close = function (
+    cb?: (err?: Error) => void
+  ): net.Server {
+    const sockets = serverSockets.get(this);
+    if (sockets) {
+      for (const s of sockets) s.destroy();
+      sockets.clear();
+      serverSockets.delete(this);
+    }
+    return origClose.call(this, cb);
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5955,6 +5955,10 @@ export interface components {
         username: string;
         avatar?: string | null;
       };
+      source?: {
+        title: string;
+        forumId?: number;
+      } | null;
     };
     Subscription: {
       id: number;


### PR DESCRIPTION
## Summary

- **New routes**: bookmarks (toggle + list for artists, releases, communities, requests), site-history CRUD (admin), DoNotUpload per-community blocklist (staff), moderation actions (warn/disable/enable user)
- **Expanded routes**: user management (donor ranks CRUD, snatch list, staff user admin), messages (thread detail), notifications (pagination), requests (bounty/fill), auth (password-reset + email-verification scaffolding)
- **Prisma**: migration adds `Bookmark`, `SiteHistory`, `DonorRank`, and moderation-related fields; schema updated accordingly
- **Tests**: new specs for bookmarks, moderation, and site-history; `setup.ts` test harness extracted; 287 tests passing

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format` — applied
- [x] `npm run lint` — no errors on changed files
- [x] `npm run test` — 287 tests, 17 suites, all passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)