### PR TITLE
Artist subscriptions, comment subscriptions, and notification improvements

### DIFF
--- a/prisma/migrations/20260520173910_20260520183000_add_dismissed_launch_checklist_to_site_settings/migration.sql
+++ b/prisma/migrations/20260520173910_20260520183000_add_dismissed_launch_checklist_to_site_settings/migration.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "site_settings"
-ADD COLUMN "dismissedLaunchChecklist" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/migrations/20260520183000_add_dismissed_launch_checklist_to_site_settings/migration.sql
+++ b/prisma/migrations/20260520183000_add_dismissed_launch_checklist_to_site_settings/migration.sql
@@ -1,2 +1,3 @@
 -- AlterTable
+ALTER TABLE "site_settings" ADD COLUMN "dismissedLaunchChecklist" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
 ALTER TABLE "site_settings" ALTER COLUMN "dismissedLaunchChecklist" DROP DEFAULT;

--- a/prisma/migrations/20260521010505_artist_subscription_notification/migration.sql
+++ b/prisma/migrations/20260521010505_artist_subscription_notification/migration.sql
@@ -1,0 +1,24 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'artist_release';
+
+-- CreateTable
+CREATE TABLE "artist_subscriptions" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "artistId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "artist_subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "artist_subscriptions_artistId_idx" ON "artist_subscriptions"("artistId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "artist_subscriptions_userId_artistId_key" ON "artist_subscriptions"("userId", "artistId");
+
+-- AddForeignKey
+ALTER TABLE "artist_subscriptions" ADD CONSTRAINT "artist_subscriptions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "artist_subscriptions" ADD CONSTRAINT "artist_subscriptions_artistId_fkey" FOREIGN KEY ("artistId") REFERENCES "artists"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260521030000_add_contributions_subscription_page/migration.sql
+++ b/prisma/migrations/20260521030000_add_contributions_subscription_page/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SubscriptionPage" ADD VALUE 'contributions';

--- a/prisma/migrations/20260521040000_add_release_subscription_page/migration.sql
+++ b/prisma/migrations/20260521040000_add_release_subscription_page/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SubscriptionPage" ADD VALUE 'release';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,7 @@ enum SubscriptionPage {
   collages
   requests
   communities
+  contributions
 }
 
 enum NotificationType {
@@ -108,6 +109,7 @@ enum NotificationType {
   request_filled
   collage_updated
   comment_sub
+  artist_release
 }
 
 enum ThreadType {
@@ -343,6 +345,7 @@ model User {
   bookmarkRequests      BookmarkRequest[]
   subscriptions         Subscription[]
   commentSubscriptions  CommentSubscription[]
+  artistSubscriptions   ArtistSubscription[]
   notifications         Notification[]        @relation("NotificationUser")
   actedNotifications    Notification[]        @relation("NotificationActor")
   blogs                 Blog[]
@@ -653,6 +656,7 @@ model Artist {
   bookmarks      BookmarkArtist[]
   comments       Comment[]
   RequestArtist  RequestArtist[]
+  subscriptions  ArtistSubscription[]
 
   @@map("artists")
 }
@@ -694,6 +698,19 @@ model ArtistTag {
   @@unique([artistId, tagId])
   @@index([artistId])
   @@map("artist_tags")
+}
+
+model ArtistSubscription {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  artistId  Int
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  artist    Artist   @relation(fields: [artistId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+
+  @@unique([userId, artistId])
+  @@index([artistId])
+  @@map("artist_subscriptions")
 }
 
 model Concert {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,7 @@ enum SubscriptionPage {
   requests
   communities
   contributions
+  release
 }
 
 enum NotificationType {

--- a/src/artist.spec.ts
+++ b/src/artist.spec.ts
@@ -224,14 +224,32 @@ describe('GET /api/artists/:id', () => {
     prismaMock.community.findMany.mockResolvedValue([{ id: 3 }] as never);
   };
 
-  it('returns an artist with community-filtered releases', async () => {
+  it('returns an artist with community-filtered releases and isSubscribed false', async () => {
     setupAccessMocks();
     prismaMock.artist.findUnique.mockResolvedValue(makeArtist() as never);
+    prismaMock.artistSubscription.findUnique.mockResolvedValue(null);
 
     const res = await request(app).get('/api/artists/1');
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Miles Davis');
+    expect(res.body.isSubscribed).toBe(false);
+  });
+
+  it('returns isSubscribed true when the user follows the artist', async () => {
+    setupAccessMocks();
+    prismaMock.artist.findUnique.mockResolvedValue(makeArtist() as never);
+    prismaMock.artistSubscription.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 7,
+      artistId: 1,
+      createdAt: new Date()
+    } as never);
+
+    const res = await request(app).get('/api/artists/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.isSubscribed).toBe(true);
   });
 
   it('returns 404 when the artist does not exist', async () => {
@@ -258,6 +276,104 @@ describe('GET /api/artists/:id', () => {
     const res = await request(app).get('/api/artists/1');
 
     expect(res.status).toBe(200);
+  });
+});
+
+// ─── GET /api/artists/:id/subscribe ──────────────────────────────────────────
+
+describe('GET /api/artists/:id/subscribe', () => {
+  it('returns subscribed false when not following', async () => {
+    const res = await request(app).get('/api/artists/1/subscribe');
+    expect(res.status).toBe(200);
+    expect(res.body.subscribed).toBe(false);
+  });
+
+  it('returns subscribed true when following', async () => {
+    prismaMock.artistSubscription.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 7,
+      artistId: 1,
+      createdAt: new Date()
+    } as never);
+
+    const res = await request(app).get('/api/artists/1/subscribe');
+
+    expect(res.status).toBe(200);
+    expect(res.body.subscribed).toBe(true);
+  });
+
+  it('returns 400 for a non-numeric id', async () => {
+    const res = await request(app).get('/api/artists/abc/subscribe');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── POST /api/artists/:id/subscribe ─────────────────────────────────────────
+
+describe('POST /api/artists/:id/subscribe', () => {
+  it('subscribes to an artist and returns subscribed true', async () => {
+    prismaMock.artist.findUnique.mockResolvedValue(makeArtist() as never);
+    prismaMock.artistSubscription.upsert.mockResolvedValue({
+      id: 1,
+      userId: 7,
+      artistId: 1,
+      createdAt: new Date()
+    } as never);
+
+    const res = await request(app).post('/api/artists/1/subscribe');
+
+    expect(res.status).toBe(200);
+    expect(res.body.subscribed).toBe(true);
+    expect(prismaMock.artistSubscription.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_artistId: { userId: 7, artistId: 1 } },
+        create: { userId: 7, artistId: 1 }
+      })
+    );
+  });
+
+  it('returns 404 when the artist does not exist', async () => {
+    prismaMock.artist.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).post('/api/artists/99/subscribe');
+
+    expect(res.status).toBe(404);
+    expect(res.body.msg).toBe('Artist not found');
+  });
+
+  it('returns 400 for a non-numeric id', async () => {
+    const res = await request(app).post('/api/artists/abc/subscribe');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── DELETE /api/artists/:id/subscribe ───────────────────────────────────────
+
+describe('DELETE /api/artists/:id/subscribe', () => {
+  it('unsubscribes and returns subscribed false', async () => {
+    prismaMock.artistSubscription.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app).delete('/api/artists/1/subscribe');
+
+    expect(res.status).toBe(200);
+    expect(res.body.subscribed).toBe(false);
+    expect(prismaMock.artistSubscription.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 7, artistId: 1 }
+    });
+  });
+
+  it('returns 200 even when no subscription existed (idempotent)', async () => {
+    prismaMock.artistSubscription.deleteMany.mockResolvedValue({ count: 0 });
+
+    const res = await request(app).delete('/api/artists/1/subscribe');
+
+    expect(res.status).toBe(200);
+    expect(res.body.subscribed).toBe(false);
+  });
+
+  it('returns 400 for a non-numeric id', async () => {
+    const res = await request(app).delete('/api/artists/abc/subscribe');
+    expect(res.status).toBe(400);
   });
 });
 

--- a/src/comments.spec.ts
+++ b/src/comments.spec.ts
@@ -286,10 +286,11 @@ describe('POST /api/comments', () => {
     expect(callData.map((d) => d.userId)).not.toContain(7);
   });
 
-  it('skips comment subscription notifications for non-subscribable pages', async () => {
+  it('checks comment subscriptions for release page', async () => {
     prismaMock.comment.create.mockResolvedValue(
       makeComment({ id: 31, page: 'release' as never, releaseId: 9 }) as never
     );
+    prismaMock.commentSubscription.findMany.mockResolvedValue([]);
 
     const res = await request(app).post('/api/comments').send({
       page: 'release',
@@ -298,8 +299,9 @@ describe('POST /api/comments', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(prismaMock.commentSubscription.findMany).not.toHaveBeenCalled();
-    expect(prismaMock.notification.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.commentSubscription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { page: 'release', pageId: 9 } })
+    );
   });
 });
 

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -299,7 +299,8 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
       id: 15,
       releaseId: 3,
       userId: 7,
-      type: FileType.flac
+      type: FileType.flac,
+      release: { id: 3, title: 'Kind of Blue', communityId: 1, artistId: 5 }
     } as never);
 
     const res = await request(app)
@@ -313,6 +314,42 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
       releaseId: 3,
       input: expect.objectContaining({ fileType: 'flac' })
     });
+  });
+
+  it('emits artist_release notifications to subscribers when contribution is added', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ allowDuplicateFormats: true }) as never
+    );
+    addContributionToReleaseMock.mockResolvedValue({
+      id: 15,
+      releaseId: 3,
+      userId: 7,
+      type: FileType.flac,
+      release: { id: 3, title: 'Kind of Blue', communityId: 1, artistId: 5 }
+    } as never);
+    prismaMock.artistSubscription.findMany.mockResolvedValue([
+      { userId: 99 }
+    ] as never);
+
+    const res = await request(app)
+      .post('/api/communities/1/releases/3/contributions')
+      .send(validPayload);
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.artistSubscription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { artistId: 5 } })
+    );
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'artist_release',
+            page: 'contributions',
+            pageId: 15
+          })
+        ])
+      })
+    );
   });
 });
 

--- a/src/content.spec.ts
+++ b/src/content.spec.ts
@@ -257,7 +257,8 @@ describe('API content and shared flows', () => {
     createContributionSubmissionMock.mockResolvedValue({
       id: 5,
       releaseId: 3,
-      userId: 7
+      userId: 7,
+      collaborators: []
     } as never);
 
     const res = await request(app)
@@ -560,5 +561,79 @@ describe('API content and shared flows', () => {
       })
     });
     expect(res.body.release.title).toBe('Test Release');
+  });
+
+  it('emits artist_release notifications to subscribers of each collaborating artist', async () => {
+    createContributionSubmissionMock.mockResolvedValue({
+      id: 12,
+      user: { id: 7, username: 'kai' },
+      release: { id: 55, title: 'Test Release', communityId: 3 },
+      collaborators: [
+        { id: 21, name: 'Miles Davis' },
+        { id: 22, name: 'John Coltrane' }
+      ],
+      releaseDescription: 'A real contribution'
+    } as Awaited<ReturnType<typeof createContributionSubmissionMock>>);
+
+    prismaMock.artistSubscription.findMany.mockResolvedValue([
+      { userId: 99 },
+      { userId: 100 }
+    ] as never);
+
+    const res = await request(app)
+      .post('/api/contributions')
+      .send({
+        communityId: 3,
+        type: 'Music',
+        title: 'Test Release',
+        year: 2024,
+        fileType: 'wav',
+        downloadUrl: 'https://example.com/download',
+        sizeInBytes: 12345,
+        collaborators: [
+          { artist: 'Miles Davis', importance: 'primary' },
+          { artist: 'John Coltrane', importance: 'secondary' }
+        ]
+      });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.artistSubscription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { artistId: { in: [21, 22] } } })
+    );
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'artist_release',
+            page: 'contributions',
+            pageId: 12
+          })
+        ])
+      })
+    );
+  });
+
+  it('skips notification emission when the contribution has no collaborators', async () => {
+    createContributionSubmissionMock.mockResolvedValue({
+      id: 13,
+      collaborators: [],
+      release: { id: 56, title: 'Solo', communityId: 3 }
+    } as never);
+
+    const res = await request(app)
+      .post('/api/contributions')
+      .send({
+        communityId: 3,
+        type: 'Music',
+        title: 'Solo',
+        year: 2024,
+        fileType: 'wav',
+        downloadUrl: 'https://example.com/download',
+        sizeInBytes: 12345,
+        collaborators: [{ artist: 'Unknown', importance: 'primary' }]
+      });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.artistSubscription.findMany).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -873,7 +873,14 @@ const Notification = registry.register(
   'Notification',
   z.object({
     id: z.number(),
-    type: z.string(),
+    type: z.enum([
+      'forum_quote',
+      'forum_sub',
+      'request_filled',
+      'collage_updated',
+      'comment_sub',
+      'artist_release'
+    ]),
     actorId: z.number().nullable().optional(),
     actor: z
       .object({
@@ -889,7 +896,12 @@ const Notification = registry.register(
     readAt: z.string().nullable().optional(),
     createdAt: z.string(),
     source: z
-      .object({ title: z.string(), forumId: z.number().optional() })
+      .object({
+        title: z.string(),
+        forumId: z.number().optional(),
+        releaseId: z.number().optional(),
+        communityId: z.number().optional()
+      })
       .nullable()
       .optional()
   })
@@ -2333,7 +2345,8 @@ const Artist = registry.register(
             .optional()
         })
       )
-      .optional()
+      .optional(),
+    isSubscribed: z.boolean().optional()
   })
 );
 
@@ -2450,6 +2463,61 @@ registry.registerPath({
     404: {
       description: 'Not found',
       content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/artists/{id}/subscribe',
+  tags: ['Artists'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Subscription status',
+      content: {
+        'application/json': {
+          schema: z.object({ subscribed: z.boolean() })
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/artists/{id}/subscribe',
+  tags: ['Artists'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Subscribed',
+      content: {
+        'application/json': {
+          schema: z.object({ subscribed: z.boolean() })
+        }
+      }
+    },
+    404: {
+      description: 'Artist not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/artists/{id}/subscribe',
+  tags: ['Artists'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Unsubscribed',
+      content: {
+        'application/json': {
+          schema: z.object({ subscribed: z.boolean() })
+        }
+      }
     }
   }
 });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1165,6 +1165,25 @@ registry.registerPath({
   }
 });
 
+registry.registerPath({
+  method: 'get',
+  path: '/subscriptions/comment-status',
+  tags: ['Subscriptions'],
+  request: {
+    query: subscribeCommentsSchema.omit({ action: true })
+  },
+  responses: {
+    200: {
+      description: 'Comment subscription status',
+      content: {
+        'application/json': {
+          schema: z.object({ subscribed: z.boolean() })
+        }
+      }
+    }
+  }
+});
+
 // ─── Forums ───────────────────────────────────────────────────────────────────
 
 const Forum = registry.register(

--- a/src/modules/contribution.ts
+++ b/src/modules/contribution.ts
@@ -227,7 +227,9 @@ export const addContributionToRelease = async ({
           createdAt: true,
           updatedAt: true,
           user: { select: { id: true, username: true } },
-          release: { select: { id: true, title: true, communityId: true } },
+          release: {
+            select: { id: true, title: true, communityId: true, artistId: true }
+          },
           collaborators: { select: { id: true, name: true } }
         }
       });

--- a/src/routes/api/comments.ts
+++ b/src/routes/api/comments.ts
@@ -108,10 +108,12 @@ router.post(
         { subPage: SubscriptionPage; pageId: number | undefined }
       >
     > = {
+      release: { subPage: 'release', pageId: releaseId },
       requests: { subPage: 'requests', pageId: requestId },
       artist: { subPage: 'artist', pageId: artistId },
       collages: { subPage: 'collages', pageId: collageId },
-      communities: { subPage: 'communities', pageId: communityId }
+      communities: { subPage: 'communities', pageId: communityId },
+      contributions: { subPage: 'contributions', pageId: contributionId }
     };
     const subTarget = subPageMap[page];
 

--- a/src/routes/api/communities/artist.ts
+++ b/src/routes/api/communities/artist.ts
@@ -154,6 +154,52 @@ router.post(
   })
 );
 
+// GET /api/artists/:id/subscribe
+router.get(
+  '/:id/subscribe',
+  requireAuth,
+  validateParams(artistIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const sub = await prisma.artistSubscription.findUnique({
+      where: { userId_artistId: { userId: req.user.id, artistId: id } }
+    });
+    res.json({ subscribed: sub !== null });
+  })
+);
+
+// POST /api/artists/:id/subscribe
+router.post(
+  '/:id/subscribe',
+  requireAuth,
+  validateParams(artistIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const artist = await prisma.artist.findUnique({ where: { id } });
+    if (!artist) return res.status(404).json({ msg: 'Artist not found' });
+    await prisma.artistSubscription.upsert({
+      where: { userId_artistId: { userId: req.user.id, artistId: id } },
+      create: { userId: req.user.id, artistId: id },
+      update: {}
+    });
+    res.json({ subscribed: true });
+  })
+);
+
+// DELETE /api/artists/:id/subscribe
+router.delete(
+  '/:id/subscribe',
+  requireAuth,
+  validateParams(artistIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    await prisma.artistSubscription.deleteMany({
+      where: { userId: req.user.id, artistId: id }
+    });
+    res.json({ subscribed: false });
+  })
+);
+
 // GET /api/artists/:id
 router.get(
   '/:id',
@@ -185,25 +231,30 @@ router.get(
     ];
     const accessibleCommunityIds = [...new Set(accessibleIds)];
 
-    const artist = await prisma.artist.findUnique({
-      where: { id },
-      include: {
-        aliases: {
-          include: { redirect: { select: { id: true, name: true } } }
-        },
-        tags: { include: { tag: true } },
-        similarTo: {
-          include: { similarArtist: { select: { id: true, name: true } } }
-        },
-        releases: {
-          where: { communityId: { in: accessibleCommunityIds } },
-          include: { community: { select: { id: true, name: true } } },
-          orderBy: [{ year: 'desc' }, { title: 'asc' }]
+    const [artist, subscription] = await Promise.all([
+      prisma.artist.findUnique({
+        where: { id },
+        include: {
+          aliases: {
+            include: { redirect: { select: { id: true, name: true } } }
+          },
+          tags: { include: { tag: true } },
+          similarTo: {
+            include: { similarArtist: { select: { id: true, name: true } } }
+          },
+          releases: {
+            where: { communityId: { in: accessibleCommunityIds } },
+            include: { community: { select: { id: true, name: true } } },
+            orderBy: [{ year: 'desc' }, { title: 'asc' }]
+          }
         }
-      }
-    });
+      }),
+      prisma.artistSubscription.findUnique({
+        where: { userId_artistId: { userId: req.user.id, artistId: id } }
+      })
+    ]);
     if (!artist) return res.status(404).json({ msg: 'Artist not found' });
-    res.json(artist);
+    res.json({ ...artist, isSubscribed: subscription !== null });
   })
 );
 

--- a/src/routes/api/communities/contributions.ts
+++ b/src/routes/api/communities/contributions.ts
@@ -5,6 +5,7 @@ import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { createContributionSubmission } from '../../../modules/contribution';
 import { fileReport } from '../../../modules/reports';
 import { recordContributionReport } from '../../../modules/linkHealth';
+import { emitNotifications } from '../../../lib/notifications';
 import { requireAuth } from '../../../middleware/auth';
 import {
   parsedBody,
@@ -32,10 +33,12 @@ const reportSchema = z.object({
 router.get(
   '/',
   requireAuth,
-  asyncHandler(async (req: Request, res: Response) => {
+  authHandler(async (req, res) => {
     const pg = parsePage(req);
+    const where = { userId: req.user.id };
     const [contributions, total] = await Promise.all([
       prisma.contribution.findMany({
+        where,
         skip: pg.skip,
         take: pg.limit,
         select: {
@@ -62,7 +65,7 @@ router.get(
           collaborators: { select: { id: true, name: true } }
         }
       }),
-      prisma.contribution.count()
+      prisma.contribution.count({ where })
     ]);
     paginatedResponse(res, contributions, total, pg);
   })
@@ -140,6 +143,26 @@ router.post(
     });
     if (!contribution)
       return res.status(404).json({ msg: 'Community not found' });
+
+    const artistIds = contribution.collaborators.map((c) => c.id);
+    if (artistIds.length > 0) {
+      await prisma.$transaction(async (tx) => {
+        const subs = await tx.artistSubscription.findMany({
+          where: { artistId: { in: artistIds } },
+          select: { userId: true }
+        });
+        const userIds = [...new Set(subs.map((s) => s.userId))];
+        if (userIds.length > 0) {
+          await emitNotifications(tx, {
+            userIds,
+            type: 'artist_release',
+            actorId: req.user.id,
+            page: 'contributions',
+            pageId: contribution.id
+          });
+        }
+      });
+    }
 
     res.status(201).json(contribution);
   })

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -26,6 +26,7 @@ import {
   type AddContributionToReleaseInput
 } from '../../../schemas/contribution';
 import { addContributionToRelease } from '../../../modules/contribution';
+import { emitNotifications } from '../../../lib/notifications';
 import { recomputeVoteAggregate } from '../../../modules/top10';
 import { getSettings } from '../../../modules/settings';
 import { FileType } from '@prisma/client';
@@ -294,6 +295,23 @@ router.post(
     });
     if (!contribution)
       return res.status(404).json({ msg: 'Release not found' });
+
+    await prisma.$transaction(async (tx) => {
+      const subs = await tx.artistSubscription.findMany({
+        where: { artistId: contribution.release.artistId },
+        select: { userId: true }
+      });
+      if (subs.length > 0) {
+        await emitNotifications(tx, {
+          userIds: subs.map((s) => s.userId),
+          type: 'artist_release',
+          actorId: req.user.id,
+          page: 'contributions',
+          pageId: contribution.id
+        });
+      }
+    });
+
     res.status(201).json(contribution);
   })
 );

--- a/src/routes/api/notifications.ts
+++ b/src/routes/api/notifications.ts
@@ -10,7 +10,12 @@ const notificationIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
 
-type NotificationSource = { title: string; forumId?: number } | null;
+type NotificationSource = {
+  title: string;
+  forumId?: number;
+  releaseId?: number;
+  communityId?: number;
+} | null;
 
 function groupIds(
   notifications: { page: string; pageId: number }[],
@@ -67,8 +72,9 @@ router.get(
     const collageIds = groupIds(notifications, 'collages');
     const requestIds = groupIds(notifications, 'requests');
     const communityIds = groupIds(notifications, 'communities');
+    const contributionIds = groupIds(notifications, 'contributions');
 
-    const [topics, artists, collages, requests, communities] =
+    const [topics, artists, collages, requests, communities, contributions] =
       await Promise.all([
         forumIds.length > 0
           ? prisma.forumTopic.findMany({
@@ -99,6 +105,17 @@ router.get(
               where: { id: { in: communityIds } },
               select: { id: true, name: true }
             })
+          : [],
+        contributionIds.length > 0
+          ? prisma.contribution.findMany({
+              where: { id: { in: contributionIds } },
+              select: {
+                id: true,
+                release: {
+                  select: { id: true, title: true, communityId: true }
+                }
+              }
+            })
           : []
       ]);
 
@@ -107,6 +124,9 @@ router.get(
     const collageMap = new Map(collages.map((c) => [c.id, c]));
     const requestMap = new Map(requests.map((r) => [r.id, r]));
     const communityMap = new Map(communities.map((c) => [c.id, c]));
+    const contributionMap = new Map(
+      (contributions as { id: number; release: { id: number; title: string; communityId: number | null } }[]).map((c) => [c.id, c])
+    );
 
     const enriched = notifications.map((n) => {
       let source: NotificationSource = null;
@@ -125,6 +145,15 @@ router.get(
       } else if (n.page === 'communities') {
         const c = communityMap.get(n.pageId);
         source = c ? { title: c.name } : null;
+      } else if (n.page === 'contributions') {
+        const c = contributionMap.get(n.pageId);
+        source = c
+          ? {
+              title: c.release.title,
+              releaseId: c.release.id,
+              communityId: c.release.communityId ?? undefined
+            }
+          : null;
       }
       return { ...n, source };
     });

--- a/src/routes/api/notifications.ts
+++ b/src/routes/api/notifications.ts
@@ -73,51 +73,65 @@ router.get(
     const requestIds = groupIds(notifications, 'requests');
     const communityIds = groupIds(notifications, 'communities');
     const contributionIds = groupIds(notifications, 'contributions');
+    const releaseIds = groupIds(notifications, 'release');
 
-    const [topics, artists, collages, requests, communities, contributions] =
-      await Promise.all([
-        forumIds.length > 0
-          ? prisma.forumTopic.findMany({
-              where: { id: { in: forumIds } },
-              select: { id: true, forumId: true, title: true }
-            })
-          : [],
-        artistIds.length > 0
-          ? prisma.artist.findMany({
-              where: { id: { in: artistIds } },
-              select: { id: true, name: true }
-            })
-          : [],
-        collageIds.length > 0
-          ? prisma.collage.findMany({
-              where: { id: { in: collageIds } },
-              select: { id: true, name: true }
-            })
-          : [],
-        requestIds.length > 0
-          ? prisma.request.findMany({
-              where: { id: { in: requestIds } },
-              select: { id: true, title: true }
-            })
-          : [],
-        communityIds.length > 0
-          ? prisma.community.findMany({
-              where: { id: { in: communityIds } },
-              select: { id: true, name: true }
-            })
-          : [],
-        contributionIds.length > 0
-          ? prisma.contribution.findMany({
-              where: { id: { in: contributionIds } },
-              select: {
-                id: true,
-                release: {
-                  select: { id: true, title: true, communityId: true }
-                }
+    const [
+      topics,
+      artists,
+      collages,
+      requests,
+      communities,
+      contributions,
+      releases
+    ] = await Promise.all([
+      forumIds.length > 0
+        ? prisma.forumTopic.findMany({
+            where: { id: { in: forumIds } },
+            select: { id: true, forumId: true, title: true }
+          })
+        : [],
+      artistIds.length > 0
+        ? prisma.artist.findMany({
+            where: { id: { in: artistIds } },
+            select: { id: true, name: true }
+          })
+        : [],
+      collageIds.length > 0
+        ? prisma.collage.findMany({
+            where: { id: { in: collageIds } },
+            select: { id: true, name: true }
+          })
+        : [],
+      requestIds.length > 0
+        ? prisma.request.findMany({
+            where: { id: { in: requestIds } },
+            select: { id: true, title: true }
+          })
+        : [],
+      communityIds.length > 0
+        ? prisma.community.findMany({
+            where: { id: { in: communityIds } },
+            select: { id: true, name: true }
+          })
+        : [],
+      contributionIds.length > 0
+        ? prisma.contribution.findMany({
+            where: { id: { in: contributionIds } },
+            select: {
+              id: true,
+              release: {
+                select: { id: true, title: true, communityId: true }
               }
-            })
-          : []
-      ]);
+            }
+          })
+        : [],
+      releaseIds.length > 0
+        ? prisma.release.findMany({
+            where: { id: { in: releaseIds } },
+            select: { id: true, title: true, communityId: true }
+          })
+        : []
+    ]);
 
     const topicMap = new Map(topics.map((t) => [t.id, t]));
     const artistMap = new Map(artists.map((a) => [a.id, a]));
@@ -125,7 +139,17 @@ router.get(
     const requestMap = new Map(requests.map((r) => [r.id, r]));
     const communityMap = new Map(communities.map((c) => [c.id, c]));
     const contributionMap = new Map(
-      (contributions as { id: number; release: { id: number; title: string; communityId: number | null } }[]).map((c) => [c.id, c])
+      (
+        contributions as {
+          id: number;
+          release: { id: number; title: string; communityId: number | null };
+        }[]
+      ).map((c) => [c.id, c])
+    );
+    const releaseMap = new Map(
+      (
+        releases as { id: number; title: string; communityId: number | null }[]
+      ).map((r) => [r.id, r])
     );
 
     const enriched = notifications.map((n) => {
@@ -152,6 +176,15 @@ router.get(
               title: c.release.title,
               releaseId: c.release.id,
               communityId: c.release.communityId ?? undefined
+            }
+          : null;
+      } else if (n.page === 'release') {
+        const r = releaseMap.get(n.pageId);
+        source = r
+          ? {
+              title: r.title,
+              releaseId: r.id,
+              communityId: r.communityId ?? undefined
             }
           : null;
       }

--- a/src/routes/api/subscriptions.ts
+++ b/src/routes/api/subscriptions.ts
@@ -1,14 +1,23 @@
 import express from 'express';
+import { z } from 'zod';
+import { SubscriptionPage } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
-import { validate, parsedBody } from '../../middleware/validate';
+import { validate, parsedBody, validateQuery } from '../../middleware/validate';
 import {
   subscribeSchema,
   subscribeCommentsSchema,
   type SubscribeInput,
   type SubscribeCommentsInput
 } from '../../schemas/subscription';
+
+const commentStatusQuerySchema = z.object({
+  page: z.enum(
+    Object.values(SubscriptionPage) as [SubscriptionPage, ...SubscriptionPage[]]
+  ),
+  pageId: z.coerce.number().int().positive()
+});
 
 const router = express.Router();
 
@@ -46,6 +55,23 @@ router.get(
       take: 100
     });
     res.json(subscriptions);
+  })
+);
+
+// GET /api/subscriptions/comment-status
+router.get(
+  '/comment-status',
+  requireAuth,
+  validateQuery(commentStatusQuerySchema),
+  authHandler(async (req, res) => {
+    const { page, pageId } = res.locals.parsedQuery as {
+      page: SubscriptionPage;
+      pageId: number;
+    };
+    const sub = await prisma.commentSubscription.findUnique({
+      where: { userId_page_pageId: { userId: req.user.id, page, pageId } }
+    });
+    res.json({ subscribed: !!sub });
   })
 );
 

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -345,6 +345,8 @@ export const resetApiTestState = (): void => {
   prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
   prismaMock.commentSubscription.findMany.mockResolvedValue([]);
   prismaMock.collageSubscription.findMany.mockResolvedValue([]);
+  prismaMock.artistSubscription.findMany.mockResolvedValue([]);
+  prismaMock.artistSubscription.findUnique.mockResolvedValue(null);
   prismaMock.notification.createMany.mockResolvedValue({ count: 0 });
   prismaMock.siteSettings.upsert.mockResolvedValue({
     id: 1,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5946,7 +5946,13 @@ export interface components {
     };
     Notification: {
       id: number;
-      type: string;
+      type:
+        | 'forum_quote'
+        | 'forum_sub'
+        | 'request_filled'
+        | 'collage_updated'
+        | 'comment_sub'
+        | 'artist_release';
       actorId?: number | null;
       actor?: {
         id: number;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1318,7 +1318,14 @@ export interface paths {
         content: {
           'application/json': {
             /** @enum {string} */
-            page: 'forums' | 'artist' | 'collages' | 'requests' | 'communities';
+            page:
+              | 'forums'
+              | 'artist'
+              | 'collages'
+              | 'requests'
+              | 'communities'
+              | 'contributions'
+              | 'release';
             pageId: number;
             /** @enum {string} */
             action: 'subscribe' | 'unsubscribe';
@@ -1335,6 +1342,54 @@ export interface paths {
         };
       };
     };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/subscriptions/comment-status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query: {
+          /** @enum {string} */
+          page:
+            | 'forums'
+            | 'artist'
+            | 'collages'
+            | 'requests'
+            | 'communities'
+            | 'contributions'
+            | 'release';
+          pageId: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Comment subscription status */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              subscribed: boolean;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;


### PR DESCRIPTION
## Summary

- **Artist follow**: Subscribe/Unsubscribe button on artist pages; `ArtistSubscription` model; new-contribution notifications emitted to followers (`artist_release` type)
- **Comment subscriptions**: Subscribe checkbox in `CommentsSection` on all pages (artist, collages, communities, contributions, requests, release); `release` added to `SubscriptionPage` enum
- **Release page subscribe button**: Dedicated Subscribe/Unsubscribe action in the release page action row (next to Bookmark); hides the in-form checkbox when already subscribed
- **Notification rendering**: `artist_release` and `comment_sub` for release/contribution pages rendered correctly with links to the release
- **Auth cache hardening**: `resetApiState()` on login to flush stale cross-user cache
- **Security fix**: `GET /api/contributions` scoped to the authenticated user's own contributions
- **New endpoint**: `GET /subscriptions/comment-status` for reading current comment subscription state

## Test plan

- [ ] Subscribe to an artist → create a contribution for a release linked to that artist → bell shows `artist_release` notification → clicking it navigates to the release page
- [ ] Unsubscribe from artist → create another contribution → no notification received
- [ ] On a release page: click Subscribe → button changes to Unsubscribe, in-form checkbox disappears → click Unsubscribe → button reverts, checkbox reappears
- [ ] Post a comment while subscribe checkbox is checked → subsequent comment by another user triggers a `comment_sub` notification
- [ ] Verify `GET /api/contributions` only returns the logged-in user's contributions
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run test --no-coverage` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)