### PR TITLE
Release edit history, contributor edit access, and revert

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -1,0 +1,233 @@
+# Stellar ↔ Gazelle Feature Parity
+
+Legend: ✅ complete | 🔧 backend only | 🎨 frontend only | ❌ not started | N/A not applicable
+
+Audit notes (2026-05-21):
+- This file previously overstated several gaps. Invite tree, privacy controls, PM drafts, staff canned responses, collage comments, and comment subscription UI are implemented.
+- Bonus points are permanently deferred from the current launch scope.
+- Forum post edit history UI is complete. Public forum post payloads now expose only `lastEdit` attribution; moderator-only revision bodies load from a dedicated endpoint instead of being embedded in the thread payload.
+- Account recovery admin flow is complete. Stellar's recovery is standard forgot-password (not legacy-tracker migration as in Gazelle), so the staff queue shows pending/used/expired tokens rather than a claim/approve/deny evidence-review workflow. Staff can revoke pending tokens from the queue, and admins can trigger recovery emails directly from the user profile panel. OpenAPI spec updated for the three new user endpoints; frontend types regenerated.
+
+Audit notes (2026-05-22):
+- Tag voting is complete. The implicit Prisma many-to-many release-tag relation was replaced with explicit ReleaseTag and ReleaseTagVote models. POST /:releaseId/tags/:tagId/vote; tag deletion now requires communities_manage. ReleaseHistory added to audit all release changes.
+- Personal collage limits are complete. `personalCollageLimit` on `UserRank` (0 = unlimited); enforced in POST /api/collages for the personal category; staff/admin bypass, collages_moderate does not. Seeded as User=1 / Power User=2 / Staff=3 / SysOp=4 on fresh installs; existing installs default to 0 and must be configured via the admin rank form. Counter and submit gate added to the collage create form.
+
+## Auth & Account
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Login / logout | ✅ | Cookie-based JWT, session tracked |
+| Register (open / invite-only) | ✅ | registrationStatus setting honored |
+| Change password | ✅ | POST /api/auth/password |
+| Change email | ✅ | PUT /api/auth/email + UserEmailHistory |
+| Account recovery (self-service) | ✅ | token flow, 2h TTL |
+| Session list / revoke | ✅ | GET/DELETE /api/auth/sessions |
+| 2FA / TOTP | ❌ | nice-to-have |
+| Paranoia / privacy settings | ✅ | privacy fields persisted in UserSettings and enforced in profile projection; implemented as coarse flags + paranoia level rather than Gazelle's serialized paranoia array |
+
+## User Management
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Profile view / edit | ✅ | /api/profile/me, /api/profile/user/:id |
+| User settings | ✅ | GET/PUT /api/users/settings |
+| Staff: ip/email history | ✅ | |
+| Staff: disable / enable | ✅ | POST /api/users/:id/disable\|enable |
+| Staff: warn user | ✅ | POST /api/users/:id/warn + UserWarning |
+| Staff: moderation notes | ✅ | GET/POST/DELETE /api/users/:id/notes |
+| Staff: set rank | ✅ | PUT /api/users/:id/rank |
+| Donor ranks admin CRUD | ✅ | GET/POST/PUT/DELETE /api/users/donor-ranks |
+| Grant / revoke donor | ✅ | POST/DELETE /api/users/:id/donor |
+| Invite system (send, use) | ✅ | /api/profile/:id/invites, register flow |
+| Invite tree visualization | ✅ | profile payload includes `inviteTree`; frontend route/component renders it |
+| Snatch list | ✅ | GET /api/users/me/snatch-list |
+| Account recovery admin queue | ✅ | GET/DELETE /api/users/recovery-requests + POST /api/users/:id/recovery; queue page at /private/staff/tools/recovery-queue; trigger-recovery button on user profile; deviation from Gazelle: token-based monitoring queue (not claim/approve/invite flow — no legacy migration) |
+
+## Releases / Contributions
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Browse releases (search, filter) | ✅ | /api/search + community releases |
+| Release detail | ✅ | /api/communities/:cid/releases/:rid |
+| Release create / edit / delete | ✅ | via contributions |
+| Tag system (add/remove) | ✅ | tag routes on artist |
+| Tag voting | ✅ | POST /:releaseId/tags/:tagId/vote; ReleaseTag/ReleaseTagVote models with score tracking |
+| Cover art management | ❌ | image field exists, no dedicated upload |
+| Edit history / revision log | ✅ | ReleaseHistory audits create, edit, tag add/remove, contribution added |
+| Random release | ✅ | GET /api/random |
+| Vanity house releases | 🔧 | isVanityHouse field, home.ts exposes it |
+
+## Requests & Bounties
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| List / search requests | ✅ | GET /api/requests |
+| Create / edit / delete request | ✅ | full CRUD |
+| Add bounty (vote) | ✅ | POST /api/requests/:id/bounty |
+| Fill request | ✅ | POST /api/requests/:id/fill |
+| Unfill request | ✅ | POST /api/requests/:id/unfill |
+| Notify requester + voters on fill | ✅ | emits request_filled notifications |
+
+## Notifications & Subscriptions
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Forum subscription (subscribe/unsubscribe) | ✅ | Subscription model |
+| Forum post → notify subscribers | ✅ | forum.ts fires createMany (type: forum_sub) |
+| Forum quote → notify quoted user | ✅ | type: forum_quote |
+| Comment subscription (subscribe/unsubscribe) | ✅ | comment subscription routes + UI present on commentable surfaces |
+| Comment posted → notify comment subscribers | ✅ | comments.ts fires (type: comment_sub) |
+| Collage subscription (subscribe/unsubscribe) | ✅ | CollageSubscription model + route |
+| Collage entry added → notify subscribers | ✅ | collages.ts fires (type: collage_updated) |
+| Request filled → notify requester + voters | ✅ | requests.ts fires (type: request_filled) |
+| PM unread indicator | ✅ | MessageParticipant.unreadCount in NotificationCorner |
+| Artist subscription (follow/unfollow) | ✅ | ArtistSubscription model + GET/POST/DELETE /:id/subscribe |
+| New-contribution → notify followers | ✅ | artist_release notification on contribution creation |
+| Notification bell — per-type text | ✅ | NotificationCorner renderNotificationText |
+| Mark read / delete / mark all read | ✅ | |
+
+## Messaging
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| PM inbox / sent / conversation | ✅ | full CRUD |
+| Unread count | ✅ | |
+| Bulk operations | ✅ | POST /api/messages/bulk-update |
+| Search PMs | ✅ | query param |
+| PM drafts | ✅ | GET/POST/PUT/DELETE `/api/messages/drafts` + ComposeForm/DraftsPage |
+| Forward message | ❌ | no route |
+| Staff inbox (tickets) | ✅ | full CRUD |
+| Staff inbox scoreboard | ✅ | |
+| Staff canned responses | ✅ | `/api/staff-inbox/responses` + CannedResponsesPage/TicketView integration |
+| Staff PM (staff-to-staff) | 🔧 | staffPm.ts module + routes, no UI |
+
+## Forums
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Forum / category CRUD | ✅ | |
+| Topic CRUD (create, lock, sticky, delete) | ✅ | |
+| Post CRUD (create, edit, delete) | ✅ | |
+| Post edit history | ✅ | inline last-edited marker for all readers; staff-only revision history in ForumTopicPost |
+| Polls (create, vote) | ✅ | |
+| Topic notes (staff) | ✅ | |
+| Last-read tracking | ✅ | |
+| Class-level read/write gates | ✅ | minClassRead/Write enforced |
+
+## Artists
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Artist profile | ✅ | GET /api/communities/:cid/artist/:id |
+| Artist CRUD | ✅ | create/update/delete |
+| Artist history / reverts | ✅ | |
+| Similar artists | ✅ | add/remove/vote |
+| Artist aliases | ✅ | |
+| Artist tags | ✅ | |
+| Artist subscription ("follow") | ✅ | ArtistSubscription model + subscribe/unsubscribe/status routes; follow button on ArtistPage |
+| New-release notification to followers | ✅ | artist_release emitted on contribution creation; rendered in NotificationCorner |
+
+## Collages
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Collage CRUD | ✅ | |
+| Collage entries (add/remove/sort) | ✅ | |
+| Subscribe / unsubscribe | ✅ | GET/POST in collages route |
+| Entry added → notify subscribers | ✅ | emits collage_updated notifications |
+| Collage comments | ✅ | shared comments route supports `page=collages`; CollageDetail renders CommentsSection |
+| Personal collages (class limit) | ✅ | `personalCollageLimit` on `UserRank` (0 = unlimited); staff/admin bypass; seeded User=1/PU=2/Staff=3/SysOp=4 |
+
+## Wiki
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Article CRUD + soft-delete | ✅ | |
+| Revision history + compare | ✅ | |
+| Aliases | ✅ | |
+| Permission levels (minRead, minEdit) | ✅ | |
+| Full-text search | ✅ | |
+
+## Reports
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| File report (user-submitted) | ✅ | |
+| Staff queue (claim/unclaim/resolve) | ✅ | |
+| Staff notes | ✅ | |
+| Report stats | ✅ | |
+
+## Bookmarks
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Artist / release / collage / request bookmarks | ✅ | all 4 types |
+| Bulk remove snatched | ❌ | nice-to-have |
+
+## Stats & Charts
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Site stats | ✅ | |
+| Top 10 (releases, users, tags) | ✅ | TTL-cached + snapshots |
+| Historical stats | ❌ | nice-to-have |
+
+## Site History / Audit Log
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Searchable audit log | ✅ | |
+
+## Search
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Cross-domain search | ✅ | GET /api/search |
+| Full-text (DB LIKE) | ✅ | |
+| Sphinx / advanced FTS | ❌ | nice-to-have post-launch |
+
+## Bonus Economy
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Bonus point balance | ❌ | no model, no route |
+| Earn points (contribute/seed events) | ❌ | not started |
+| Bonus point history | ❌ | not started |
+| Bonus store (tokens, invites, titles) | ❌ | not started |
+| EconomyTransaction ledger | 🔧 | immutable ledger exists and is used for download grant debit/credit/reversal flows; no bonus-facing routes or history yet |
+
+## Miscellaneous
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Downloads / access grants | ✅ | |
+| Announcements | ✅ | |
+| Posts (blog) | ✅ | |
+| Site settings (admin) | ✅ | |
+| Stylesheet / theme per user | 🔧 | route exists, frontend may not use it |
+| Applications / staff roles | ❌ | Applicant stub model |
+| Friends system | ❌ | stub model |
+| Staff directory | ❌ | nice-to-have |
+
+---
+
+## Priority Queue
+
+### Launch-blocking
+
+(none — all launch-blocking items resolved)
+
+### Quick wins (backend done, just needs UI)
+
+1. PARITY tracker cleanup — several rows below still need periodic revalidation as features land so the queue stays trustworthy
+2. Staff PM scoreboard/review pass — verify current implementation against Gazelle workflow before scheduling follow-up work
+
+### Nice-to-have
+
+1. Historical stats
+2. Applications / staff roles, friends system, and staff directory
+3. 2FA / TOTP
+
+
+### Implement once primary funcitonality is complete
+1. Stylesheet / theme application (settings persist, but the client does not apply site appearance or external stylesheet globally)

--- a/prisma/migrations/20260522165830_release_history_snapshots/migration.sql
+++ b/prisma/migrations/20260522165830_release_history_snapshots/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "release_histories" ADD COLUMN     "snapshot" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1438,6 +1438,7 @@ model ReleaseHistory {
   changedFields String[]
   before        Json?
   after         Json?
+  snapshot      Json?
   createdAt     DateTime             @default(now())
 
   @@index([releaseId, createdAt])

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -147,6 +147,22 @@ describe('GET /api/communities/:communityId/releases/:releaseId', () => {
       myVotes: { up: true, down: false }
     });
     expect(res.body.historyEntries[0].summary).toBe('Tag "jazz" added');
+    expect(res.body.isContributor).toBe(false);
+  });
+
+  it('returns isContributor true when the current user has a contribution', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue(
+      makeRelease({
+        contributions: [{ id: 5, userId: 7 }]
+      }) as never
+    );
+    prismaMock.releaseVote.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/communities/1/releases/3');
+
+    expect(res.status).toBe(200);
+    expect(res.body.isContributor).toBe(true);
   });
 });
 
@@ -334,6 +350,35 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
         changedFields: ['title']
       })
     });
+  });
+
+  it('returns 403 when caller has no communities_manage and no contribution', async () => {
+    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.contribution.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).put('/api/communities/1/releases/3').send({
+      title: 'Unauthorized Update'
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows a contributor without communities_manage to edit the release', async () => {
+    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.contribution.findFirst.mockResolvedValue({ id: 5 } as never);
+    prismaMock.release.update.mockResolvedValue(
+      makeRelease({ title: 'Updated by Contributor' }) as never
+    );
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease({ title: 'Updated by Contributor' }) as never
+    );
+
+    const res = await request(app)
+      .put('/api/communities/1/releases/3')
+      .send({ title: 'Updated by Contributor' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Updated by Contributor');
   });
 });
 
@@ -749,6 +794,165 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId',
         releaseId: 3,
         actorId: 7,
         action: 'tag_removed'
+      })
+    });
+  });
+});
+
+describe('GET /api/communities/:communityId/releases/:releaseId/history', () => {
+  const makeHistoryEntry = (overrides: Record<string, unknown> = {}) => ({
+    id: 91,
+    releaseId: 3,
+    actorId: 7,
+    action: 'edit',
+    summary: 'Title changed',
+    changedFields: ['title'],
+    before: { title: 'Old Title' },
+    after: { title: 'New Title' },
+    snapshot: null,
+    createdAt: new Date('2024-06-01T00:00:00Z'),
+    actor: { id: 7, username: 'user' },
+    ...overrides
+  });
+
+  it('returns paginated history entries', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
+    prismaMock.releaseHistory.findMany.mockResolvedValue([
+      makeHistoryEntry()
+    ] as never);
+    prismaMock.releaseHistory.count.mockResolvedValue(1);
+
+    const res = await request(app).get(
+      '/api/communities/1/releases/3/history?page=1'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].summary).toBe('Title changed');
+    expect(res.body.meta.total).toBe(1);
+    expect(prismaMock.releaseHistory.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { releaseId: 3 },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]
+      })
+    );
+  });
+
+  it('returns 404 when the release does not exist', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get(
+      '/api/communities/1/releases/999/history'
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when the user is not a member of a restricted community', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ registrationStatus: RegistrationStatus.invite }) as never
+    );
+    prismaMock.consumer.findFirst.mockResolvedValue(null);
+    prismaMock.contributor.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/communities/1/releases/3/history');
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/communities/:communityId/releases/:releaseId/history/:historyId/revert', () => {
+  const editEntry = {
+    id: 91,
+    releaseId: 3,
+    action: 'edit',
+    summary: 'Title changed',
+    changedFields: ['title'],
+    before: {
+      title: 'Old Title',
+      description: 'Classic',
+      image: null,
+      year: 1959,
+      isEdition: false,
+      edition: null,
+      tagIds: [],
+      tagNames: []
+    },
+    after: null,
+    snapshot: null,
+    createdAt: new Date('2024-06-01T00:00:00Z'),
+    actorId: 7
+  };
+
+  it('requires communities_manage permission', async () => {
+    const res = await request(app).post(
+      '/api/communities/1/releases/3/history/91/revert'
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when the history entry is not found', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.releaseHistory.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).post(
+      '/api/communities/1/releases/3/history/91/revert'
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 422 when the history entry is not an edit action', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.releaseHistory.findFirst.mockResolvedValue({
+      ...editEntry,
+      action: 'created'
+    } as never);
+
+    const res = await request(app).post(
+      '/api/communities/1/releases/3/history/91/revert'
+    );
+
+    expect(res.status).toBe(422);
+    expect(res.body.msg).toBe('Only edit revisions can be reverted');
+  });
+
+  it('reverts the release to the before-snapshot and writes a revert history entry', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.releaseHistory.findFirst.mockResolvedValue(editEntry as never);
+    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease({ title: 'Old Title' }) as never
+    );
+
+    const res = await request(app).post(
+      '/api/communities/1/releases/3/history/91/revert'
+    );
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.release.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 3 },
+        data: expect.objectContaining({ title: 'Old Title' })
+      })
+    );
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'edit',
+        summary: expect.stringContaining('Reverted to revision from')
       })
     });
   });

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -191,6 +191,11 @@ describe('POST /api/communities/:communityId/releases', () => {
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
     );
     prismaMock.release.create.mockResolvedValue(makeRelease() as never);
+    prismaMock.tag.findMany.mockResolvedValue([
+      { id: 7, name: 'jazz' },
+      { id: 9, name: 'fusion' }
+    ] as never);
+    prismaMock.releaseTag.create.mockResolvedValue({ id: 99 } as never);
     prismaMock.release.findUniqueOrThrow.mockResolvedValue(
       makeRelease() as never
     );
@@ -215,11 +220,18 @@ describe('POST /api/communities/:communityId/releases', () => {
         image: null
       })
     });
-    expect(prismaMock.releaseTag.createMany).toHaveBeenCalledWith({
-      data: [
-        { releaseId: 3, tagId: 7 },
-        { releaseId: 3, tagId: 9 }
-      ]
+    expect(prismaMock.tag.findMany).toHaveBeenCalledWith({
+      where: { id: { in: [7, 9] } },
+      select: { id: true, name: true }
+    });
+    expect(prismaMock.releaseTag.create).toHaveBeenCalledWith({
+      data: {
+        releaseId: 3,
+        tagId: 7,
+        userId: 7,
+        positiveVotes: 3,
+        negativeVotes: 1
+      }
     });
     expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
@@ -265,6 +277,10 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
         ]
       }) as never
     );
+    prismaMock.tag.findMany.mockResolvedValue([
+      { id: 8, name: 'fusion' }
+    ] as never);
+    prismaMock.releaseTag.create.mockResolvedValue({ id: 99 } as never);
     prismaMock.release.findUniqueOrThrow.mockResolvedValue(
       makeRelease({
         title: 'Updated',
@@ -299,17 +315,23 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
       include: { artist: true, releaseTags: { include: { tag: true } } }
     });
     expect(prismaMock.releaseTag.deleteMany).toHaveBeenCalledWith({
-      where: { releaseId: 3, tagId: { in: [7] } }
+      where: { releaseId: 3, tagId: 7 }
     });
-    expect(prismaMock.releaseTag.createMany).toHaveBeenCalledWith({
-      data: [{ releaseId: 3, tagId: 8 }]
+    expect(prismaMock.releaseTag.create).toHaveBeenCalledWith({
+      data: {
+        releaseId: 3,
+        tagId: 8,
+        userId: 7,
+        positiveVotes: 3,
+        negativeVotes: 1
+      }
     });
     expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         releaseId: 3,
         actorId: 7,
         action: 'edit',
-        changedFields: expect.arrayContaining(['title', 'tags'])
+        changedFields: ['title']
       })
     });
   });
@@ -588,10 +610,6 @@ describe('POST /api/communities/:communityId/releases/:releaseId/tags', () => {
         userId: 7,
         positiveVotes: 3,
         negativeVotes: 1
-      },
-      include: {
-        tag: true,
-        user: { select: { id: true, username: true } }
       }
     });
     expect(prismaMock.releaseTagVote.create).toHaveBeenCalledWith({

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -430,6 +430,9 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
       type: FileType.flac,
       release: { id: 3, title: 'Kind of Blue', communityId: 1, artistId: 5 }
     } as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease() as never
+    );
 
     const res = await request(app)
       .post('/api/communities/1/releases/3/contributions')
@@ -466,6 +469,9 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
     prismaMock.artistSubscription.findMany.mockResolvedValue([
       { userId: 99 }
     ] as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease() as never
+    );
 
     const res = await request(app)
       .post('/api/communities/1/releases/3/contributions')
@@ -584,6 +590,16 @@ describe('POST /api/communities/:communityId/releases/:releaseId/tags', () => {
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
     );
     prismaMock.tag.upsert.mockResolvedValue({ id: 9, name: 'fusion' } as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue({
+      id: 3,
+      title: 'Kind of Blue',
+      description: 'Classic',
+      image: null,
+      year: 1959,
+      isEdition: false,
+      edition: null,
+      releaseTags: []
+    } as never);
     prismaMock.releaseTag.create.mockResolvedValue({
       id: 19,
       positiveVotes: 3,
@@ -709,6 +725,9 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId',
     prismaMock.tag.findUnique.mockResolvedValue({ name: 'jazz' } as never);
     prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease() as never
     );
     prismaMock.release.update.mockResolvedValue(makeRelease() as never);
     prismaMock.tag.update.mockResolvedValue({ id: 9 } as never);

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2065,6 +2065,20 @@ const ReleaseTagEnriched = registry.register(
   })
 );
 
+const ReleaseSnapshot = registry.register(
+  'ReleaseSnapshot',
+  z.object({
+    title: z.string(),
+    description: z.string(),
+    image: z.string().nullable(),
+    year: z.number(),
+    isEdition: z.boolean(),
+    edition: z.unknown().nullable(),
+    tagIds: z.array(z.number()),
+    tagNames: z.array(z.string())
+  })
+);
+
 const ReleaseHistoryEntry = registry.register(
   'ReleaseHistoryEntry',
   z.object({
@@ -2080,6 +2094,7 @@ const ReleaseHistoryEntry = registry.register(
     changedFields: z.array(z.string()),
     before: z.record(z.string(), z.unknown()).nullable().optional(),
     after: z.record(z.string(), z.unknown()).nullable().optional(),
+    snapshot: ReleaseSnapshot.nullable().optional(),
     createdAt: z.string(),
     actor: z.object({ id: z.number(), username: z.string() })
   })
@@ -2232,6 +2247,33 @@ registry.registerPath({
     },
     404: {
       description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/communities/{communityId}/releases/{releaseId}/history/{historyId}/revert',
+  tags: ['Communities'],
+  request: {
+    params: z.object({
+      communityId: z.string(),
+      releaseId: z.string(),
+      historyId: z.string()
+    })
+  },
+  responses: {
+    200: {
+      description: 'Release after revert',
+      content: { 'application/json': { schema: Release } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    422: {
+      description: 'Not an edit revision',
       content: { 'application/json': { schema: MsgResponse } }
     }
   }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2126,7 +2126,8 @@ const Release = registry.register(
       })
       .nullable()
       .optional(),
-    contributions: z.array(ReleaseContribution).optional()
+    contributions: z.array(ReleaseContribution).optional(),
+    isContributor: z.boolean().optional()
   })
 );
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2046,6 +2046,45 @@ const Contribution = registry.register(
   })
 );
 
+const ReleaseTagEnriched = registry.register(
+  'ReleaseTagEnriched',
+  z.object({
+    id: z.number(),
+    tagId: z.number(),
+    name: z.string(),
+    occurrences: z.number(),
+    score: z.number(),
+    positiveVotes: z.number(),
+    negativeVotes: z.number(),
+    addedBy: z
+      .object({ id: z.number(), username: z.string() })
+      .nullable()
+      .optional(),
+    createdAt: z.string().nullable().optional(),
+    myVotes: z.object({ up: z.boolean(), down: z.boolean() }).optional()
+  })
+);
+
+const ReleaseHistoryEntry = registry.register(
+  'ReleaseHistoryEntry',
+  z.object({
+    id: z.number(),
+    action: z.enum([
+      'created',
+      'edit',
+      'tag_added',
+      'tag_removed',
+      'contribution_added'
+    ]),
+    summary: z.string(),
+    changedFields: z.array(z.string()),
+    before: z.record(z.string(), z.unknown()).nullable().optional(),
+    after: z.record(z.string(), z.unknown()).nullable().optional(),
+    createdAt: z.string(),
+    actor: z.object({ id: z.number(), username: z.string() })
+  })
+);
+
 const Release = registry.register(
   'Release',
   z.object({
@@ -2054,11 +2093,24 @@ const Release = registry.register(
     communityId: z.number().nullable(),
     year: z.number().nullable().optional(),
     type: z.string().nullable().optional(),
+    releaseType: z.string().nullable().optional(),
     image: z.string().nullable().optional(),
     description: z.string().nullable().optional(),
+    isEdition: z.boolean().optional(),
+    edition: z.unknown().nullable().optional(),
     createdAt: z.string().optional(),
     artist: ReleaseArtist.optional(),
     tags: z.array(ReleaseTag).optional(),
+    releaseTags: z.array(ReleaseTagEnriched).optional(),
+    myVote: z.enum(['up', 'down']).nullable().optional(),
+    voteAggregate: z
+      .object({
+        ups: z.number(),
+        total: z.number(),
+        score: z.number()
+      })
+      .nullable()
+      .optional(),
     contributions: z.array(ReleaseContribution).optional()
   })
 );
@@ -2147,6 +2199,110 @@ registry.registerPath({
     200: {
       description: 'Release',
       content: { 'application/json': { schema: Release } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/communities/{communityId}/releases/{releaseId}/history',
+  tags: ['Communities'],
+  request: {
+    params: z.object({ communityId: z.string(), releaseId: z.string() })
+  },
+  responses: {
+    200: {
+      description: 'Paginated release history',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(ReleaseHistoryEntry),
+            meta: PaginationMeta
+          })
+        }
+      }
+    },
+    403: {
+      description: 'Not a community member',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/communities/{communityId}/releases/{releaseId}/tags',
+  tags: ['Communities'],
+  request: {
+    params: z.object({ communityId: z.string(), releaseId: z.string() }),
+    body: {
+      content: {
+        'application/json': { schema: z.object({ name: z.string() }) }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Tag added',
+      content: { 'application/json': { schema: ReleaseTag } }
+    },
+    409: {
+      description: 'Release already has this tag',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/communities/{communityId}/releases/{releaseId}/tags/{tagId}',
+  tags: ['Communities'],
+  request: {
+    params: z.object({
+      communityId: z.string(),
+      releaseId: z.string(),
+      tagId: z.string()
+    })
+  },
+  responses: {
+    204: { description: 'Tag removed' },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/communities/{communityId}/releases/{releaseId}/tags/{tagId}/vote',
+  tags: ['Communities'],
+  request: {
+    params: z.object({
+      communityId: z.string(),
+      releaseId: z.string(),
+      tagId: z.string()
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({ direction: z.enum(['up', 'down']) })
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Updated tag with vote counts',
+      content: { 'application/json': { schema: ReleaseTagEnriched } }
     },
     404: {
       description: 'Not found',

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -33,6 +33,7 @@ import { recomputeVoteAggregate } from '../../../modules/top10';
 import { getSettings } from '../../../modules/settings';
 import {
   FileType,
+  Prisma,
   RegistrationStatus,
   ReleaseHistoryAction,
   ReleaseTagVoteDirection
@@ -181,6 +182,69 @@ const buildPlainTags = (
     .map((releaseTag) => releaseTag.tag)
     .sort((a, b) => a.name.localeCompare(b.name));
 
+const attachTagWithVotes = async (
+  tx: Prisma.TransactionClient,
+  releaseId: number,
+  actorId: number,
+  tag: { id: number; name: string },
+  writeHistory: boolean
+): Promise<void> => {
+  const releaseTag = await tx.releaseTag.create({
+    data: {
+      releaseId,
+      tagId: tag.id,
+      userId: actorId,
+      positiveVotes: 3,
+      negativeVotes: 1
+    }
+  });
+  await tx.releaseTagVote.create({
+    data: {
+      releaseTagId: releaseTag.id,
+      userId: actorId,
+      direction: ReleaseTagVoteDirection.up
+    }
+  });
+  if (writeHistory) {
+    await tx.releaseHistory.create({
+      data: {
+        releaseId,
+        actorId,
+        action: ReleaseHistoryAction.tag_added,
+        summary: `Tag "${tag.name}" added`,
+        changedFields: ['tags'],
+        before: { tagId: tag.id, name: tag.name, score: 0 } as never,
+        after: { tagId: tag.id, name: tag.name, score: 2 } as never
+      }
+    });
+  }
+};
+
+const detachTag = async (
+  tx: Prisma.TransactionClient,
+  releaseId: number,
+  actorId: number,
+  tag: { id: number; name?: string }
+): Promise<void> => {
+  await tx.releaseTag.deleteMany({ where: { releaseId, tagId: tag.id } });
+  await tx.tag.update({
+    where: { id: tag.id },
+    data: { occurrences: { decrement: 1 } }
+  });
+  await tx.releaseHistory.create({
+    data: {
+      releaseId,
+      actorId,
+      action: ReleaseHistoryAction.tag_removed,
+      summary: `Tag "${tag.name ?? `#${tag.id}`}" removed`,
+      changedFields: ['tags'],
+      before: tag.name
+        ? ({ tagId: tag.id, name: tag.name } as never)
+        : undefined
+    }
+  });
+};
+
 // GET /api/communities/:communityId/releases
 router.get(
   '/',
@@ -229,6 +293,42 @@ router.get(
   })
 );
 
+// GET /api/communities/:communityId/releases/:releaseId/history
+router.get(
+  '/:releaseId/history',
+  requireAuth,
+  validateParams(releaseParamsSchema),
+  authHandler(async (req, res) => {
+    const { communityId, releaseId: id } = parsedParams<{
+      communityId: number;
+      releaseId: number;
+    }>(res);
+    const community = await getAccessibleCommunity(communityId, req.user.id);
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (community === 'forbidden') {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
+    const release = await prisma.release.findFirst({
+      where: { id, communityId },
+      select: { id: true }
+    });
+    if (!release) return res.status(404).json({ msg: 'Release not found' });
+
+    const pg = parsePage(req);
+    const [entries, total] = await Promise.all([
+      prisma.releaseHistory.findMany({
+        where: { releaseId: id },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        skip: pg.skip,
+        take: pg.limit,
+        include: { actor: { select: { id: true, username: true } } }
+      }),
+      prisma.releaseHistory.count({ where: { releaseId: id } })
+    ]);
+    paginatedResponse(res, entries, total, pg);
+  })
+);
+
 // GET /api/communities/:communityId/releases/:releaseId
 router.get(
   '/:releaseId',
@@ -257,12 +357,6 @@ router.get(
                 select: { direction: true }
               },
               user: { select: { id: true, username: true } }
-            }
-          },
-          historyEntries: {
-            orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-            include: {
-              actor: { select: { id: true, username: true } }
             }
           },
           voteAggregate: true,
@@ -314,8 +408,7 @@ router.get(
       ...release,
       tags: buildPlainTags(release.releaseTags),
       myVote,
-      releaseTags,
-      historyEntries: release.historyEntries
+      releaseTags
     });
   })
 );
@@ -364,20 +457,17 @@ router.post(
       });
 
       if (uniqueTagIds.length > 0) {
-        await tx.releaseTag.createMany({
-          data: uniqueTagIds.map((tagId) => ({
-            releaseId: created.id,
-            tagId
-          }))
+        const tags = await tx.tag.findMany({
+          where: { id: { in: uniqueTagIds } },
+          select: { id: true, name: true }
         });
-        await Promise.all(
-          uniqueTagIds.map((tagId) =>
-            tx.tag.update({
-              where: { id: tagId },
-              data: { occurrences: { increment: 1 } }
-            })
-          )
-        );
+        for (const tag of tags) {
+          await tx.tag.update({
+            where: { id: tag.id },
+            data: { occurrences: { increment: 1 } }
+          });
+          await attachTagWithVotes(tx, created.id, req.user!.id, tag, false);
+        }
       }
 
       const release = await tx.release.findUniqueOrThrow({
@@ -470,34 +560,29 @@ router.put(
       });
 
       if (removedTagIds.length > 0) {
-        await tx.releaseTag.deleteMany({
-          where: { releaseId: id, tagId: { in: removedTagIds } }
-        });
-        await Promise.all(
-          removedTagIds.map((tagId) =>
-            tx.tag.update({
-              where: { id: tagId },
-              data: { occurrences: { decrement: 1 } }
-            })
-          )
+        const existingTagMap = new Map(
+          existing.releaseTags.map((rt) => [rt.tag.id, rt.tag])
         );
+        for (const tagId of removedTagIds) {
+          await detachTag(tx, id, actorId, {
+            id: tagId,
+            name: existingTagMap.get(tagId)?.name
+          });
+        }
       }
 
       if (addedTagIds.length > 0) {
-        await tx.releaseTag.createMany({
-          data: addedTagIds.map((tagId) => ({
-            releaseId: id,
-            tagId
-          }))
+        const addedTags = await tx.tag.findMany({
+          where: { id: { in: addedTagIds } },
+          select: { id: true, name: true }
         });
-        await Promise.all(
-          addedTagIds.map((tagId) =>
-            tx.tag.update({
-              where: { id: tagId },
-              data: { occurrences: { increment: 1 } }
-            })
-          )
-        );
+        for (const tag of addedTags) {
+          await tx.tag.update({
+            where: { id: tag.id },
+            data: { occurrences: { increment: 1 } }
+          });
+          await attachTagWithVotes(tx, id, actorId, tag, true);
+        }
       }
 
       const refreshed = await tx.release.findUniqueOrThrow({
@@ -506,7 +591,11 @@ router.put(
       });
 
       const after = snapshotRelease(refreshed);
-      const changedFields = changedReleaseFields(before, after);
+      // Tags are already covered by per-tag history entries; exclude from the
+      // edit entry so the summary reflects only metadata field changes.
+      const changedFields = changedReleaseFields(before, after).filter(
+        (f) => f !== 'tags'
+      );
 
       if (changedFields.length > 0) {
         await tx.releaseHistory.create({
@@ -740,37 +829,7 @@ router.post(
         create: { name, occurrences: 1 },
         update: { occurrences: { increment: 1 } }
       });
-      const releaseTag = await tx.releaseTag.create({
-        data: {
-          releaseId: id,
-          tagId: t.id,
-          userId: req.user.id,
-          positiveVotes: 3,
-          negativeVotes: 1
-        },
-        include: {
-          tag: true,
-          user: { select: { id: true, username: true } }
-        }
-      });
-      await tx.releaseTagVote.create({
-        data: {
-          releaseTagId: releaseTag.id,
-          userId: req.user.id,
-          direction: ReleaseTagVoteDirection.up
-        }
-      });
-      await tx.releaseHistory.create({
-        data: {
-          releaseId: id,
-          actorId: req.user.id,
-          action: ReleaseHistoryAction.tag_added,
-          summary: `Tag "${t.name}" added`,
-          changedFields: ['tags'],
-          before: { tagId: t.id, name: t.name, score: 0 } as never,
-          after: { tagId: t.id, name: t.name, score: 2 } as never
-        }
-      });
+      await attachTagWithVotes(tx, id, req.user.id, t, true);
       return t;
     });
 

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 import { prisma } from '../../../lib/prisma';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { requireAuth } from '../../../middleware/auth';
-import { requirePermission } from '../../../middleware/permissions';
+import {
+  requirePermission,
+  loadPermissions
+} from '../../../middleware/permissions';
 import { isCommunityMember } from './communities';
 import {
   validate,
@@ -502,11 +505,16 @@ router.get(
       }))
     );
 
+    const isContributor = release.contributions.some(
+      (c) => c.userId === req.user.id
+    );
+
     res.json({
       ...release,
       tags: buildPlainTags(release.releaseTags),
       myVote,
-      releaseTags
+      releaseTags,
+      isContributor
     });
   })
 );
@@ -593,14 +601,13 @@ router.post(
   })
 );
 
-// PUT /api/communities/:communityId/releases/:releaseId — requires communities_manage
+// PUT /api/communities/:communityId/releases/:releaseId — contributor or communities_manage
 router.put(
   '/:releaseId',
-  ...requirePermission('communities_manage'),
+  requireAuth,
   validateParams(releaseParamsSchema),
   validate(updateGroupSchema),
-  asyncHandler(async (req: Request, res: Response) => {
-    if (!req.user) return res.status(401).json({ msg: 'Unauthorized' });
+  authHandler(async (req, res) => {
     const actorId = req.user.id;
     const { communityId, releaseId: id } = parsedParams<{
       communityId: number;
@@ -614,6 +621,24 @@ router.put(
       }
     });
     if (!existing) return res.status(404).json({ msg: 'Release not found' });
+
+    const perms = await loadPermissions(req, res);
+    const canManage = !!(
+      perms['communities_manage'] ||
+      perms['admin'] ||
+      perms['staff']
+    );
+    if (!canManage) {
+      const contribution = await prisma.contribution.findFirst({
+        where: { releaseId: id, userId: actorId },
+        select: { id: true }
+      });
+      if (!contribution) {
+        return res
+          .status(403)
+          .json({ msg: 'Must be a contributor or staff to edit this release' });
+      }
+    }
 
     const {
       title,

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -187,7 +187,8 @@ const attachTagWithVotes = async (
   releaseId: number,
   actorId: number,
   tag: { id: number; name: string },
-  writeHistory: boolean
+  writeHistory: boolean,
+  snapshot?: ReleaseSnapshot
 ): Promise<void> => {
   const releaseTag = await tx.releaseTag.create({
     data: {
@@ -214,7 +215,8 @@ const attachTagWithVotes = async (
         summary: `Tag "${tag.name}" added`,
         changedFields: ['tags'],
         before: { tagId: tag.id, name: tag.name, score: 0 } as never,
-        after: { tagId: tag.id, name: tag.name, score: 2 } as never
+        after: { tagId: tag.id, name: tag.name, score: 2 } as never,
+        ...(snapshot !== undefined && { snapshot: snapshot as never })
       }
     });
   }
@@ -224,7 +226,8 @@ const detachTag = async (
   tx: Prisma.TransactionClient,
   releaseId: number,
   actorId: number,
-  tag: { id: number; name?: string }
+  tag: { id: number; name?: string },
+  snapshot?: ReleaseSnapshot
 ): Promise<void> => {
   await tx.releaseTag.deleteMany({ where: { releaseId, tagId: tag.id } });
   await tx.tag.update({
@@ -240,7 +243,8 @@ const detachTag = async (
       changedFields: ['tags'],
       before: tag.name
         ? ({ tagId: tag.id, name: tag.name } as never)
-        : undefined
+        : undefined,
+      ...(snapshot !== undefined && { snapshot: snapshot as never })
     }
   });
 };
@@ -326,6 +330,100 @@ router.get(
       prisma.releaseHistory.count({ where: { releaseId: id } })
     ]);
     paginatedResponse(res, entries, total, pg);
+  })
+);
+
+// POST /api/communities/:communityId/releases/:releaseId/history/:historyId/revert — requires communities_manage or staff/admin
+const revertParamsSchema = z.object({
+  communityId: z.coerce.number().int().positive(),
+  releaseId: z.coerce.number().int().positive(),
+  historyId: z.coerce.number().int().positive()
+});
+
+router.post(
+  '/:releaseId/history/:historyId/revert',
+  ...requirePermission('communities_manage', 'admin'),
+  validateParams(revertParamsSchema),
+  authHandler(async (req, res) => {
+    const {
+      communityId,
+      releaseId: id,
+      historyId
+    } = parsedParams<{
+      communityId: number;
+      releaseId: number;
+      historyId: number;
+    }>(res);
+    const community = await getAccessibleCommunity(communityId, req.user.id);
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (community === 'forbidden') {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
+
+    const targetEntry = await prisma.releaseHistory.findFirst({
+      where: { id: historyId, releaseId: id }
+    });
+    if (!targetEntry)
+      return res.status(404).json({ msg: 'History entry not found' });
+    if (targetEntry.action !== ReleaseHistoryAction.edit) {
+      return res
+        .status(422)
+        .json({ msg: 'Only edit revisions can be reverted' });
+    }
+
+    const restoreState = targetEntry.before as unknown as ReleaseSnapshot;
+
+    const existing = await prisma.release.findFirst({
+      where: { id, communityId },
+      include: { releaseTags: { include: { tag: true } } }
+    });
+    if (!existing) return res.status(404).json({ msg: 'Release not found' });
+
+    const currentSnapshot = snapshotRelease(existing);
+
+    const release = await prisma.$transaction(async (tx) => {
+      await tx.release.update({
+        where: { id },
+        data: {
+          title: restoreState.title,
+          description: restoreState.description,
+          image: restoreState.image,
+          year: restoreState.year,
+          isEdition: restoreState.isEdition,
+          edition: (restoreState.edition ?? undefined) as never
+        }
+      });
+
+      const changedFields = changedReleaseFields(
+        currentSnapshot,
+        restoreState
+      ).filter((f) => f !== 'tags');
+
+      await tx.releaseHistory.create({
+        data: {
+          releaseId: id,
+          actorId: req.user.id,
+          action: ReleaseHistoryAction.edit,
+          summary: `Reverted to revision from ${targetEntry.createdAt.toISOString()}`,
+          changedFields,
+          before: currentSnapshot as never,
+          after: restoreState as never,
+          snapshot: restoreState as never
+        }
+      });
+
+      const refreshed = await tx.release.findUniqueOrThrow({
+        where: { id },
+        include: { artist: true, releaseTags: { include: { tag: true } } }
+      });
+
+      return {
+        ...refreshed,
+        tags: buildPlainTags(refreshed.releaseTags)
+      };
+    });
+
+    res.json(release);
   })
 );
 
@@ -474,6 +572,7 @@ router.post(
         where: { id: created.id },
         include: { artist: true, releaseTags: { include: { tag: true } } }
       });
+      const createdSnapshot = snapshotRelease(release);
       await tx.releaseHistory.create({
         data: {
           releaseId: release.id,
@@ -481,14 +580,8 @@ router.post(
           action: ReleaseHistoryAction.created,
           summary: 'Release created',
           changedFields: [],
-          after: {
-            title: release.title,
-            artistName: release.artist.name,
-            type: release.type,
-            releaseType: release.releaseType,
-            year: release.year,
-            tagIds: uniqueTagIds
-          } as never
+          after: createdSnapshot as never,
+          snapshot: createdSnapshot as never
         }
       });
       return {
@@ -559,15 +652,26 @@ router.put(
         include: { artist: true, releaseTags: { include: { tag: true } } }
       });
 
+      let runningSnapshot = { ...before };
+
       if (removedTagIds.length > 0) {
         const existingTagMap = new Map(
           existing.releaseTags.map((rt) => [rt.tag.id, rt.tag])
         );
         for (const tagId of removedTagIds) {
-          await detachTag(tx, id, actorId, {
-            id: tagId,
-            name: existingTagMap.get(tagId)?.name
-          });
+          const tagName = existingTagMap.get(tagId)?.name;
+          runningSnapshot = {
+            ...runningSnapshot,
+            tagIds: runningSnapshot.tagIds.filter((tid) => tid !== tagId),
+            tagNames: runningSnapshot.tagNames.filter((n) => n !== tagName)
+          };
+          await detachTag(
+            tx,
+            id,
+            actorId,
+            { id: tagId, name: tagName },
+            runningSnapshot
+          );
         }
       }
 
@@ -581,7 +685,12 @@ router.put(
             where: { id: tag.id },
             data: { occurrences: { increment: 1 } }
           });
-          await attachTagWithVotes(tx, id, actorId, tag, true);
+          runningSnapshot = {
+            ...runningSnapshot,
+            tagIds: [...runningSnapshot.tagIds, tag.id].sort((a, b) => a - b),
+            tagNames: [...runningSnapshot.tagNames, tag.name].sort()
+          };
+          await attachTagWithVotes(tx, id, actorId, tag, true, runningSnapshot);
         }
       }
 
@@ -607,7 +716,8 @@ router.put(
               editSummary?.trim() || summarizeReleaseChanges(changedFields),
             changedFields,
             before: before as never,
-            after: after as never
+            after: after as never,
+            snapshot: after as never
           }
         });
       }
@@ -689,6 +799,10 @@ router.post(
           pageId: contribution.id
         });
       }
+      const releaseWithTags = await tx.release.findUniqueOrThrow({
+        where: { id: contribution.release.id },
+        include: { releaseTags: { include: { tag: true } } }
+      });
       await tx.releaseHistory.create({
         data: {
           releaseId: contribution.release.id,
@@ -701,7 +815,8 @@ router.post(
             type: contribution.type,
             sizeInBytes: contribution.sizeInBytes ?? null,
             contributor: contribution.user?.username ?? null
-          } as never
+          } as never,
+          snapshot: snapshotRelease(releaseWithTags) as never
         }
       });
     });
@@ -829,7 +944,22 @@ router.post(
         create: { name, occurrences: 1 },
         update: { occurrences: { increment: 1 } }
       });
-      await attachTagWithVotes(tx, id, req.user.id, t, true);
+      const currentRelease = await tx.release.findUniqueOrThrow({
+        where: { id },
+        include: { releaseTags: { include: { tag: true } } }
+      });
+      const postAddSnapshot: ReleaseSnapshot = {
+        ...snapshotRelease(currentRelease),
+        tagIds: [
+          ...currentRelease.releaseTags.map((rt) => rt.tag.id),
+          t.id
+        ].sort((a, b) => a - b),
+        tagNames: [
+          ...currentRelease.releaseTags.map((rt) => rt.tag.name),
+          t.name
+        ].sort()
+      };
+      await attachTagWithVotes(tx, id, req.user.id, t, true, postAddSnapshot);
       return t;
     });
 
@@ -991,6 +1121,21 @@ router.delete(
     });
 
     await prisma.$transaction(async (tx) => {
+      const currentRelease = await tx.release.findUniqueOrThrow({
+        where: { id },
+        include: { releaseTags: { include: { tag: true } } }
+      });
+      const postRemovalSnapshot: ReleaseSnapshot = {
+        ...snapshotRelease(currentRelease),
+        tagIds: currentRelease.releaseTags
+          .filter((rt) => rt.tag.id !== tagId)
+          .map((rt) => rt.tag.id)
+          .sort((a, b) => a - b),
+        tagNames: currentRelease.releaseTags
+          .filter((rt) => rt.tag.id !== tagId)
+          .map((rt) => rt.tag.name)
+          .sort()
+      };
       await tx.releaseTag.deleteMany({
         where: { releaseId: id, tagId }
       });
@@ -1005,7 +1150,8 @@ router.delete(
           action: ReleaseHistoryAction.tag_removed,
           summary: `Tag "${tag?.name ?? `#${tagId}`}" removed`,
           changedFields: ['tags'],
-          before: tag ? ({ tagId, name: tag.name } as never) : undefined
+          before: tag ? ({ tagId, name: tag.name } as never) : undefined,
+          snapshot: postRemovalSnapshot as never
         }
       });
     });


### PR DESCRIPTION
## Summary

- Adds `ReleaseHistory` tracking for all release mutations: create, edit, tag add/remove, contribution added. Each entry captures a full `snapshot` of the release state plus field-level before/after diffs for edits.
- Expands edit permission on `PUT /communities/:cid/releases/:rid` to allow any contributor (not just `communities_manage`) to edit release metadata — contributors can edit releases they have uploaded to.
- Adds `isContributor: boolean` to the release detail response so the frontend can gate the edit button without a separate fetch.
- Adds paginated `GET /history` endpoint and `POST /history/:historyId/revert` for reverting to any prior edit revision.

## Endpoints changed

| Method | Path | Change |
|--------|------|--------|
| `GET` | `/communities/:cid/releases/:rid` | + `isContributor` field |
| `PUT` | `/communities/:cid/releases/:rid` | Permission expanded: contributor OR communities\_manage |
| `GET` | `/communities/:cid/releases/:rid/history` | New — paginated history |
| `POST` | `/communities/:cid/releases/:rid/history/:hid/revert` | New — revert to edit revision (communities\_manage required) |

## Migrations

`20260522165830_release_history_snapshots` — adds `snapshot JSONB` column to `release_histories`.

> Run `npm run db:generate` after pulling to regenerate the Prisma client.

## Test plan

- [ ] `npx jest --runInBand "communityReleases"` — 41 tests passing
- [ ] Edit a release as a contributor (no staff permission) — verify edit saves and history entry appears
- [ ] Edit a release as staff — verify history entry with before/after diff
- [ ] Attempt revert on a `created` entry — expect 422
- [ ] Revert an `edit` entry — verify release fields restored and new history row written
- [ ] Non-contributor, non-staff PUT — expect 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)