### PR TITLE
Add account recovery admin flow and email delivery

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -1,0 +1,236 @@
+# Stellar ↔ Gazelle Feature Parity
+
+Legend: ✅ complete | 🔧 backend only | 🎨 frontend only | ❌ not started | N/A not applicable
+
+Audit notes (2026-05-21):
+- This file previously overstated several gaps. Invite tree, privacy controls, PM drafts, staff canned responses, collage comments, and comment subscription UI are implemented.
+- Bonus points are permanently deferred from the current launch scope.
+- Forum post edit history UI is complete. Public forum post payloads now expose only `lastEdit` attribution; moderator-only revision bodies load from a dedicated endpoint instead of being embedded in the thread payload.
+- Account recovery admin flow is complete. Stellar's recovery is standard forgot-password (not legacy-tracker migration as in Gazelle), so the staff queue shows pending/used/expired tokens rather than a claim/approve/deny evidence-review workflow. Staff can revoke pending tokens from the queue, and admins can trigger recovery emails directly from the user profile panel. OpenAPI spec updated for the three new user endpoints; frontend types regenerated.
+
+## Auth & Account
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Login / logout | ✅ | Cookie-based JWT, session tracked |
+| Register (open / invite-only) | ✅ | registrationStatus setting honored |
+| Change password | ✅ | POST /api/auth/password |
+| Change email | ✅ | PUT /api/auth/email + UserEmailHistory |
+| Account recovery (self-service) | ✅ | token flow, 2h TTL |
+| Session list / revoke | ✅ | GET/DELETE /api/auth/sessions |
+| 2FA / TOTP | ❌ | nice-to-have |
+| Paranoia / privacy settings | ✅ | privacy fields persisted in UserSettings and enforced in profile projection; implemented as coarse flags + paranoia level rather than Gazelle's serialized paranoia array |
+
+## User Management
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Profile view / edit | ✅ | /api/profile/me, /api/profile/user/:id |
+| User settings | ✅ | GET/PUT /api/users/settings |
+| Staff: ip/email history | ✅ | |
+| Staff: disable / enable | ✅ | POST /api/users/:id/disable\|enable |
+| Staff: warn user | ✅ | POST /api/users/:id/warn + UserWarning |
+| Staff: moderation notes | ✅ | GET/POST/DELETE /api/users/:id/notes |
+| Staff: set rank | ✅ | PUT /api/users/:id/rank |
+| Donor ranks admin CRUD | ✅ | GET/POST/PUT/DELETE /api/users/donor-ranks |
+| Grant / revoke donor | ✅ | POST/DELETE /api/users/:id/donor |
+| Invite system (send, use) | ✅ | /api/profile/:id/invites, register flow |
+| Invite tree visualization | ✅ | profile payload includes `inviteTree`; frontend route/component renders it |
+| Snatch list | ✅ | GET /api/users/me/snatch-list |
+| Account recovery admin queue | ✅ | GET/DELETE /api/users/recovery-requests + POST /api/users/:id/recovery; queue page at /private/staff/tools/recovery-queue; trigger-recovery button on user profile; deviation from Gazelle: token-based monitoring queue (not claim/approve/invite flow — no legacy migration) |
+
+## Releases / Contributions
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Browse releases (search, filter) | ✅ | /api/search + community releases |
+| Release detail | ✅ | /api/communities/:cid/releases/:rid |
+| Release create / edit / delete | ✅ | via contributions |
+| Tag system (add/remove) | ✅ | tag routes on artist |
+| Tag voting | ❌ | no route to vote on release tags |
+| Cover art management | ❌ | image field exists, no dedicated upload |
+| Edit history / revision log | ❌ | Gazelle tracks per-torrent edit logs |
+| Random release | ✅ | GET /api/random |
+| Vanity house releases | 🔧 | isVanityHouse field, home.ts exposes it |
+
+## Requests & Bounties
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| List / search requests | ✅ | GET /api/requests |
+| Create / edit / delete request | ✅ | full CRUD |
+| Add bounty (vote) | ✅ | POST /api/requests/:id/bounty |
+| Fill request | ✅ | POST /api/requests/:id/fill |
+| Unfill request | ✅ | POST /api/requests/:id/unfill |
+| Notify requester + voters on fill | ✅ | emits request_filled notifications |
+
+## Notifications & Subscriptions
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Forum subscription (subscribe/unsubscribe) | ✅ | Subscription model |
+| Forum post → notify subscribers | ✅ | forum.ts fires createMany (type: forum_sub) |
+| Forum quote → notify quoted user | ✅ | type: forum_quote |
+| Comment subscription (subscribe/unsubscribe) | ✅ | comment subscription routes + UI present on commentable surfaces |
+| Comment posted → notify comment subscribers | ✅ | comments.ts fires (type: comment_sub) |
+| Collage subscription (subscribe/unsubscribe) | ✅ | CollageSubscription model + route |
+| Collage entry added → notify subscribers | ✅ | collages.ts fires (type: collage_updated) |
+| Request filled → notify requester + voters | ✅ | requests.ts fires (type: request_filled) |
+| PM unread indicator | ✅ | MessageParticipant.unreadCount in NotificationCorner |
+| Artist subscription (follow/unfollow) | ✅ | ArtistSubscription model + GET/POST/DELETE /:id/subscribe |
+| New-contribution → notify followers | ✅ | artist_release notification on contribution creation |
+| Notification bell — per-type text | ✅ | NotificationCorner renderNotificationText |
+| Mark read / delete / mark all read | ✅ | |
+
+## Messaging
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| PM inbox / sent / conversation | ✅ | full CRUD |
+| Unread count | ✅ | |
+| Bulk operations | ✅ | POST /api/messages/bulk-update |
+| Search PMs | ✅ | query param |
+| PM drafts | ✅ | GET/POST/PUT/DELETE `/api/messages/drafts` + ComposeForm/DraftsPage |
+| Forward message | ❌ | no route |
+| Staff inbox (tickets) | ✅ | full CRUD |
+| Staff inbox scoreboard | ✅ | |
+| Staff canned responses | ✅ | `/api/staff-inbox/responses` + CannedResponsesPage/TicketView integration |
+| Staff PM (staff-to-staff) | 🔧 | staffPm.ts module + routes, no UI |
+
+## Forums
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Forum / category CRUD | ✅ | |
+| Topic CRUD (create, lock, sticky, delete) | ✅ | |
+| Post CRUD (create, edit, delete) | ✅ | |
+| Post edit history | ✅ | inline last-edited marker for all readers; staff-only revision history in ForumTopicPost |
+| Polls (create, vote) | ✅ | |
+| Topic notes (staff) | ✅ | |
+| Last-read tracking | ✅ | |
+| Class-level read/write gates | ✅ | minClassRead/Write enforced |
+
+## Artists
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Artist profile | ✅ | GET /api/communities/:cid/artist/:id |
+| Artist CRUD | ✅ | create/update/delete |
+| Artist history / reverts | ✅ | |
+| Similar artists | ✅ | add/remove/vote |
+| Artist aliases | ✅ | |
+| Artist tags | ✅ | |
+| Artist subscription ("follow") | ✅ | ArtistSubscription model + subscribe/unsubscribe/status routes; follow button on ArtistPage |
+| New-release notification to followers | ✅ | artist_release emitted on contribution creation; rendered in NotificationCorner |
+
+## Collages
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Collage CRUD | ✅ | |
+| Collage entries (add/remove/sort) | ✅ | |
+| Subscribe / unsubscribe | ✅ | GET/POST in collages route |
+| Entry added → notify subscribers | ✅ | emits collage_updated notifications |
+| Collage comments | ✅ | shared comments route supports `page=collages`; CollageDetail renders CommentsSection |
+| Personal collages (class limit) | ❌ | no per-user collage limits |
+
+## Wiki
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Article CRUD + soft-delete | ✅ | |
+| Revision history + compare | ✅ | |
+| Aliases | ✅ | |
+| Permission levels (minRead, minEdit) | ✅ | |
+| Full-text search | ✅ | |
+
+## Reports
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| File report (user-submitted) | ✅ | |
+| Staff queue (claim/unclaim/resolve) | ✅ | |
+| Staff notes | ✅ | |
+| Report stats | ✅ | |
+
+## Bookmarks
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Artist / release / collage / request bookmarks | ✅ | all 4 types |
+| Bulk remove snatched | ❌ | nice-to-have |
+
+## Stats & Charts
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Site stats | ✅ | |
+| Top 10 (releases, users, tags) | ✅ | TTL-cached + snapshots |
+| Historical stats | ❌ | nice-to-have |
+
+## Site History / Audit Log
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Searchable audit log | ✅ | |
+
+## Search
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Cross-domain search | ✅ | GET /api/search |
+| Full-text (DB LIKE) | ✅ | |
+| Sphinx / advanced FTS | ❌ | nice-to-have post-launch |
+
+## Bonus Economy
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Bonus point balance | ❌ | no model, no route |
+| Earn points (contribute/seed events) | ❌ | not started |
+| Bonus point history | ❌ | not started |
+| Bonus store (tokens, invites, titles) | ❌ | not started |
+| EconomyTransaction ledger | 🔧 | immutable ledger exists and is used for download grant debit/credit/reversal flows; no bonus-facing routes or history yet |
+
+## Miscellaneous
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Downloads / access grants | ✅ | |
+| Announcements | ✅ | |
+| Posts (blog) | ✅ | |
+| Site settings (admin) | ✅ | |
+| Stylesheet / theme per user | 🔧 | route exists, frontend may not use it |
+| Applications / staff roles | ❌ | Applicant stub model |
+| Friends system | ❌ | stub model |
+| Staff directory | ❌ | nice-to-have |
+
+---
+
+## Priority Queue
+
+### Launch-blocking
+
+(none — all launch-blocking items resolved)
+
+### High priority (ship shortly after launch)
+
+2. Staff PM (staff-to-staff) UI and product definition
+3. Stylesheet / theme application (settings persist, but the client does not apply site appearance or external stylesheet globally)
+4. Cover art management
+
+### Quick wins (backend done, just needs UI)
+
+5. PARITY tracker cleanup — several rows below still need periodic revalidation as features land so the queue stays trustworthy
+6. Staff PM scoreboard/review pass — verify current implementation against Gazelle workflow before scheduling follow-up work
+
+### Nice-to-have
+
+8. 2FA / TOTP
+9. Tag voting on releases
+10. Cover art management
+11. Release edit history / revision log
+12. Forward message
+13. Personal collage limits per class
+14. Historical stats
+15. Applications / staff roles, friends system, and staff directory

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -16,6 +16,9 @@ import {
 } from './test/apiTestHarness';
 import { makeUser, asUserMock } from './test/factories';
 import { updateProfile } from './modules/profile';
+import { sendRecoveryEmail } from './lib/mailer';
+
+const sendRecoveryEmailMock = sendRecoveryEmail as jest.Mock;
 
 describe('API auth/profile/user flows', () => {
   beforeEach(() => {
@@ -419,22 +422,23 @@ describe('API auth/profile/user flows', () => {
   });
 
   it('handles recovery requests and reset flows', async () => {
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    prismaMock.user.findUnique.mockResolvedValueOnce({ id: 7 } as never);
-    prismaMock.accountRecovery.create.mockResolvedValueOnce({ id: 1 } as never);
+    sendRecoveryEmailMock.mockResolvedValue(true);
+
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 7,
+      email: 'kai@example.com'
+    } as never);
+    prismaMock.$transaction.mockResolvedValueOnce([{}, { id: 1 }] as never);
 
     const requestRes = await request(app)
       .post('/api/auth/recovery/request')
       .send({ email: 'kai@example.com' });
 
     expect(requestRes.status).toBe(200);
-    expect(prismaMock.accountRecovery.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        userId: 7,
-        token: expect.any(String),
-        expiresAt: expect.any(Date)
-      })
-    });
+    expect(sendRecoveryEmailMock).toHaveBeenCalledWith(
+      'kai@example.com',
+      expect.stringContaining('/recovery?token=')
+    );
 
     prismaMock.accountRecovery.findFirst.mockResolvedValueOnce(null);
     const invalidReset = await request(app)
@@ -470,8 +474,22 @@ describe('API auth/profile/user flows', () => {
       where: { userId: 7, revokedAt: null },
       data: { revokedAt: expect.any(Date) }
     });
+  });
 
-    logSpy.mockRestore();
+  it('skips token creation when sendRecoveryEmail returns false (SMTP off)', async () => {
+    sendRecoveryEmailMock.mockResolvedValueOnce(false);
+
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 7,
+      email: 'kai@example.com'
+    } as never);
+
+    const res = await request(app)
+      .post('/api/auth/recovery/request')
+      .send({ email: 'kai@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
   it('lists and revokes the current user sessions', async () => {

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -4,6 +4,16 @@ import { getLogger } from '../modules/logging';
 
 const log = getLogger('mailer');
 
+function createTransporter() {
+  return nodemailer.createTransport({
+    host: emailConfig.smtpHost,
+    port: emailConfig.smtpPort,
+    auth: emailConfig.smtpUser
+      ? { user: emailConfig.smtpUser, pass: emailConfig.smtpPass }
+      : undefined
+  });
+}
+
 export async function sendInviteEmail(
   to: string,
   inviteKey: string
@@ -13,19 +23,29 @@ export async function sendInviteEmail(
     return false;
   }
 
-  const transporter = nodemailer.createTransport({
-    host: emailConfig.smtpHost,
-    port: emailConfig.smtpPort,
-    auth: emailConfig.smtpUser
-      ? { user: emailConfig.smtpUser, pass: emailConfig.smtpPass }
-      : undefined
-  });
-
-  await transporter.sendMail({
+  await createTransporter().sendMail({
     from: emailConfig.fromAddress,
     to,
     subject: "You've been invited",
     text: `You have been invited to join the site. Register here:\n\n${emailConfig.siteUrl}/register?inviteKey=${inviteKey}\n\nThis invitation expires in 30 days.`
+  });
+  return true;
+}
+
+export async function sendRecoveryEmail(
+  to: string,
+  resetUrl: string
+): Promise<boolean> {
+  if (!emailConfig.smtpHost) {
+    log.warn('STELLAR_SMTP_HOST not set — recovery email not sent', { to });
+    return false;
+  }
+
+  await createTransporter().sendMail({
+    from: emailConfig.fromAddress,
+    to,
+    subject: 'Account recovery',
+    text: `You requested a password reset. Follow this link to set a new password:\n\n${resetUrl}\n\nThis link expires in 2 hours. If you did not request this, you can ignore this email.`
   });
   return true;
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -640,6 +640,102 @@ registry.registerPath({
   }
 });
 
+// ─── Staff recovery queue ─────────────────────────────────────────────────────
+
+const RecoveryRequestItem = registry.register(
+  'RecoveryRequestItem',
+  z.object({
+    id: z.number(),
+    userId: z.number(),
+    username: z.string(),
+    email: z.string(),
+    status: z.enum(['pending', 'used', 'expired']),
+    createdAt: z.string().datetime(),
+    expiresAt: z.string().datetime(),
+    usedAt: z.string().datetime().nullable()
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/users/recovery-requests',
+  tags: ['Users'],
+  request: {
+    query: z.object({
+      status: z.enum(['pending', 'used', 'expired']).optional(),
+      page: z.coerce.number().int().positive().optional(),
+      limit: z.coerce.number().int().positive().optional()
+    })
+  },
+  responses: {
+    200: {
+      description: 'Paginated list of account recovery requests',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(RecoveryRequestItem),
+            meta: PaginationMeta
+          })
+        }
+      }
+    },
+    403: {
+      description: 'Forbidden',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/users/recovery-requests/{reqId}',
+  tags: ['Users'],
+  request: { params: z.object({ reqId: z.string() }) },
+  responses: {
+    200: {
+      description: 'Recovery request revoked',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    409: {
+      description: 'Token already used',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    403: {
+      description: 'Forbidden',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/users/{id}/recovery',
+  tags: ['Users'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Recovery email sent',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'User not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    502: {
+      description: 'Email delivery not configured',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    403: {
+      description: 'Forbidden',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 // ─── Profile ──────────────────────────────────────────────────────────────────
 
 registry.registerPath({

--- a/src/moderation.spec.ts
+++ b/src/moderation.spec.ts
@@ -9,6 +9,9 @@ import {
   createUserMock
 } from './test/apiTestHarness';
 import { makeUser } from './test/factories';
+import { sendRecoveryEmail } from './lib/mailer';
+
+const sendRecoveryEmailMock = sendRecoveryEmail as jest.Mock;
 
 beforeEach(() => resetApiTestState());
 
@@ -1037,5 +1040,125 @@ describe('POST /api/users/:id/donor with expiresAt', () => {
       .send({ donorRankId: 3, expiresAt: '2027-01-01T00:00:00.000Z' });
 
     expect(res.status).toBe(201);
+  });
+});
+
+// ─── Staff recovery queue ─────────────────────────────────────────────────────
+
+const setUsersEdit = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue(
+    makeUserRank({ users_edit: true, staff: true, admin: true })
+  );
+
+describe('GET /api/users/recovery-requests', () => {
+  beforeEach(() => setUsersEdit());
+
+  it('returns paginated pending recovery requests', async () => {
+    prismaMock.accountRecovery.findMany.mockResolvedValue([
+      {
+        id: 1,
+        userId: 9,
+        token: 'abc',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: null,
+        createdAt: new Date(),
+        user: { username: 'alice', email: 'alice@example.com' }
+      }
+    ] as never);
+    prismaMock.accountRecovery.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/users/recovery-requests');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].username).toBe('alice');
+    expect(res.body.meta.total).toBe(1);
+  });
+
+  it('returns 403 without users_edit permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).get('/api/users/recovery-requests');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/users/recovery-requests/:reqId', () => {
+  beforeEach(() => setUsersEdit());
+
+  it('deletes a pending recovery request and audits', async () => {
+    prismaMock.accountRecovery.findUnique.mockResolvedValue({
+      id: 5,
+      usedAt: null
+    } as never);
+    prismaMock.accountRecovery.delete.mockResolvedValue({} as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).delete('/api/users/recovery-requests/5');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ msg: 'Recovery request revoked' });
+  });
+
+  it('returns 404 for an unknown request', async () => {
+    prismaMock.accountRecovery.findUnique.mockResolvedValue(null);
+    const res = await request(app).delete('/api/users/recovery-requests/99');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when token has already been used', async () => {
+    prismaMock.accountRecovery.findUnique.mockResolvedValue({
+      id: 5,
+      usedAt: new Date()
+    } as never);
+    const res = await request(app).delete('/api/users/recovery-requests/5');
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 403 without users_edit permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).delete('/api/users/recovery-requests/5');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/users/:id/recovery', () => {
+  beforeEach(() => setUsersEdit());
+
+  it('sends a recovery email and audits', async () => {
+    sendRecoveryEmailMock.mockResolvedValue(true);
+    prismaMock.user.findUnique.mockResolvedValue(
+      makeUser({ id: 9, email: 'target@example.com', disabled: false }) as never
+    );
+    prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/users/9/recovery');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ msg: 'Recovery email sent' });
+    expect(sendRecoveryEmailMock).toHaveBeenCalledWith(
+      'target@example.com',
+      expect.stringContaining('/recovery?token=')
+    );
+  });
+
+  it('returns 404 for an unknown user', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    const res = await request(app).post('/api/users/999/recovery');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a disabled user', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(
+      makeUser({ id: 9, disabled: true }) as never
+    );
+    const res = await request(app).post('/api/users/9/recovery');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 without users_edit permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).post('/api/users/9/recovery');
+    expect(res.status).toBe(403);
   });
 });

--- a/src/routes/api/auth.ts
+++ b/src/routes/api/auth.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { prisma } from '../../lib/prisma';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
-import { auth as authConfig } from '../../modules/config';
+import { auth as authConfig, email as emailConfig } from '../../modules/config';
 import { requireAuth } from '../../middleware/auth';
 import {
   validate,
@@ -35,6 +35,7 @@ import {
   toAuthUser
 } from '../../modules/auth';
 import { getSettings } from '../../modules/settings';
+import { sendRecoveryEmail } from '../../lib/mailer';
 import { z } from 'zod';
 
 const router = express.Router();
@@ -255,22 +256,37 @@ router.post(
   validate(recoveryRequestSchema),
   asyncHandler(async (req: Request, res: Response) => {
     const { email } = parsedBody<RecoveryRequestInput>(res);
+    const genericMsg = 'If that email exists, a recovery link has been sent';
 
     const user = await prisma.user.findUnique({
       where: { email: email.toLowerCase() },
-      select: { id: true }
+      select: { id: true, email: true }
     });
 
     if (user) {
       const token = crypto.randomBytes(32).toString('hex');
-      const expiresAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
-      await prisma.accountRecovery.create({
-        data: { userId: user.id, token, expiresAt }
-      });
-      console.log(`[recovery] token for user ${user.id}: ${token}`);
+      const resetUrl = `${emailConfig.siteUrl}/recovery?token=${token}`;
+
+      // Only write to DB if email delivery succeeds — avoids dead rows when SMTP is off
+      const sent = await sendRecoveryEmail(user.email, resetUrl);
+      if (sent) {
+        const now = new Date();
+        const expiresAt = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+
+        // Enforce single-active-token: expire any pending tokens before creating a new one
+        await prisma.$transaction([
+          prisma.accountRecovery.updateMany({
+            where: { userId: user.id, usedAt: null, expiresAt: { gt: now } },
+            data: { expiresAt: now }
+          }),
+          prisma.accountRecovery.create({
+            data: { userId: user.id, token, expiresAt }
+          })
+        ]);
+      }
     }
 
-    res.json({ msg: 'If that email exists, a recovery link has been sent' });
+    res.json({ msg: genericMsg });
   })
 );
 

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -33,6 +33,10 @@ import {
   type GrantDonorInput
 } from '../../schemas/user';
 import { audit } from '../../lib/audit';
+import { parsePage, paginatedResponse } from '../../lib/pagination';
+import { sendRecoveryEmail } from '../../lib/mailer';
+import { email as emailConfig } from '../../modules/config';
+import crypto from 'crypto';
 
 const router = express.Router();
 const userIdParamsSchema = z.object({
@@ -49,6 +53,12 @@ const warningParamsSchema = z.object({
   id: z.coerce.number().int().positive(),
   warnId: z.coerce.number().int().positive()
 });
+const reqIdParamsSchema = z.object({
+  reqId: z.coerce.number().int().positive()
+});
+const recoveryStatusSchema = z
+  .enum(['pending', 'used', 'expired'])
+  .default('pending');
 
 // ─── Donor ranks (static paths — must come before /:id) ──────────────────────
 
@@ -201,6 +211,80 @@ router.put(
   })
 );
 
+// ─── Staff recovery tools (static paths — must be before /:id) ───────────────
+
+// GET /api/users/recovery-requests
+router.get(
+  '/recovery-requests',
+  ...requirePermission('users_edit'),
+  authHandler(async (req, res) => {
+    const rawStatus = req.query.status as string | undefined;
+    const statusResult = recoveryStatusSchema.safeParse(rawStatus ?? 'pending');
+    const status = statusResult.success ? statusResult.data : 'pending';
+
+    const now = new Date();
+    const where =
+      status === 'pending'
+        ? { usedAt: null, expiresAt: { gt: now } }
+        : status === 'used'
+        ? { usedAt: { not: null } }
+        : { usedAt: null, expiresAt: { lte: now } };
+
+    const pg = parsePage(req);
+    const [records, total] = await Promise.all([
+      prisma.accountRecovery.findMany({
+        where,
+        include: { user: { select: { username: true, email: true } } },
+        orderBy: { createdAt: 'desc' },
+        skip: pg.skip,
+        take: pg.limit
+      }),
+      prisma.accountRecovery.count({ where })
+    ]);
+
+    const data = records.map((r) => ({
+      id: r.id,
+      userId: r.userId,
+      username: r.user.username,
+      email: r.user.email,
+      status,
+      createdAt: r.createdAt,
+      expiresAt: r.expiresAt,
+      usedAt: r.usedAt
+    }));
+
+    paginatedResponse(res, data, total, pg);
+  })
+);
+
+// DELETE /api/users/recovery-requests/:reqId
+router.delete(
+  '/recovery-requests/:reqId',
+  ...requirePermission('users_edit'),
+  validateParams(reqIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { reqId } = parsedParams<{ reqId: number }>(res);
+    const record = await prisma.accountRecovery.findUnique({
+      where: { id: reqId }
+    });
+    if (!record)
+      return res.status(404).json({ msg: 'Recovery request not found' });
+    if (record.usedAt)
+      return res
+        .status(409)
+        .json({ msg: 'Cannot revoke a used recovery token' });
+    await prisma.accountRecovery.delete({ where: { id: reqId } });
+    await audit(
+      prisma,
+      req.user.id,
+      'recovery.revoked',
+      'AccountRecovery',
+      reqId
+    );
+    res.json({ msg: 'Recovery request revoked' });
+  })
+);
+
 // GET /api/users/:id — get user by id (public profile)
 router.get(
   '/:id',
@@ -251,6 +335,47 @@ router.post(
 );
 
 // ─── User moderation routes (after /:id) ─────────────────────────────────────
+
+// POST /api/users/:id/recovery — admin-triggered recovery email
+router.post(
+  '/:id/recovery',
+  ...requirePermission('users_edit'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: { id: true, email: true, disabled: true }
+    });
+    if (!user || user.disabled)
+      return res.status(404).json({ msg: 'User not found' });
+
+    const token = crypto.randomBytes(32).toString('hex');
+    const resetUrl = `${emailConfig.siteUrl}/recovery?token=${token}`;
+
+    // Send email first — only touch DB if delivery succeeds
+    const sent = await sendRecoveryEmail(user.email, resetUrl);
+    if (!sent) {
+      return res.status(502).json({ msg: 'Email delivery is not configured' });
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+    await prisma.$transaction([
+      prisma.accountRecovery.updateMany({
+        where: { userId: id, usedAt: null, expiresAt: { gt: now } },
+        data: { expiresAt: now }
+      }),
+      prisma.accountRecovery.create({
+        data: { userId: id, token, expiresAt }
+      })
+    ]);
+
+    await audit(prisma, req.user.id, 'recovery.admin_triggered', 'User', id);
+    res.json({ msg: 'Recovery email sent' });
+  })
+);
 
 // GET /api/users/:id/warnings
 router.get(

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -99,6 +99,11 @@ jest.mock('../modules/staffInbox', () => ({
   deleteResponse: jest.fn()
 }));
 
+jest.mock('../lib/mailer', () => ({
+  sendInviteEmail: jest.fn().mockResolvedValue(true),
+  sendRecoveryEmail: jest.fn().mockResolvedValue(true)
+}));
+
 jest.mock('../modules/staffPm', () => ({
   createTicket: jest.fn(),
   listMyTickets: jest.fn(),


### PR DESCRIPTION
## Summary

- **Email delivery**: `sendRecoveryEmail()` added to mailer; self-service and admin-triggered flows both write to DB only after confirmed email delivery, avoiding dead token rows when SMTP is unconfigured
- **Single-token policy**: both flows expire all pending tokens before creating a new one — users can no longer accumulate multiple valid reset links
- **Staff endpoints**: `GET /users/recovery-requests` (paginated queue, Zod-validated `?status`), `DELETE /users/recovery-requests/:reqId` (revoke pending; 409 on used), `POST /users/:id/recovery` (admin-triggered with email-first write order)
- **OpenAPI**: all three endpoints registered in `openapi.ts`; `openapi.json` regenerated

## Intentional deviations from Gazelle

Gazelle's recovery is a legacy-tracker migration flow (screenshot evidence, announce-key matching, backup DB). Stellar's is standard forgot-password — user identity is established by the linked `userId`, so no claim/approve/deny review workflow is needed. The staff queue is monitoring and control only.

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean on changed files
- [ ] `npm run test --no-coverage` — 1048 passed
- [ ] Self-service: POST `/api/auth/recovery/request` with a known email → email triggered; POST again → previous token expired, new one issued
- [ ] Self-service: SMTP unconfigured → generic 200 returned, no DB rows written
- [ ] Staff: `GET /api/users/recovery-requests?status=pending` → lists pending tokens
- [ ] Staff: `DELETE /api/users/recovery-requests/:id` on a pending token → 200; on a used token → 409
- [ ] Staff: `POST /api/users/:id/recovery` → email sent, old pending tokens expired; SMTP off → 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)