### PR TITLE
Add historical stats snapshots and history endpoints

### DIFF
--- a/prisma/migrations/20260522185257_historical_stats/migration.sql
+++ b/prisma/migrations/20260522185257_historical_stats/migration.sql
@@ -1,0 +1,54 @@
+-- CreateEnum
+CREATE TYPE "StatSnapshotPeriod" AS ENUM ('Daily', 'Monthly', 'Yearly');
+
+-- CreateTable
+CREATE TABLE "user_stat_snapshots" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "period" "StatSnapshotPeriod" NOT NULL,
+    "bucketAt" TIMESTAMP(3) NOT NULL,
+    "capturedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "contributed" BIGINT NOT NULL DEFAULT 0,
+    "consumed" BIGINT NOT NULL DEFAULT 0,
+    "contributionCount" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "user_stat_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "site_stat_snapshots" (
+    "id" SERIAL NOT NULL,
+    "bucketAt" TIMESTAMP(3) NOT NULL,
+    "capturedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "maxUsers" INTEGER NOT NULL DEFAULT 0,
+    "totalUsers" INTEGER NOT NULL DEFAULT 0,
+    "enabledUsers" INTEGER NOT NULL DEFAULT 0,
+    "activeToday" INTEGER NOT NULL DEFAULT 0,
+    "activeThisWeek" INTEGER NOT NULL DEFAULT 0,
+    "activeThisMonth" INTEGER NOT NULL DEFAULT 0,
+    "communities" INTEGER NOT NULL DEFAULT 0,
+    "releases" INTEGER NOT NULL DEFAULT 0,
+    "artists" INTEGER NOT NULL DEFAULT 0,
+    "blogPosts" INTEGER NOT NULL DEFAULT 0,
+    "announcements" INTEGER NOT NULL DEFAULT 0,
+    "comments" INTEGER NOT NULL DEFAULT 0,
+    "contributedLinks" INTEGER NOT NULL DEFAULT 0,
+    "contributedLinkDownloads" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "site_stat_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_stat_snapshots_userId_period_capturedAt_idx" ON "user_stat_snapshots"("userId", "period", "capturedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_stat_snapshots_userId_period_bucketAt_key" ON "user_stat_snapshots"("userId", "period", "bucketAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "site_stat_snapshots_bucketAt_key" ON "site_stat_snapshots"("bucketAt");
+
+-- CreateIndex
+CREATE INDEX "site_stat_snapshots_capturedAt_idx" ON "site_stat_snapshots"("capturedAt");
+
+-- AddForeignKey
+ALTER TABLE "user_stat_snapshots" ADD CONSTRAINT "user_stat_snapshots_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -405,6 +405,7 @@ model User {
   wikiPagesAuthored         WikiPage[]     @relation("WikiPageAuthor")
   wikiRevisionsAuthored     WikiRevision[] @relation("WikiRevisionAuthor")
   wikiAliasesCreated        WikiAlias[]    @relation("WikiAliasCreator")
+  userStatSnapshots         UserStatSnapshot[]
 
   @@index([userRankId])
   @@map("users")
@@ -1995,6 +1996,12 @@ enum Top10SnapshotType {
   Weekly
 }
 
+enum StatSnapshotPeriod {
+  Daily
+  Monthly
+  Yearly
+}
+
 model Top10Snapshot {
   id        Int               @id @default(autoincrement())
   type      Top10SnapshotType
@@ -2018,4 +2025,44 @@ model Top10SnapshotEntry {
   @@index([snapshotId])
   @@index([releaseId])
   @@map("top10_snapshot_entries")
+}
+
+model UserStatSnapshot {
+  id                Int               @id @default(autoincrement())
+  userId            Int
+  period            StatSnapshotPeriod
+  bucketAt          DateTime
+  capturedAt        DateTime          @default(now())
+  contributed       BigInt            @default(0)
+  consumed          BigInt            @default(0)
+  contributionCount Int               @default(0)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, period, bucketAt])
+  @@index([userId, period, capturedAt])
+  @@map("user_stat_snapshots")
+}
+
+model SiteStatSnapshot {
+  id                       Int      @id @default(autoincrement())
+  bucketAt                 DateTime @unique
+  capturedAt               DateTime @default(now())
+  maxUsers                 Int      @default(0)
+  totalUsers               Int      @default(0)
+  enabledUsers             Int      @default(0)
+  activeToday              Int      @default(0)
+  activeThisWeek           Int      @default(0)
+  activeThisMonth          Int      @default(0)
+  communities              Int      @default(0)
+  releases                 Int      @default(0)
+  artists                  Int      @default(0)
+  blogPosts                Int      @default(0)
+  announcements            Int      @default(0)
+  comments                 Int      @default(0)
+  contributedLinks         Int      @default(0)
+  contributedLinkDownloads Int      @default(0)
+
+  @@index([capturedAt])
+  @@map("site_stat_snapshots")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import { getLogger } from './modules/logging';
 import { http } from './modules/config';
 import { isInstalled } from './modules/installState';
 import { startLinkHealthJob } from './modules/linkHealthJob';
+import { startStatsJob } from './modules/statsJob';
 
 import installRouter from './routes/api/install';
 import homeRouter from './routes/api/home';
@@ -140,6 +141,7 @@ export const createApp = () => {
   );
 
   startLinkHealthJob();
+  startStatsJob();
 
   return app;
 };

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -966,6 +966,41 @@ const SiteStats = registry.register(
   })
 );
 
+const SiteStatSnapshot = registry.register(
+  'SiteStatSnapshot',
+  z.object({
+    id: z.number(),
+    capturedAt: z.string(),
+    maxUsers: z.number(),
+    totalUsers: z.number(),
+    enabledUsers: z.number(),
+    activeToday: z.number(),
+    activeThisWeek: z.number(),
+    activeThisMonth: z.number(),
+    communities: z.number(),
+    releases: z.number(),
+    artists: z.number(),
+    blogPosts: z.number(),
+    announcements: z.number(),
+    comments: z.number(),
+    contributedLinks: z.number(),
+    contributedLinkDownloads: z.number()
+  })
+);
+
+const UserStatSnapshot = registry.register(
+  'UserStatSnapshot',
+  z.object({
+    id: z.number(),
+    userId: z.number(),
+    period: z.enum(['Daily', 'Monthly', 'Yearly']),
+    capturedAt: z.string(),
+    contributed: z.string().nullable(),
+    consumed: z.string().nullable(),
+    contributionCount: z.number()
+  })
+);
+
 const Notification = registry.register(
   'Notification',
   z.object({
@@ -1118,6 +1153,58 @@ registry.registerPath({
     200: {
       description: 'Site statistics',
       content: { 'application/json': { schema: SiteStats } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/stats/history',
+  summary: 'Site-wide historical stat snapshots',
+  tags: ['Stats'],
+  responses: {
+    200: {
+      description: 'Historical site stat snapshots (ascending by capturedAt)',
+      content: { 'application/json': { schema: z.array(SiteStatSnapshot) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/stats/snapshot',
+  summary: 'Manually trigger a site stat snapshot (admin only)',
+  tags: ['Stats'],
+  responses: {
+    204: { description: 'Snapshot captured' },
+    403: {
+      description: 'Forbidden',
+      content: { 'application/json': { schema: z.object({ msg: z.string() }) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/users/{id}/stats/history',
+  summary: 'User historical stat snapshots',
+  tags: ['Users'],
+  request: {
+    params: z.object({ id: z.string() }),
+    query: z.object({ period: z.enum(['Daily', 'Monthly', 'Yearly']) })
+  },
+  responses: {
+    200: {
+      description: 'Historical user stat snapshots (ascending by capturedAt)',
+      content: { 'application/json': { schema: z.array(UserStatSnapshot) } }
+    },
+    403: {
+      description: 'Stats are private',
+      content: { 'application/json': { schema: z.object({ msg: z.string() }) } }
+    },
+    404: {
+      description: 'User not found',
+      content: { 'application/json': { schema: z.object({ msg: z.string() }) } }
     }
   }
 });

--- a/src/modules/statsHistory.ts
+++ b/src/modules/statsHistory.ts
@@ -1,0 +1,161 @@
+import { StatSnapshotPeriod, UserSettings } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
+import { getSystemStats } from './stats';
+
+// ─── Bucket helpers ──────────────────────────────────────────────────────────
+
+function hourBucket(d = new Date()): Date {
+  return new Date(Math.floor(d.getTime() / 3_600_000) * 3_600_000);
+}
+
+function dayBucket(d = new Date()): Date {
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+  );
+}
+
+function weekBucket(d = new Date()): Date {
+  const day = d.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  const mon = new Date(d);
+  mon.setUTCDate(d.getUTCDate() + diff);
+  return new Date(
+    Date.UTC(mon.getUTCFullYear(), mon.getUTCMonth(), mon.getUTCDate())
+  );
+}
+
+function getBucket(period: StatSnapshotPeriod): Date {
+  if (period === 'Daily') return hourBucket();
+  if (period === 'Monthly') return dayBucket();
+  return weekBucket();
+}
+
+function getRetentionCutoff(period: StatSnapshotPeriod): Date {
+  const now = new Date();
+  if (period === 'Daily') return new Date(now.getTime() - 25 * 60 * 60 * 1000);
+  if (period === 'Monthly')
+    return new Date(now.getTime() - 32 * 24 * 60 * 60 * 1000);
+  return new Date(now.getTime() - 53 * 7 * 24 * 60 * 60 * 1000);
+}
+
+// ─── Capture functions ───────────────────────────────────────────────────────
+
+type UserAggRow = {
+  id: number;
+  contributed: bigint;
+  consumed: bigint;
+  contributionCount: number;
+};
+
+export async function captureUserStats(
+  period: StatSnapshotPeriod
+): Promise<void> {
+  const bucketAt = getBucket(period);
+
+  const rows = await prisma.$queryRaw<UserAggRow[]>`
+    SELECT u.id, u.contributed, u.consumed, COUNT(c.id)::int AS "contributionCount"
+    FROM "users" u
+    LEFT JOIN "contributions" c ON c."userId" = u.id
+    WHERE u.disabled = false
+    GROUP BY u.id, u.contributed, u.consumed
+  `;
+
+  if (rows.length > 0) {
+    await prisma.userStatSnapshot.createMany({
+      data: rows.map((r) => ({
+        userId: r.id,
+        period,
+        bucketAt,
+        contributed: r.contributed,
+        consumed: r.consumed,
+        contributionCount: r.contributionCount
+      })),
+      skipDuplicates: true
+    });
+  }
+
+  await prisma.userStatSnapshot.deleteMany({
+    where: { period, capturedAt: { lt: getRetentionCutoff(period) } }
+  });
+}
+
+export async function captureSiteStats(): Promise<void> {
+  const bucketAt = hourBucket();
+  const stats = await getSystemStats();
+
+  await prisma.siteStatSnapshot.upsert({
+    where: { bucketAt },
+    update: {},
+    create: {
+      bucketAt,
+      maxUsers: stats.maxUsers,
+      totalUsers: stats.totalUsers,
+      enabledUsers: stats.enabledUsers,
+      activeToday: stats.activeToday,
+      activeThisWeek: stats.activeThisWeek,
+      activeThisMonth: stats.activeThisMonth,
+      communities: stats.communities,
+      releases: stats.releases,
+      artists: stats.artists,
+      blogPosts: stats.blogPosts,
+      announcements: stats.announcements,
+      comments: stats.comments,
+      contributedLinks: stats.contributedLinks,
+      contributedLinkDownloads: stats.contributedLinkDownloads
+    }
+  });
+}
+
+// ─── Query functions ─────────────────────────────────────────────────────────
+
+type UserWithSettings = {
+  id: number;
+  userSettings: UserSettings | null;
+};
+
+export async function getUserStatHistory(
+  userId: number,
+  period: StatSnapshotPeriod,
+  requesterId: number,
+  isRequesterStaff: boolean,
+  userAndSettings: UserWithSettings
+) {
+  const isOwner = requesterId === userId;
+  const settings = userAndSettings.userSettings;
+
+  if (!isOwner && !isRequesterStaff) {
+    const canSeeAny =
+      settings?.showContributedStats || settings?.showConsumedStats;
+    if (!canSeeAny) throw new AppError(403, 'Stats are private');
+  }
+
+  const rows = await prisma.userStatSnapshot.findMany({
+    where: { userId, period },
+    orderBy: { capturedAt: 'asc' }
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    userId: row.userId,
+    period: row.period,
+    capturedAt: row.capturedAt.toISOString(),
+    contributed:
+      isOwner || isRequesterStaff || settings?.showContributedStats
+        ? row.contributed.toString()
+        : null,
+    consumed:
+      isOwner || isRequesterStaff || settings?.showConsumedStats
+        ? row.consumed.toString()
+        : null,
+    contributionCount: row.contributionCount
+  }));
+}
+
+export async function getSiteStatHistory(limit = 100) {
+  const rows = await prisma.siteStatSnapshot.findMany({
+    orderBy: { capturedAt: 'desc' },
+    take: limit
+  });
+  return rows.reverse();
+}

--- a/src/modules/statsJob.ts
+++ b/src/modules/statsJob.ts
@@ -1,0 +1,45 @@
+import { getLogger } from './logging';
+import { captureUserStats, captureSiteStats } from './statsHistory';
+
+const log = getLogger('statsJob');
+
+const HOURLY_MS = 60 * 60 * 1000;
+const DAILY_MS = 24 * 60 * 60 * 1000;
+const WEEKLY_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const startStatsJob = (): void => {
+  // Daily period: captured hourly, 25h retention
+  const runHourly = () =>
+    Promise.all([captureUserStats('Daily'), captureSiteStats()]).catch((err) =>
+      log.error('Hourly stats capture failed', { err })
+    );
+  const hourlyDelay = setTimeout(() => {
+    runHourly();
+    setInterval(runHourly, HOURLY_MS).unref();
+  }, 60_000);
+  hourlyDelay.unref();
+
+  // Monthly period: captured daily, 32d retention
+  const runDaily = () =>
+    captureUserStats('Monthly').catch((err) =>
+      log.error('Daily stats capture failed', { err })
+    );
+  const dailyDelay = setTimeout(() => {
+    runDaily();
+    setInterval(runDaily, DAILY_MS).unref();
+  }, 90_000);
+  dailyDelay.unref();
+
+  // Yearly period: captured weekly, 53w retention
+  const runWeekly = () =>
+    captureUserStats('Yearly').catch((err) =>
+      log.error('Weekly stats capture failed', { err })
+    );
+  const weeklyDelay = setTimeout(() => {
+    runWeekly();
+    setInterval(runWeekly, WEEKLY_MS).unref();
+  }, 120_000);
+  weeklyDelay.unref();
+
+  log.info('Stats snapshot job scheduled');
+};

--- a/src/routes/api/stats.ts
+++ b/src/routes/api/stats.ts
@@ -1,9 +1,34 @@
 import express, { Request, Response } from 'express';
 import { asyncHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/permissions';
 import { getSystemStats } from '../../modules/stats';
+import {
+  getSiteStatHistory,
+  captureSiteStats
+} from '../../modules/statsHistory';
 
 const router = express.Router();
+
+// GET /api/stats/history — site-wide historical snapshots
+router.get(
+  '/history',
+  requireAuth,
+  asyncHandler(async (_req: Request, res: Response) => {
+    const snapshots = await getSiteStatHistory();
+    res.json(snapshots);
+  })
+);
+
+// POST /api/stats/snapshot — manually trigger a site stat snapshot (admin only)
+router.post(
+  '/snapshot',
+  ...requirePermission('admin'),
+  asyncHandler(async (_req: Request, res: Response) => {
+    await captureSiteStats();
+    res.sendStatus(204);
+  })
+);
 
 // GET /api/stats
 router.get(

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -8,14 +8,16 @@ import {
   createUser
 } from '../../modules/user';
 import { requireAuth } from '../../middleware/auth';
-import { requirePermission } from '../../middleware/permissions';
+import { requirePermission, isModerator } from '../../middleware/permissions';
 import {
   validate,
   validateParams,
+  validateQuery,
   parsedBody,
-  parsedParams
+  parsedParams,
+  parsedQuery
 } from '../../middleware/validate';
-import { Prisma } from '@prisma/client';
+import { Prisma, StatSnapshotPeriod } from '@prisma/client';
 import {
   adminCreateUserSchema,
   userSettingsSchema,
@@ -36,6 +38,11 @@ import { audit } from '../../lib/audit';
 import { parsePage, paginatedResponse } from '../../lib/pagination';
 import { sendRecoveryEmail } from '../../lib/mailer';
 import { email as emailConfig } from '../../modules/config';
+import {
+  statsPeriodQuerySchema,
+  type StatsPeriodQuery
+} from '../../schemas/statsHistory';
+import { getUserStatHistory } from '../../modules/statsHistory';
 import crypto from 'crypto';
 
 const router = express.Router();
@@ -282,6 +289,33 @@ router.delete(
       reqId
     );
     res.json({ msg: 'Recovery request revoked' });
+  })
+);
+
+// GET /api/users/:id/stats/history — user historical stats (own or staff)
+router.get(
+  '/:id/stats/history',
+  requireAuth,
+  validateParams(userIdParamsSchema),
+  validateQuery(statsPeriodQuerySchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { period } = parsedQuery<StatsPeriodQuery>(res);
+    const isStaff = await isModerator(req, res);
+    const userAndSettings = await prisma.user.findUnique({
+      where: { id },
+      include: { userSettings: true }
+    });
+    if (!userAndSettings)
+      return res.status(404).json({ msg: 'User not found' });
+    const history = await getUserStatHistory(
+      id,
+      period as StatSnapshotPeriod,
+      req.user.id,
+      isStaff,
+      userAndSettings
+    );
+    res.json(history);
   })
 );
 

--- a/src/schemas/statsHistory.ts
+++ b/src/schemas/statsHistory.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const statsPeriodQuerySchema = z.object({
+  period: z.enum(['Daily', 'Monthly', 'Yearly'])
+});
+
+export type StatsPeriodQuery = z.infer<typeof statsPeriodQuerySchema>;

--- a/src/stats.spec.ts
+++ b/src/stats.spec.ts
@@ -1,14 +1,36 @@
-import { request, app, resetApiTestState } from './test/apiTestHarness';
+import {
+  request,
+  app,
+  prismaMock,
+  makeUserRank,
+  resetApiTestState
+} from './test/apiTestHarness';
 
 jest.mock('./modules/stats', () => ({
   getSystemStats: jest.fn()
 }));
 
+jest.mock('./modules/statsHistory', () => ({
+  getSiteStatHistory: jest.fn(),
+  captureSiteStats: jest.fn(),
+  captureUserStats: jest.fn(),
+  getUserStatHistory: jest.fn()
+}));
+
 import { getSystemStats } from './modules/stats';
+import * as statsHistoryModule from './modules/statsHistory';
 
 const getStatsMock = getSystemStats as jest.MockedFunction<
   typeof getSystemStats
 >;
+const historyMock = statsHistoryModule as jest.Mocked<
+  typeof statsHistoryModule
+>;
+
+const setAdmin = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue(
+    makeUserRank({ admin: true })
+  );
 
 const mockStats = {
   maxUsers: 5000,
@@ -19,9 +41,33 @@ const mockStats = {
   totalCommunities: 12
 };
 
+const mockSnapshots = [
+  {
+    id: 1,
+    bucketAt: new Date(),
+    capturedAt: new Date(),
+    maxUsers: 5000,
+    totalUsers: 250,
+    enabledUsers: 240,
+    activeToday: 10,
+    activeThisWeek: 50,
+    activeThisMonth: 100,
+    communities: 5,
+    releases: 200,
+    artists: 80,
+    blogPosts: 3,
+    announcements: 1,
+    comments: 500,
+    contributedLinks: 200,
+    contributedLinkDownloads: 1000
+  }
+];
+
 beforeEach(() => {
   resetApiTestState();
   getStatsMock.mockResolvedValue(mockStats as never);
+  historyMock.getSiteStatHistory.mockResolvedValue(mockSnapshots as never);
+  historyMock.captureSiteStats.mockResolvedValue(undefined);
 });
 
 describe('GET /api/stats', () => {
@@ -32,5 +78,38 @@ describe('GET /api/stats', () => {
     expect(res.body.maxUsers).toBe(5000);
     expect(res.body.totalUsers).toBe(250);
     expect(res.body.totalReleases).toBe(1800);
+  });
+});
+
+describe('GET /api/stats/history', () => {
+  it('returns array of site stat snapshots', async () => {
+    const res = await request(app).get('/api/stats/history');
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toMatchObject({
+      totalUsers: 250,
+      enabledUsers: 240,
+      communities: 5
+    });
+  });
+
+  it('calls getSiteStatHistory', async () => {
+    await request(app).get('/api/stats/history');
+    expect(historyMock.getSiteStatHistory).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/stats/snapshot', () => {
+  it('returns 403 for non-admin user', async () => {
+    const res = await request(app).post('/api/stats/snapshot');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 204 for admin user', async () => {
+    setAdmin();
+    const res = await request(app).post('/api/stats/snapshot');
+    expect(res.status).toBe(204);
+    expect(historyMock.captureSiteStats).toHaveBeenCalled();
   });
 });

--- a/src/statsHistoryModule.spec.ts
+++ b/src/statsHistoryModule.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for statsHistory module — verifies DB call shapes using mocked Prisma.
+ */
+
+import { prismaMock, resetApiTestState } from './test/apiTestHarness';
+import { AppError } from './lib/errors';
+
+jest.mock('./modules/stats', () => ({
+  getSystemStats: jest.fn()
+}));
+
+import type * as StatsHistoryModule from './modules/statsHistory';
+const {
+  captureUserStats,
+  captureSiteStats,
+  getUserStatHistory,
+  getSiteStatHistory
+} = jest.requireActual<typeof StatsHistoryModule>('./modules/statsHistory');
+
+import { getSystemStats } from './modules/stats';
+const getSystemStatsMock = getSystemStats as jest.MockedFunction<
+  typeof getSystemStats
+>;
+
+beforeEach(() => resetApiTestState());
+
+// ─── captureUserStats ─────────────────────────────────────────────────────────
+
+describe('captureUserStats', () => {
+  it('calls createMany with skipDuplicates and prunes old records', async () => {
+    prismaMock.$queryRaw.mockResolvedValue([
+      {
+        id: 1,
+        contributed: BigInt(1000),
+        consumed: BigInt(500),
+        contributionCount: 3
+      }
+    ]);
+    prismaMock.userStatSnapshot.createMany.mockResolvedValue({ count: 1 });
+    prismaMock.userStatSnapshot.deleteMany.mockResolvedValue({ count: 0 });
+
+    await captureUserStats('Daily');
+
+    expect(prismaMock.userStatSnapshot.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skipDuplicates: true })
+    );
+    expect(prismaMock.userStatSnapshot.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ period: 'Daily' })
+      })
+    );
+  });
+
+  it('skips createMany when no users found', async () => {
+    prismaMock.$queryRaw.mockResolvedValue([]);
+    prismaMock.userStatSnapshot.deleteMany.mockResolvedValue({ count: 0 });
+
+    await captureUserStats('Monthly');
+
+    expect(prismaMock.userStatSnapshot.createMany).not.toHaveBeenCalled();
+  });
+});
+
+// ─── captureSiteStats ─────────────────────────────────────────────────────────
+
+describe('captureSiteStats', () => {
+  const mockStats = {
+    maxUsers: 5000,
+    totalUsers: 100,
+    enabledUsers: 98,
+    activeToday: 10,
+    activeThisWeek: 30,
+    activeThisMonth: 60,
+    communities: 2,
+    releases: 50,
+    artists: 20,
+    blogPosts: 1,
+    announcements: 0,
+    comments: 200,
+    contributedLinks: 50,
+    contributedLinkDownloads: 300
+  };
+
+  it('upserts a site snapshot using hourBucket', async () => {
+    getSystemStatsMock.mockResolvedValue(mockStats as never);
+    prismaMock.siteStatSnapshot.upsert.mockResolvedValue({} as never);
+
+    await captureSiteStats();
+
+    expect(prismaMock.siteStatSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {},
+        create: expect.objectContaining({ totalUsers: 100 })
+      })
+    );
+  });
+
+  it('is idempotent — upsert update is a no-op', async () => {
+    getSystemStatsMock.mockResolvedValue(mockStats as never);
+    prismaMock.siteStatSnapshot.upsert.mockResolvedValue({} as never);
+
+    await captureSiteStats();
+    await captureSiteStats();
+
+    expect(prismaMock.siteStatSnapshot.upsert).toHaveBeenCalledTimes(2);
+    const calls = prismaMock.siteStatSnapshot.upsert.mock.calls;
+    expect(calls[0][0].update).toEqual({});
+    expect(calls[1][0].update).toEqual({});
+  });
+});
+
+// ─── getUserStatHistory ───────────────────────────────────────────────────────
+
+describe('getUserStatHistory', () => {
+  const privateSettings = {
+    showContributedStats: false,
+    showConsumedStats: false
+  };
+  const publicSettings = {
+    showContributedStats: true,
+    showConsumedStats: true
+  };
+  const halfSettings = { showContributedStats: true, showConsumedStats: false };
+
+  const mockRows = [
+    {
+      id: 1,
+      userId: 5,
+      period: 'Daily',
+      bucketAt: new Date(),
+      capturedAt: new Date(),
+      contributed: BigInt(1_000_000),
+      consumed: BigInt(500_000),
+      contributionCount: 3
+    }
+  ];
+
+  beforeEach(() => {
+    prismaMock.userStatSnapshot.findMany.mockResolvedValue(mockRows as never);
+  });
+
+  it('throws 403 when non-owner, non-staff, all stats private', async () => {
+    await expect(
+      getUserStatHistory(5, 'Daily', 7, false, {
+        id: 5,
+        userSettings: privateSettings as never
+      })
+    ).rejects.toThrow(AppError);
+
+    await expect(
+      getUserStatHistory(5, 'Daily', 7, false, {
+        id: 5,
+        userSettings: privateSettings as never
+      })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('returns full data for owner', async () => {
+    const result = await getUserStatHistory(5, 'Daily', 5, false, {
+      id: 5,
+      userSettings: publicSettings as never
+    });
+    expect(result[0].contributed).toBe('1000000');
+    expect(result[0].consumed).toBe('500000');
+  });
+
+  it('nulls out consumed when showConsumedStats is false for non-owner', async () => {
+    const result = await getUserStatHistory(5, 'Daily', 7, false, {
+      id: 5,
+      userSettings: halfSettings as never
+    });
+    expect(result[0].contributed).toBe('1000000');
+    expect(result[0].consumed).toBeNull();
+  });
+
+  it('staff bypasses all privacy settings', async () => {
+    const result = await getUserStatHistory(5, 'Daily', 7, true, {
+      id: 5,
+      userSettings: privateSettings as never
+    });
+    expect(result[0].contributed).toBe('1000000');
+    expect(result[0].consumed).toBe('500000');
+  });
+});
+
+// ─── getSiteStatHistory ───────────────────────────────────────────────────────
+
+describe('getSiteStatHistory', () => {
+  it('returns results in ascending capturedAt order (fetches desc, reverses)', async () => {
+    const older = { id: 1, capturedAt: new Date('2024-01-01') };
+    const newer = { id: 2, capturedAt: new Date('2024-01-02') };
+    prismaMock.siteStatSnapshot.findMany.mockResolvedValue([
+      newer,
+      older
+    ] as never);
+
+    const result = await getSiteStatHistory();
+
+    expect(result[0].capturedAt).toEqual(older.capturedAt);
+    expect(result[1].capturedAt).toEqual(newer.capturedAt);
+  });
+
+  it('passes take limit to findMany', async () => {
+    prismaMock.siteStatSnapshot.findMany.mockResolvedValue([]);
+    await getSiteStatHistory(50);
+    expect(prismaMock.siteStatSnapshot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 50 })
+    );
+  });
+});

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -46,6 +46,10 @@ jest.mock('../modules/linkHealthJob', () => ({
   startLinkHealthJob: jest.fn()
 }));
 
+jest.mock('../modules/statsJob', () => ({
+  startStatsJob: jest.fn()
+}));
+
 jest.mock('../modules/artist', () => ({
   createArtist: jest.fn(),
   updateArtist: jest.fn(),

--- a/src/userStatsHistory.spec.ts
+++ b/src/userStatsHistory.spec.ts
@@ -1,0 +1,123 @@
+import {
+  request,
+  app,
+  prismaMock,
+  makeUserRank,
+  resetApiTestState
+} from './test/apiTestHarness';
+import { AppError } from './lib/errors';
+
+jest.mock('./modules/statsHistory', () => ({
+  getSiteStatHistory: jest.fn(),
+  captureSiteStats: jest.fn(),
+  captureUserStats: jest.fn(),
+  getUserStatHistory: jest.fn()
+}));
+
+import * as statsHistoryModule from './modules/statsHistory';
+
+const historyMock = statsHistoryModule as jest.Mocked<
+  typeof statsHistoryModule
+>;
+
+const setStaff = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue(
+    makeUserRank({ staff: true })
+  );
+
+const mockHistory = [
+  {
+    id: 1,
+    userId: 7,
+    period: 'Daily',
+    capturedAt: new Date().toISOString(),
+    contributed: '1073741824',
+    consumed: '536870912',
+    contributionCount: 5
+  }
+];
+
+const mockUserWithSettings = {
+  id: 7,
+  userSettings: { showContributedStats: true, showConsumedStats: true }
+};
+
+beforeEach(() => {
+  resetApiTestState();
+  historyMock.getUserStatHistory.mockResolvedValue(mockHistory as never);
+});
+
+describe('GET /api/users/:id/stats/history', () => {
+  it('returns 400 when period is missing', async () => {
+    const res = await request(app).get('/api/users/7/stats/history');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ msg: 'Validation failed' });
+  });
+
+  it('returns 400 when period is invalid', async () => {
+    const res = await request(app).get(
+      '/api/users/7/stats/history?period=Hourly'
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ msg: 'Validation failed' });
+  });
+
+  it('returns 404 when user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    const res = await request(app).get(
+      '/api/users/999/stats/history?period=Daily'
+    );
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ msg: 'User not found' });
+  });
+
+  it('returns 200 with history for own user (id=7 matches harness user)', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(mockUserWithSettings as never);
+    const res = await request(app).get(
+      '/api/users/7/stats/history?period=Daily'
+    );
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(historyMock.getUserStatHistory).toHaveBeenCalledWith(
+      7,
+      'Daily',
+      7,
+      false,
+      mockUserWithSettings
+    );
+  });
+
+  it('returns 200 for staff viewing another user', async () => {
+    setStaff();
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 99,
+      userSettings: { showContributedStats: false, showConsumedStats: false }
+    } as never);
+    const res = await request(app).get(
+      '/api/users/99/stats/history?period=Monthly'
+    );
+    expect(res.status).toBe(200);
+    expect(historyMock.getUserStatHistory).toHaveBeenCalledWith(
+      99,
+      'Monthly',
+      7,
+      true,
+      expect.objectContaining({ id: 99 })
+    );
+  });
+
+  it('returns 403 when getUserStatHistory throws AppError 403', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 99,
+      userSettings: { showContributedStats: false, showConsumedStats: false }
+    } as never);
+    historyMock.getUserStatHistory.mockRejectedValue(
+      new AppError(403, 'Stats are private')
+    );
+    const res = await request(app).get(
+      '/api/users/99/stats/history?period=Daily'
+    );
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ msg: 'Stats are private' });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `UserStatSnapshot` and `SiteStatSnapshot` Prisma models with migration; user snapshots use a `@@unique([userId, period, bucketAt])` constraint and `createMany({ skipDuplicates: true })` for multi-instance dedup
- Adds `statsHistory.ts` module with capture functions (`captureUserStats`, `captureSiteStats`) and query functions (`getUserStatHistory`, `getSiteStatHistory`); user stats respect `showContributedStats`/`showConsumedStats` privacy settings and staff bypass
- Adds `statsJob.ts` background job (started in `createApp()`, all timers `.unref()`'d): hourly for Daily user stats + site stats, daily for Monthly, weekly for Yearly; retention windows match legacy behavior (25h / 32d / 53w)
- Extends `GET /stats` router with `GET /stats/history` (auth required) and `POST /stats/snapshot` (admin only); adds `GET /users/:id/stats/history?period=` with full validation and privacy enforcement
- Adds OpenAPI schemas and `registerPath()` entries for all four new endpoints
- Full unit test coverage: module-level (bucket dedup, retention pruning, privacy masking, staff bypass) and route-level (401/400/403/404/200 cases)

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean on changed files
- [ ] `npm run test --no-coverage` — all suites pass
- [ ] Run `npm run db:migrate` then start dev server; `POST /api/stats/snapshot` (admin token) seeds first site snapshot
- [ ] Verify `GET /api/stats/history` returns ascending array of site snapshots
- [ ] Verify `GET /api/users/:id/stats/history?period=Daily` returns user snapshots; confirm 403 for private-stats user viewed by non-owner non-staff

🤖 Generated with [Claude Code](https://claude.com/claude-code)