### PR TITLE
feat(parity): notification read tracking, request owner unfill, atomic report resolve

### DIFF
--- a/prisma/migrations/20260516200000_add_notification_read_at/migration.sql
+++ b/prisma/migrations/20260516200000_add_notification_read_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "notifications" ADD COLUMN "readAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1306,6 +1306,7 @@ model Notification {
   page      SubscriptionPage
   pageId    Int
   postId    Int
+  readAt    DateTime?
   createdAt DateTime         @default(now())
 
   @@map("notifications")

--- a/src/modules.spec.ts
+++ b/src/modules.spec.ts
@@ -393,17 +393,15 @@ describe('reports.unclaimReport', () => {
 // ─── reports.resolveReport ───────────────────────────────────────────────────
 
 describe('reports.resolveReport', () => {
-  it('resolves an open report', async () => {
-    prismaMock.report.findUnique.mockResolvedValue({
-      status: 'Open'
-    } as never);
-    prismaMock.report.update.mockResolvedValue({} as never);
+  it('resolves an open report atomically', async () => {
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
 
     const result = await resolveReport(1, 7, 'Confirmed spam', 'UserWarned');
 
     expect(result.ok).toBe(true);
-    expect(prismaMock.report.update).toHaveBeenCalledWith(
+    expect(prismaMock.report.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: expect.objectContaining({ id: 1, status: { not: 'Resolved' } }),
         data: expect.objectContaining({
           status: 'Resolved',
           resolvedById: 7,
@@ -415,6 +413,7 @@ describe('reports.resolveReport', () => {
   });
 
   it('returns not_found when report does not exist', async () => {
+    prismaMock.report.updateMany.mockResolvedValue({ count: 0 } as never);
     prismaMock.report.findUnique.mockResolvedValue(null);
     const result = await resolveReport(1, 7, 'reason', 'UserWarned');
     expect(result.ok).toBe(false);
@@ -422,9 +421,8 @@ describe('reports.resolveReport', () => {
   });
 
   it('returns already_resolved when report is already resolved', async () => {
-    prismaMock.report.findUnique.mockResolvedValue({
-      status: 'Resolved'
-    } as never);
+    prismaMock.report.updateMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.report.findUnique.mockResolvedValue({ id: 1 } as never);
     const result = await resolveReport(1, 7, 'reason', 'UserWarned');
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('already_resolved');

--- a/src/modules/reports.ts
+++ b/src/modules/reports.ts
@@ -325,16 +325,10 @@ export async function resolveReport(
   resolution: string,
   resolutionAction: ReportResolutionAction
 ) {
-  const report = await prisma.report.findUnique({
-    where: { id },
-    select: { status: true }
-  });
-  if (!report) return { ok: false as const, reason: 'not_found' };
-  if (report.status === 'Resolved')
-    return { ok: false as const, reason: 'already_resolved' };
-
-  await prisma.report.update({
-    where: { id },
+  // Atomic compare-and-swap: only updates rows not yet resolved.
+  // Prevents a race where two staff members resolve simultaneously.
+  const result = await prisma.report.updateMany({
+    where: { id, status: { not: 'Resolved' } },
     data: {
       status: 'Resolved',
       resolvedById: staffUserId,
@@ -345,6 +339,17 @@ export async function resolveReport(
       claimedAt: null
     }
   });
+
+  if (result.count === 0) {
+    const exists = await prisma.report.findUnique({
+      where: { id },
+      select: { id: true }
+    });
+    return exists
+      ? { ok: false as const, reason: 'already_resolved' }
+      : { ok: false as const, reason: 'not_found' };
+  }
+
   return { ok: true as const };
 }
 

--- a/src/requests.spec.ts
+++ b/src/requests.spec.ts
@@ -17,6 +17,7 @@ import {
 } from './test/apiTestHarness';
 import { makeRequest } from './test/factories';
 import * as requestModule from './modules/requests';
+import { RequestStatus } from '@prisma/client';
 
 jest.mock('./modules/requests');
 
@@ -179,12 +180,21 @@ describe('POST /api/requests/:id/fill', () => {
 });
 
 describe('POST /api/requests/:id/unfill', () => {
-  beforeEach(() => {
-    resetApiTestState();
-    setStaffPerms(); // unfill requires staff or admin
+  // A filled request owned by someone other than the test user (id 7),
+  // so only staff permission (not ownership) grants access in most tests.
+  const FILLED_REQUEST_MOCK = makeRequest({
+    userId: 99,
+    fillerId: 88,
+    status: RequestStatus.filled
   });
 
-  it('calls unfillRequest with moderatorId and optional reason', async () => {
+  beforeEach(() => {
+    resetApiTestState();
+    setStaffPerms();
+    prismaMock.request.findUnique.mockResolvedValue(FILLED_REQUEST_MOCK);
+  });
+
+  it('calls unfillRequest when caller is staff', async () => {
     mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
     const res = await request(app)
       .post('/api/requests/1/unfill')
@@ -200,8 +210,32 @@ describe('POST /api/requests/:id/unfill', () => {
     expect(mod.unfillRequest).toHaveBeenCalledWith(7, 1, undefined);
   });
 
-  it('returns 403 when user lacks staff/admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+  it('allows owner to unfill their own request', async () => {
+    // Reset to a filled request owned by the test user (id 7)
+    prismaMock.request.findUnique.mockResolvedValue(
+      makeRequest({ userId: 7, fillerId: 88, status: RequestStatus.filled })
+    );
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
+    mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
+    const res = await request(app)
+      .post('/api/requests/1/unfill')
+      .send({ reason: 'Changed my mind' });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows filler to unfill their own fill', async () => {
+    // Reset to a filled request where filler is the test user (id 7)
+    prismaMock.request.findUnique.mockResolvedValue(
+      makeRequest({ userId: 99, fillerId: 7, status: RequestStatus.filled })
+    );
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
+    mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
+    const res = await request(app).post('/api/requests/1/unfill').send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 when user is not staff, owner, or filler', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
     const res = await request(app)
       .post('/api/requests/1/unfill')
       .send({ reason: 'test' });

--- a/src/routes/api/notifications.ts
+++ b/src/routes/api/notifications.ts
@@ -23,6 +23,31 @@ function groupIds(
   ];
 }
 
+// GET /api/notifications/unread-count
+router.get(
+  '/unread-count',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const count = await prisma.notification.count({
+      where: { userId: req.user.id, readAt: null }
+    });
+    res.json({ count });
+  })
+);
+
+// POST /api/notifications/read-all
+router.post(
+  '/read-all',
+  requireAuth,
+  authHandler(async (req, res) => {
+    await prisma.notification.updateMany({
+      where: { userId: req.user.id, readAt: null },
+      data: { readAt: new Date() }
+    });
+    res.status(204).send();
+  })
+);
+
 // GET /api/notifications
 router.get(
   '/',
@@ -105,6 +130,27 @@ router.get(
     });
 
     res.json(enriched);
+  })
+);
+
+// POST /api/notifications/:id/read
+router.post(
+  '/:id/read',
+  requireAuth,
+  validateParams(notificationIdParamsSchema),
+  authHandler(async (req, res) => {
+    const id = Number(res.locals.parsedParams.id);
+    const notif = await prisma.notification.findUnique({ where: { id } });
+    if (!notif) return res.status(404).json({ msg: 'Notification not found' });
+    if (notif.userId !== req.user.id)
+      return res.status(403).json({ msg: 'Not authorized' });
+    if (!notif.readAt) {
+      await prisma.notification.update({
+        where: { id },
+        data: { readAt: new Date() }
+      });
+    }
+    res.status(204).send();
   })
 );
 

--- a/src/routes/api/requests.ts
+++ b/src/routes/api/requests.ts
@@ -1,8 +1,5 @@
 import { Router } from 'express';
-import {
-  requirePermission,
-  loadPermissions
-} from '../../middleware/permissions';
+import { loadPermissions } from '../../middleware/permissions';
 import { requireAuth } from '../../middleware/auth';
 import {
   validate,
@@ -17,12 +14,14 @@ import * as requestModule from '../../modules/requests';
 import { prisma } from '../../lib/prisma';
 import {
   createRequestSchema,
+  updateRequestSchema,
   addBountySchema,
   fillRequestSchema,
   unfillRequestSchema,
   listRequestsQuerySchema,
   requestIdParamsSchema,
-  type ListRequestsQuery
+  type ListRequestsQuery,
+  type UpdateRequestInput
 } from '../../schemas/requests';
 import { AppError } from '../../lib/errors';
 import type { AuthenticatedRequest } from '../../types/auth';
@@ -207,16 +206,77 @@ router.post(
   })
 );
 
-// ─── POST /requests/:id/unfill — staff unfill ─────────────────────────────────
+// ─── PUT /requests/:id — owner or staff edit ──────────────────────────────────
+
+router.put(
+  '/:id',
+  requireAuth,
+  validateParams(requestIdParamsSchema),
+  validate(updateRequestSchema),
+  authHandler(async (req: AuthenticatedRequest, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const input = parsedBody<UpdateRequestInput>(res);
+
+    const existing = await prisma.request.findUnique({
+      where: { id, deletedAt: null },
+      select: { userId: true, status: true }
+    });
+    if (!existing) throw new AppError(404, 'Request not found');
+    if (existing.status !== 'open')
+      throw new AppError(422, 'Only open requests can be edited');
+
+    const perms = await loadPermissions(req, res);
+    const isStaff = !!(perms['staff'] || perms['admin']);
+    if (existing.userId !== req.user.id && !isStaff)
+      throw new AppError(403, 'Permission denied');
+
+    const updated = await prisma.request.update({
+      where: { id },
+      data: {
+        ...(input.title !== undefined && { title: input.title }),
+        ...(input.description !== undefined && {
+          description: input.description
+        }),
+        ...(input.type !== undefined && { type: input.type }),
+        ...(input.year !== undefined && { year: input.year }),
+        ...(input.image !== undefined && { image: input.image })
+      },
+      include: {
+        user: { select: { id: true, username: true } },
+        bounties: true
+      }
+    });
+    res.json(requestModule.serializeRequest(updated));
+  })
+);
+
+// ─── POST /requests/:id/unfill — owner, filler, or staff unfill ───────────────
 
 router.post(
   '/:id/unfill',
-  ...requirePermission('staff', 'admin'),
+  requireAuth,
   validateParams(requestIdParamsSchema),
   validate(unfillRequestSchema),
-  authHandler(async (req, res) => {
+  authHandler(async (req: AuthenticatedRequest, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { reason } = parsedBody<{ reason?: string }>(res);
+
+    const existing = await prisma.request.findUnique({
+      where: { id, deletedAt: null },
+      select: { userId: true, fillerId: true, status: true }
+    });
+    if (!existing) throw new AppError(404, 'Request not found');
+    if (existing.status !== 'filled')
+      throw new AppError(422, 'Request is not filled');
+
+    const perms = await loadPermissions(req, res);
+    const isStaff = !!(perms['staff'] || perms['admin']);
+    const isOwner = existing.userId === req.user.id;
+    const isFiller = existing.fillerId === req.user.id;
+
+    if (!isStaff && !isOwner && !isFiller)
+      throw new AppError(403, 'Permission denied');
+
     const request = await requestModule.unfillRequest(req.user.id, id, reason);
     res.json(request);
   })

--- a/src/schemas/requests.ts
+++ b/src/schemas/requests.ts
@@ -25,6 +25,19 @@ export const createRequestSchema = z.object({
 
 export type CreateRequestInput = z.infer<typeof createRequestSchema>;
 
+export const updateRequestSchema = z.object({
+  title: z.string().min(1).max(256).optional(),
+  description: z.string().min(1).optional(),
+  type: releaseTypeEnum.optional(),
+  year: z.number().int().min(1900).max(2100).nullable().optional(),
+  image: z
+    .union([z.string().url(), z.literal('')])
+    .optional()
+    .transform((v) => (v === '' ? null : v))
+});
+
+export type UpdateRequestInput = z.infer<typeof updateRequestSchema>;
+
 export const addBountySchema = z.object({
   amount: z.coerce.bigint().min(BigInt(1), 'Bounty amount must be positive')
 });

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -284,6 +284,7 @@ export function makeNotification(
     page: SubscriptionPage.forums,
     pageId: 1,
     postId: 1,
+    readAt: null,
     createdAt: new Date(),
     ...overrides
   };


### PR DESCRIPTION
## Summary

Closes three Gazelle parity gaps identified in the non-torrent feature audit.

**Gap 1 — Notifications: read tracking**
- Adds `readAt DateTime?` to `Notification` model (migration included)
- `GET /api/notifications/unread-count` — badge count for the bell
- `POST /api/notifications/:id/read` — mark one read
- `POST /api/notifications/read-all` — mark all read at once

**Gap 2 — Requests: owner/filler can edit and unfill**
- `PUT /api/requests/:id` — owner or staff can edit title, description, type, year, image on open requests (matches Gazelle's `takeedit.php`)
- `POST /api/requests/:id/unfill` relaxed from staff-only to owner OR filler OR staff — filler can voluntarily cancel their own fill, requestor can revert
- Adds `updateRequestSchema` to schemas

**Gap 4 — Reports: atomic resolve**
- `resolveReport` replaced `findUnique` + `update` (TOCTOU race) with a single `updateMany WHERE status != Resolved` — same pattern as `fillRequest`. Second concurrent resolve returns `already_resolved`.

## Test plan

- [ ] 308/308 tests passing (`npm run test --no-coverage`)
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean on changed files
- [ ] Notification bell shows unread count; drops to zero after mark-all-read
- [ ] Request owner can edit an open request; 422 on filled request
- [ ] Request filler can unfill their own fill; non-participant gets 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)