### PR TITLE
Refine Gazelle-style profile surfaces

### DIFF
--- a/prisma/migrations/20260517090000_profile_visibility_settings/migration.sql
+++ b/prisma/migrations/20260517090000_profile_visibility_settings/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "user_settings"
+ADD COLUMN "showEmail" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "showLastSeen" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "showUploadedStats" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "showDownloadedStats" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "showRatioStats" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -267,6 +267,11 @@ model UserSettings {
   styledTooltips       Boolean            @default(true)
   paranoia             Int                @default(0)
   notificationMethod   NotificationMethod @default(Popup)
+  showEmail            Boolean            @default(false)
+  showLastSeen         Boolean            @default(false)
+  showUploadedStats    Boolean            @default(true)
+  showDownloadedStats  Boolean            @default(true)
+  showRatioStats       Boolean            @default(true)
   user                 User?
 
   @@map("user_settings")

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -6,6 +6,8 @@ import {
   makeUserRank,
   bcryptMock,
   createInviteMock,
+  getProfileByIdMock,
+  getProfileByLookupMock,
   updateProfileMock,
   getUserSettingsMock,
   updateUserSettingsMock,
@@ -208,10 +210,42 @@ describe('API auth/profile/user flows', () => {
         externalStylesheet: null,
         styledTooltips: true,
         paranoia: 0,
-        notificationMethod: 'Popup' as const
+        notificationMethod: 'Popup' as const,
+        showEmail: false,
+        showLastSeen: false,
+        showUploadedStats: true,
+        showDownloadedStats: true,
+        showRatioStats: true
       },
-      userRank: { name: 'User', color: '' },
-      inviteTree: []
+      userRank: { name: 'User', color: '', badge: '' },
+      inviteTree: [],
+      email: null,
+      dateRegistered: '2026-04-24T00:00:00.000Z',
+      lastSeen: null,
+      isArtist: false,
+      isDonor: false,
+      disabled: false,
+      warned: null,
+      inviteCount: 0,
+      stats: {
+        uploaded: '0',
+        downloaded: '0',
+        totalEarned: '0',
+        ratio: '1.00',
+        buffer: '0'
+      },
+      activitySummary: {
+        contributions: 0,
+        requestsCreated: 0,
+        requestsFilled: 0,
+        forumTopics: 0,
+        forumPosts: 0,
+        comments: 0,
+        collagesStarted: 0,
+        collageEntries: 0
+      },
+      recentContributions: [],
+      recentSnatches: []
     } as Awaited<ReturnType<typeof updateProfile>>);
 
     const res = await request(app).put('/api/profile/me').send({
@@ -225,6 +259,120 @@ describe('API auth/profile/user flows', () => {
       siteAppearance: 'dark'
     });
     expect(res.body.profile.profileTitle).toBe('New Title');
+  });
+
+  it('returns the current profile aggregate from /api/profile/me', async () => {
+    getProfileByIdMock.mockResolvedValue({
+      id: 7,
+      username: 'kai',
+      avatar: null,
+      email: 'kai@example.com',
+      dateRegistered: '2026-04-24T00:00:00.000Z',
+      lastSeen: '2026-04-24T00:00:00.000Z',
+      isArtist: false,
+      isDonor: false,
+      disabled: false,
+      warned: null,
+      inviteCount: 1,
+      stats: {
+        uploaded: '100',
+        downloaded: '50',
+        totalEarned: '100',
+        ratio: '2.00',
+        buffer: '50'
+      },
+      userRank: { name: 'User', color: '', badge: '' },
+      profile: {
+        id: 3,
+        avatar: null,
+        avatarMouseoverText: null,
+        profileTitle: 'Title',
+        profileInfo: '<p>bio</p>'
+      },
+      userSettings: {
+        id: 4,
+        siteAppearance: 'dark',
+        externalStylesheet: null,
+        styledTooltips: true,
+        paranoia: 0,
+        notificationMethod: 'Popup',
+        showEmail: true,
+        showLastSeen: true,
+        showUploadedStats: true,
+        showDownloadedStats: true,
+        showRatioStats: true
+      },
+      activitySummary: {
+        contributions: 1,
+        requestsCreated: 2,
+        requestsFilled: 3,
+        forumTopics: 4,
+        forumPosts: 5,
+        comments: 6,
+        collagesStarted: 7,
+        collageEntries: 8
+      },
+      recentContributions: [],
+      recentSnatches: [],
+      inviteTree: []
+    });
+
+    const res = await request(app).get('/api/profile/me');
+
+    expect(res.status).toBe(200);
+    expect(getProfileByIdMock).toHaveBeenCalledWith(7, 7);
+    expect(res.body.stats.ratio).toBe('2.00');
+  });
+
+  it('returns the viewer-aware profile aggregate from /api/profile/user/:userId', async () => {
+    getProfileByLookupMock.mockResolvedValue({
+      id: 9,
+      username: 'target-user',
+      avatar: null,
+      email: null,
+      dateRegistered: '2026-04-24T00:00:00.000Z',
+      lastSeen: null,
+      isArtist: false,
+      isDonor: false,
+      disabled: false,
+      warned: null,
+      inviteCount: null,
+      stats: {
+        uploaded: null,
+        downloaded: null,
+        totalEarned: null,
+        ratio: null,
+        buffer: null
+      },
+      userRank: { name: 'User', color: '', badge: '' },
+      profile: {
+        id: 5,
+        avatar: null,
+        avatarMouseoverText: null,
+        profileTitle: 'Hidden Stats',
+        profileInfo: '<p>bio</p>'
+      },
+      activitySummary: {
+        contributions: 0,
+        requestsCreated: 0,
+        requestsFilled: 0,
+        forumTopics: 0,
+        forumPosts: 0,
+        comments: 0,
+        collagesStarted: 0,
+        collageEntries: 0
+      },
+      recentContributions: [],
+      recentSnatches: [],
+      userSettings: undefined,
+      inviteTree: []
+    });
+
+    const res = await request(app).get('/api/profile/user/target-user');
+
+    expect(res.status).toBe(200);
+    expect(getProfileByLookupMock).toHaveBeenCalledWith('target-user', 7);
+    expect(res.body.email).toBeNull();
   });
 
   it('disables the current account and clears the auth cookie', async () => {
@@ -251,7 +399,12 @@ describe('API auth/profile/user flows', () => {
       externalStylesheet: null,
       styledTooltips: true,
       paranoia: 1,
-      notificationMethod: 'Popup' as const
+      notificationMethod: 'Popup' as const,
+      showEmail: false,
+      showLastSeen: false,
+      showUploadedStats: true,
+      showDownloadedStats: true,
+      showRatioStats: true
     });
 
     const res = await request(app).get('/api/users/settings');
@@ -269,7 +422,12 @@ describe('API auth/profile/user flows', () => {
       styledTooltips: false,
       paranoia: 2,
       avatar: 'https://example.com/avatar.png',
-      notificationMethod: 'Popup' as const
+      notificationMethod: 'Popup' as const,
+      showEmail: true,
+      showLastSeen: true,
+      showUploadedStats: false,
+      showDownloadedStats: false,
+      showRatioStats: false
     });
 
     const res = await request(app).put('/api/users/settings').send({
@@ -277,7 +435,12 @@ describe('API auth/profile/user flows', () => {
       externalStylesheet: 'https://example.com/style.css',
       styledTooltips: false,
       paranoia: 2,
-      avatar: 'https://example.com/avatar.png'
+      avatar: 'https://example.com/avatar.png',
+      showEmail: true,
+      showLastSeen: true,
+      showUploadedStats: false,
+      showDownloadedStats: false,
+      showRatioStats: false
     });
 
     expect(res.status).toBe(200);
@@ -286,7 +449,12 @@ describe('API auth/profile/user flows', () => {
       externalStylesheet: 'https://example.com/style.css',
       styledTooltips: false,
       paranoia: 2,
-      avatar: 'https://example.com/avatar.png'
+      avatar: 'https://example.com/avatar.png',
+      showEmail: true,
+      showLastSeen: true,
+      showUploadedStats: false,
+      showDownloadedStats: false,
+      showRatioStats: false
     });
     expect(res.body.avatar).toBe('https://example.com/avatar.png');
   });

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -217,7 +217,7 @@ describe('API auth/profile/user flows', () => {
         showDownloadedStats: true,
         showRatioStats: true
       },
-      userRank: { name: 'User', color: '', badge: '' },
+      userRank: { id: 1, name: 'User', color: '', badge: '' },
       inviteTree: [],
       email: null,
       dateRegistered: '2026-04-24T00:00:00.000Z',
@@ -244,6 +244,19 @@ describe('API auth/profile/user flows', () => {
         collagesStarted: 0,
         collageEntries: 0
       },
+      percentiles: {
+        uploaded: { percentile: 100, rank: 1, total: 1 },
+        downloaded: { percentile: 100, rank: 1, total: 1 },
+        contributions: { percentile: 100, rank: 1, total: 1 },
+        forumPosts: { percentile: 100, rank: 1, total: 1 },
+        requestsFilled: { percentile: 100, rank: 1, total: 1 }
+      },
+      donorPresentation: null,
+      collageShelves: {
+        featuredPersonalCollages: [],
+        publicCollages: []
+      },
+      staffPmOverview: null,
       recentContributions: [],
       recentSnatches: []
     } as Awaited<ReturnType<typeof updateProfile>>);
@@ -281,7 +294,7 @@ describe('API auth/profile/user flows', () => {
         ratio: '2.00',
         buffer: '50'
       },
-      userRank: { name: 'User', color: '', badge: '' },
+      userRank: { id: 1, name: 'User', color: '', badge: '' },
       profile: {
         id: 3,
         avatar: null,
@@ -312,6 +325,19 @@ describe('API auth/profile/user flows', () => {
         collagesStarted: 7,
         collageEntries: 8
       },
+      percentiles: {
+        uploaded: { percentile: 90, rank: 2, total: 10 },
+        downloaded: { percentile: 80, rank: 3, total: 10 },
+        contributions: { percentile: 70, rank: 4, total: 10 },
+        forumPosts: { percentile: 60, rank: 5, total: 10 },
+        requestsFilled: { percentile: 50, rank: 6, total: 10 }
+      },
+      donorPresentation: null,
+      collageShelves: {
+        featuredPersonalCollages: [],
+        publicCollages: []
+      },
+      staffPmOverview: null,
       recentContributions: [],
       recentSnatches: [],
       inviteTree: []
@@ -344,7 +370,7 @@ describe('API auth/profile/user flows', () => {
         ratio: null,
         buffer: null
       },
-      userRank: { name: 'User', color: '', badge: '' },
+      userRank: { id: 1, name: 'User', color: '', badge: '' },
       profile: {
         id: 5,
         avatar: null,
@@ -362,6 +388,19 @@ describe('API auth/profile/user flows', () => {
         collagesStarted: 0,
         collageEntries: 0
       },
+      percentiles: {
+        uploaded: { percentile: 10, rank: 9, total: 10 },
+        downloaded: { percentile: 10, rank: 9, total: 10 },
+        contributions: { percentile: 10, rank: 9, total: 10 },
+        forumPosts: { percentile: 10, rank: 9, total: 10 },
+        requestsFilled: { percentile: 10, rank: 9, total: 10 }
+      },
+      donorPresentation: null,
+      collageShelves: {
+        featuredPersonalCollages: [],
+        publicCollages: []
+      },
+      staffPmOverview: null,
       recentContributions: [],
       recentSnatches: [],
       userSettings: undefined,

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -354,7 +354,7 @@ const ProfileContribution = registry.register(
     release: z.object({
       id: z.number(),
       title: z.string(),
-      communityId: z.number(),
+      communityId: z.number().nullable(),
       artist: z
         .object({
           id: z.number(),
@@ -362,6 +362,72 @@ const ProfileContribution = registry.register(
         })
         .nullable()
     })
+  })
+);
+
+const ProfilePercentile = registry.register(
+  'ProfilePercentile',
+  z.object({
+    percentile: z.number(),
+    rank: z.number(),
+    total: z.number()
+  })
+);
+
+const ProfilePercentiles = registry.register(
+  'ProfilePercentiles',
+  z.object({
+    uploaded: ProfilePercentile,
+    downloaded: ProfilePercentile,
+    contributions: ProfilePercentile,
+    forumPosts: ProfilePercentile,
+    requestsFilled: ProfilePercentile
+  })
+);
+
+const ProfileCollageShelf = registry.register(
+  'ProfileCollageShelf',
+  z.object({
+    id: z.number(),
+    name: z.string(),
+    categoryId: z.number(),
+    isFeatured: z.boolean(),
+    numEntries: z.number(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    coverImages: z.array(z.string())
+  })
+);
+
+const ProfileCollageShelves = registry.register(
+  'ProfileCollageShelves',
+  z.object({
+    featuredPersonalCollages: z.array(ProfileCollageShelf),
+    publicCollages: z.array(ProfileCollageShelf)
+  })
+);
+
+const DonorPresentation = registry.register(
+  'DonorPresentation',
+  z.object({
+    rank: z
+      .object({
+        name: z.string(),
+        badge: z.string(),
+        color: z.string(),
+        grantedAt: z.string(),
+        expiresAt: z.string().nullable()
+      })
+      .nullable(),
+    customIcon: z.string().nullable(),
+    customIconLink: z.string().nullable(),
+    secondAvatar: z.string().nullable(),
+    profileBlocks: z.array(
+      z.object({
+        title: z.string(),
+        body: z.string()
+      })
+    )
   })
 );
 
@@ -411,9 +477,14 @@ const PublicProfile = registry.register(
     warned: z.string().nullable(),
     inviteCount: z.number().nullable(),
     stats: ProfileStats,
-    userRank: UserRankSummary,
+    userRank: UserRankSummary.extend({
+      id: z.number()
+    }),
     profile: ProfileDetails,
     activitySummary: ProfileActivitySummary,
+    percentiles: ProfilePercentiles,
+    donorPresentation: DonorPresentation.nullable(),
+    collageShelves: ProfileCollageShelves,
     recentContributions: z.array(ProfileContribution),
     recentSnatches: z.array(ProfileSnatch),
     inviteTree: z.array(InviteNode)

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -305,7 +305,77 @@ const UserSettings = registry.register(
     siteAppearance: z.string(),
     externalStylesheet: z.string().nullable().optional(),
     styledTooltips: z.boolean(),
-    paranoia: z.number()
+    paranoia: z.number(),
+    notificationMethod: z.enum([
+      'Disabled',
+      'Popup',
+      'Traditional',
+      'Push',
+      'Combined'
+    ]),
+    showEmail: z.boolean(),
+    showLastSeen: z.boolean(),
+    showUploadedStats: z.boolean(),
+    showDownloadedStats: z.boolean(),
+    showRatioStats: z.boolean()
+  })
+);
+
+const ProfileStats = registry.register(
+  'ProfileStats',
+  z.object({
+    uploaded: z.string().nullable(),
+    downloaded: z.string().nullable(),
+    totalEarned: z.string().nullable(),
+    ratio: z.string().nullable(),
+    buffer: z.string().nullable()
+  })
+);
+
+const ProfileActivitySummary = registry.register(
+  'ProfileActivitySummary',
+  z.object({
+    contributions: z.number(),
+    requestsCreated: z.number(),
+    requestsFilled: z.number(),
+    forumTopics: z.number(),
+    forumPosts: z.number(),
+    comments: z.number(),
+    collagesStarted: z.number(),
+    collageEntries: z.number()
+  })
+);
+
+const ProfileContribution = registry.register(
+  'ProfileContribution',
+  z.object({
+    id: z.number(),
+    createdAt: z.string(),
+    release: z.object({
+      id: z.number(),
+      title: z.string(),
+      communityId: z.number(),
+      artist: z
+        .object({
+          id: z.number(),
+          name: z.string()
+        })
+        .nullable()
+    })
+  })
+);
+
+const ProfileSnatch = registry.register(
+  'ProfileSnatch',
+  z.object({
+    id: z.number(),
+    downloadedAt: z.string(),
+    release: z.object({
+      id: z.number(),
+      title: z.string(),
+      communityId: z.number().nullable()
+    }),
+    artist: z.object({ name: z.string() }).nullable()
   })
 );
 
@@ -314,7 +384,7 @@ const InviteNodeSchema: z.ZodType<any> = z.lazy(() =>
   z.object({
     id: z.number(),
     username: z.string(),
-    email: z.string().email(),
+    email: z.string().email().optional(),
     joinedAt: z.string(),
     lastSeen: z.string().nullable().optional(),
     uploaded: z.string().optional(),
@@ -332,31 +402,29 @@ const PublicProfile = registry.register(
     id: z.number(),
     username: z.string(),
     avatar: z.string().nullable(),
+    email: z.string().email().nullable(),
     dateRegistered: z.string(),
+    lastSeen: z.string().nullable(),
     isArtist: z.boolean(),
     isDonor: z.boolean(),
+    disabled: z.boolean(),
+    warned: z.string().nullable(),
+    inviteCount: z.number().nullable(),
+    stats: ProfileStats,
     userRank: UserRankSummary,
     profile: ProfileDetails,
-    userSettings: z.object({
-      siteAppearance: z.string().optional(),
-      styledTooltips: z.boolean().optional()
-    })
+    activitySummary: ProfileActivitySummary,
+    recentContributions: z.array(ProfileContribution),
+    recentSnatches: z.array(ProfileSnatch),
+    inviteTree: z.array(InviteNode)
   })
 );
 
 const MyProfile = registry.register(
   'MyProfile',
   z.object({
-    id: z.number(),
-    username: z.string(),
-    avatar: z.string().nullable(),
-    profile: ProfileDetails,
-    userSettings: UserSettings,
-    userRank: z.object({
-      name: z.string(),
-      color: z.string()
-    }),
-    inviteTree: z.array(InviteNode)
+    ...PublicProfile.shape,
+    userSettings: UserSettings
   })
 );
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -355,6 +355,7 @@ const ProfileContribution = registry.register(
       id: z.number(),
       title: z.string(),
       communityId: z.number().nullable(),
+      image: z.string().nullable(),
       artist: z
         .object({
           id: z.number(),
@@ -431,6 +432,34 @@ const DonorPresentation = registry.register(
   })
 );
 
+const ProfileStaffPmSummary = registry.register(
+  'ProfileStaffPmSummary',
+  z.object({
+    id: z.number(),
+    subject: z.string(),
+    status: z.enum(['Unanswered', 'Open', 'Resolved']),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    assignedStaff: z
+      .object({
+        id: z.number(),
+        username: z.string()
+      })
+      .nullable(),
+    replyCount: z.number(),
+    viewerCanOpen: z.boolean()
+  })
+);
+
+const ProfileStaffPmOverview = registry.register(
+  'ProfileStaffPmOverview',
+  z.object({
+    total: z.number(),
+    unresolved: z.number(),
+    recentConversations: z.array(ProfileStaffPmSummary)
+  })
+);
+
 const ProfileSnatch = registry.register(
   'ProfileSnatch',
   z.object({
@@ -485,6 +514,7 @@ const PublicProfile = registry.register(
     percentiles: ProfilePercentiles,
     donorPresentation: DonorPresentation.nullable(),
     collageShelves: ProfileCollageShelves,
+    staffPmOverview: ProfileStaffPmOverview.nullable(),
     recentContributions: z.array(ProfileContribution),
     recentSnatches: z.array(ProfileSnatch),
     inviteTree: z.array(InviteNode)

--- a/src/moderation.spec.ts
+++ b/src/moderation.spec.ts
@@ -289,13 +289,43 @@ describe('GET /api/users/:id/ip-history', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
-    expect(res.body[0].ipAddress).toBe('1.2.3.4');
+    expect(res.body[0]).toEqual({
+      ip: '1.2.3.4',
+      seenAt: expect.any(String)
+    });
   });
 
   it('returns 403 without staff permission', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
     const res = await request(app).get('/api/users/9/ip-history');
     expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/users/:id/email-history', () => {
+  beforeEach(() => setStaff());
+
+  it('returns email history entries in the frontend contract shape', async () => {
+    prismaMock.userEmailHistory.findMany.mockResolvedValue([
+      {
+        id: 1,
+        userId: 9,
+        newEmail: 'first@example.com',
+        oldEmail: 'older@example.com',
+        ipAddress: null,
+        changedAt: new Date('2026-05-01T00:00:00.000Z')
+      } as never
+    ]);
+
+    const res = await request(app).get('/api/users/9/email-history');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        email: 'first@example.com',
+        changedAt: '2026-05-01T00:00:00.000Z'
+      }
+    ]);
   });
 });
 

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import type { NotificationMethod, Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { sanitizeHtml, sanitizePlain } from '../lib/sanitize';
 import { sendInviteEmail } from '../lib/mailer';
@@ -6,10 +7,30 @@ import { getLogger } from './logging';
 
 const log = getLogger('profile');
 
-export type InviteTreeNode = {
+type ViewerContext = {
+  viewerId: number | null;
+  isOwner: boolean;
+  isStaff: boolean;
+};
+
+type UserSettingsView = {
+  id: number;
+  siteAppearance: string;
+  externalStylesheet: string | null;
+  styledTooltips: boolean;
+  paranoia: number;
+  notificationMethod: NotificationMethod;
+  showEmail: boolean;
+  showLastSeen: boolean;
+  showUploadedStats: boolean;
+  showDownloadedStats: boolean;
+  showRatioStats: boolean;
+};
+
+type InviteTreeNode = {
   id: number;
   username: string;
-  email: string;
+  email?: string;
   joinedAt: string;
   lastSeen: string | null;
   uploaded: string;
@@ -17,6 +38,79 @@ export type InviteTreeNode = {
   ratio: string;
   children: InviteTreeNode[];
 };
+
+type RecentContribution = {
+  id: number;
+  createdAt: string;
+  release: {
+    id: number;
+    title: string;
+    communityId: number | null;
+    artist: { id: number; name: string } | null;
+  };
+};
+
+type RecentSnatch = {
+  id: number;
+  downloadedAt: string;
+  release: {
+    id: number;
+    title: string;
+    communityId: number | null;
+  };
+  artist: { name: string } | null;
+};
+
+type ProfileActivitySummary = {
+  contributions: number;
+  requestsCreated: number;
+  requestsFilled: number;
+  forumTopics: number;
+  forumPosts: number;
+  comments: number;
+  collagesStarted: number;
+  collageEntries: number;
+};
+
+const PROFILE_BASE_SELECT = {
+  id: true,
+  profileId: true,
+  username: true,
+  email: true,
+  avatar: true,
+  dateRegistered: true,
+  lastLogin: true,
+  isArtist: true,
+  isDonor: true,
+  disabled: true,
+  warned: true,
+  inviteCount: true,
+  uploaded: true,
+  downloaded: true,
+  totalEarned: true,
+  ratio: true,
+  userRank: { select: { name: true, color: true, badge: true } },
+  profile: true,
+  userSettings: {
+    select: {
+      id: true,
+      siteAppearance: true,
+      externalStylesheet: true,
+      styledTooltips: true,
+      paranoia: true,
+      notificationMethod: true,
+      showEmail: true,
+      showLastSeen: true,
+      showUploadedStats: true,
+      showDownloadedStats: true,
+      showRatioStats: true
+    }
+  }
+} as const;
+
+type ProfileUserRecord = Prisma.UserGetPayload<{
+  select: typeof PROFILE_BASE_SELECT;
+}>;
 
 const buildInviteTree = (
   rows: Array<{
@@ -32,7 +126,8 @@ const buildInviteTree = (
       downloaded: bigint;
       ratio: number;
     };
-  }>
+  }>,
+  includeEmail: boolean
 ): InviteTreeNode[] => {
   if (!rows.length) return [];
 
@@ -45,7 +140,7 @@ const buildInviteTree = (
     const node: InviteTreeNode = {
       id: row.user.id,
       username: row.user.username,
-      email: row.user.email,
+      ...(includeEmail ? { email: row.user.email } : {}),
       joinedAt: row.user.dateRegistered.toISOString(),
       lastSeen: row.user.lastLogin?.toISOString() ?? null,
       uploaded: row.user.uploaded.toString(),
@@ -70,47 +165,296 @@ const buildInviteTree = (
   return roots;
 };
 
-export const getCurrentProfile = async (userId: number) => {
-  const [user, inviteRows] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        username: true,
-        avatar: true,
-        profile: true,
-        userSettings: true,
-        userRank: { select: { name: true, color: true } }
+const loadViewerContext = async (
+  targetUserId: number,
+  viewerUserId?: number
+): Promise<ViewerContext> => {
+  if (!viewerUserId) {
+    return { viewerId: null, isOwner: false, isStaff: false };
+  }
+
+  if (viewerUserId === targetUserId) {
+    return { viewerId: viewerUserId, isOwner: true, isStaff: false };
+  }
+
+  const viewer = await prisma.user.findUnique({
+    where: { id: viewerUserId },
+    select: {
+      userRank: { select: { permissions: true } }
+    }
+  });
+  const perms = (viewer?.userRank.permissions ?? {}) as Record<string, boolean>;
+  const isStaff = !!(
+    perms.staff ||
+    perms.admin ||
+    perms.users_edit ||
+    perms.users_warn ||
+    perms.users_disable
+  );
+
+  return { viewerId: viewerUserId, isOwner: false, isStaff };
+};
+
+const getActivitySummary = async (
+  userId: number
+): Promise<ProfileActivitySummary> => {
+  const [
+    contributions,
+    requestsCreated,
+    requestsFilled,
+    forumTopics,
+    forumPosts,
+    comments,
+    collagesStarted,
+    collageEntries
+  ] = await Promise.all([
+    prisma.contribution.count({ where: { userId } }),
+    prisma.request.count({ where: { userId, deletedAt: null } }),
+    prisma.request.count({ where: { fillerId: userId, deletedAt: null } }),
+    prisma.forumTopic.count({ where: { authorId: userId, deletedAt: null } }),
+    prisma.forumPost.count({ where: { authorId: userId, deletedAt: null } }),
+    prisma.comment.count({ where: { authorId: userId, deletedAt: null } }),
+    prisma.collage.count({ where: { userId, isDeleted: false } }),
+    prisma.collageEntry.count({ where: { userId } })
+  ]);
+
+  return {
+    contributions,
+    requestsCreated,
+    requestsFilled,
+    forumTopics,
+    forumPosts,
+    comments,
+    collagesStarted,
+    collageEntries
+  };
+};
+
+const getRecentContributions = async (
+  userId: number
+): Promise<RecentContribution[]> => {
+  const rows = await prisma.contribution.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+    select: {
+      id: true,
+      createdAt: true,
+      release: {
+        select: {
+          id: true,
+          title: true,
+          communityId: true,
+          artist: { select: { id: true, name: true } }
+        }
       }
-    }),
-    prisma.inviteTree.findMany({
-      where: { treeId: userId },
-      orderBy: { treePosition: 'asc' },
-      select: {
-        treeLevel: true,
-        treePosition: true,
-        user: {
-          select: {
-            id: true,
-            username: true,
-            email: true,
-            dateRegistered: true,
-            lastLogin: true,
-            uploaded: true,
-            downloaded: true,
-            ratio: true
+    }
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt.toISOString(),
+    release: {
+      id: row.release.id,
+      title: row.release.title,
+      communityId: row.release.communityId,
+      artist: row.release.artist
+    }
+  }));
+};
+
+const getRecentSnatches = async (userId: number): Promise<RecentSnatch[]> => {
+  const grants = await prisma.downloadAccessGrant.findMany({
+    where: { consumerId: userId, status: 'COMPLETED' },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      contribution: {
+        include: {
+          release: {
+            select: {
+              id: true,
+              title: true,
+              communityId: true,
+              artist: { select: { name: true } }
+            }
           }
         }
       }
-    })
-  ]);
+    },
+    take: 25
+  });
 
-  if (!user?.profile) return null;
+  const seen = new Set<number>();
+  const items: RecentSnatch[] = [];
+
+  for (const grant of grants) {
+    const release = grant.contribution.release;
+    if (seen.has(release.id)) continue;
+    seen.add(release.id);
+    items.push({
+      id: grant.id,
+      downloadedAt: grant.createdAt.toISOString(),
+      release: {
+        id: release.id,
+        title: release.title,
+        communityId: release.communityId
+      },
+      artist: release.artist ?? null
+    });
+    if (items.length >= 5) break;
+  }
+
+  return items;
+};
+
+const buildProfileView = async (
+  user: ProfileUserRecord,
+  viewer: ViewerContext,
+  includeInviteTree: boolean
+) => {
+  const settings = user.userSettings as UserSettingsView;
+  const profile = user.profile ?? {
+    id: user.profileId,
+    avatar: null,
+    avatarMouseoverText: null,
+    profileTitle: null,
+    profileInfo: null
+  };
+  const canSeeEmail = viewer.isOwner || viewer.isStaff || settings.showEmail;
+  const canSeeLastSeen =
+    viewer.isOwner || viewer.isStaff || settings.showLastSeen;
+  const canSeeUploaded =
+    viewer.isOwner || viewer.isStaff || settings.showUploadedStats;
+  const canSeeDownloaded =
+    viewer.isOwner || viewer.isStaff || settings.showDownloadedStats;
+  const canSeeRatio =
+    viewer.isOwner || viewer.isStaff || settings.showRatioStats;
+  const canSeeSnatches = viewer.isOwner || viewer.isStaff;
+
+  const [activitySummary, recentContributions, recentSnatches, inviteRows] =
+    await Promise.all([
+      getActivitySummary(user.id),
+      getRecentContributions(user.id),
+      canSeeSnatches ? getRecentSnatches(user.id) : Promise.resolve([]),
+      includeInviteTree
+        ? prisma.inviteTree.findMany({
+            where: { treeId: user.id },
+            orderBy: { treePosition: 'asc' },
+            select: {
+              treeLevel: true,
+              treePosition: true,
+              user: {
+                select: {
+                  id: true,
+                  username: true,
+                  email: true,
+                  dateRegistered: true,
+                  lastLogin: true,
+                  uploaded: true,
+                  downloaded: true,
+                  ratio: true
+                }
+              }
+            }
+          })
+        : Promise.resolve([])
+    ]);
 
   return {
-    ...user,
-    inviteTree: buildInviteTree(inviteRows)
+    id: user.id,
+    username: user.username,
+    avatar: user.avatar,
+    email: canSeeEmail ? user.email : null,
+    dateRegistered: user.dateRegistered.toISOString(),
+    lastSeen: canSeeLastSeen ? user.lastLogin?.toISOString() ?? null : null,
+    isArtist: user.isArtist,
+    isDonor: user.isDonor,
+    disabled: user.disabled,
+    warned: user.warned?.toISOString() ?? null,
+    inviteCount: viewer.isOwner || viewer.isStaff ? user.inviteCount : null,
+    stats: {
+      uploaded: canSeeUploaded ? user.uploaded.toString() : null,
+      downloaded: canSeeDownloaded ? user.downloaded.toString() : null,
+      totalEarned: canSeeRatio ? user.totalEarned.toString() : null,
+      ratio: canSeeRatio ? user.ratio.toFixed(2) : null,
+      buffer:
+        canSeeUploaded || canSeeDownloaded
+          ? (user.uploaded - user.downloaded).toString()
+          : null
+    },
+    userRank: user.userRank,
+    profile,
+    userSettings: viewer.isOwner
+      ? {
+          id: settings.id,
+          siteAppearance: settings.siteAppearance,
+          externalStylesheet: settings.externalStylesheet,
+          styledTooltips: settings.styledTooltips,
+          paranoia: settings.paranoia,
+          notificationMethod: settings.notificationMethod,
+          showEmail: settings.showEmail,
+          showLastSeen: settings.showLastSeen,
+          showUploadedStats: settings.showUploadedStats,
+          showDownloadedStats: settings.showDownloadedStats,
+          showRatioStats: settings.showRatioStats
+        }
+      : undefined,
+    activitySummary,
+    recentContributions,
+    recentSnatches,
+    inviteTree:
+      includeInviteTree && inviteRows.length
+        ? buildInviteTree(inviteRows, viewer.isOwner || viewer.isStaff)
+        : []
   };
+};
+
+export const getProfileById = async (
+  targetUserId: number,
+  viewerUserId?: number
+) => {
+  const viewer = await loadViewerContext(targetUserId, viewerUserId);
+  const user = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: PROFILE_BASE_SELECT
+  });
+  if (!user) return null;
+  return buildProfileView(user, viewer, viewer.isOwner || viewer.isStaff);
+};
+
+export const getProfileByLookup = async (
+  userIdOrUsername: string,
+  viewerUserId?: number
+) => {
+  const trimmedLookup = userIdOrUsername.trim();
+  const numericId = Number(trimmedLookup);
+  const isNumeric =
+    !Number.isNaN(numericId) && Number.isInteger(numericId) && numericId > 0;
+
+  let user = isNumeric
+    ? await prisma.user.findUnique({
+        where: { id: numericId },
+        select: PROFILE_BASE_SELECT
+      })
+    : await prisma.user.findFirst({
+        where: {
+          username: { equals: trimmedLookup, mode: 'insensitive' }
+        },
+        select: PROFILE_BASE_SELECT
+      });
+
+  if (!user && isNumeric) {
+    user = await prisma.user.findFirst({
+      where: {
+        username: { equals: trimmedLookup, mode: 'insensitive' }
+      },
+      select: PROFILE_BASE_SELECT
+    });
+  }
+
+  if (!user) return null;
+  const viewer = await loadViewerContext(user.id, viewerUserId);
+  return buildProfileView(user, viewer, viewer.isOwner || viewer.isStaff);
 };
 
 export const updateProfile = async (
@@ -123,6 +467,13 @@ export const updateProfile = async (
     siteAppearance?: string;
     externalStylesheet?: string;
     styledTooltips?: boolean;
+    paranoia?: number;
+    notificationMethod?: NotificationMethod;
+    showEmail?: boolean;
+    showLastSeen?: boolean;
+    showUploadedStats?: boolean;
+    showDownloadedStats?: boolean;
+    showRatioStats?: boolean;
   }
 ) => {
   const user = await prisma.user.findUnique({
@@ -136,16 +487,20 @@ export const updateProfile = async (
       where: { id: user.profileId },
       data: {
         ...(data.avatar !== undefined && {
-          avatar: sanitizePlain(data.avatar)
+          avatar: data.avatar ? sanitizePlain(data.avatar) : null
         }),
         ...(data.avatarMouseoverText !== undefined && {
-          avatarMouseoverText: sanitizePlain(data.avatarMouseoverText)
+          avatarMouseoverText: data.avatarMouseoverText
+            ? sanitizePlain(data.avatarMouseoverText)
+            : null
         }),
         ...(data.profileTitle !== undefined && {
-          profileTitle: sanitizePlain(data.profileTitle)
+          profileTitle: data.profileTitle
+            ? sanitizePlain(data.profileTitle)
+            : null
         }),
         ...(data.profileInfo !== undefined && {
-          profileInfo: sanitizeHtml(data.profileInfo)
+          profileInfo: data.profileInfo ? sanitizeHtml(data.profileInfo) : null
         })
       }
     }),
@@ -156,16 +511,35 @@ export const updateProfile = async (
           siteAppearance: data.siteAppearance
         }),
         ...(data.externalStylesheet !== undefined && {
-          externalStylesheet: data.externalStylesheet
+          externalStylesheet: data.externalStylesheet || null
         }),
         ...(data.styledTooltips !== undefined && {
           styledTooltips: data.styledTooltips
+        }),
+        ...(data.paranoia !== undefined && {
+          paranoia: data.paranoia
+        }),
+        ...(data.notificationMethod !== undefined && {
+          notificationMethod: data.notificationMethod
+        }),
+        ...(data.showEmail !== undefined && { showEmail: data.showEmail }),
+        ...(data.showLastSeen !== undefined && {
+          showLastSeen: data.showLastSeen
+        }),
+        ...(data.showUploadedStats !== undefined && {
+          showUploadedStats: data.showUploadedStats
+        }),
+        ...(data.showDownloadedStats !== undefined && {
+          showDownloadedStats: data.showDownloadedStats
+        }),
+        ...(data.showRatioStats !== undefined && {
+          showRatioStats: data.showRatioStats
         })
       }
     })
   ]);
 
-  return getCurrentProfile(userId);
+  return getProfileById(userId, userId);
 };
 
 type CreateInviteResult =
@@ -177,6 +551,9 @@ export const createInvite = async (
   email: string,
   reason: string
 ): Promise<CreateInviteResult> => {
+  const normalizedEmail = sanitizePlain(email).trim().toLowerCase();
+  const normalizedReason = sanitizePlain(reason).trim();
+
   const inviter = await prisma.user.findUnique({
     where: { id: inviterId },
     select: { inviteCount: true }
@@ -185,7 +562,9 @@ export const createInvite = async (
     return { ok: false, reason: 'no_invites' };
   }
 
-  const existing = await prisma.invite.findUnique({ where: { email } });
+  const existing = await prisma.invite.findFirst({
+    where: { email: normalizedEmail }
+  });
   if (existing) {
     return { ok: false, reason: 'already_invited' };
   }
@@ -198,9 +577,9 @@ export const createInvite = async (
       data: {
         inviterId,
         inviteKey,
-        email: sanitizePlain(email),
+        email: normalizedEmail,
         expires,
-        reason: sanitizePlain(reason)
+        reason: normalizedReason
       }
     }),
     prisma.user.update({
@@ -211,9 +590,9 @@ export const createInvite = async (
 
   let emailSent = false;
   try {
-    emailSent = await sendInviteEmail(email, inviteKey);
+    emailSent = await sendInviteEmail(normalizedEmail, inviteKey);
   } catch (err) {
-    log.error('Failed to send invite email', { to: email, err });
+    log.error('Failed to send invite email', { to: normalizedEmail, err });
   }
 
   return { ok: true, inviteKey, emailSent };

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -1,5 +1,9 @@
 import crypto from 'crypto';
-import type { NotificationMethod, Prisma } from '@prisma/client';
+import type {
+  NotificationMethod,
+  Prisma,
+  StaffInboxStatus
+} from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { sanitizeHtml, sanitizePlain } from '../lib/sanitize';
 import { sendInviteEmail } from '../lib/mailer';
@@ -46,6 +50,7 @@ type RecentContribution = {
     id: number;
     title: string;
     communityId: number | null;
+    image: string | null;
     artist: { id: number; name: string } | null;
   };
 };
@@ -98,6 +103,23 @@ type ProfilePercentileSummary = {
   contributions: ProfilePercentile;
   forumPosts: ProfilePercentile;
   requestsFilled: ProfilePercentile;
+};
+
+type ProfileStaffPmSummary = {
+  id: number;
+  subject: string;
+  status: StaffInboxStatus;
+  createdAt: string;
+  updatedAt: string;
+  assignedStaff: { id: number; username: string } | null;
+  replyCount: number;
+  viewerCanOpen: boolean;
+};
+
+type ProfileStaffPmOverview = {
+  total: number;
+  unresolved: number;
+  recentConversations: ProfileStaffPmSummary[];
 };
 
 type ProfileActivitySummary = {
@@ -312,6 +334,7 @@ const getRecentContributions = async (
           id: true,
           title: true,
           communityId: true,
+          image: true,
           artist: { select: { id: true, name: true } }
         }
       }
@@ -325,6 +348,7 @@ const getRecentContributions = async (
       id: row.release.id,
       title: row.release.title,
       communityId: row.release.communityId,
+      image: row.release.image,
       artist: row.release.artist
     }
   }));
@@ -610,6 +634,63 @@ const getPercentileSummary = async (
   };
 };
 
+const getStaffPmOverview = async (
+  userId: number,
+  viewerId: number
+): Promise<ProfileStaffPmOverview> => {
+  const [total, unresolved, conversations] = await Promise.all([
+    prisma.privateConversation.count({
+      where: {
+        isStaffTicket: true,
+        participants: { some: { userId } }
+      }
+    }),
+    prisma.privateConversation.count({
+      where: {
+        isStaffTicket: true,
+        participants: { some: { userId } },
+        ticketStatus: { not: 'Resolved' }
+      }
+    }),
+    prisma.privateConversation.findMany({
+      where: {
+        isStaffTicket: true,
+        participants: { some: { userId } }
+      },
+      orderBy: { updatedAt: 'desc' },
+      take: 5,
+      select: {
+        id: true,
+        subject: true,
+        ticketStatus: true,
+        createdAt: true,
+        updatedAt: true,
+        assignedStaff: { select: { id: true, username: true } },
+        participants: {
+          where: { userId: viewerId },
+          select: { userId: true }
+        },
+        _count: { select: { messages: true } }
+      }
+    })
+  ]);
+
+  return {
+    total,
+    unresolved,
+    recentConversations: conversations.map((conversation) => ({
+      id: conversation.id,
+      subject: conversation.subject,
+      status: conversation.ticketStatus ?? 'Unanswered',
+      createdAt: conversation.createdAt.toISOString(),
+      updatedAt: conversation.updatedAt.toISOString(),
+      assignedStaff: conversation.assignedStaff,
+      replyCount: Math.max(0, conversation._count.messages - 1),
+      viewerCanOpen: conversation.participants.length > 0
+    }))
+  };
+};
+
 const buildProfileView = async (
   user: ProfileUserRecord,
   viewer: ViewerContext,
@@ -639,7 +720,8 @@ const buildProfileView = async (
     recentContributions,
     recentSnatches,
     inviteRows,
-    collageShelves
+    collageShelves,
+    staffPmOverview
   ] = await Promise.all([
     getActivitySummary(user.id),
     getRecentContributions(user.id),
@@ -666,7 +748,10 @@ const buildProfileView = async (
           }
         })
       : Promise.resolve([]),
-    getProfileCollages(user.id)
+    getProfileCollages(user.id),
+    viewer.isStaff && viewer.viewerId
+      ? getStaffPmOverview(user.id, viewer.viewerId)
+      : Promise.resolve(null)
   ]);
   const percentiles = await getPercentileSummary(user, activitySummary);
   const donorPresentation = buildDonorPresentation(user);
@@ -693,7 +778,19 @@ const buildProfileView = async (
           ? (user.uploaded - user.downloaded).toString()
           : null
     },
-    userRank: user.userRank,
+    userRank: user.userRank
+      ? {
+          id: user.userRank.id,
+          name: user.userRank.name,
+          color: user.userRank.color,
+          badge: user.userRank.badge
+        }
+      : {
+          id: 0,
+          name: '',
+          color: '',
+          badge: ''
+        },
     profile,
     userSettings: viewer.isOwner
       ? {
@@ -714,6 +811,7 @@ const buildProfileView = async (
     percentiles,
     donorPresentation,
     collageShelves,
+    staffPmOverview,
     recentContributions,
     recentSnatches,
     inviteTree:

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -61,6 +61,45 @@ type RecentSnatch = {
   artist: { name: string } | null;
 };
 
+type ProfileCollagePreview = {
+  id: number;
+  name: string;
+  categoryId: number;
+  isFeatured: boolean;
+  numEntries: number;
+  createdAt: string;
+  updatedAt: string;
+  coverImages: string[];
+};
+
+type DonorPresentation = {
+  rank: {
+    name: string;
+    badge: string;
+    color: string;
+    grantedAt: string;
+    expiresAt: string | null;
+  } | null;
+  customIcon: string | null;
+  customIconLink: string | null;
+  secondAvatar: string | null;
+  profileBlocks: Array<{ title: string; body: string }>;
+};
+
+type ProfilePercentile = {
+  percentile: number;
+  rank: number;
+  total: number;
+};
+
+type ProfilePercentileSummary = {
+  uploaded: ProfilePercentile;
+  downloaded: ProfilePercentile;
+  contributions: ProfilePercentile;
+  forumPosts: ProfilePercentile;
+  requestsFilled: ProfilePercentile;
+};
+
 type ProfileActivitySummary = {
   contributions: number;
   requestsCreated: number;
@@ -89,8 +128,36 @@ const PROFILE_BASE_SELECT = {
   downloaded: true,
   totalEarned: true,
   ratio: true,
-  userRank: { select: { name: true, color: true, badge: true } },
+  userRank: { select: { id: true, name: true, color: true, badge: true } },
   profile: true,
+  donorRank: {
+    select: {
+      grantedAt: true,
+      expiresAt: true,
+      donorRank: {
+        select: {
+          name: true,
+          badge: true,
+          color: true
+        }
+      }
+    }
+  },
+  donorReward: {
+    select: {
+      customIcon: true,
+      customIconLink: true,
+      secondAvatar: true,
+      profileInfoTitle1: true,
+      profileInfo1: true,
+      profileInfoTitle2: true,
+      profileInfo2: true,
+      profileInfoTitle3: true,
+      profileInfo3: true,
+      profileInfoTitle4: true,
+      profileInfo4: true
+    }
+  },
   userSettings: {
     select: {
       id: true,
@@ -307,6 +374,242 @@ const getRecentSnatches = async (userId: number): Promise<RecentSnatch[]> => {
   return items;
 };
 
+const getProfileCollages = async (
+  userId: number
+): Promise<{
+  featuredPersonalCollages: ProfileCollagePreview[];
+  publicCollages: ProfileCollagePreview[];
+}> => {
+  const select = {
+    id: true,
+    name: true,
+    categoryId: true,
+    isFeatured: true,
+    numEntries: true,
+    createdAt: true,
+    updatedAt: true,
+    entries: {
+      orderBy: { sort: 'asc' as const },
+      take: 4,
+      select: {
+        release: {
+          select: {
+            image: true
+          }
+        }
+      }
+    }
+  };
+
+  const [featuredPersonalCollages, publicCollages] = await Promise.all([
+    prisma.collage.findMany({
+      where: {
+        userId,
+        categoryId: 0,
+        isDeleted: false,
+        isFeatured: true
+      },
+      orderBy: [{ updatedAt: 'desc' }],
+      take: 3,
+      select
+    }),
+    prisma.collage.findMany({
+      where: {
+        userId,
+        categoryId: { gt: 0 },
+        isDeleted: false
+      },
+      orderBy: [{ updatedAt: 'desc' }],
+      take: 6,
+      select
+    })
+  ]);
+
+  const mapCollage = (
+    collage: (typeof featuredPersonalCollages)[number]
+  ): ProfileCollagePreview => ({
+    id: collage.id,
+    name: collage.name,
+    categoryId: collage.categoryId,
+    isFeatured: collage.isFeatured,
+    numEntries: collage.numEntries,
+    createdAt: collage.createdAt.toISOString(),
+    updatedAt: collage.updatedAt.toISOString(),
+    coverImages: collage.entries
+      .map((entry) => entry.release.image)
+      .filter((image): image is string => !!image)
+  });
+
+  return {
+    featuredPersonalCollages: featuredPersonalCollages.map(mapCollage),
+    publicCollages: publicCollages.map(mapCollage)
+  };
+};
+
+const buildDonorPresentation = (
+  user: ProfileUserRecord
+): DonorPresentation | null => {
+  const donorRank = user.donorRank;
+  const donorReward = user.donorReward;
+
+  const profileBlocks = donorReward
+    ? [
+        {
+          title: donorReward.profileInfoTitle1,
+          body: donorReward.profileInfo1
+        },
+        {
+          title: donorReward.profileInfoTitle2,
+          body: donorReward.profileInfo2
+        },
+        {
+          title: donorReward.profileInfoTitle3,
+          body: donorReward.profileInfo3
+        },
+        {
+          title: donorReward.profileInfoTitle4,
+          body: donorReward.profileInfo4
+        }
+      ].filter((block) => block.title.trim() || block.body.trim())
+    : [];
+
+  const presentation: DonorPresentation = {
+    rank: donorRank
+      ? {
+          name: donorRank.donorRank.name,
+          badge: donorRank.donorRank.badge,
+          color: donorRank.donorRank.color,
+          grantedAt: donorRank.grantedAt.toISOString(),
+          expiresAt: donorRank.expiresAt?.toISOString() ?? null
+        }
+      : null,
+    customIcon: donorReward?.customIcon || null,
+    customIconLink: donorReward?.customIconLink || null,
+    secondAvatar: donorReward?.secondAvatar || null,
+    profileBlocks
+  };
+
+  if (
+    !presentation.rank &&
+    !presentation.customIcon &&
+    !presentation.customIconLink &&
+    !presentation.secondAvatar &&
+    !presentation.profileBlocks.length
+  ) {
+    return null;
+  }
+
+  return presentation;
+};
+
+const buildPercentile = async (
+  totalUsers: number,
+  aboveCount: number
+): Promise<ProfilePercentile> => {
+  const rank = aboveCount + 1;
+  const percentile =
+    totalUsers <= 1
+      ? 100
+      : Math.max(1, Math.round(((totalUsers - rank) / (totalUsers - 1)) * 100));
+
+  return {
+    percentile,
+    rank,
+    total: totalUsers
+  };
+};
+
+const getPercentileSummary = async (
+  user: ProfileUserRecord,
+  activitySummary: ProfileActivitySummary
+): Promise<ProfilePercentileSummary> => {
+  const [
+    totalRow,
+    uploadedRows,
+    downloadedRows,
+    contributionsRows,
+    forumRows,
+    fillsRows
+  ] = await Promise.all([
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM "users"
+      WHERE "disabled" = false
+    `,
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM "users"
+      WHERE "disabled" = false
+        AND "uploaded" > ${user.uploaded}
+    `,
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM "users"
+      WHERE "disabled" = false
+        AND "downloaded" > ${user.downloaded}
+    `,
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM (
+        SELECT u."id", COUNT(c."id")::bigint AS metric_count
+        FROM "users" u
+        LEFT JOIN "contributions" c ON c."userId" = u."id"
+        WHERE u."disabled" = false
+        GROUP BY u."id"
+      ) ranked
+      WHERE ranked.metric_count > ${activitySummary.contributions}
+    `,
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM (
+        SELECT u."id", COUNT(fp."id")::bigint AS metric_count
+        FROM "users" u
+        LEFT JOIN "forum_posts" fp
+          ON fp."authorId" = u."id" AND fp."deletedAt" IS NULL
+        WHERE u."disabled" = false
+        GROUP BY u."id"
+      ) ranked
+      WHERE ranked.metric_count > ${activitySummary.forumPosts}
+    `,
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM (
+        SELECT u."id", COUNT(rf."id")::bigint AS metric_count
+        FROM "users" u
+        LEFT JOIN "request_fills" rf ON rf."fillerId" = u."id"
+        WHERE u."disabled" = false
+        GROUP BY u."id"
+      ) ranked
+      WHERE ranked.metric_count > ${activitySummary.requestsFilled}
+    `
+  ]);
+
+  const totalUsers = Number(totalRow[0]?.count ?? BigInt(0));
+
+  const [uploaded, downloaded, contributions, forumPosts, requestsFilled] =
+    await Promise.all([
+      buildPercentile(totalUsers, Number(uploadedRows[0]?.count ?? BigInt(0))),
+      buildPercentile(
+        totalUsers,
+        Number(downloadedRows[0]?.count ?? BigInt(0))
+      ),
+      buildPercentile(
+        totalUsers,
+        Number(contributionsRows[0]?.count ?? BigInt(0))
+      ),
+      buildPercentile(totalUsers, Number(forumRows[0]?.count ?? BigInt(0))),
+      buildPercentile(totalUsers, Number(fillsRows[0]?.count ?? BigInt(0)))
+    ]);
+
+  return {
+    uploaded,
+    downloaded,
+    contributions,
+    forumPosts,
+    requestsFilled
+  };
+};
+
 const buildProfileView = async (
   user: ProfileUserRecord,
   viewer: ViewerContext,
@@ -331,34 +634,42 @@ const buildProfileView = async (
     viewer.isOwner || viewer.isStaff || settings.showRatioStats;
   const canSeeSnatches = viewer.isOwner || viewer.isStaff;
 
-  const [activitySummary, recentContributions, recentSnatches, inviteRows] =
-    await Promise.all([
-      getActivitySummary(user.id),
-      getRecentContributions(user.id),
-      canSeeSnatches ? getRecentSnatches(user.id) : Promise.resolve([]),
-      includeInviteTree
-        ? prisma.inviteTree.findMany({
-            where: { treeId: user.id },
-            orderBy: { treePosition: 'asc' },
-            select: {
-              treeLevel: true,
-              treePosition: true,
-              user: {
-                select: {
-                  id: true,
-                  username: true,
-                  email: true,
-                  dateRegistered: true,
-                  lastLogin: true,
-                  uploaded: true,
-                  downloaded: true,
-                  ratio: true
-                }
+  const [
+    activitySummary,
+    recentContributions,
+    recentSnatches,
+    inviteRows,
+    collageShelves
+  ] = await Promise.all([
+    getActivitySummary(user.id),
+    getRecentContributions(user.id),
+    canSeeSnatches ? getRecentSnatches(user.id) : Promise.resolve([]),
+    includeInviteTree
+      ? prisma.inviteTree.findMany({
+          where: { treeId: user.id },
+          orderBy: { treePosition: 'asc' },
+          select: {
+            treeLevel: true,
+            treePosition: true,
+            user: {
+              select: {
+                id: true,
+                username: true,
+                email: true,
+                dateRegistered: true,
+                lastLogin: true,
+                uploaded: true,
+                downloaded: true,
+                ratio: true
               }
             }
-          })
-        : Promise.resolve([])
-    ]);
+          }
+        })
+      : Promise.resolve([]),
+    getProfileCollages(user.id)
+  ]);
+  const percentiles = await getPercentileSummary(user, activitySummary);
+  const donorPresentation = buildDonorPresentation(user);
 
   return {
     id: user.id,
@@ -400,6 +711,9 @@ const buildProfileView = async (
         }
       : undefined,
     activitySummary,
+    percentiles,
+    donorPresentation,
+    collageShelves,
     recentContributions,
     recentSnatches,
     inviteTree:

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -762,7 +762,8 @@ const buildProfileView = async (
     avatar: user.avatar,
     email: canSeeEmail ? user.email : null,
     dateRegistered: user.dateRegistered.toISOString(),
-    lastSeen: canSeeLastSeen ? user.lastLogin?.toISOString() ?? null : null,
+    lastSeen:
+      canSeeLastSeen && user.lastLogin ? user.lastLogin.toISOString() : null,
     isArtist: user.isArtist,
     isDonor: user.isDonor,
     disabled: user.disabled,

--- a/src/modules/user.ts
+++ b/src/modules/user.ts
@@ -20,6 +20,17 @@ export const updateUserSettings = async (
     styledTooltips?: boolean;
     paranoia?: number;
     avatar?: string;
+    notificationMethod?:
+      | 'Disabled'
+      | 'Popup'
+      | 'Traditional'
+      | 'Push'
+      | 'Combined';
+    showEmail?: boolean;
+    showLastSeen?: boolean;
+    showUploadedStats?: boolean;
+    showDownloadedStats?: boolean;
+    showRatioStats?: boolean;
   }
 ) => {
   const user = await prisma.user.findUnique({
@@ -41,7 +52,23 @@ export const updateUserSettings = async (
         ...(data.styledTooltips !== undefined && {
           styledTooltips: data.styledTooltips
         }),
-        ...(data.paranoia !== undefined && { paranoia: data.paranoia })
+        ...(data.paranoia !== undefined && { paranoia: data.paranoia }),
+        ...(data.notificationMethod !== undefined && {
+          notificationMethod: data.notificationMethod
+        }),
+        ...(data.showEmail !== undefined && { showEmail: data.showEmail }),
+        ...(data.showLastSeen !== undefined && {
+          showLastSeen: data.showLastSeen
+        }),
+        ...(data.showUploadedStats !== undefined && {
+          showUploadedStats: data.showUploadedStats
+        }),
+        ...(data.showDownloadedStats !== undefined && {
+          showDownloadedStats: data.showDownloadedStats
+        }),
+        ...(data.showRatioStats !== undefined && {
+          showRatioStats: data.showRatioStats
+        })
       }
     }),
     ...(data.avatar !== undefined

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -2,13 +2,15 @@ import express, { Request, Response } from 'express';
 import { prisma } from '../../lib/prisma';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import {
-  getCurrentProfile,
+  getProfileById,
+  getProfileByLookup,
   updateProfile,
   createInvite
 } from '../../modules/profile';
 import { getRatioStats } from '../../modules/ratio';
 import { getPolicyState } from '../../modules/ratioPolicy';
 import { requireAuth } from '../../middleware/auth';
+import { audit } from '../../lib/audit';
 import { validate, parsedBody } from '../../middleware/validate';
 import {
   profileUpdateSchema,
@@ -18,31 +20,12 @@ import {
 } from '../../schemas/profile';
 
 const router = express.Router();
-
-const PROFILE_SELECT = {
-  id: true,
-  username: true,
-  avatar: true,
-  dateRegistered: true,
-  isArtist: true,
-  isDonor: true,
-  disabled: true,
-  warned: true,
-  uploaded: true,
-  downloaded: true,
-  totalEarned: true,
-  ratio: true,
-  userRank: { select: { name: true, color: true, badge: true } },
-  profile: true,
-  userSettings: { select: { siteAppearance: true, styledTooltips: true } }
-} as const;
-
 // GET /api/profile/me
 router.get(
   '/me',
   requireAuth,
   authHandler(async (req, res) => {
-    const user = await getCurrentProfile(req.user.id);
+    const user = await getProfileById(req.user.id, req.user.id);
     if (!user) return res.status(404).json({ msg: 'Profile not found' });
     res.json(user);
   })
@@ -69,22 +52,10 @@ router.get(
 // GET /api/profile/user/:userId — accepts numeric ID or username (case-insensitive)
 router.get(
   '/user/:userId',
+  requireAuth,
   asyncHandler(async (req: Request, res: Response) => {
     const { userId } = req.params;
-
-    const numericId = Number(userId);
-    const isNumeric =
-      !isNaN(numericId) && Number.isInteger(numericId) && numericId > 0;
-
-    const user = isNumeric
-      ? await prisma.user.findUnique({
-          where: { id: numericId },
-          select: PROFILE_SELECT
-        })
-      : await prisma.user.findFirst({
-          where: { username: { equals: userId.trim(), mode: 'insensitive' } },
-          select: PROFILE_SELECT
-        });
+    const user = await getProfileByLookup(userId, req.user!.id);
 
     if (!user) return res.status(404).json({ msg: 'Profile not found' });
     res.json(user);
@@ -113,6 +84,9 @@ router.put(
     const data = parsedBody<ProfileUpdateInput>(res);
     const updated = await updateProfile(req.user.id, data);
     if (!updated) return res.status(404).json({ msg: 'User not found' });
+    await audit(prisma, req.user.id, 'profile.update', 'User', req.user.id, {
+      fields: Object.keys(data).sort()
+    });
     res.json(updated);
   })
 );
@@ -126,6 +100,13 @@ router.delete(
       where: { id: req.user.id },
       data: { disabled: true }
     });
+    await audit(
+      prisma,
+      req.user.id,
+      'profile.disable_self',
+      'User',
+      req.user.id
+    );
     res.clearCookie('token');
     res.status(204).send();
   })
@@ -146,6 +127,14 @@ router.post(
         .status(409)
         .json({ msg: 'An invite has already been sent to that address' });
     }
+    await audit(
+      prisma,
+      req.user.id,
+      'profile.invite.create',
+      'Invite',
+      undefined,
+      { email: email.toLowerCase() }
+    );
     res
       .status(201)
       .json({ inviteKey: result.inviteKey, emailSent: result.emailSent });

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -520,7 +520,20 @@ router.get(
       orderBy: { createdAt: 'desc' },
       take: 50
     });
-    res.json(sessions);
+    const history = new Map<string, string>();
+    for (const session of sessions) {
+      if (!session.ipAddress) continue;
+      const seenAt = (session.lastActiveAt ?? session.createdAt).toISOString();
+      if (!history.has(session.ipAddress)) {
+        history.set(session.ipAddress, seenAt);
+      }
+    }
+    res.json(
+      Array.from(history.entries()).map(([ip, seenAt]) => ({
+        ip,
+        seenAt
+      }))
+    );
   })
 );
 
@@ -533,9 +546,18 @@ router.get(
     const { id } = parsedParams<{ id: number }>(res);
     const history = await prisma.userEmailHistory.findMany({
       where: { userId: id },
+      select: {
+        newEmail: true,
+        changedAt: true
+      },
       orderBy: { changedAt: 'desc' }
     });
-    res.json(history);
+    res.json(
+      history.map((row) => ({
+        email: row.newEmail,
+        changedAt: row.changedAt.toISOString()
+      }))
+    );
   })
 );
 

--- a/src/schemas/profile.ts
+++ b/src/schemas/profile.ts
@@ -7,7 +7,16 @@ export const profileUpdateSchema = z.object({
   profileInfo: z.string().max(10000).optional(),
   siteAppearance: z.string().optional(),
   externalStylesheet: z.string().url().optional().or(z.literal('')),
-  styledTooltips: z.boolean().optional()
+  styledTooltips: z.boolean().optional(),
+  paranoia: z.coerce.number().int().min(0).max(3).optional(),
+  notificationMethod: z
+    .enum(['Disabled', 'Popup', 'Traditional', 'Push', 'Combined'])
+    .optional(),
+  showEmail: z.boolean().optional(),
+  showLastSeen: z.boolean().optional(),
+  showUploadedStats: z.boolean().optional(),
+  showDownloadedStats: z.boolean().optional(),
+  showRatioStats: z.boolean().optional()
 });
 
 export const inviteSchema = z.object({

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -15,7 +15,12 @@ export const userSettingsSchema = z.object({
   avatar: z.string().optional(),
   notificationMethod: z
     .enum(['Disabled', 'Popup', 'Traditional', 'Push', 'Combined'])
-    .optional()
+    .optional(),
+  showEmail: z.boolean().optional(),
+  showLastSeen: z.boolean().optional(),
+  showUploadedStats: z.boolean().optional(),
+  showDownloadedStats: z.boolean().optional(),
+  showRatioStats: z.boolean().optional()
 });
 
 export const warnUserSchema = z.object({

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -8,7 +8,8 @@ jest.mock('../modules/installState', () => ({
 }));
 
 jest.mock('../modules/profile', () => ({
-  getCurrentProfile: jest.fn(),
+  getProfileById: jest.fn(),
+  getProfileByLookup: jest.fn(),
   updateProfile: jest.fn(),
   createInvite: jest.fn()
 }));
@@ -126,7 +127,12 @@ import { type PrismaClient } from '@prisma/client';
 import app from '../app';
 import { isInstalled } from '../modules/installState';
 import { prisma } from '../lib/prisma';
-import { createInvite, updateProfile } from '../modules/profile';
+import {
+  createInvite,
+  updateProfile,
+  getProfileById,
+  getProfileByLookup
+} from '../modules/profile';
 import { createContributionSubmission } from '../modules/contribution';
 import {
   getUserSettings,
@@ -163,6 +169,12 @@ export const bcryptMock = bcrypt as unknown as {
 
 export const createInviteMock = createInvite as jest.MockedFunction<
   typeof createInvite
+>;
+export const getProfileByIdMock = getProfileById as jest.MockedFunction<
+  typeof getProfileById
+>;
+export const getProfileByLookupMock = getProfileByLookup as jest.MockedFunction<
+  typeof getProfileByLookup
 >;
 export const updateProfileMock = updateProfile as jest.MockedFunction<
   typeof updateProfile


### PR DESCRIPTION
## Summary
- refine the profile aggregate and UI toward Gazelle-style profile surfaces
- align staff-facing profile sections with current profile work on feature/profile
- include the current backend/frontend contract and UI updates for the profile slice

## Testing
- npm run build
- npm run lint
- npm test -- --runInBand src/install-auth.spec.ts
- npm run openapi:export
- npm run api:generate
- npm run typecheck
- npx eslint src/components/profile/UserProfile.tsx src/store/services/userApi.ts