### PR TITLE
Preserve notification actors during migration

### DIFF
--- a/prisma/migrations/20260520182607_notification_events/migration.sql
+++ b/prisma/migrations/20260520182607_notification_events/migration.sql
@@ -1,9 +1,3 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `quoterId` on the `notifications` table. All the data in the column will be lost.
-
-*/
 -- CreateEnum
 CREATE TYPE "NotificationType" AS ENUM ('forum_quote', 'forum_sub', 'request_filled', 'collage_updated', 'comment_sub');
 
@@ -11,10 +5,17 @@ CREATE TYPE "NotificationType" AS ENUM ('forum_quote', 'forum_sub', 'request_fil
 ALTER TABLE "notifications" DROP CONSTRAINT "notifications_quoterId_fkey";
 
 -- AlterTable
-ALTER TABLE "notifications" DROP COLUMN "quoterId",
-ADD COLUMN     "actorId" INTEGER,
+ALTER TABLE "notifications" ADD COLUMN     "actorId" INTEGER,
 ADD COLUMN     "type" "NotificationType" NOT NULL DEFAULT 'forum_quote',
 ALTER COLUMN "postId" DROP NOT NULL;
+
+-- Backfill legacy quote notifications before removing the old actor column.
+UPDATE "notifications"
+SET "actorId" = "quoterId"
+WHERE "actorId" IS NULL;
+
+-- Drop legacy column after backfill.
+ALTER TABLE "notifications" DROP COLUMN "quoterId";
 
 -- CreateIndex
 CREATE INDEX "notifications_userId_readAt_idx" ON "notifications"("userId", "readAt");

--- a/prisma/migrations/20260520182607_notification_events/migration.sql
+++ b/prisma/migrations/20260520182607_notification_events/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `quoterId` on the `notifications` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('forum_quote', 'forum_sub', 'request_filled', 'collage_updated', 'comment_sub');
+
+-- DropForeignKey
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_quoterId_fkey";
+
+-- AlterTable
+ALTER TABLE "notifications" DROP COLUMN "quoterId",
+ADD COLUMN     "actorId" INTEGER,
+ADD COLUMN     "type" "NotificationType" NOT NULL DEFAULT 'forum_quote',
+ALTER COLUMN "postId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "notifications_userId_readAt_idx" ON "notifications"("userId", "readAt");
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,14 @@ enum SubscriptionPage {
   communities
 }
 
+enum NotificationType {
+  forum_quote
+  forum_sub
+  request_filled
+  collage_updated
+  comment_sub
+}
+
 enum ThreadType {
   forum
   application
@@ -336,7 +344,7 @@ model User {
   subscriptions         Subscription[]
   commentSubscriptions  CommentSubscription[]
   notifications         Notification[]        @relation("NotificationUser")
-  quotedInNotifications Notification[]        @relation("NotificationQuoter")
+  actedNotifications    Notification[]        @relation("NotificationActor")
   blogs                 Blog[]
   posts                 Post[]
   apiApplications       ApiApplication[]
@@ -1323,14 +1331,16 @@ model Notification {
   id        Int              @id @default(autoincrement())
   userId    Int
   user      User             @relation("NotificationUser", fields: [userId], references: [id])
-  quoterId  Int
-  quoter    User             @relation("NotificationQuoter", fields: [quoterId], references: [id])
+  type      NotificationType @default(forum_quote)
+  actorId   Int?
+  actor     User?            @relation("NotificationActor", fields: [actorId], references: [id])
   page      SubscriptionPage
   pageId    Int
-  postId    Int
+  postId    Int?
   readAt    DateTime?
   createdAt DateTime         @default(now())
 
+  @@index([userId, readAt])
   @@map("notifications")
 }
 

--- a/src/collages.spec.ts
+++ b/src/collages.spec.ts
@@ -869,12 +869,72 @@ describe('collages Prisma contract', () => {
     prismaMock.collageEntry.aggregate.mockResolvedValue(
       makeEntryAggregateResult(10)
     );
-    prismaMock.$transaction.mockResolvedValue([makeCollageEntryDetail(), {}]);
+    prismaMock.collageEntry.create.mockResolvedValue(makeCollageEntryDetail());
+    prismaMock.collage.update.mockResolvedValue(makeCollage());
 
-    await request(app).post('/api/collages/1/entries').send({ releaseId: 42 });
+    const res = await request(app)
+      .post('/api/collages/1/entries')
+      .send({ releaseId: 42 });
 
-    const txArgs = (prismaMock.$transaction as jest.Mock).mock
-      .calls[0][0] as unknown[];
-    expect(txArgs).toHaveLength(2);
+    expect(res.status).toBe(201);
+    // interactive transaction used (function form)
+    expect(prismaMock.$transaction).toHaveBeenCalledWith(expect.any(Function));
+    expect(prismaMock.collageEntry.create).toHaveBeenCalled();
+    expect(prismaMock.collage.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { numEntries: { increment: 1 } } })
+    );
+  });
+
+  it('POST /:id/entries notifies collage subscribers excluding the adder', async () => {
+    prismaMock.collage.findUnique.mockResolvedValue(makeCollage({ id: 1 }));
+    prismaMock.release.findUnique.mockResolvedValue(makeRelease());
+    prismaMock.collageEntry.findUnique.mockResolvedValue(null);
+    prismaMock.collageEntry.aggregate.mockResolvedValue(
+      makeEntryAggregateResult(10)
+    );
+    prismaMock.collageEntry.create.mockResolvedValue(makeCollageEntryDetail());
+    prismaMock.collage.update.mockResolvedValue(makeCollage());
+    prismaMock.collageSubscription.findMany.mockResolvedValue([
+      { userId: 10 },
+      { userId: 11 },
+      { userId: 7 } // 7 is the auth user — should be excluded
+    ] as never);
+
+    const res = await request(app)
+      .post('/api/collages/1/entries')
+      .send({ releaseId: 42 });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ userId: 10, type: 'collage_updated' }),
+          expect.objectContaining({ userId: 11, type: 'collage_updated' })
+        ]),
+        skipDuplicates: true
+      })
+    );
+    const callData = (prismaMock.notification.createMany as jest.Mock).mock
+      .calls[0][0].data as { userId: number }[];
+    expect(callData.map((d) => d.userId)).not.toContain(7);
+  });
+
+  it('POST /:id/entries emits no notification when no subscribers', async () => {
+    prismaMock.collage.findUnique.mockResolvedValue(makeCollage({ id: 1 }));
+    prismaMock.release.findUnique.mockResolvedValue(makeRelease());
+    prismaMock.collageEntry.findUnique.mockResolvedValue(null);
+    prismaMock.collageEntry.aggregate.mockResolvedValue(
+      makeEntryAggregateResult(10)
+    );
+    prismaMock.collageEntry.create.mockResolvedValue(makeCollageEntryDetail());
+    prismaMock.collage.update.mockResolvedValue(makeCollage());
+    prismaMock.collageSubscription.findMany.mockResolvedValue([]);
+
+    const res = await request(app)
+      .post('/api/collages/1/entries')
+      .send({ releaseId: 42 });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.notification.createMany).not.toHaveBeenCalled();
   });
 });

--- a/src/comments.spec.ts
+++ b/src/comments.spec.ts
@@ -254,6 +254,53 @@ describe('POST /api/comments', () => {
     expect(res.status).toBe(400);
     expect(prismaMock.comment.create).not.toHaveBeenCalled();
   });
+
+  it('notifies comment subscribers on pages with subscription support', async () => {
+    prismaMock.comment.create.mockResolvedValue(
+      makeComment({ id: 30, page: 'requests' as never, requestId: 14 }) as never
+    );
+    prismaMock.commentSubscription.findMany.mockResolvedValue([
+      { userId: 20 },
+      { userId: 21 },
+      { userId: 7 } // auth user — should be excluded
+    ] as never);
+
+    const res = await request(app).post('/api/comments').send({
+      page: 'requests',
+      body: 'Nice.',
+      requestId: 14
+    });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ userId: 20, type: 'comment_sub' }),
+          expect.objectContaining({ userId: 21, type: 'comment_sub' })
+        ]),
+        skipDuplicates: true
+      })
+    );
+    const callData = (prismaMock.notification.createMany as jest.Mock).mock
+      .calls[0][0].data as { userId: number }[];
+    expect(callData.map((d) => d.userId)).not.toContain(7);
+  });
+
+  it('skips comment subscription notifications for non-subscribable pages', async () => {
+    prismaMock.comment.create.mockResolvedValue(
+      makeComment({ id: 31, page: 'release' as never, releaseId: 9 }) as never
+    );
+
+    const res = await request(app).post('/api/comments').send({
+      page: 'release',
+      body: 'Great.',
+      releaseId: 9
+    });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.commentSubscription.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.notification.createMany).not.toHaveBeenCalled();
+  });
 });
 
 // ─── PUT /api/comments/:id ────────────────────────────────────────────────────

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,33 @@
+import { Prisma, NotificationType, SubscriptionPage } from '@prisma/client';
+
+type TxClient = Prisma.TransactionClient;
+
+export async function emitNotifications(
+  tx: TxClient,
+  opts: {
+    userIds: number[];
+    type: NotificationType;
+    actorId?: number;
+    page: SubscriptionPage;
+    pageId: number;
+    postId?: number;
+  }
+): Promise<void> {
+  const recipients = opts.actorId
+    ? opts.userIds.filter((id) => id !== opts.actorId)
+    : opts.userIds;
+
+  if (recipients.length === 0) return;
+
+  await tx.notification.createMany({
+    data: recipients.map((userId) => ({
+      userId,
+      type: opts.type,
+      actorId: opts.actorId ?? null,
+      page: opts.page,
+      pageId: opts.pageId,
+      postId: opts.postId ?? null
+    })),
+    skipDuplicates: true
+  });
+}

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -873,15 +873,21 @@ const Notification = registry.register(
   'Notification',
   z.object({
     id: z.number(),
+    type: z.string(),
+    actorId: z.number().nullable().optional(),
+    actor: z
+      .object({
+        id: z.number(),
+        username: z.string(),
+        avatar: z.string().nullable().optional()
+      })
+      .nullable()
+      .optional(),
     page: z.string(),
     pageId: z.number(),
-    postId: z.number(),
+    postId: z.number().nullable().optional(),
+    readAt: z.string().nullable().optional(),
     createdAt: z.string(),
-    quoter: z.object({
-      id: z.number(),
-      username: z.string(),
-      avatar: z.string().nullable().optional()
-    }),
     source: z
       .object({ title: z.string(), forumId: z.number().optional() })
       .nullable()

--- a/src/modules/forum.spec.ts
+++ b/src/modules/forum.spec.ts
@@ -188,14 +188,16 @@ describe('createPost', () => {
       data: [
         {
           userId: 9,
-          quoterId: 7,
+          type: 'forum_sub',
+          actorId: 7,
           page: 'forums',
           pageId: 44,
           postId: 31
         },
         {
           userId: 11,
-          quoterId: 7,
+          type: 'forum_sub',
+          actorId: 7,
           page: 'forums',
           pageId: 44,
           postId: 31

--- a/src/modules/forum.ts
+++ b/src/modules/forum.ts
@@ -110,7 +110,8 @@ export const createPost = async (
       await tx.notification.createMany({
         data: notifyUserIds.map((uid) => ({
           userId: uid,
-          quoterId: authorId,
+          type: 'forum_sub' as const,
+          actorId: authorId,
           page: 'forums' as const,
           pageId: forumTopicId,
           postId: post.id

--- a/src/modules/requests.spec.ts
+++ b/src/modules/requests.spec.ts
@@ -31,7 +31,8 @@ const mockTx = {
   economyTransaction: { create: jest.fn() },
   requestAction: { create: jest.fn() },
   requestFill: { create: jest.fn() },
-  contribution: { findUnique: jest.fn() }
+  contribution: { findUnique: jest.fn() },
+  notification: { createMany: jest.fn() }
 };
 
 const mockTransaction = jest.fn();
@@ -438,6 +439,97 @@ describe('fillRequest', () => {
         data: expect.objectContaining({ action: 'FILL' })
       })
     );
+  });
+
+  it('notifies requester and bounty holders, excluding the filler', async () => {
+    // makeRequest(): userId=1, bounties=[{userId:1}]
+    // filler is userId=1 → should be excluded (actor === recipient)
+    const requestWithBounties = makeRequest({
+      userId: 2, // requester
+      bounties: [
+        {
+          id: 1,
+          requestId: 10,
+          userId: 2,
+          amount: BigInt('209715200'),
+          createdAt: new Date()
+        },
+        {
+          id: 2,
+          requestId: 10,
+          userId: 3,
+          amount: BigInt('104857600'),
+          createdAt: new Date()
+        }
+      ]
+    });
+    mockTx.contribution.findUnique.mockResolvedValue(makeContribution());
+    mockTx.request.findUnique
+      .mockResolvedValueOnce(requestWithBounties)
+      .mockResolvedValueOnce({
+        ...requestWithBounties,
+        status: 'filled',
+        fillerId: 1
+      });
+    mockTx.request.findFirst.mockResolvedValue(null);
+    mockTx.request.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('1073741824')
+    });
+    mockTx.user.update.mockResolvedValue(undefined);
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.requestFill.create.mockResolvedValue(undefined);
+    mockTx.requestAction.create.mockResolvedValue(undefined);
+    mockTx.notification.createMany.mockResolvedValue({ count: 2 });
+
+    await fillRequest(1, 10, 5); // filler = userId 1
+
+    expect(mockTx.notification.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ userId: 2, type: 'request_filled' }),
+          expect.objectContaining({ userId: 3, type: 'request_filled' })
+        ]),
+        skipDuplicates: true
+      })
+    );
+    const notifData = (mockTx.notification.createMany as jest.Mock).mock
+      .calls[0][0].data as { userId: number }[];
+    expect(notifData.map((d) => d.userId)).not.toContain(1); // filler excluded
+  });
+
+  it('emits no notification when filler is the only interested party', async () => {
+    const selfRequest = makeRequest({
+      userId: 1,
+      bounties: [
+        {
+          id: 1,
+          requestId: 10,
+          userId: 1,
+          amount: BigInt('209715200'),
+          createdAt: new Date()
+        }
+      ]
+    });
+    mockTx.contribution.findUnique.mockResolvedValue(makeContribution());
+    mockTx.request.findUnique
+      .mockResolvedValueOnce(selfRequest)
+      .mockResolvedValueOnce({ ...selfRequest, status: 'filled', fillerId: 1 });
+    mockTx.request.findFirst.mockResolvedValue(null);
+    mockTx.request.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('1073741824')
+    });
+    mockTx.user.update.mockResolvedValue(undefined);
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.requestFill.create.mockResolvedValue(undefined);
+    mockTx.requestAction.create.mockResolvedValue(undefined);
+
+    await fillRequest(1, 10, 5); // filler = userId 1 = requester
+
+    expect(mockTx.notification.createMany).not.toHaveBeenCalled();
   });
 });
 

--- a/src/modules/requests.ts
+++ b/src/modules/requests.ts
@@ -4,6 +4,7 @@ import { AppError } from '../lib/errors';
 import { economy } from './config';
 import { computeRatio } from './ratio';
 import { CreateRequestInput } from '../schemas/requests';
+import { emitNotifications } from '../lib/notifications';
 
 export const MINIMUM_BOUNTY = BigInt(economy.minimumBounty);
 
@@ -355,6 +356,20 @@ export async function fillRequest(
           awardedAmount: totalBounty.toString()
         }
       }
+    });
+
+    // Notify requester + all bounty contributors (excluding the filler)
+    const interestedUserIds = [
+      request.userId,
+      ...request.bounties.map((b) => b.userId)
+    ];
+    const uniqueIds = [...new Set(interestedUserIds)];
+    await emitNotifications(tx, {
+      userIds: uniqueIds,
+      type: 'request_filled',
+      actorId: userId,
+      page: 'requests',
+      pageId: requestId
     });
 
     const filled = await tx.request.findUnique({

--- a/src/notifications.spec.ts
+++ b/src/notifications.spec.ts
@@ -8,13 +8,14 @@ import {
 const makeNotif = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
   userId: 7,
-  quoterId: 10,
+  type: 'forum_sub',
+  actorId: 10,
   page: 'forums',
   pageId: 5,
   postId: 3,
   readAt: null,
   createdAt: new Date('2026-01-01'),
-  quoter: { id: 10, username: 'alice', avatar: null },
+  actor: { id: 10, username: 'alice', avatar: null },
   ...overrides
 });
 

--- a/src/routes/api/collages.ts
+++ b/src/routes/api/collages.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
 import { prisma } from '../../lib/prisma';
+import { emitNotifications } from '../../lib/notifications';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
 import {
@@ -444,8 +445,8 @@ router.post(
     });
     const nextSort = (maxSort._max.sort ?? 0) + 10;
 
-    const [entry] = await prisma.$transaction([
-      prisma.collageEntry.create({
+    const entry = await prisma.$transaction(async (tx) => {
+      const created = await tx.collageEntry.create({
         data: { collageId: id, releaseId, userId, sort: nextSort },
         include: {
           release: {
@@ -460,12 +461,26 @@ router.post(
           },
           user: { select: { id: true, username: true } }
         }
-      }),
-      prisma.collage.update({
+      });
+      await tx.collage.update({
         where: { id },
         data: { numEntries: { increment: 1 } }
-      })
-    ]);
+      });
+
+      const subs = await tx.collageSubscription.findMany({
+        where: { collageId: id },
+        select: { userId: true }
+      });
+      await emitNotifications(tx, {
+        userIds: subs.map((s) => s.userId),
+        type: 'collage_updated',
+        actorId: userId,
+        page: 'collages',
+        pageId: id
+      });
+
+      return created;
+    });
 
     res.status(201).json(entry);
   })

--- a/src/routes/api/comments.ts
+++ b/src/routes/api/comments.ts
@@ -1,7 +1,8 @@
 import express, { Request, Response } from 'express';
-import { CommentPage } from '@prisma/client';
+import { CommentPage, SubscriptionPage } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../lib/prisma';
+import { emitNotifications } from '../../lib/notifications';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
 import { isModerator } from '../../middleware/permissions';
@@ -100,22 +101,57 @@ router.post(
       collageId
     } = parsedBody<CreateCommentInput>(res);
 
-    const comment = await prisma.comment.create({
-      data: {
-        page,
-        body: sanitizeHtml(body),
-        authorId: req.user.id,
-        ...(communityId && { communityId }),
-        ...(contributionId && { contributionId }),
-        ...(requestId && { requestId }),
-        ...(artistId && { artistId }),
-        ...(releaseId && { releaseId }),
-        ...(collageId && { collageId })
-      },
-      include: {
-        author: { select: { id: true, username: true, avatar: true } }
+    // Map CommentPage + entity FK to SubscriptionPage + pageId for notification lookup
+    const subPageMap: Partial<
+      Record<
+        CommentPage,
+        { subPage: SubscriptionPage; pageId: number | undefined }
+      >
+    > = {
+      requests: { subPage: 'requests', pageId: requestId },
+      artist: { subPage: 'artist', pageId: artistId },
+      collages: { subPage: 'collages', pageId: collageId },
+      communities: { subPage: 'communities', pageId: communityId }
+    };
+    const subTarget = subPageMap[page];
+
+    const comment = await prisma.$transaction(async (tx) => {
+      const created = await tx.comment.create({
+        data: {
+          page,
+          body: sanitizeHtml(body),
+          authorId: req.user.id,
+          ...(communityId && { communityId }),
+          ...(contributionId && { contributionId }),
+          ...(requestId && { requestId }),
+          ...(artistId && { artistId }),
+          ...(releaseId && { releaseId }),
+          ...(collageId && { collageId })
+        },
+        include: {
+          author: { select: { id: true, username: true, avatar: true } }
+        }
+      });
+
+      if (subTarget?.pageId) {
+        const subs = await tx.commentSubscription.findMany({
+          where: { page: subTarget.subPage, pageId: subTarget.pageId },
+          select: { userId: true }
+        });
+        if (subs.length > 0) {
+          await emitNotifications(tx, {
+            userIds: subs.map((s) => s.userId),
+            type: 'comment_sub',
+            actorId: req.user.id,
+            page: subTarget.subPage,
+            pageId: subTarget.pageId
+          });
+        }
       }
+
+      return created;
     });
+
     res.status(201).json(comment);
   })
 );

--- a/src/routes/api/notifications.ts
+++ b/src/routes/api/notifications.ts
@@ -58,7 +58,7 @@ router.get(
       orderBy: { createdAt: 'desc' },
       take: 50,
       include: {
-        quoter: { select: { id: true, username: true, avatar: true } }
+        actor: { select: { id: true, username: true, avatar: true } }
       }
     });
 

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -343,6 +343,9 @@ export const resetApiTestState = (): void => {
     ) => callback(null, 'signed-jwt')
   );
   prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+  prismaMock.commentSubscription.findMany.mockResolvedValue([]);
+  prismaMock.collageSubscription.findMany.mockResolvedValue([]);
+  prismaMock.notification.createMany.mockResolvedValue({ count: 0 });
   prismaMock.siteSettings.upsert.mockResolvedValue({
     id: 1,
     approvedDomains: [],
@@ -353,11 +356,7 @@ export const resetApiTestState = (): void => {
   });
   prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
     if (typeof arg === 'function') {
-      return arg({
-        userSettings: prismaMock.userSettings,
-        profile: prismaMock.profile,
-        user: prismaMock.user
-      });
+      return arg(prismaMock);
     }
     return Promise.all(arg as Promise<unknown>[]);
   });

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -281,7 +281,8 @@ export function makeNotification(
   return {
     id: 8,
     userId: TEST_USER_ID,
-    quoterId: 99,
+    type: 'forum_sub' as const,
+    actorId: 99,
     page: SubscriptionPage.forums,
     pageId: 1,
     postId: 1,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5946,15 +5946,18 @@ export interface components {
     };
     Notification: {
       id: number;
-      page: string;
-      pageId: number;
-      postId: number;
-      createdAt: string;
-      quoter: {
+      type: string;
+      actorId?: number | null;
+      actor?: {
         id: number;
         username: string;
         avatar?: string | null;
-      };
+      } | null;
+      page: string;
+      pageId: number;
+      postId?: number | null;
+      readAt?: string | null;
+      createdAt: string;
       source?: {
         title: string;
         forumId?: number;


### PR DESCRIPTION
## Summary

**Notification event system (generalized schema + event emission)**
- Add `NotificationType` enum (`forum_quote`, `forum_sub`, `request_filled`, `collage_updated`, `comment_sub`) to Prisma schema
- Rename `quoterId` → `actorId` (nullable) and make `postId` nullable so non-quote events can be stored
- Add `src/lib/notifications.ts` — `emitNotifications(tx, opts)` helper; filters actor from recipient list, inserts inside the caller's transaction
- Wire events at all three new emission sites: `fillRequest` notifies requester + bounty holders, collage entry creation notifies subscribers, comment creation notifies comment subscribers
- Update `forum.ts` subscription notifications to use `actorId` + `type: 'forum_sub'`
- Update `notifications.ts` route to include `actor` relation instead of `quoter`
- Update OpenAPI schema and generated API types to match new Notification shape
- Fix all stale `quoterId` / `quoter` references in specs and factories

**Preserve notification actors during migration**
- Backfill `actorId` from `quoterId` before dropping the legacy column so existing notifications retain their actor reference
- Drop `quoterId` only after the backfill is confirmed safe for existing databases

## Test plan
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run format && npm run lint` — clean
- [ ] `npm run test --no-coverage` — 1018/1018 passing
- [ ] Smoke: create forum post → subscribers receive notification
- [ ] Smoke: fill a request as a different user → requester receives `request_filled` notification
- [ ] Smoke: add collage entry → subscribers receive `collage_updated` notification
- [ ] Smoke: existing `quoterId` rows in notifications table retain actor after migration