### PR TITLE
Add user stylesheet / theme system

### DIFF
--- a/prisma/migrations/20260524120000_stylesheets_seed/migration.sql
+++ b/prisma/migrations/20260524120000_stylesheets_seed/migration.sql
@@ -1,0 +1,29 @@
+-- Add description and isDefault columns to stylesheets
+ALTER TABLE "stylesheets" ADD COLUMN "description" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "stylesheets" ADD COLUMN "isDefault" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill stale siteAppearance default: cayer_make -> sublime
+UPDATE "user_settings"
+SET "siteAppearance" = 'sublime'
+WHERE "siteAppearance" = 'cayer_make';
+
+-- Seed built-in stylesheets
+INSERT INTO "stylesheets" ("name", "description", "cssUrl", "isDefault", "createdAt")
+VALUES
+  ('sublime', 'Default Stellar theme',       '/stylesheets/sublime/style.css', true,  NOW()),
+  ('kuro',    'Gazelle-inspired dark theme', '/stylesheets/kuro/style.css',    false, NOW())
+ON CONFLICT ("name") DO UPDATE SET
+  "description" = EXCLUDED."description",
+  "cssUrl"      = EXCLUDED."cssUrl",
+  "isDefault"   = EXCLUDED."isDefault";
+
+-- Normalise: ensure only sublime is default before adding the unique constraint
+UPDATE "stylesheets"
+SET "isDefault" = false
+WHERE "isDefault" = true AND "name" <> 'sublime';
+
+-- DB-level single-default invariant (partial unique index)
+-- Prisma DSL does not support partial unique indexes; this is managed via raw SQL migration only.
+CREATE UNIQUE INDEX "stylesheets_one_default"
+  ON "stylesheets"("isDefault")
+  WHERE "isDefault" = true;

--- a/prisma/migrations/20260524181515_add_stylesheets/migration.sql
+++ b/prisma/migrations/20260524181515_add_stylesheets/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_settings" ALTER COLUMN "siteAppearance" SET DEFAULT 'sublime';

--- a/prisma/migrations/20260524200000_add_legacy_stylesheets/migration.sql
+++ b/prisma/migrations/20260524200000_add_legacy_stylesheets/migration.sql
@@ -1,0 +1,10 @@
+-- Add legacy stylesheets: Layer Cake, Proton, Postmod, Dark Ambient
+INSERT INTO "stylesheets" ("name", "description", "cssUrl", "isDefault", "createdAt")
+VALUES
+  ('layer-cake',   'Warm dark theme with golden amber accents', '/stylesheets/layer-cake/style.css',   false, NOW()),
+  ('proton',       'Cool dark theme with teal accents',         '/stylesheets/proton/style.css',        false, NOW()),
+  ('postmod',      'Stark minimalist theme with red accents',   '/stylesheets/postmod/style.css',       false, NOW()),
+  ('dark-ambient', 'Deep atmospheric theme with muted blue',    '/stylesheets/dark-ambient/style.css',  false, NOW())
+ON CONFLICT ("name") DO UPDATE SET
+  "description" = EXCLUDED."description",
+  "cssUrl"      = EXCLUDED."cssUrl";

--- a/prisma/migrations/20260524213000_remove_dark_ambient/migration.sql
+++ b/prisma/migrations/20260524213000_remove_dark_ambient/migration.sql
@@ -1,0 +1,6 @@
+UPDATE "user_settings"
+SET "siteAppearance" = 'sublime'
+WHERE "siteAppearance" = 'dark-ambient';
+
+DELETE FROM "stylesheets"
+WHERE "name" = 'dark-ambient';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -275,7 +275,7 @@ model UserRank {
 
 model UserSettings {
   id                   Int                @id @default(autoincrement())
-  siteAppearance       String             @default("cayer_make")
+  siteAppearance       String             @default("sublime")
   externalStylesheet   String?
   styledTooltips       Boolean            @default(true)
   paranoia             Int                @default(0)
@@ -462,11 +462,16 @@ model Profile {
   @@map("profiles")
 }
 
+/// A partial unique index enforces exactly one default stylesheet at the DB level.
+/// This index is not representable in Prisma DSL and is created in raw SQL migration:
+/// CREATE UNIQUE INDEX "stylesheets_one_default" ON "stylesheets"("isDefault") WHERE "isDefault" = true;
 model Stylesheet {
-  id        Int      @id @default(autoincrement())
-  name      String   @unique
-  cssUrl    String
-  createdAt DateTime @default(now())
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  description String   @default("")
+  cssUrl      String
+  isDefault   Boolean  @default(false)
+  createdAt   DateTime @default(now())
 
   @@map("stylesheets")
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -31,7 +31,10 @@ import {
   artistAliasSchema,
   artistTagSchema
 } from '../schemas/artist';
-import { stylesheetSchema } from '../schemas/stylesheet';
+import {
+  stylesheetSchema,
+  stylesheetUpdateSchema
+} from '../schemas/stylesheet';
 import {
   subscribeSchema,
   subscribeCommentsSchema
@@ -1052,8 +1055,19 @@ const Stylesheet = registry.register(
   z.object({
     id: z.number(),
     name: z.string(),
+    description: z.string(),
     cssUrl: z.string(),
+    isDefault: z.boolean(),
     createdAt: z.string()
+  })
+);
+
+const StylesheetStat = registry.register(
+  'StylesheetStat',
+  z.object({
+    id: z.number(),
+    name: z.string(),
+    userCount: z.number()
   })
 );
 
@@ -1216,9 +1230,19 @@ registry.registerPath({
   responses: {
     200: {
       description: 'Available stylesheets',
-      content: {
-        'application/json': { schema: z.array(Stylesheet) }
-      }
+      content: { 'application/json': { schema: z.array(Stylesheet) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/stylesheet/admin/stats',
+  tags: ['Stylesheets'],
+  responses: {
+    200: {
+      description: 'Stylesheet user counts (admin only)',
+      content: { 'application/json': { schema: z.array(StylesheetStat) } }
     }
   }
 });
@@ -1260,6 +1284,32 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: 'put',
+  path: '/stylesheet/{id}',
+  tags: ['Stylesheets'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: { 'application/json': { schema: stylesheetUpdateSchema } }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Stylesheet updated',
+      content: { 'application/json': { schema: Stylesheet } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
   method: 'delete',
   path: '/stylesheet/{id}',
   tags: ['Stylesheets'],
@@ -1267,6 +1317,10 @@ registry.registerPath({
   responses: {
     204: {
       description: 'Stylesheet removed'
+    },
+    400: {
+      description: 'Cannot delete the default stylesheet',
+      content: { 'application/json': { schema: MsgResponse } }
     },
     404: {
       description: 'Not found',

--- a/src/middleware/permissions.ts
+++ b/src/middleware/permissions.ts
@@ -74,6 +74,21 @@ export const requirePermission = (
   }
 ];
 
+// Returns [requireAuth, permissionCheck] — admits only users with the literal 'admin' permission.
+// Staff alone does not pass (unlike requirePermission('admin') which treats staff ≡ admin).
+export const requireStrictAdmin = (): RequestHandler[] => [
+  requireAuth,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const perms = await loadPermissions(req as AuthenticatedRequest, res);
+      if (perms['admin']) return next();
+      res.status(403).json({ msg: 'Permission denied' });
+    } catch (err) {
+      next(err);
+    }
+  }
+];
+
 // Passes if req.user owns the resource OR has the given permission.
 // getOwnerId receives req and should return the resource owner's userId synchronously.
 export const requireOwnerOrPermission = (

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import { computeRatio } from './ratio';
+import { getDefaultStylesheetName } from './stylesheet';
 
 export const isPasswordBanned = async (password: string): Promise<boolean> => {
   const found = await prisma.badPassword.findFirst({ where: { password } });
@@ -85,7 +86,10 @@ export const registerUser = async (
   const hashedPassword = await bcrypt.hash(password, await bcrypt.genSalt(10));
 
   const user = await prisma.$transaction(async (tx) => {
-    const settings = await tx.userSettings.create({ data: {} });
+    const defaultTheme = await getDefaultStylesheetName(tx);
+    const settings = await tx.userSettings.create({
+      data: { siteAppearance: defaultTheme }
+    });
     const profile = await tx.profile.create({ data: {} });
     return tx.user.create({
       data: {

--- a/src/modules/stylesheet.ts
+++ b/src/modules/stylesheet.ts
@@ -1,0 +1,82 @@
+import { PrismaClient } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
+
+type Tx = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0];
+
+export const getDefaultStylesheetName = async (tx?: Tx): Promise<string> => {
+  const db = tx ?? prisma;
+  const row = await db.stylesheet.findFirst({
+    where: { isDefault: true },
+    select: { name: true }
+  });
+  return row?.name ?? 'sublime';
+};
+
+export const getStylesheetStats = async () => {
+  const [stylesheets, grouped] = await Promise.all([
+    prisma.stylesheet.findMany({ select: { id: true, name: true } }),
+    prisma.userSettings.groupBy({
+      by: ['siteAppearance'],
+      _count: { siteAppearance: true }
+    })
+  ]);
+  const countMap = Object.fromEntries(
+    grouped.map((g) => [g.siteAppearance, g._count.siteAppearance])
+  );
+  return stylesheets.map((s) => ({
+    id: s.id,
+    name: s.name,
+    userCount: countMap[s.name] ?? 0
+  }));
+};
+
+export const createStylesheet = async (data: {
+  name: string;
+  description: string;
+  cssUrl: string;
+  isDefault: boolean;
+}) => {
+  if (data.isDefault) {
+    return prisma.$transaction(async (tx) => {
+      await tx.stylesheet.updateMany({
+        where: { isDefault: true },
+        data: { isDefault: false }
+      });
+      return tx.stylesheet.create({ data });
+    });
+  }
+  return prisma.stylesheet.create({ data });
+};
+
+export const updateStylesheet = async (
+  id: number,
+  data: Partial<{
+    name: string;
+    description: string;
+    cssUrl: string;
+    isDefault: boolean;
+  }>
+) => {
+  const existing = await prisma.stylesheet.findUnique({ where: { id } });
+  if (!existing) throw new AppError(404, 'Stylesheet not found');
+
+  if (data.isDefault) {
+    return prisma.$transaction(async (tx) => {
+      await tx.stylesheet.updateMany({
+        where: { isDefault: true },
+        data: { isDefault: false }
+      });
+      return tx.stylesheet.update({ where: { id }, data });
+    });
+  }
+  return prisma.stylesheet.update({ where: { id }, data });
+};
+
+export const deleteStylesheet = async (id: number) => {
+  const existing = await prisma.stylesheet.findUnique({ where: { id } });
+  if (!existing) throw new AppError(404, 'Stylesheet not found');
+  if (existing.isDefault)
+    throw new AppError(400, 'Cannot delete the default stylesheet');
+  await prisma.stylesheet.delete({ where: { id } });
+};

--- a/src/modules/user.ts
+++ b/src/modules/user.ts
@@ -2,6 +2,7 @@ import bcrypt from 'bcryptjs';
 import { prisma } from '../lib/prisma';
 import { audit } from '../lib/audit';
 import { AppError } from '../lib/errors';
+import { getDefaultStylesheetName } from './stylesheet';
 
 export const getUserSettings = async (userId: number) => {
   const user = await prisma.user.findUnique({
@@ -107,7 +108,10 @@ export const createUser = async (
   );
 
   const user = await prisma.$transaction(async (tx) => {
-    const settings = await tx.userSettings.create({ data: {} });
+    const defaultTheme = await getDefaultStylesheetName(tx);
+    const settings = await tx.userSettings.create({
+      data: { siteAppearance: defaultTheme }
+    });
     const profile = await tx.profile.create({ data: {} });
     return tx.user.create({
       data: {

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -17,6 +17,7 @@ import { getSettings } from '../../modules/settings';
 import { seedRanks, seedForums } from '../../modules/bootstrap';
 import { AppError } from '../../lib/errors';
 import { authUserSelect, toAuthUser } from '../../modules/auth';
+import { getDefaultStylesheetName } from '../../modules/stylesheet';
 
 const TOKEN_TTL_SECONDS = 3600;
 const STARTUP_BUFFER = 5_368_709_120n; // 5 GiB — matches self-registration buffer
@@ -187,7 +188,10 @@ router.post(
     );
 
     const rawUser = await prisma.$transaction(async (tx) => {
-      const settings = await tx.userSettings.create({ data: {} });
+      const defaultTheme = await getDefaultStylesheetName(tx);
+      const settings = await tx.userSettings.create({
+        data: { siteAppearance: defaultTheme }
+      });
       const profile = await tx.profile.create({ data: {} });
       return tx.user.create({
         data: {

--- a/src/routes/api/stylesheet.ts
+++ b/src/routes/api/stylesheet.ts
@@ -1,8 +1,8 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
-import { prisma } from '../../lib/prisma';
 import { asyncHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
+import { requireStrictAdmin } from '../../middleware/permissions';
 import {
   validate,
   validateParams,
@@ -11,13 +11,32 @@ import {
 } from '../../middleware/validate';
 import {
   stylesheetSchema,
-  type StylesheetInput
+  stylesheetUpdateSchema,
+  type StylesheetInput,
+  type StylesheetUpdateInput
 } from '../../schemas/stylesheet';
+import {
+  createStylesheet,
+  updateStylesheet,
+  deleteStylesheet,
+  getStylesheetStats
+} from '../../modules/stylesheet';
+import { prisma } from '../../lib/prisma';
 
 const router = express.Router();
 const stylesheetIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
+
+// GET /api/stylesheet/admin/stats — must be before /:id
+router.get(
+  '/admin/stats',
+  ...requireStrictAdmin(),
+  asyncHandler(async (_req: Request, res: Response) => {
+    const stats = await getStylesheetStats();
+    res.json(stats);
+  })
+);
 
 // GET /api/stylesheet
 router.get(
@@ -25,7 +44,7 @@ router.get(
   requireAuth,
   asyncHandler(async (_req: Request, res: Response) => {
     const stylesheets = await prisma.stylesheet.findMany({
-      orderBy: { createdAt: 'desc' }
+      orderBy: { createdAt: 'asc' }
     });
     res.json(stylesheets);
   })
@@ -48,27 +67,42 @@ router.get(
 // POST /api/stylesheet
 router.post(
   '/',
-  requireAuth,
+  ...requireStrictAdmin(),
   validate(stylesheetSchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const { name, cssUrl } = parsedBody<StylesheetInput>(res);
-    const stylesheet = await prisma.stylesheet.create({
-      data: { name, cssUrl }
+    const data = parsedBody<StylesheetInput>(res);
+    const stylesheet = await createStylesheet({
+      name: data.name,
+      description: data.description ?? '',
+      cssUrl: data.cssUrl,
+      isDefault: data.isDefault ?? false
     });
     res.status(201).json(stylesheet);
+  })
+);
+
+// PUT /api/stylesheet/:id
+router.put(
+  '/:id',
+  ...requireStrictAdmin(),
+  validateParams(stylesheetIdParamsSchema),
+  validate(stylesheetUpdateSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const data = parsedBody<StylesheetUpdateInput>(res);
+    const stylesheet = await updateStylesheet(id, data);
+    res.json(stylesheet);
   })
 );
 
 // DELETE /api/stylesheet/:id
 router.delete(
   '/:id',
-  requireAuth,
+  ...requireStrictAdmin(),
   validateParams(stylesheetIdParamsSchema),
   asyncHandler(async (req: Request, res: Response) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const existing = await prisma.stylesheet.findUnique({ where: { id } });
-    if (!existing) return res.status(404).json({ msg: 'Stylesheet not found' });
-    await prisma.stylesheet.delete({ where: { id } });
+    await deleteStylesheet(id);
     res.status(204).send();
   })
 );

--- a/src/routes/api/wiki.ts
+++ b/src/routes/api/wiki.ts
@@ -204,7 +204,7 @@ router.get(
 
 // ─── GET /api/wiki/:id/revisions ──────────────────────────────────────────────
 // Requires canEdit (not just canRead) — revision history can expose restricted
-// prior content. Matches Gazelle's revisions.php access control.
+// prior content — only users who can edit can access revision history.
 router.get(
   '/:id/revisions',
   requireAuth,

--- a/src/schemas/profile.ts
+++ b/src/schemas/profile.ts
@@ -6,7 +6,7 @@ export const profileUpdateSchema = z.object({
   profileTitle: z.string().max(128).optional(),
   profileInfo: z.string().max(10000).optional(),
   siteAppearance: z.string().optional(),
-  externalStylesheet: z.string().url().optional().or(z.literal('')),
+  externalStylesheet: z.string().optional(),
   styledTooltips: z.boolean().optional(),
   paranoia: z.coerce.number().int().min(0).max(3).optional(),
   notificationMethod: z

--- a/src/schemas/stylesheet.ts
+++ b/src/schemas/stylesheet.ts
@@ -1,8 +1,24 @@
 import { z } from 'zod';
 
 export const stylesheetSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  cssUrl: z.string().url('CSS URL must be a valid URL')
+  name: z.string().min(1),
+  description: z.string().optional().default(''),
+  cssUrl: z.string().min(1, 'CSS URL is required'),
+  isDefault: z.boolean().optional().default(false)
 });
 
+// Defined independently so no defaults carry through — empty body is a validation error.
+export const stylesheetUpdateSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    cssUrl: z.string().min(1, 'CSS URL is required').optional(),
+    isDefault: z.boolean().optional()
+  })
+  .refine(
+    (data) => Object.values(data).some((v) => v !== undefined),
+    'At least one field must be provided'
+  );
+
 export type StylesheetInput = z.infer<typeof stylesheetSchema>;
+export type StylesheetUpdateInput = z.infer<typeof stylesheetUpdateSchema>;

--- a/src/stylesheet.spec.ts
+++ b/src/stylesheet.spec.ts
@@ -2,15 +2,18 @@ import {
   request,
   app,
   resetApiTestState,
-  prismaMock
+  prismaMock,
+  makeUserRank
 } from './test/apiTestHarness';
 
 beforeEach(() => resetApiTestState());
 
 const makeStylesheet = (overrides = {}) => ({
   id: 1,
-  name: 'Dark Theme',
-  cssUrl: 'https://example.com/dark.css',
+  name: 'sublime',
+  description: 'Default Stellar theme',
+  cssUrl: '/stylesheets/sublime/style.css',
+  isDefault: true,
   createdAt: new Date('2026-01-01'),
   ...overrides
 });
@@ -21,23 +24,81 @@ describe('GET /api/stylesheet', () => {
   it('returns the list of stylesheets', async () => {
     prismaMock.stylesheet.findMany.mockResolvedValue([
       makeStylesheet(),
-      makeStylesheet({ id: 2, name: 'Light Theme' })
+      makeStylesheet({ id: 2, name: 'kuro', isDefault: false })
     ] as never);
 
     const res = await request(app).get('/api/stylesheet');
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);
-    expect(res.body[0].name).toBe('Dark Theme');
+    expect(res.body[0].name).toBe('sublime');
+    expect(res.body[0].isDefault).toBe(true);
+    expect(res.body[0].description).toBe('Default Stellar theme');
   });
 
   it('returns an empty array when no stylesheets exist', async () => {
     prismaMock.stylesheet.findMany.mockResolvedValue([]);
-
     const res = await request(app).get('/api/stylesheet');
-
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(0);
+  });
+});
+
+// ─── GET /api/stylesheet/admin/stats ─────────────────────────────────────────
+
+describe('GET /api/stylesheet/admin/stats', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
+
+  it('returns stylesheet user counts for admin', async () => {
+    prismaMock.stylesheet.findMany.mockResolvedValue([
+      makeStylesheet({ id: 1, name: 'sublime' }),
+      makeStylesheet({ id: 2, name: 'kuro', isDefault: false })
+    ] as never);
+    (prismaMock.userSettings.groupBy as jest.Mock).mockResolvedValue([
+      { siteAppearance: 'sublime', _count: { siteAppearance: 42 } },
+      { siteAppearance: 'kuro', _count: { siteAppearance: 5 } }
+    ]);
+
+    const res = await request(app).get('/api/stylesheet/admin/stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(
+      res.body.find((s: { name: string }) => s.name === 'sublime').userCount
+    ).toBe(42);
+    expect(
+      res.body.find((s: { name: string }) => s.name === 'kuro').userCount
+    ).toBe(5);
+  });
+
+  it('returns 0 for stylesheets with no users', async () => {
+    prismaMock.stylesheet.findMany.mockResolvedValue([
+      makeStylesheet({ id: 1, name: 'sublime' })
+    ] as never);
+    (prismaMock.userSettings.groupBy as jest.Mock).mockResolvedValue([]);
+
+    const res = await request(app).get('/api/stylesheet/admin/stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].userCount).toBe(0);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).get('/api/stylesheet/admin/stats');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for staff (strict admin only)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ staff: true })
+    );
+    const res = await request(app).get('/api/stylesheet/admin/stats');
+    expect(res.status).toBe(403);
   });
 });
 
@@ -48,19 +109,15 @@ describe('GET /api/stylesheet/:id', () => {
     prismaMock.stylesheet.findUnique.mockResolvedValue(
       makeStylesheet() as never
     );
-
     const res = await request(app).get('/api/stylesheet/1');
-
     expect(res.status).toBe(200);
-    expect(res.body.name).toBe('Dark Theme');
-    expect(res.body.cssUrl).toBe('https://example.com/dark.css');
+    expect(res.body.name).toBe('sublime');
+    expect(res.body.isDefault).toBe(true);
   });
 
   it('returns 404 when the stylesheet does not exist', async () => {
     prismaMock.stylesheet.findUnique.mockResolvedValue(null);
-
     const res = await request(app).get('/api/stylesheet/99');
-
     expect(res.status).toBe(404);
     expect(res.body.msg).toBe('Stylesheet not found');
   });
@@ -74,37 +131,165 @@ describe('GET /api/stylesheet/:id', () => {
 // ─── POST /api/stylesheet ─────────────────────────────────────────────────────
 
 describe('POST /api/stylesheet', () => {
-  it('creates a stylesheet and returns 201', async () => {
-    prismaMock.stylesheet.create.mockResolvedValue(makeStylesheet() as never);
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
 
-    const res = await request(app)
-      .post('/api/stylesheet')
-      .send({ name: 'Dark Theme', cssUrl: 'https://example.com/dark.css' });
+  it('creates a stylesheet and returns 201', async () => {
+    prismaMock.stylesheet.create.mockResolvedValue(
+      makeStylesheet({ id: 3, name: 'custom', isDefault: false }) as never
+    );
+
+    const res = await request(app).post('/api/stylesheet').send({
+      name: 'custom',
+      cssUrl: '/stylesheets/custom/style.css',
+      description: 'Custom'
+    });
 
     expect(res.status).toBe(201);
-    expect(res.body.name).toBe('Dark Theme');
+    expect(res.body.name).toBe('custom');
     expect(prismaMock.stylesheet.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { name: 'Dark Theme', cssUrl: 'https://example.com/dark.css' }
+        data: expect.objectContaining({
+          name: 'custom',
+          cssUrl: '/stylesheets/custom/style.css',
+          description: 'Custom',
+          isDefault: false
+        })
       })
     );
+  });
+
+  it('clears existing default when creating with isDefault: true', async () => {
+    const newSheet = makeStylesheet({ id: 3, name: 'custom', isDefault: true });
+    prismaMock.stylesheet.updateMany.mockResolvedValue({ count: 1 } as never);
+    prismaMock.stylesheet.create.mockResolvedValue(newSheet as never);
+
+    const res = await request(app).post('/api/stylesheet').send({
+      name: 'custom',
+      cssUrl: '/stylesheets/custom/style.css',
+      isDefault: true
+    });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.stylesheet.updateMany).toHaveBeenCalledWith({
+      where: { isDefault: true },
+      data: { isDefault: false }
+    });
   });
 
   it('returns 400 when required fields are missing', async () => {
     const res = await request(app)
       .post('/api/stylesheet')
-      .send({ name: 'Dark Theme' }); // missing cssUrl
-
+      .send({ name: 'custom' });
     expect(res.status).toBe(400);
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app)
+      .post('/api/stylesheet')
+      .send({ name: 'custom', cssUrl: '/stylesheets/custom/style.css' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for staff (strict admin only)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ staff: true })
+    );
+    const res = await request(app)
+      .post('/api/stylesheet')
+      .send({ name: 'custom', cssUrl: '/stylesheets/custom/style.css' });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── PUT /api/stylesheet/:id ──────────────────────────────────────────────────
+
+describe('PUT /api/stylesheet/:id', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
+
+  it('updates a stylesheet and returns 200', async () => {
+    const updated = makeStylesheet({ description: 'Updated description' });
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet() as never
+    );
+    prismaMock.stylesheet.update.mockResolvedValue(updated as never);
+
+    const res = await request(app)
+      .put('/api/stylesheet/1')
+      .send({ description: 'Updated description' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe('Updated description');
+  });
+
+  it('clears existing default when setting isDefault: true', async () => {
+    const updated = makeStylesheet({ id: 2, name: 'kuro', isDefault: true });
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet({ id: 2, name: 'kuro', isDefault: false }) as never
+    );
+    prismaMock.stylesheet.updateMany.mockResolvedValue({ count: 1 } as never);
+    prismaMock.stylesheet.update.mockResolvedValue(updated as never);
+
+    const res = await request(app)
+      .put('/api/stylesheet/2')
+      .send({ isDefault: true });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stylesheet.updateMany).toHaveBeenCalledWith({
+      where: { isDefault: true },
+      data: { isDefault: false }
+    });
+  });
+
+  it('returns 404 when the stylesheet does not exist', async () => {
+    prismaMock.stylesheet.findUnique.mockResolvedValue(null);
+    const res = await request(app)
+      .put('/api/stylesheet/99')
+      .send({ description: 'x' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for a non-numeric id', async () => {
+    const res = await request(app)
+      .put('/api/stylesheet/abc')
+      .send({ description: 'x' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body is empty', async () => {
+    const res = await request(app).put('/api/stylesheet/1').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app)
+      .put('/api/stylesheet/1')
+      .send({ description: 'x' });
+    expect(res.status).toBe(403);
   });
 });
 
 // ─── DELETE /api/stylesheet/:id ───────────────────────────────────────────────
 
 describe('DELETE /api/stylesheet/:id', () => {
-  it('deletes a stylesheet and returns 204', async () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
+  });
+
+  it('deletes a non-default stylesheet and returns 204', async () => {
     prismaMock.stylesheet.findUnique.mockResolvedValue(
-      makeStylesheet() as never
+      makeStylesheet({ isDefault: false }) as never
     );
     prismaMock.stylesheet.delete.mockResolvedValue({} as never);
 
@@ -116,11 +301,20 @@ describe('DELETE /api/stylesheet/:id', () => {
     });
   });
 
+  it('returns 400 when trying to delete the default stylesheet', async () => {
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet({ isDefault: true }) as never
+    );
+
+    const res = await request(app).delete('/api/stylesheet/1');
+
+    expect(res.status).toBe(400);
+    expect(res.body.msg).toBe('Cannot delete the default stylesheet');
+  });
+
   it('returns 404 when the stylesheet does not exist', async () => {
     prismaMock.stylesheet.findUnique.mockResolvedValue(null);
-
     const res = await request(app).delete('/api/stylesheet/99');
-
     expect(res.status).toBe(404);
     expect(res.body.msg).toBe('Stylesheet not found');
   });
@@ -128,5 +322,19 @@ describe('DELETE /api/stylesheet/:id', () => {
   it('returns 400 for a non-numeric id', async () => {
     const res = await request(app).delete('/api/stylesheet/abc');
     expect(res.status).toBe(400);
+  });
+
+  it('returns 403 without admin permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    const res = await request(app).delete('/api/stylesheet/1');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for staff (strict admin only)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ staff: true })
+    );
+    const res = await request(app).delete('/api/stylesheet/1');
+    expect(res.status).toBe(403);
   });
 });


### PR DESCRIPTION
## Summary

- `Stylesheet` model: `name`, `description`, `cssUrl`, `isDefault`; partial unique index enforces single default
- `GET /stylesheet`, `POST /stylesheet`, `PUT /stylesheet/:id`, `DELETE /stylesheet/:id` (admin-gated); `GET /stylesheet/admin/stats` returns per-theme user counts via `groupBy`
- `isDefault` toggle uses `$transaction` to clear all others before setting; `DELETE` rejects 400 if target is the default
- Migrations seed Sublime (default) and Kuro, then Layer Cake, Proton, and Postmod
- `externalStylesheet` profile field validation relaxed from `.url()` to `.string().optional()` to allow relative paths
- OpenAPI schema extended with PUT route and admin stats endpoint

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npm run test --no-coverage` passes
- [ ] `GET /api/stylesheet` returns list with `description` and `isDefault` fields
- [ ] `POST /api/stylesheet` as non-admin → 403
- [ ] `PUT /api/stylesheet/:id` with `isDefault: true` clears previous default
- [ ] `DELETE /api/stylesheet/{default_id}` → 400
- [ ] `GET /api/stylesheet/admin/stats` returns user counts per theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)