### PR TITLE
Bifurcate staff PMs from private conversations

### DIFF
--- a/prisma/migrations/20260517180839_remove_pm_ticket_fields/migration.sql
+++ b/prisma/migrations/20260517180839_remove_pm_ticket_fields/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `assignedStaffId` on the `private_conversations` table. All the data in the column will be lost.
+  - You are about to drop the column `isStaffTicket` on the `private_conversations` table. All the data in the column will be lost.
+  - You are about to drop the column `ticketStatus` on the `private_conversations` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "private_conversations" DROP CONSTRAINT "private_conversations_assignedStaffId_fkey";
+
+-- DropIndex
+DROP INDEX "private_conversations_isStaffTicket_ticketStatus_idx";
+
+-- AlterTable
+ALTER TABLE "private_conversations" DROP COLUMN "assignedStaffId",
+DROP COLUMN "isStaffTicket",
+DROP COLUMN "ticketStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -364,7 +364,6 @@ model User {
   contributionReports       ContributionReport[]
   pmParticipations          PrivateConversationParticipant[] @relation("PmParticipant")
   pmMessagesSent            PrivateMessage[]                 @relation("PmSender")
-  pmTicketsAssigned         PrivateConversation[]            @relation("PmTicketAssignee")
   staffInboxConversations   StaffInboxConversation[]         @relation("StaffInboxOwner")
   staffInboxAssigned        StaffInboxConversation[]         @relation("StaffInboxAssignee")
   staffInboxResolved        StaffInboxConversation[]         @relation("StaffInboxResolver")
@@ -1497,18 +1496,13 @@ model AuditLog {
 // ─── Private Messaging ────────────────────────────────────────────────────────
 
 model PrivateConversation {
-  id              Int                              @id @default(autoincrement())
-  subject         String                           @db.VarChar(255)
-  isStaffTicket   Boolean                          @default(false)
-  ticketStatus    StaffInboxStatus?
-  assignedStaffId Int?
-  assignedStaff   User?                            @relation("PmTicketAssignee", fields: [assignedStaffId], references: [id])
-  messages        PrivateMessage[]
-  participants    PrivateConversationParticipant[]
-  createdAt       DateTime                         @default(now())
-  updatedAt       DateTime                         @updatedAt
+  id           Int                              @id @default(autoincrement())
+  subject      String                           @db.VarChar(255)
+  messages     PrivateMessage[]
+  participants PrivateConversationParticipant[]
+  createdAt    DateTime                         @default(now())
+  updatedAt    DateTime                         @updatedAt
 
-  @@index([isStaffTicket, ticketStatus])
   @@map("private_conversations")
 }
 

--- a/src/messages.spec.ts
+++ b/src/messages.spec.ts
@@ -9,13 +9,9 @@ import {
 
 const PAGED_EMPTY = { total: 0, page: 1, pageSize: 25, conversations: [] };
 
-const makeConversation = (isTicket = false) => ({
+const makeConversation = () => ({
   id: 1,
   subject: 'Hello',
-  isStaffTicket: isTicket,
-  ticketStatus: isTicket ? ('Unanswered' as const) : null,
-  assignedStaffId: null,
-  assignedStaff: null,
   createdAt: new Date(),
   updatedAt: new Date(),
   participants: [],

--- a/src/modules.spec.ts
+++ b/src/modules.spec.ts
@@ -164,10 +164,6 @@ describe('pm.listInbox', () => {
   const conversation = {
     id: 1,
     subject: 'Hello',
-    isStaffTicket: false,
-    ticketStatus: null,
-    assignedStaffId: null,
-    assignedStaff: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     participants: [

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -635,41 +635,24 @@ const getPercentileSummary = async (
 };
 
 const getStaffPmOverview = async (
-  userId: number,
-  viewerId: number
+  userId: number
 ): Promise<ProfileStaffPmOverview> => {
   const [total, unresolved, conversations] = await Promise.all([
-    prisma.privateConversation.count({
-      where: {
-        isStaffTicket: true,
-        participants: { some: { userId } }
-      }
+    prisma.staffInboxConversation.count({ where: { userId } }),
+    prisma.staffInboxConversation.count({
+      where: { userId, status: { not: 'Resolved' } }
     }),
-    prisma.privateConversation.count({
-      where: {
-        isStaffTicket: true,
-        participants: { some: { userId } },
-        ticketStatus: { not: 'Resolved' }
-      }
-    }),
-    prisma.privateConversation.findMany({
-      where: {
-        isStaffTicket: true,
-        participants: { some: { userId } }
-      },
+    prisma.staffInboxConversation.findMany({
+      where: { userId },
       orderBy: { updatedAt: 'desc' },
       take: 5,
       select: {
         id: true,
         subject: true,
-        ticketStatus: true,
+        status: true,
         createdAt: true,
         updatedAt: true,
-        assignedStaff: { select: { id: true, username: true } },
-        participants: {
-          where: { userId: viewerId },
-          select: { userId: true }
-        },
+        assignedUser: { select: { id: true, username: true } },
         _count: { select: { messages: true } }
       }
     })
@@ -681,12 +664,12 @@ const getStaffPmOverview = async (
     recentConversations: conversations.map((conversation) => ({
       id: conversation.id,
       subject: conversation.subject,
-      status: conversation.ticketStatus ?? 'Unanswered',
+      status: conversation.status,
       createdAt: conversation.createdAt.toISOString(),
       updatedAt: conversation.updatedAt.toISOString(),
-      assignedStaff: conversation.assignedStaff,
+      assignedStaff: conversation.assignedUser,
       replyCount: Math.max(0, conversation._count.messages - 1),
-      viewerCanOpen: conversation.participants.length > 0
+      viewerCanOpen: true
     }))
   };
 };
@@ -749,9 +732,7 @@ const buildProfileView = async (
         })
       : Promise.resolve([]),
     getProfileCollages(user.id),
-    viewer.isStaff && viewer.viewerId
-      ? getStaffPmOverview(user.id, viewer.viewerId)
-      : Promise.resolve(null)
+    viewer.isStaff ? getStaffPmOverview(user.id) : Promise.resolve(null)
   ]);
   const percentiles = await getPercentileSummary(user, activitySummary);
   const donorPresentation = buildDonorPresentation(user);


### PR DESCRIPTION
## Summary

- Removes ghost ticket fields (`isStaffTicket`, `ticketStatus`, `assignedStaffId`, `assignedStaff`) from `PrivateConversation` — remnants of a prior merge that collapsed support tickets into the PM table
- Drops the compound `[isStaffTicket, ticketStatus]` index and the `PmTicketAssignee` relation from `User`
- Rewrites `getStaffPmOverview` in `profile.ts` to query `StaffInboxConversation` directly, which is the correct owner of the staff PM workflow
- Includes the corresponding Prisma migration

## Test plan

- [ ] All 336 tests pass (`npm run test --no-coverage`)
- [ ] `npx tsc --noEmit` clean
- [ ] Migration applies cleanly (`prisma migrate deploy`)
- [ ] Staff viewing a user profile sees their staff PM history correctly
- [ ] Regular PM inbox/compose/reply unaffected