### PR TITLE
Add release tag history and protect forum edit revisions

### DIFF
--- a/prisma/migrations/20260521103000_release_tags_and_history/migration.sql
+++ b/prisma/migrations/20260521103000_release_tags_and_history/migration.sql
@@ -1,0 +1,65 @@
+CREATE TYPE "ReleaseTagVoteDirection" AS ENUM ('up', 'down');
+
+CREATE TYPE "ReleaseHistoryAction" AS ENUM ('edit', 'tag_added', 'tag_removed');
+
+CREATE TABLE "release_tags" (
+    "id" SERIAL NOT NULL,
+    "releaseId" INTEGER NOT NULL,
+    "tagId" INTEGER NOT NULL,
+    "positiveVotes" INTEGER NOT NULL DEFAULT 1,
+    "negativeVotes" INTEGER NOT NULL DEFAULT 1,
+    "userId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "release_tags_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "release_tag_votes" (
+    "id" SERIAL NOT NULL,
+    "releaseTagId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "direction" "ReleaseTagVoteDirection" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "release_tag_votes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "release_histories" (
+    "id" SERIAL NOT NULL,
+    "releaseId" INTEGER NOT NULL,
+    "actorId" INTEGER NOT NULL,
+    "action" "ReleaseHistoryAction" NOT NULL,
+    "summary" VARCHAR(255) NOT NULL,
+    "changedFields" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "before" JSONB,
+    "after" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "release_histories_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_tags_releaseId_tagId_key" ON "release_tags"("releaseId", "tagId");
+CREATE INDEX "release_tags_releaseId_idx" ON "release_tags"("releaseId");
+CREATE INDEX "release_tags_tagId_idx" ON "release_tags"("tagId");
+
+CREATE UNIQUE INDEX "release_tag_votes_releaseTagId_userId_direction_key" ON "release_tag_votes"("releaseTagId", "userId", "direction");
+CREATE INDEX "release_tag_votes_releaseTagId_idx" ON "release_tag_votes"("releaseTagId");
+CREATE INDEX "release_tag_votes_userId_idx" ON "release_tag_votes"("userId");
+
+CREATE INDEX "release_histories_releaseId_createdAt_idx" ON "release_histories"("releaseId", "createdAt");
+CREATE INDEX "release_histories_actorId_idx" ON "release_histories"("actorId");
+
+ALTER TABLE "release_tags" ADD CONSTRAINT "release_tags_releaseId_fkey" FOREIGN KEY ("releaseId") REFERENCES "releases"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_tags" ADD CONSTRAINT "release_tags_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_tags" ADD CONSTRAINT "release_tags_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "release_tag_votes" ADD CONSTRAINT "release_tag_votes_releaseTagId_fkey" FOREIGN KEY ("releaseTagId") REFERENCES "release_tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_tag_votes" ADD CONSTRAINT "release_tag_votes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "release_histories" ADD CONSTRAINT "release_histories_releaseId_fkey" FOREIGN KEY ("releaseId") REFERENCES "releases"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_histories" ADD CONSTRAINT "release_histories_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+INSERT INTO "release_tags" ("releaseId", "tagId", "updatedAt")
+SELECT "A", "B", CURRENT_TIMESTAMP
+FROM "_ReleaseToTag";

--- a/prisma/migrations/20260521182436_drop_changedfields_default/migration.sql
+++ b/prisma/migrations/20260521182436_drop_changedfields_default/migration.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "ReleaseHistoryAction" ADD VALUE IF NOT EXISTS 'created';
+ALTER TYPE "ReleaseHistoryAction" ADD VALUE IF NOT EXISTS 'contribution_added';
+
+-- AlterTable
+ALTER TABLE "release_histories" ALTER COLUMN "changedFields" DROP DEFAULT;

--- a/prisma/migrations/20260521201500_drop_legacy_release_tag_relation/migration.sql
+++ b/prisma/migrations/20260521201500_drop_legacy_release_tag_relation/migration.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "_ReleaseToTag";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -397,6 +397,9 @@ model User {
   siteHistoryEntries        SiteHistory[]
   requestVotes              RequestVote[]
   releaseVotes              ReleaseVote[]
+  releaseTagVotes           ReleaseTagVote[]
+  releaseTagsAdded          ReleaseTag[]   @relation("ReleaseTagAdder")
+  releaseHistoriesAuthored  ReleaseHistory[] @relation("ReleaseHistoryActor")
   donorRank                 UserDonorRank?
   wikiPagesAuthored         WikiPage[]     @relation("WikiPageAuthor")
   wikiRevisionsAuthored     WikiRevision[] @relation("WikiRevisionAuthor")
@@ -701,6 +704,46 @@ model ArtistTag {
   @@map("artist_tags")
 }
 
+model ReleaseTag {
+  id            Int              @id @default(autoincrement())
+  releaseId     Int
+  release       Release          @relation(fields: [releaseId], references: [id], onDelete: Cascade)
+  tagId         Int
+  tag           Tag              @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  positiveVotes Int              @default(1)
+  negativeVotes Int              @default(1)
+  userId        Int?
+  user          User?            @relation("ReleaseTagAdder", fields: [userId], references: [id], onDelete: SetNull)
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+  votes         ReleaseTagVote[]
+
+  @@unique([releaseId, tagId])
+  @@index([releaseId])
+  @@index([tagId])
+  @@map("release_tags")
+}
+
+enum ReleaseTagVoteDirection {
+  up
+  down
+}
+
+model ReleaseTagVote {
+  id           Int                     @id @default(autoincrement())
+  releaseTagId Int
+  releaseTag   ReleaseTag              @relation(fields: [releaseTagId], references: [id], onDelete: Cascade)
+  userId       Int
+  user         User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  direction    ReleaseTagVoteDirection
+  createdAt    DateTime                @default(now())
+
+  @@unique([releaseTagId, userId, direction])
+  @@index([releaseTagId])
+  @@index([userId])
+  @@map("release_tag_votes")
+}
+
 model ArtistSubscription {
   id        Int      @id @default(autoincrement())
   userId    Int
@@ -793,7 +836,6 @@ model Release {
   artistId      Int
   artist        Artist            @relation(fields: [artistId], references: [id])
   title         String            @db.VarChar(100)
-  tags          Tag[]
   image         String?
   description   String            @db.VarChar(1000)
   communityId   Int?
@@ -812,6 +854,8 @@ model Release {
   comments         Comment[]
   collageEntries   CollageEntry[]
   votes            ReleaseVote[]
+  releaseTags      ReleaseTag[]
+  historyEntries   ReleaseHistory[]
   voteAggregate    ReleaseVoteAggregate?
   snapshotEntries  Top10SnapshotEntry[]
   createdAt        DateTime          @default(now())
@@ -1368,10 +1412,36 @@ model Tag {
   id          Int         @id @default(autoincrement())
   name        String      @unique
   occurrences Int         @default(0)
-  releases    Release[]
   artistTags  ArtistTag[]
+  releaseTags ReleaseTag[]
 
   @@map("tags")
+}
+
+enum ReleaseHistoryAction {
+  created
+  edit
+  tag_added
+  tag_removed
+  contribution_added
+}
+
+model ReleaseHistory {
+  id            Int                  @id @default(autoincrement())
+  releaseId     Int
+  release       Release              @relation(fields: [releaseId], references: [id], onDelete: Cascade)
+  actorId       Int
+  actor         User                 @relation("ReleaseHistoryActor", fields: [actorId], references: [id], onDelete: Cascade)
+  action        ReleaseHistoryAction
+  summary       String               @db.VarChar(255)
+  changedFields String[]
+  before        Json?
+  after         Json?
+  createdAt     DateTime             @default(now())
+
+  @@index([releaseId, createdAt])
+  @@index([actorId])
+  @@map("release_histories")
 }
 
 model Post {

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -28,7 +28,20 @@ const makeRelease = (overrides: Record<string, unknown> = {}) => ({
   isEdition: false,
   edition: null,
   artist: { id: 2, name: 'Miles Davis' },
-  tags: [{ id: 7, name: 'jazz' }],
+  tags: [{ id: 7, name: 'jazz', occurrences: 9 }],
+  releaseTags: [
+    {
+      id: 77,
+      tagId: 7,
+      positiveVotes: 3,
+      negativeVotes: 1,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      tag: { id: 7, name: 'jazz', occurrences: 9 },
+      user: { id: 7, username: 'user' },
+      votes: []
+    }
+  ],
+  historyEntries: [],
   voteAggregate: null,
   contributions: [],
   _count: { contributions: 0 },
@@ -90,7 +103,33 @@ describe('GET /api/communities/:communityId/releases/:releaseId', () => {
 
   it('returns release detail and myVote mapping', async () => {
     prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
-    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findFirst.mockResolvedValue(
+      makeRelease({
+        releaseTags: [
+          {
+            id: 77,
+            positiveVotes: 5,
+            negativeVotes: 2,
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+            tag: { id: 7, name: 'jazz', occurrences: 9 },
+            user: { id: 11, username: 'tagger' },
+            votes: [{ direction: 'up' }]
+          }
+        ],
+        historyEntries: [
+          {
+            id: 91,
+            summary: 'Tag "jazz" added',
+            action: 'tag_added',
+            changedFields: ['tags'],
+            before: null,
+            after: null,
+            createdAt: new Date('2024-01-02T00:00:00Z'),
+            actor: { id: 11, username: 'tagger' }
+          }
+        ]
+      }) as never
+    );
     prismaMock.releaseVote.findUnique.mockResolvedValue({
       positive: true
     } as never);
@@ -100,6 +139,14 @@ describe('GET /api/communities/:communityId/releases/:releaseId', () => {
     expect(res.status).toBe(200);
     expect(res.body.myVote).toBe('up');
     expect(res.body.title).toBe('Kind of Blue');
+    expect(res.body.releaseTags[0]).toMatchObject({
+      name: 'jazz',
+      score: 3,
+      positiveVotes: 4,
+      negativeVotes: 1,
+      myVotes: { up: true, down: false }
+    });
+    expect(res.body.historyEntries[0].summary).toBe('Tag "jazz" added');
   });
 });
 
@@ -140,7 +187,13 @@ describe('POST /api/communities/:communityId/releases', () => {
       makeUserRank({ communities_manage: true })
     );
     prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
     prismaMock.release.create.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease() as never
+    );
 
     const res = await request(app)
       .post('/api/communities/1/releases')
@@ -159,10 +212,22 @@ describe('POST /api/communities/:communityId/releases', () => {
       data: expect.objectContaining({
         artistId: 2,
         communityId: 1,
-        image: null,
-        tags: { connect: [{ id: 7 }, { id: 9 }] }
-      }),
-      include: { artist: true, tags: true }
+        image: null
+      })
+    });
+    expect(prismaMock.releaseTag.createMany).toHaveBeenCalledWith({
+      data: [
+        { releaseId: 3, tagId: 7 },
+        { releaseId: 3, tagId: 9 }
+      ]
+    });
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'created',
+        summary: 'Release created'
+      })
     });
   });
 });
@@ -186,8 +251,36 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
       makeUserRank({ communities_manage: true })
     );
     prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
     prismaMock.release.update.mockResolvedValue(
-      makeRelease({ title: 'Updated' }) as never
+      makeRelease({
+        title: 'Updated',
+        releaseTags: [
+          {
+            tagId: 8,
+            tag: { id: 8, name: 'fusion', occurrences: 1 }
+          }
+        ]
+      }) as never
+    );
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease({
+        title: 'Updated',
+        releaseTags: [
+          {
+            id: 81,
+            tagId: 8,
+            positiveVotes: 3,
+            negativeVotes: 1,
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+            tag: { id: 8, name: 'fusion', occurrences: 1 },
+            user: { id: 7, username: 'user' },
+            votes: []
+          }
+        ]
+      }) as never
     );
 
     const res = await request(app)
@@ -201,10 +294,23 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
     expect(prismaMock.release.update).toHaveBeenCalledWith({
       where: { id: 3 },
       data: {
-        title: 'Updated',
-        tags: { set: [{ id: 8 }] }
+        title: 'Updated'
       },
-      include: { artist: true, tags: true }
+      include: { artist: true, releaseTags: { include: { tag: true } } }
+    });
+    expect(prismaMock.releaseTag.deleteMany).toHaveBeenCalledWith({
+      where: { releaseId: 3, tagId: { in: [7] } }
+    });
+    expect(prismaMock.releaseTag.createMany).toHaveBeenCalledWith({
+      data: [{ releaseId: 3, tagId: 8 }]
+    });
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'edit',
+        changedFields: expect.arrayContaining(['title', 'tags'])
+      })
     });
   });
 });
@@ -314,6 +420,14 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
       releaseId: 3,
       input: expect.objectContaining({ fileType: 'flac' })
     });
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'contribution_added',
+        summary: 'flac contribution added'
+      })
+    });
   });
 
   it('emits artist_release notifications to subscribers when contribution is added', async () => {
@@ -355,7 +469,8 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
 
 describe('POST /api/communities/:communityId/releases/:releaseId/vote', () => {
   it('returns 404 when the release does not exist', async () => {
-    prismaMock.release.findUnique.mockResolvedValue(null);
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue(null);
 
     const res = await request(app)
       .post('/api/communities/1/releases/3/vote')
@@ -365,7 +480,8 @@ describe('POST /api/communities/:communityId/releases/:releaseId/vote', () => {
   });
 
   it('upserts the vote and returns aggregate state', async () => {
-    prismaMock.release.findUnique.mockResolvedValue({ id: 3 } as never);
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
     prismaMock.releaseVote.upsert.mockResolvedValue({} as never);
     prismaMock.releaseVote.count
       .mockResolvedValueOnce(3)
@@ -394,6 +510,8 @@ describe('POST /api/communities/:communityId/releases/:releaseId/vote', () => {
 
 describe('DELETE /api/communities/:communityId/releases/:releaseId/vote', () => {
   it('clears the vote and returns updated aggregate', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
     prismaMock.releaseVote.deleteMany.mockResolvedValue({ count: 1 } as never);
     prismaMock.releaseVote.count
       .mockResolvedValueOnce(0)
@@ -410,6 +528,7 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId/vote', () => 
 
 describe('POST /api/communities/:communityId/releases/:releaseId/tags', () => {
   it('returns 404 when the release is missing', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
     prismaMock.release.findFirst.mockResolvedValue(null);
 
     const res = await request(app)
@@ -420,9 +539,10 @@ describe('POST /api/communities/:communityId/releases/:releaseId/tags', () => {
   });
 
   it('returns 409 when the release already has the tag', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
     prismaMock.release.findFirst.mockResolvedValue({
       id: 3,
-      tags: [{ id: 7 }]
+      releaseTags: [{ id: 17 }]
     } as never);
 
     const res = await request(app)
@@ -433,15 +553,23 @@ describe('POST /api/communities/:communityId/releases/:releaseId/tags', () => {
   });
 
   it('creates and attaches a tag transactionally', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
     prismaMock.release.findFirst.mockResolvedValue({
       id: 3,
-      tags: []
+      releaseTags: []
     } as never);
     prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
     );
     prismaMock.tag.upsert.mockResolvedValue({ id: 9, name: 'fusion' } as never);
-    prismaMock.release.update.mockResolvedValue(makeRelease() as never);
+    prismaMock.releaseTag.create.mockResolvedValue({
+      id: 19,
+      positiveVotes: 3,
+      negativeVotes: 1,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      tag: { id: 9, name: 'fusion', occurrences: 4 },
+      user: { id: 7, username: 'user' }
+    } as never);
 
     const res = await request(app)
       .post('/api/communities/1/releases/3/tags')
@@ -453,11 +581,99 @@ describe('POST /api/communities/:communityId/releases/:releaseId/tags', () => {
       create: { name: 'fusion', occurrences: 1 },
       update: { occurrences: { increment: 1 } }
     });
+    expect(prismaMock.releaseTag.create).toHaveBeenCalledWith({
+      data: {
+        releaseId: 3,
+        tagId: 9,
+        userId: 7,
+        positiveVotes: 3,
+        negativeVotes: 1
+      },
+      include: {
+        tag: true,
+        user: { select: { id: true, username: true } }
+      }
+    });
+    expect(prismaMock.releaseTagVote.create).toHaveBeenCalledWith({
+      data: { releaseTagId: 19, userId: 7, direction: 'up' }
+    });
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'tag_added'
+      })
+    });
+  });
+});
+
+describe('POST /api/communities/:communityId/releases/:releaseId/tags/:tagId/vote', () => {
+  it('increments an up-vote once and returns mapped tag state', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.releaseTag.findFirst.mockResolvedValue({
+      id: 17,
+      positiveVotes: 3,
+      negativeVotes: 1
+    } as never);
+    prismaMock.releaseTagVote.findUnique.mockResolvedValue(null);
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
+    prismaMock.releaseTag.findUniqueOrThrow.mockResolvedValue({
+      id: 17,
+      positiveVotes: 5,
+      negativeVotes: 1,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      tag: { id: 9, name: 'fusion', occurrences: 12 },
+      user: { id: 4, username: 'adder' },
+      votes: [{ direction: 'up' }]
+    } as never);
+
+    const res = await request(app)
+      .post('/api/communities/1/releases/3/tags/9/vote')
+      .send({ direction: 'up' });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.releaseTagVote.create).toHaveBeenCalledWith({
+      data: { releaseTagId: 17, userId: 7, direction: 'up' }
+    });
+    expect(prismaMock.releaseTag.update).toHaveBeenCalledWith({
+      where: { id: 17 },
+      data: { positiveVotes: { increment: 2 } }
+    });
+    expect(res.body).toMatchObject({
+      name: 'fusion',
+      score: 4,
+      positiveVotes: 4,
+      negativeVotes: 0,
+      myVotes: { up: true, down: false }
+    });
+  });
+
+  it('returns 404 when the release tag is missing', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.releaseTag.findFirst.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/communities/1/releases/3/tags/9/vote')
+      .send({ direction: 'up' });
+
+    expect(res.status).toBe(404);
   });
 });
 
 describe('DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId', () => {
+  it('requires communities_manage permission', async () => {
+    const res = await request(app).delete(
+      '/api/communities/1/releases/3/tags/9'
+    );
+    expect(res.status).toBe(403);
+  });
+
   it('returns 404 when the release/tag relation is missing', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
     prismaMock.release.findFirst.mockResolvedValue(null);
 
     const res = await request(app).delete(
@@ -468,7 +684,11 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId',
   });
 
   it('disconnects the tag and decrements occurrences', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
     prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
+    prismaMock.tag.findUnique.mockResolvedValue({ name: 'jazz' } as never);
     prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
     );
@@ -483,6 +703,16 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId',
     expect(prismaMock.tag.update).toHaveBeenCalledWith({
       where: { id: 9 },
       data: { occurrences: { decrement: 1 } }
+    });
+    expect(prismaMock.releaseTag.deleteMany).toHaveBeenCalledWith({
+      where: { releaseId: 3, tagId: 9 }
+    });
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'tag_removed'
+      })
     });
   });
 });
@@ -508,7 +738,13 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId', () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
-    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findFirst.mockResolvedValue({
+      id: 3,
+      releaseTags: [{ tagId: 7 }]
+    } as never);
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
     prismaMock.release.delete.mockResolvedValue(makeRelease() as never);
 
     const res = await request(app).delete('/api/communities/1/releases/3');
@@ -516,6 +752,10 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId', () => {
     expect(res.status).toBe(204);
     expect(prismaMock.release.delete).toHaveBeenCalledWith({
       where: { id: 3 }
+    });
+    expect(prismaMock.tag.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { occurrences: { decrement: 1 } }
     });
   });
 });

--- a/src/forum.spec.ts
+++ b/src/forum.spec.ts
@@ -108,9 +108,23 @@ describe('API forum flows', () => {
   });
 
   it('updates a forum post for the owner', async () => {
-    prismaMock.forumPost.findFirst.mockResolvedValue(
-      makeForumPost({ id: 21, forumTopicId: 44, authorId: 7, body: 'Old body' })
-    );
+    prismaMock.forumPost.findFirst
+      .mockResolvedValueOnce(
+        makeForumPost({
+          id: 21,
+          forumTopicId: 44,
+          authorId: 7,
+          body: 'Old body'
+        })
+      )
+      .mockResolvedValueOnce(
+        makeForumPost({
+          id: 21,
+          forumTopicId: 44,
+          authorId: 7,
+          body: 'New body'
+        })
+      );
     updatePostMock.mockResolvedValue({
       id: 21,
       forumTopicId: 44,
@@ -675,10 +689,21 @@ describe('DELETE /api/forums/:forumId/topics/:forumTopicId — success', () => {
 // ─── GET /api/forums/:forumId/topics/:forumTopicId/posts ─────────────────────
 
 describe('GET /api/forums/:forumId/topics/:forumTopicId/posts', () => {
-  it('returns paginated list of posts', async () => {
+  it('returns paginated list of posts with public last-edit metadata only', async () => {
     prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
     prismaMock.forumPost.findMany.mockResolvedValue([
-      makeForumPost({ id: 21, body: 'Post body' })
+      {
+        ...makeForumPost({ id: 21, body: 'Post body' }),
+        edits: [
+          {
+            id: 5,
+            forumPostId: 21,
+            editorId: 11,
+            editedAt: new Date('2024-03-04T00:00:00Z'),
+            editor: { id: 11, username: 'mod' }
+          }
+        ]
+      } as never
     ]);
     prismaMock.forumPost.count.mockResolvedValue(1);
 
@@ -686,6 +711,13 @@ describe('GET /api/forums/:forumId/topics/:forumTopicId/posts', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].edits).toBeUndefined();
+    expect(res.body.data[0].lastEdit).toMatchObject({
+      id: 5,
+      forumPostId: 21,
+      editorId: 11,
+      editor: { id: 11, username: 'mod' }
+    });
     expect(res.body.meta.total).toBe(1);
   });
 
@@ -714,14 +746,25 @@ describe('GET /api/forums/:forumId/topics/:forumTopicId/posts', () => {
 describe('GET /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
   it('returns a single post', async () => {
     prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
-    prismaMock.forumPost.findFirst.mockResolvedValue(
-      makeForumPost({ id: 21, body: 'Post body' })
-    );
+    prismaMock.forumPost.findFirst.mockResolvedValue({
+      ...makeForumPost({ id: 21, body: 'Post body' }),
+      edits: [
+        {
+          id: 5,
+          forumPostId: 21,
+          editorId: 11,
+          editedAt: new Date('2024-03-04T00:00:00Z'),
+          editor: { id: 11, username: 'mod' }
+        }
+      ]
+    } as never);
 
     const res = await request(app).get('/api/forums/9/topics/44/posts/21');
 
     expect(res.status).toBe(200);
     expect(res.body.body).toBe('Post body');
+    expect(res.body.edits).toBeUndefined();
+    expect(res.body.lastEdit.editor.username).toBe('mod');
   });
 
   it('returns 404 when forum does not exist', async () => {
@@ -752,6 +795,57 @@ describe('GET /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
 
     expect(res.status).toBe(404);
     expect(res.body.msg).toBe('Post not found');
+  });
+});
+
+describe('GET /api/forums/:forumId/topics/:forumTopicId/posts/:id/edits', () => {
+  it('returns moderator edit history newest first', async () => {
+    prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ forums_moderate: true })
+    );
+    prismaMock.forumPost.findFirst.mockResolvedValue({
+      ...makeForumPost({ id: 21, body: 'Current body' }),
+      edits: [
+        {
+          id: 6,
+          forumPostId: 21,
+          editorId: 12,
+          previousBody: 'Second draft',
+          editedAt: new Date('2024-03-05T00:00:00Z'),
+          editor: { id: 12, username: 'charlie' }
+        },
+        {
+          id: 5,
+          forumPostId: 21,
+          editorId: 11,
+          previousBody: 'Original body',
+          editedAt: new Date('2024-03-04T00:00:00Z'),
+          editor: { id: 11, username: 'mod' }
+        }
+      ]
+    } as never);
+
+    const res = await request(app).get(
+      '/api/forums/9/topics/44/posts/21/edits'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].previousBody).toBe('Second draft');
+    expect(res.body.data[1].previousBody).toBe('Original body');
+  });
+
+  it('returns 403 for non-moderators', async () => {
+    prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app).get(
+      '/api/forums/9/topics/44/posts/21/edits'
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.msg).toBe('Insufficient permission to view edit history');
   });
 });
 
@@ -803,9 +897,26 @@ describe('PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ forums_moderate: true })
     );
-    prismaMock.forumPost.findFirst.mockResolvedValue(
-      makeForumPost({ id: 21, authorId: 99, body: 'Old body' })
-    );
+    prismaMock.forumPost.findFirst
+      .mockResolvedValueOnce(
+        makeForumPost({ id: 21, authorId: 99, body: 'Old body' })
+      )
+      .mockResolvedValueOnce({
+        ...makeForumPost({
+          id: 21,
+          authorId: 99,
+          body: 'Edited by mod'
+        }),
+        edits: [
+          {
+            id: 8,
+            forumPostId: 21,
+            editorId: 7,
+            editedAt: new Date('2024-03-06T00:00:00Z'),
+            editor: { id: 7, username: 'testuser' }
+          }
+        ]
+      } as never);
     updatePostMock.mockResolvedValue(
       makeForumPost({
         id: 21,
@@ -825,6 +936,8 @@ describe('PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
       'Old body',
       'Edited by mod'
     );
+    expect(res.body.lastEdit.editor.username).toBe('testuser');
+    expect(res.body.edits).toBeUndefined();
   });
 
   it('returns 403 when user is not the post author', async () => {

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1269,6 +1269,17 @@ const ForumPostEdit = registry.register(
   })
 );
 
+const ForumPostLastEdit = registry.register(
+  'ForumPostLastEdit',
+  z.object({
+    id: z.number(),
+    forumPostId: z.number(),
+    editorId: z.number(),
+    editedAt: z.string(),
+    editor: z.object({ id: z.number(), username: z.string() }).optional()
+  })
+);
+
 const ForumPost = registry.register(
   'ForumPost',
   z.object({
@@ -1276,7 +1287,7 @@ const ForumPost = registry.register(
     forumTopicId: z.number(),
     authorId: z.number(),
     body: z.string(),
-    edits: z.array(ForumPostEdit),
+    lastEdit: ForumPostLastEdit.optional(),
     author: z
       .object({
         id: z.number(),
@@ -1620,6 +1631,39 @@ registry.registerPath({
     200: {
       description: 'Post',
       content: { 'application/json': { schema: ForumPost } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/forums/{forumId}/topics/{topicId}/posts/{id}/edits',
+  tags: ['Forums'],
+  request: {
+    params: z.object({
+      forumId: z.string(),
+      topicId: z.string(),
+      id: z.string()
+    })
+  },
+  responses: {
+    200: {
+      description: 'Moderator edit history',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(ForumPostEdit)
+          })
+        }
+      }
+    },
+    403: {
+      description: 'Insufficient permission',
+      content: { 'application/json': { schema: MsgResponse } }
     },
     404: {
       description: 'Not found',

--- a/src/modules/contribution.ts
+++ b/src/modules/contribution.ts
@@ -86,6 +86,18 @@ export const createContributionSubmission = async ({
       (c) => artistMap.get(c.artist)!
     );
     const primaryArtist = collaboratorRecords[0];
+    const tagRecords =
+      normalizedTags.length > 0
+        ? await Promise.all(
+            normalizedTags.map((name) =>
+              tx.tag.upsert({
+                where: { name },
+                create: { name, occurrences: 1 },
+                update: { occurrences: { increment: 1 } }
+              })
+            )
+          )
+        : [];
 
     const release = await tx.release.create({
       data: {
@@ -100,21 +112,21 @@ export const createContributionSubmission = async ({
             : ReleaseCategory.Unknown,
         image: image ?? null,
         description: description ?? releaseDescription ?? title,
-        contributors: { connect: { id: contributor.id } },
-        ...(normalizedTags.length > 0 && {
-          tags: {
-            connectOrCreate: normalizedTags.map((tagName) => ({
-              where: { name: tagName },
-              create: { name: tagName }
-            }))
-          }
-        })
+        contributors: { connect: { id: contributor.id } }
       },
       include: {
-        artist: true,
-        tags: true
+        artist: true
       }
     });
+
+    if (tagRecords.length > 0) {
+      await tx.releaseTag.createMany({
+        data: tagRecords.map((tag) => ({
+          releaseId: release.id,
+          tagId: tag.id
+        }))
+      });
+    }
 
     return tx.contribution.create({
       data: {

--- a/src/modules/top10.spec.ts
+++ b/src/modules/top10.spec.ts
@@ -2,6 +2,9 @@ const prismaMock = {
   tag: {
     findMany: jest.fn()
   },
+  releaseTag: {
+    findMany: jest.fn()
+  },
   release: {
     findMany: jest.fn()
   },
@@ -55,8 +58,8 @@ describe('getTopReleases', () => {
         contributionCount: 4
       }
     ]);
-    prismaMock.release.findMany.mockResolvedValue([
-      { id: 1, tags: [{ id: 5, name: 'jazz' }] }
+    prismaMock.releaseTag.findMany.mockResolvedValue([
+      { releaseId: 1, tag: { id: 5, name: 'jazz' } }
     ]);
 
     const result = await getTopReleases({
@@ -119,9 +122,7 @@ describe('getTopReleases', () => {
           contributionCount: 1
         }
       ]);
-    prismaMock.release.findMany
-      .mockResolvedValueOnce([{ id: 3, tags: [] }])
-      .mockResolvedValueOnce([{ id: 4, tags: [] }]);
+    prismaMock.releaseTag.findMany.mockResolvedValue([]);
 
     const consumed = await getTopReleases({
       type: 'consumed',
@@ -410,8 +411,8 @@ describe('createSnapshot', () => {
         contributionCount: 5
       }
     ]);
-    prismaMock.release.findMany.mockResolvedValue([
-      { id: 9, tags: [{ id: 1, name: 'jazz' }] }
+    prismaMock.releaseTag.findMany.mockResolvedValue([
+      { releaseId: 9, tag: { id: 1, name: 'jazz' } }
     ]);
     prismaMock.top10Snapshot.create.mockResolvedValue(undefined);
 

--- a/src/modules/top10.ts
+++ b/src/modules/top10.ts
@@ -126,12 +126,20 @@ async function resolveExcludeTagIds(excludeTags?: string): Promise<number[]> {
 async function attachTags(
   releaseIds: number[]
 ): Promise<Map<number, Array<{ id: number; name: string }>>> {
-  const releases = await prisma.release.findMany({
-    where: { id: { in: releaseIds } },
-    select: { id: true, tags: { select: { id: true, name: true } } }
+  const releaseTags = await prisma.releaseTag.findMany({
+    where: { releaseId: { in: releaseIds } },
+    select: {
+      releaseId: true,
+      tag: { select: { id: true, name: true } }
+    }
   });
   const map = new Map<number, Array<{ id: number; name: string }>>();
-  for (const r of releases) map.set(r.id, r.tags);
+  for (const releaseId of releaseIds) map.set(releaseId, []);
+  for (const row of releaseTags) {
+    const tags = map.get(row.releaseId) ?? [];
+    tags.push(row.tag);
+    map.set(row.releaseId, tags);
+  }
   return map;
 }
 
@@ -159,8 +167,8 @@ export async function getTopReleases(
   const tagFilter =
     excludeTagIds.length > 0
       ? Prisma.sql`AND NOT EXISTS (
-          SELECT 1 FROM "_ReleaseToTag" rt
-          WHERE rt."A" = r.id AND rt."B" = ANY(${excludeTagIds}::int[])
+          SELECT 1 FROM release_tags rt
+          WHERE rt."releaseId" = r.id AND rt."tagId" = ANY(${excludeTagIds}::int[])
         )`
       : Prisma.empty;
 
@@ -469,9 +477,9 @@ export async function getTopVotedReleases(
   const tagFilter =
     tags && tags.trim()
       ? Prisma.sql`AND EXISTS (
-          SELECT 1 FROM "_ReleaseToTag" rt
-          INNER JOIN tags tg ON tg.id = rt."B"
-          WHERE rt."A" = r.id
+          SELECT 1 FROM release_tags rt
+          INNER JOIN tags tg ON tg.id = rt."tagId"
+          WHERE rt."releaseId" = r.id
             AND tg.name = ANY(${tags
               .split(',')
               .map((s) => s.trim().toLowerCase())

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -16,10 +16,12 @@ import {
   updateGroupSchema,
   releaseVoteSchema,
   releaseTagSchema,
+  releaseTagVoteSchema,
   type CreateGroupInput,
   type UpdateGroupInput,
   type ReleaseVoteInput,
-  type ReleaseTagInput
+  type ReleaseTagInput,
+  type ReleaseTagVoteInput
 } from '../../../schemas/community';
 import {
   addContributionToReleaseSchema,
@@ -29,7 +31,12 @@ import { addContributionToRelease } from '../../../modules/contribution';
 import { emitNotifications } from '../../../lib/notifications';
 import { recomputeVoteAggregate } from '../../../modules/top10';
 import { getSettings } from '../../../modules/settings';
-import { FileType } from '@prisma/client';
+import {
+  FileType,
+  RegistrationStatus,
+  ReleaseHistoryAction,
+  ReleaseTagVoteDirection
+} from '@prisma/client';
 import { parsePage, paginatedResponse } from '../../../lib/pagination';
 
 const router = express.Router({ mergeParams: true });
@@ -41,6 +48,139 @@ const releaseParamsSchema = z.object({
   releaseId: z.coerce.number().int().positive()
 });
 
+type ReleaseSnapshot = {
+  title: string;
+  description: string;
+  image: string | null;
+  year: number;
+  isEdition: boolean;
+  edition: unknown;
+  tagIds: number[];
+  tagNames: string[];
+};
+
+const getAccessibleCommunity = async (
+  communityId: number,
+  userId: number
+): Promise<{ registrationStatus: RegistrationStatus } | null | 'forbidden'> => {
+  const community = await prisma.community.findUnique({
+    where: { id: communityId },
+    select: { registrationStatus: true }
+  });
+  if (!community) return null;
+  const isMember = await isCommunityMember(
+    communityId,
+    userId,
+    community.registrationStatus
+  );
+  return isMember ? community : 'forbidden';
+};
+
+const snapshotRelease = (release: {
+  title: string;
+  description: string;
+  image: string | null;
+  year: number;
+  isEdition: boolean;
+  edition: unknown;
+  releaseTags: Array<{ tag: { id: number; name: string } }>;
+}): ReleaseSnapshot => ({
+  title: release.title,
+  description: release.description,
+  image: release.image ?? null,
+  year: release.year,
+  isEdition: release.isEdition,
+  edition: release.edition ?? null,
+  tagIds: release.releaseTags.map((tag) => tag.tag.id).sort((a, b) => a - b),
+  tagNames: release.releaseTags.map((tag) => tag.tag.name).sort()
+});
+
+const changedReleaseFields = (
+  before: ReleaseSnapshot,
+  after: ReleaseSnapshot
+): string[] => {
+  const changed: string[] = [];
+  if (before.title !== after.title) changed.push('title');
+  if (before.description !== after.description) changed.push('description');
+  if (before.image !== after.image) changed.push('image');
+  if (before.year !== after.year) changed.push('year');
+  if (before.isEdition !== after.isEdition) changed.push('isEdition');
+  if (JSON.stringify(before.edition) !== JSON.stringify(after.edition)) {
+    changed.push('edition');
+  }
+  if (JSON.stringify(before.tagIds) !== JSON.stringify(after.tagIds)) {
+    changed.push('tags');
+  }
+  return changed;
+};
+
+const summarizeReleaseChanges = (fields: string[]): string => {
+  if (fields.length === 0) return 'Release metadata updated';
+  const labels = fields.map((field) => {
+    switch (field) {
+      case 'isEdition':
+        return 'edition flag';
+      default:
+        return field;
+    }
+  });
+  return `Updated ${labels.join(', ')}`;
+};
+
+const buildReleaseTagPayload = (
+  tags: Array<{ id: number; name: string; occurrences: number }>,
+  releaseTags: Array<{
+    id: number;
+    tagId: number;
+    positiveVotes: number;
+    negativeVotes: number;
+    createdAt: Date;
+    user: { id: number; username: string } | null;
+    votes: Array<{ direction: ReleaseTagVoteDirection }>;
+  }>
+) => {
+  const byTagId = new Map(
+    releaseTags.map((releaseTag) => [releaseTag.tagId, releaseTag])
+  );
+
+  return tags
+    .map((tag) => {
+      const releaseTag = byTagId.get(tag.id);
+      const positiveVotes = releaseTag?.positiveVotes ?? 1;
+      const negativeVotes = releaseTag?.negativeVotes ?? 1;
+
+      return {
+        id: releaseTag?.id ?? tag.id,
+        tagId: tag.id,
+        name: tag.name,
+        occurrences: tag.occurrences,
+        score: positiveVotes - negativeVotes,
+        positiveVotes: Math.max(0, positiveVotes - 1),
+        negativeVotes: Math.max(0, negativeVotes - 1),
+        addedBy: releaseTag?.user ?? null,
+        createdAt: releaseTag?.createdAt ?? null,
+        myVotes: {
+          up:
+            releaseTag?.votes.some(
+              (vote) => vote.direction === ReleaseTagVoteDirection.up
+            ) ?? false,
+          down:
+            releaseTag?.votes.some(
+              (vote) => vote.direction === ReleaseTagVoteDirection.down
+            ) ?? false
+        }
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+};
+
+const buildPlainTags = (
+  releaseTags: Array<{ tag: { id: number; name: string; occurrences: number } }>
+) =>
+  releaseTags
+    .map((releaseTag) => releaseTag.tag)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
 // GET /api/communities/:communityId/releases
 router.get(
   '/',
@@ -48,18 +188,9 @@ router.get(
   validateParams(communityIdParamsSchema),
   authHandler(async (req, res) => {
     const { communityId } = parsedParams<{ communityId: number }>(res);
-    const community = await prisma.community.findUnique({
-      where: { id: communityId },
-      select: { registrationStatus: true }
-    });
+    const community = await getAccessibleCommunity(communityId, req.user.id);
     if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (
-      !(await isCommunityMember(
-        communityId,
-        req.user.id,
-        community.registrationStatus
-      ))
-    ) {
+    if (community === 'forbidden') {
       return res.status(403).json({ msg: 'Not a member of this community' });
     }
     const pg = parsePage(req);
@@ -70,7 +201,7 @@ router.get(
         take: pg.limit,
         include: {
           artist: { select: { id: true, name: true } },
-          tags: true,
+          releaseTags: { include: { tag: true } },
           _count: { select: { contributions: true } },
           contributions: {
             select: {
@@ -86,7 +217,15 @@ router.get(
       }),
       prisma.release.count({ where: { communityId } })
     ]);
-    paginatedResponse(res, releases, total, pg);
+    paginatedResponse(
+      res,
+      releases.map((release) => ({
+        ...release,
+        tags: buildPlainTags(release.releaseTags)
+      })),
+      total,
+      pg
+    );
   })
 );
 
@@ -100,18 +239,9 @@ router.get(
       communityId: number;
       releaseId: number;
     }>(res);
-    const community = await prisma.community.findUnique({
-      where: { id: communityId },
-      select: { registrationStatus: true }
-    });
+    const community = await getAccessibleCommunity(communityId, req.user.id);
     if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (
-      !(await isCommunityMember(
-        communityId,
-        req.user.id,
-        community.registrationStatus
-      ))
-    ) {
+    if (community === 'forbidden') {
       return res.status(403).json({ msg: 'Not a member of this community' });
     }
     const [release, myVoteRecord] = await Promise.all([
@@ -119,7 +249,22 @@ router.get(
         where: { id, communityId },
         include: {
           artist: true,
-          tags: true,
+          releaseTags: {
+            include: {
+              tag: { select: { id: true, name: true, occurrences: true } },
+              votes: {
+                where: { userId: req.user.id },
+                select: { direction: true }
+              },
+              user: { select: { id: true, username: true } }
+            }
+          },
+          historyEntries: {
+            orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+            include: {
+              actor: { select: { id: true, username: true } }
+            }
+          },
           voteAggregate: true,
           contributions: {
             select: {
@@ -152,7 +297,26 @@ router.get(
         ? 'up'
         : 'down'
       : null;
-    res.json({ ...release, myVote });
+    const releaseTags = buildReleaseTagPayload(
+      buildPlainTags(release.releaseTags),
+      release.releaseTags.map((releaseTag) => ({
+        id: releaseTag.id,
+        tagId: releaseTag.tag.id,
+        positiveVotes: releaseTag.positiveVotes,
+        negativeVotes: releaseTag.negativeVotes,
+        createdAt: releaseTag.createdAt,
+        user: releaseTag.user ?? null,
+        votes: releaseTag.votes
+      }))
+    );
+
+    res.json({
+      ...release,
+      tags: buildPlainTags(release.releaseTags),
+      myVote,
+      releaseTags,
+      historyEntries: release.historyEntries
+    });
   })
 );
 
@@ -181,24 +345,66 @@ router.post(
       isEdition,
       edition
     } = parsedBody<CreateGroupInput>(res);
+    const uniqueTagIds = tagIds ? [...new Set(tagIds)] : [];
 
-    const release = await prisma.release.create({
-      data: {
-        artistId,
-        communityId,
-        title,
-        description,
-        type,
-        releaseType,
-        year,
-        image: image ?? null,
-        isEdition: isEdition ?? false,
-        edition: (edition ?? undefined) as never,
-        ...(tagIds?.length && {
-          tags: { connect: tagIds.map((tid: number) => ({ id: tid })) }
-        })
-      },
-      include: { artist: true, tags: true }
+    const release = await prisma.$transaction(async (tx) => {
+      const created = await tx.release.create({
+        data: {
+          artistId,
+          communityId,
+          title,
+          description,
+          type,
+          releaseType,
+          year,
+          image: image ?? null,
+          isEdition: isEdition ?? false,
+          edition: (edition ?? undefined) as never
+        }
+      });
+
+      if (uniqueTagIds.length > 0) {
+        await tx.releaseTag.createMany({
+          data: uniqueTagIds.map((tagId) => ({
+            releaseId: created.id,
+            tagId
+          }))
+        });
+        await Promise.all(
+          uniqueTagIds.map((tagId) =>
+            tx.tag.update({
+              where: { id: tagId },
+              data: { occurrences: { increment: 1 } }
+            })
+          )
+        );
+      }
+
+      const release = await tx.release.findUniqueOrThrow({
+        where: { id: created.id },
+        include: { artist: true, releaseTags: { include: { tag: true } } }
+      });
+      await tx.releaseHistory.create({
+        data: {
+          releaseId: release.id,
+          actorId: req.user!.id,
+          action: ReleaseHistoryAction.created,
+          summary: 'Release created',
+          changedFields: [],
+          after: {
+            title: release.title,
+            artistName: release.artist.name,
+            type: release.type,
+            releaseType: release.releaseType,
+            year: release.year,
+            tagIds: uniqueTagIds
+          } as never
+        }
+      });
+      return {
+        ...release,
+        tags: buildPlainTags(release.releaseTags)
+      };
     });
     res.status(201).json(release);
   })
@@ -211,32 +417,116 @@ router.put(
   validateParams(releaseParamsSchema),
   validate(updateGroupSchema),
   asyncHandler(async (req: Request, res: Response) => {
+    if (!req.user) return res.status(401).json({ msg: 'Unauthorized' });
+    const actorId = req.user.id;
     const { communityId, releaseId: id } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
 
     const existing = await prisma.release.findFirst({
-      where: { id, communityId }
+      where: { id, communityId },
+      include: {
+        releaseTags: { include: { tag: { select: { id: true, name: true } } } }
+      }
     });
     if (!existing) return res.status(404).json({ msg: 'Release not found' });
 
-    const { title, description, image, year, isEdition, edition, tagIds } =
-      parsedBody<UpdateGroupInput>(res);
-    const release = await prisma.release.update({
-      where: { id },
-      data: {
-        ...(title !== undefined && { title }),
-        ...(description !== undefined && { description }),
-        ...(image !== undefined && { image }),
-        ...(year !== undefined && { year }),
-        ...(isEdition !== undefined && { isEdition }),
-        ...(edition !== undefined && { edition: edition as never }),
-        ...(tagIds !== undefined && {
-          tags: { set: tagIds.map((tid: number) => ({ id: tid })) }
-        })
-      },
-      include: { artist: true, tags: true }
+    const {
+      title,
+      description,
+      image,
+      year,
+      isEdition,
+      edition,
+      tagIds,
+      editSummary
+    } = parsedBody<UpdateGroupInput>(res);
+    const before = snapshotRelease(existing);
+    const nextTagIds = tagIds
+      ? [...new Set(tagIds)].sort((a, b) => a - b)
+      : null;
+    const removedTagIds =
+      nextTagIds === null
+        ? []
+        : before.tagIds.filter((tagId) => !nextTagIds.includes(tagId));
+    const addedTagIds =
+      nextTagIds === null
+        ? []
+        : nextTagIds.filter((tagId) => !before.tagIds.includes(tagId));
+
+    const release = await prisma.$transaction(async (tx) => {
+      await tx.release.update({
+        where: { id },
+        data: {
+          ...(title !== undefined && { title }),
+          ...(description !== undefined && { description }),
+          ...(image !== undefined && { image }),
+          ...(year !== undefined && { year }),
+          ...(isEdition !== undefined && { isEdition }),
+          ...(edition !== undefined && { edition: edition as never })
+        },
+        include: { artist: true, releaseTags: { include: { tag: true } } }
+      });
+
+      if (removedTagIds.length > 0) {
+        await tx.releaseTag.deleteMany({
+          where: { releaseId: id, tagId: { in: removedTagIds } }
+        });
+        await Promise.all(
+          removedTagIds.map((tagId) =>
+            tx.tag.update({
+              where: { id: tagId },
+              data: { occurrences: { decrement: 1 } }
+            })
+          )
+        );
+      }
+
+      if (addedTagIds.length > 0) {
+        await tx.releaseTag.createMany({
+          data: addedTagIds.map((tagId) => ({
+            releaseId: id,
+            tagId
+          }))
+        });
+        await Promise.all(
+          addedTagIds.map((tagId) =>
+            tx.tag.update({
+              where: { id: tagId },
+              data: { occurrences: { increment: 1 } }
+            })
+          )
+        );
+      }
+
+      const refreshed = await tx.release.findUniqueOrThrow({
+        where: { id },
+        include: { artist: true, releaseTags: { include: { tag: true } } }
+      });
+
+      const after = snapshotRelease(refreshed);
+      const changedFields = changedReleaseFields(before, after);
+
+      if (changedFields.length > 0) {
+        await tx.releaseHistory.create({
+          data: {
+            releaseId: id,
+            actorId,
+            action: ReleaseHistoryAction.edit,
+            summary:
+              editSummary?.trim() || summarizeReleaseChanges(changedFields),
+            changedFields,
+            before: before as never,
+            after: after as never
+          }
+        });
+      }
+
+      return {
+        ...refreshed,
+        tags: buildPlainTags(refreshed.releaseTags)
+      };
     });
     res.json(release);
   })
@@ -310,6 +600,21 @@ router.post(
           pageId: contribution.id
         });
       }
+      await tx.releaseHistory.create({
+        data: {
+          releaseId: contribution.release.id,
+          actorId: req.user.id,
+          action: ReleaseHistoryAction.contribution_added,
+          summary: `${contribution.type} contribution added`,
+          changedFields: [],
+          after: {
+            contributionId: contribution.id,
+            type: contribution.type,
+            sizeInBytes: contribution.sizeInBytes ?? null,
+            contributor: contribution.user?.username ?? null
+          } as never
+        }
+      });
     });
 
     res.status(201).json(contribution);
@@ -331,14 +636,19 @@ router.post(
   validateParams(releaseParamsSchema),
   validate(releaseVoteSchema),
   authHandler(async (req, res) => {
-    const { releaseId: id } = parsedParams<{
+    const { communityId, releaseId: id } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
     const { positive } = parsedBody<ReleaseVoteInput>(res);
+    const community = await getAccessibleCommunity(communityId, req.user.id);
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (community === 'forbidden') {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
 
-    const exists = await prisma.release.findUnique({
-      where: { id },
+    const exists = await prisma.release.findFirst({
+      where: { id, communityId },
       select: { id: true }
     });
     if (!exists) return res.status(404).json({ msg: 'Release not found' });
@@ -364,10 +674,21 @@ router.delete(
   requireAuth,
   validateParams(releaseParamsSchema),
   authHandler(async (req, res) => {
-    const { releaseId: id } = parsedParams<{
+    const { communityId, releaseId: id } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
+    const community = await getAccessibleCommunity(communityId, req.user.id);
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (community === 'forbidden') {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
+
+    const exists = await prisma.release.findFirst({
+      where: { id, communityId },
+      select: { id: true }
+    });
+    if (!exists) return res.status(404).json({ msg: 'Release not found' });
 
     await prisma.releaseVote.deleteMany({
       where: { releaseId: id, userId: req.user.id }
@@ -396,13 +717,21 @@ router.post(
       releaseId: number;
     }>(res);
     const { name } = parsedBody<ReleaseTagInput>(res);
+    const community = await getAccessibleCommunity(communityId, req.user.id);
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (community === 'forbidden') {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
 
     const release = await prisma.release.findFirst({
       where: { id, communityId },
-      select: { id: true, tags: { where: { name }, select: { id: true } } }
+      select: {
+        id: true,
+        releaseTags: { where: { tag: { name } }, select: { id: true } }
+      }
     });
     if (!release) return res.status(404).json({ msg: 'Release not found' });
-    if (release.tags.length > 0)
+    if (release.releaseTags.length > 0)
       return res.status(409).json({ msg: 'Release already has this tag' });
 
     const tag = await prisma.$transaction(async (tx) => {
@@ -411,9 +740,36 @@ router.post(
         create: { name, occurrences: 1 },
         update: { occurrences: { increment: 1 } }
       });
-      await tx.release.update({
-        where: { id },
-        data: { tags: { connect: { id: t.id } } }
+      const releaseTag = await tx.releaseTag.create({
+        data: {
+          releaseId: id,
+          tagId: t.id,
+          userId: req.user.id,
+          positiveVotes: 3,
+          negativeVotes: 1
+        },
+        include: {
+          tag: true,
+          user: { select: { id: true, username: true } }
+        }
+      });
+      await tx.releaseTagVote.create({
+        data: {
+          releaseTagId: releaseTag.id,
+          userId: req.user.id,
+          direction: ReleaseTagVoteDirection.up
+        }
+      });
+      await tx.releaseHistory.create({
+        data: {
+          releaseId: id,
+          actorId: req.user.id,
+          action: ReleaseHistoryAction.tag_added,
+          summary: `Tag "${t.name}" added`,
+          changedFields: ['tags'],
+          before: { tagId: t.id, name: t.name, score: 0 } as never,
+          after: { tagId: t.id, name: t.name, score: 2 } as never
+        }
       });
       return t;
     });
@@ -422,12 +778,137 @@ router.post(
   })
 );
 
+// POST /api/communities/:communityId/releases/:releaseId/tags/:tagId/vote
+router.post(
+  '/:releaseId/tags/:tagId/vote',
+  requireAuth,
+  validateParams(tagParamsSchema),
+  validate(releaseTagVoteSchema),
+  authHandler(async (req, res) => {
+    const {
+      communityId,
+      releaseId: id,
+      tagId
+    } = parsedParams<{
+      communityId: number;
+      releaseId: number;
+      tagId: number;
+    }>(res);
+    const { direction } = parsedBody<ReleaseTagVoteInput>(res);
+    const community = await getAccessibleCommunity(communityId, req.user.id);
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (community === 'forbidden') {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
+
+    const releaseTag = await prisma.releaseTag.findFirst({
+      where: { releaseId: id, tagId, release: { communityId } },
+      select: { id: true, positiveVotes: true, negativeVotes: true }
+    });
+    if (!releaseTag) {
+      return res.status(404).json({ msg: 'Release tag not found' });
+    }
+
+    const dir = direction as ReleaseTagVoteDirection;
+    const oppositeDir =
+      dir === ReleaseTagVoteDirection.up
+        ? ReleaseTagVoteDirection.down
+        : ReleaseTagVoteDirection.up;
+
+    const [existingVote, oppositeVote] = await Promise.all([
+      prisma.releaseTagVote.findUnique({
+        where: {
+          releaseTagId_userId_direction: {
+            releaseTagId: releaseTag.id,
+            userId: req.user.id,
+            direction: dir
+          }
+        }
+      }),
+      prisma.releaseTagVote.findUnique({
+        where: {
+          releaseTagId_userId_direction: {
+            releaseTagId: releaseTag.id,
+            userId: req.user.id,
+            direction: oppositeDir
+          }
+        }
+      })
+    ]);
+
+    if (!existingVote) {
+      await prisma.$transaction(async (tx) => {
+        await tx.releaseTagVote.create({
+          data: {
+            releaseTagId: releaseTag.id,
+            userId: req.user.id,
+            direction: dir
+          }
+        });
+        if (oppositeVote) {
+          await tx.releaseTagVote.delete({ where: { id: oppositeVote.id } });
+        }
+        await tx.releaseTag.update({
+          where: { id: releaseTag.id },
+          data:
+            dir === ReleaseTagVoteDirection.up
+              ? {
+                  positiveVotes: { increment: 2 },
+                  ...(oppositeVote ? { negativeVotes: { decrement: 1 } } : {})
+                }
+              : {
+                  negativeVotes: { increment: 1 },
+                  ...(oppositeVote ? { positiveVotes: { decrement: 1 } } : {})
+                }
+        });
+      });
+    }
+
+    const updated = await prisma.releaseTag.findUniqueOrThrow({
+      where: { id: releaseTag.id },
+      include: {
+        tag: true,
+        user: { select: { id: true, username: true } },
+        votes: {
+          where: { userId: req.user.id },
+          select: { direction: true }
+        }
+      }
+    });
+
+    res.json(
+      buildReleaseTagPayload(
+        [
+          {
+            id: updated.tag.id,
+            name: updated.tag.name,
+            occurrences: updated.tag.occurrences
+          }
+        ],
+        [
+          {
+            id: updated.id,
+            tagId: updated.tag.id,
+            positiveVotes: updated.positiveVotes,
+            negativeVotes: updated.negativeVotes,
+            createdAt: updated.createdAt,
+            user: updated.user ?? null,
+            votes: updated.votes
+          }
+        ]
+      )[0]
+    );
+  })
+);
+
 // DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId
 router.delete(
   '/:releaseId/tags/:tagId',
-  requireAuth,
+  ...requirePermission('communities_manage'),
   validateParams(tagParamsSchema),
-  authHandler(async (req, res) => {
+  asyncHandler(async (req: Request, res: Response) => {
+    if (!req.user) return res.status(401).json({ msg: 'Unauthorized' });
+    const actorId = req.user.id;
     const {
       communityId,
       releaseId: id,
@@ -439,20 +920,34 @@ router.delete(
     }>(res);
 
     const release = await prisma.release.findFirst({
-      where: { id, communityId, tags: { some: { id: tagId } } },
+      where: { id, communityId, releaseTags: { some: { tagId } } },
       select: { id: true }
     });
     if (!release)
       return res.status(404).json({ msg: 'Release or tag not found' });
 
+    const tag = await prisma.tag.findUnique({
+      where: { id: tagId },
+      select: { name: true }
+    });
+
     await prisma.$transaction(async (tx) => {
-      await tx.release.update({
-        where: { id },
-        data: { tags: { disconnect: { id: tagId } } }
+      await tx.releaseTag.deleteMany({
+        where: { releaseId: id, tagId }
       });
       await tx.tag.update({
         where: { id: tagId },
         data: { occurrences: { decrement: 1 } }
+      });
+      await tx.releaseHistory.create({
+        data: {
+          releaseId: id,
+          actorId,
+          action: ReleaseHistoryAction.tag_removed,
+          summary: `Tag "${tag?.name ?? `#${tagId}`}" removed`,
+          changedFields: ['tags'],
+          before: tag ? ({ tagId, name: tag.name } as never) : undefined
+        }
       });
     });
 
@@ -471,10 +966,21 @@ router.delete(
       releaseId: number;
     }>(res);
     const existing = await prisma.release.findFirst({
-      where: { id, communityId }
+      where: { id, communityId },
+      select: { id: true, releaseTags: { select: { tagId: true } } }
     });
     if (!existing) return res.status(404).json({ msg: 'Release not found' });
-    await prisma.release.delete({ where: { id } });
+    await prisma.$transaction(async (tx) => {
+      await Promise.all(
+        existing.releaseTags.map((tag) =>
+          tx.tag.update({
+            where: { id: tag.tagId },
+            data: { occurrences: { decrement: 1 } }
+          })
+        )
+      );
+      await tx.release.delete({ where: { id } });
+    });
     res.status(204).send();
   })
 );

--- a/src/routes/api/forum/forumPost.ts
+++ b/src/routes/api/forum/forumPost.ts
@@ -31,13 +31,45 @@ const forumPostParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
 
-const postInclude = {
+const publicPostInclude = {
   author: { select: { id: true, username: true, avatar: true } },
   edits: {
-    orderBy: { editedAt: 'asc' as const },
+    orderBy: { editedAt: 'desc' as const },
+    take: 1,
+    select: {
+      id: true,
+      forumPostId: true,
+      editorId: true,
+      editedAt: true,
+      editor: { select: { id: true, username: true } }
+    }
+  }
+};
+
+const editHistoryInclude = {
+  edits: {
+    orderBy: { editedAt: 'desc' as const },
     include: { editor: { select: { id: true, username: true } } }
   }
 };
+
+const serializeForumPost = <
+  T extends {
+    edits?: Array<{
+      id: number;
+      forumPostId: number;
+      editorId: number;
+      editedAt: Date;
+      editor?: { id: number; username: string } | null;
+    }>;
+  }
+>(
+  post: T
+) => ({
+  ...post,
+  ...(post.edits?.[0] ? { lastEdit: post.edits[0] } : {}),
+  edits: undefined
+});
 
 // GET /api/forums/:forumId/topics/:forumTopicId/posts
 router.get(
@@ -72,7 +104,7 @@ router.get(
         orderBy: { createdAt: 'asc' },
         skip: pg.skip,
         take: pg.limit,
-        include: postInclude
+        include: publicPostInclude
       }),
       prisma.forumPost.count({
         where: {
@@ -82,7 +114,12 @@ router.get(
         }
       })
     ]);
-    paginatedResponse(res, posts, total, pg);
+    paginatedResponse(
+      res,
+      posts.map((post) => serializeForumPost(post)),
+      total,
+      pg
+    );
   })
 );
 
@@ -116,10 +153,52 @@ router.get(
         deletedAt: null,
         forumTopic: { forumId, deletedAt: null }
       },
-      include: postInclude
+      include: publicPostInclude
     });
     if (!post) return res.status(404).json({ msg: 'Post not found' });
-    res.json(post);
+    res.json(serializeForumPost(post));
+  })
+);
+
+// GET /api/forums/:forumId/topics/:forumTopicId/posts/:id/edits — moderator only
+router.get(
+  '/:id/edits',
+  requireAuth,
+  validateParams(forumPostParamsSchema),
+  authHandler(async (req, res) => {
+    const { forumId, forumTopicId, id } = parsedParams<{
+      forumId: number;
+      forumTopicId: number;
+      id: number;
+    }>(res);
+
+    const forum = await prisma.forum.findUnique({
+      where: { id: forumId },
+      select: { minClassRead: true }
+    });
+    if (!forum) return res.status(404).json({ msg: 'Forum not found' });
+    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+      return res
+        .status(403)
+        .json({ msg: 'Insufficient class to read this forum' });
+    }
+    if (!(await isModerator(req, res))) {
+      return res
+        .status(403)
+        .json({ msg: 'Insufficient permission to view edit history' });
+    }
+
+    const post = await prisma.forumPost.findFirst({
+      where: {
+        id,
+        forumTopicId,
+        deletedAt: null,
+        forumTopic: { forumId, deletedAt: null }
+      },
+      include: editHistoryInclude
+    });
+    if (!post) return res.status(404).json({ msg: 'Post not found' });
+    res.json({ data: post.edits });
   })
 );
 
@@ -178,8 +257,19 @@ router.put(
     if (!isOwner && !(await isModerator(req, res)))
       return res.status(403).json({ msg: 'Not authorized' });
 
-    const updated = await updatePost(id, req.user.id, post.body, body);
-    res.json(updated);
+    await updatePost(id, req.user.id, post.body, body);
+
+    const updated = await prisma.forumPost.findFirst({
+      where: {
+        id,
+        forumTopicId,
+        deletedAt: null,
+        forumTopic: { forumId, deletedAt: null }
+      },
+      include: publicPostInclude
+    });
+    if (!updated) return res.status(404).json({ msg: 'Post not found' });
+    res.json(serializeForumPost(updated));
   })
 );
 

--- a/src/routes/api/search.ts
+++ b/src/routes/api/search.ts
@@ -32,8 +32,12 @@ function buildTagWhere(
     .filter(Boolean);
   if (!names?.length) return undefined;
   return tagMode === 'all'
-    ? { AND: names.map((name) => ({ tags: { some: { name } } })) }
-    : { tags: { some: { name: { in: names } } } };
+    ? {
+        AND: names.map((name) => ({
+          releaseTags: { some: { tag: { name } } }
+        }))
+      }
+    : { releaseTags: { some: { tag: { name: { in: names } } } } };
 }
 
 function buildArtistTagWhere(
@@ -68,7 +72,7 @@ const RELEASE_SELECT = {
   description: true,
   createdAt: true,
   artist: { select: { id: true, name: true, vanityHouse: true } },
-  tags: { select: { id: true, name: true } },
+  releaseTags: { select: { tag: { select: { id: true, name: true } } } },
   _count: { select: { consumers: true, contributors: true } }
 } as const;
 
@@ -145,7 +149,15 @@ router.get(
         take: q.limit,
         select: RELEASE_SELECT
       });
-      return paginatedResponse(res, data, count, pg);
+      return paginatedResponse(
+        res,
+        data.map((release) => ({
+          ...release,
+          tags: release.releaseTags.map((entry) => entry.tag)
+        })),
+        count,
+        pg
+      );
     }
 
     const orderByMap: Record<string, unknown> = {
@@ -166,7 +178,15 @@ router.get(
       prisma.release.count({ where })
     ]);
 
-    paginatedResponse(res, data, total, pg);
+    paginatedResponse(
+      res,
+      data.map((release) => ({
+        ...release,
+        tags: release.releaseTags.map((entry) => entry.tag)
+      })),
+      total,
+      pg
+    );
   })
 );
 

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -73,7 +73,8 @@ export const updateGroupSchema = z.object({
   year: z.number().int().min(1900).max(2100).optional(),
   isEdition: z.boolean().optional(),
   edition: z.record(z.string(), z.unknown()).optional(),
-  tagIds: z.array(z.number().int().positive()).optional()
+  tagIds: z.array(z.number().int().positive()).optional(),
+  editSummary: z.string().trim().max(255).optional()
 });
 
 export const releaseVoteSchema = z.object({
@@ -88,9 +89,14 @@ export const releaseTagSchema = z.object({
     .transform((s) => s.trim().toLowerCase())
 });
 
+export const releaseTagVoteSchema = z.object({
+  direction: z.enum(['up', 'down'])
+});
+
 export type CreateCommunityInput = z.infer<typeof createCommunitySchema>;
 export type UpdateCommunityInput = z.infer<typeof updateCommunitySchema>;
 export type CreateGroupInput = z.infer<typeof createGroupSchema>;
 export type UpdateGroupInput = z.infer<typeof updateGroupSchema>;
 export type ReleaseVoteInput = z.infer<typeof releaseVoteSchema>;
 export type ReleaseTagInput = z.infer<typeof releaseTagSchema>;
+export type ReleaseTagVoteInput = z.infer<typeof releaseTagVoteSchema>;

--- a/src/search.spec.ts
+++ b/src/search.spec.ts
@@ -43,7 +43,7 @@ describe('GET /api/search/releases', () => {
     expect(prismaMock.release.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          tags: { some: { name: { in: ['jazz'] } } }
+          releaseTags: { some: { tag: { name: { in: ['jazz'] } } } }
         })
       })
     );
@@ -57,8 +57,8 @@ describe('GET /api/search/releases', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           AND: [
-            { tags: { some: { name: 'jazz' } } },
-            { tags: { some: { name: 'blues' } } }
+            { releaseTags: { some: { tag: { name: 'jazz' } } } },
+            { releaseTags: { some: { tag: { name: 'blues' } } } }
           ]
         })
       })


### PR DESCRIPTION
## Summary
- add release tag voting, history tracking, and search/sorting support for community releases
- expose release history and tag-voting API contracts in OpenAPI and backend tests
- restrict forum post revision bodies to moderators with a dedicated edit-history endpoint while keeping public last-edit attribution

## Commits
- `0ad4c3b` Add release tag voting and history tracking
- `1b24079` Protect forum edit history behind moderator-only fetch

## Testing
- `npm run openapi:export`
- `npm test -- --runInBand src/forum.spec.ts src/modules/forum.spec.ts src/docs.spec.ts`
- `npm run build`
- `npm run lint`
