### PR TITLE
Forum edit history and staff post editing

### DIFF
--- a/src/forum.spec.ts
+++ b/src/forum.spec.ts
@@ -798,8 +798,37 @@ describe('POST /api/forums/:forumId/topics/:forumTopicId/posts — error paths',
 
 // ─── PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id (403) ───────────
 
-describe('PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id — 403', () => {
+describe('PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
+  it('allows moderators to edit another user post', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ forums_moderate: true })
+    );
+    prismaMock.forumPost.findFirst.mockResolvedValue(
+      makeForumPost({ id: 21, authorId: 99, body: 'Old body' })
+    );
+    updatePostMock.mockResolvedValue(
+      makeForumPost({
+        id: 21,
+        authorId: 99,
+        body: 'Edited by mod'
+      }) as Awaited<ReturnType<typeof updatePost>>
+    );
+
+    const res = await request(app)
+      .put('/api/forums/9/topics/44/posts/21')
+      .send({ body: 'Edited by mod' });
+
+    expect(res.status).toBe(200);
+    expect(updatePostMock).toHaveBeenCalledWith(
+      21,
+      7,
+      'Old body',
+      'Edited by mod'
+    );
+  });
+
   it('returns 403 when user is not the post author', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
     prismaMock.forumPost.findFirst.mockResolvedValue(
       makeForumPost({ id: 21, authorId: 99 })
     );

--- a/src/routes/api/forum/forumPost.ts
+++ b/src/routes/api/forum/forumPost.ts
@@ -151,7 +151,7 @@ router.post(
   })
 );
 
-// PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id — author only
+// PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id — author or moderator
 router.put(
   '/:id',
   requireAuth,
@@ -174,7 +174,8 @@ router.put(
       }
     });
     if (!post) return res.status(404).json({ msg: 'Post not found' });
-    if (post.authorId !== req.user.id)
+    const isOwner = post.authorId === req.user.id;
+    if (!isOwner && !(await isModerator(req, res)))
       return res.status(403).json({ msg: 'Not authorized' });
 
     const updated = await updatePost(id, req.user.id, post.body, body);


### PR DESCRIPTION
## Summary
- allow moderators/staff to edit other users' forum posts
- add forum post edit history UI with inline last-edited metadata
- add focused backend and frontend coverage for staff editing and revision history

## Verification
- npm test -- --runInBand src/forum.spec.ts
