### PR TITLE
Bug fixes and admin tooling: May 2026

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -50,6 +50,9 @@ import dnuRouter from './routes/api/communities/dnu';
 import searchRouter from './routes/api/search';
 import randomRouter from './routes/api/random';
 import top10Router from './routes/api/top10';
+import ipBansRouter from './routes/api/ipBans';
+import emailBlacklistRouter from './routes/api/emailBlacklist';
+import donationsRouter from './routes/api/donations';
 
 const log = getLogger('app');
 
@@ -111,6 +114,9 @@ export const createApp = () => {
   app.use('/api/search', searchRouter);
   app.use('/api/random', randomRouter);
   app.use('/api/top10', top10Router);
+  app.use('/api/ip-bans', ipBansRouter);
+  app.use('/api/email-blacklist', emailBlacklistRouter);
+  app.use('/api/donations', donationsRouter);
 
   app.use(
     (

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -880,8 +880,26 @@ describe('POST /api/communities/:communityId/releases/:releaseId/history/:histor
       tagIds: [],
       tagNames: []
     },
-    after: null,
-    snapshot: null,
+    after: {
+      title: 'Revision Title',
+      description: 'Classic',
+      image: null,
+      year: 1959,
+      isEdition: false,
+      edition: null,
+      tagIds: [],
+      tagNames: []
+    },
+    snapshot: {
+      title: 'Revision Title',
+      description: 'Classic',
+      image: null,
+      year: 1959,
+      isEdition: false,
+      edition: null,
+      tagIds: [],
+      tagNames: []
+    },
     createdAt: new Date('2024-06-01T00:00:00Z'),
     actorId: 7
   };
@@ -925,7 +943,7 @@ describe('POST /api/communities/:communityId/releases/:releaseId/history/:histor
     expect(res.body.msg).toBe('Only edit revisions can be reverted');
   });
 
-  it('reverts the release to the before-snapshot and writes a revert history entry', async () => {
+  it('reverts the release to the selected revision snapshot and writes a revert history entry', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
@@ -933,7 +951,7 @@ describe('POST /api/communities/:communityId/releases/:releaseId/history/:histor
     prismaMock.releaseHistory.findFirst.mockResolvedValue(editEntry as never);
     prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
     prismaMock.release.findUniqueOrThrow.mockResolvedValue(
-      makeRelease({ title: 'Old Title' }) as never
+      makeRelease({ title: 'Revision Title' }) as never
     );
 
     const res = await request(app).post(
@@ -944,7 +962,7 @@ describe('POST /api/communities/:communityId/releases/:releaseId/history/:histor
     expect(prismaMock.release.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 3 },
-        data: expect.objectContaining({ title: 'Old Title' })
+        data: expect.objectContaining({ title: 'Revision Title' })
       })
     );
     expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
@@ -952,6 +970,7 @@ describe('POST /api/communities/:communityId/releases/:releaseId/history/:histor
         releaseId: 3,
         actorId: 7,
         action: 'edit',
+        after: expect.objectContaining({ title: 'Revision Title' }),
         summary: expect.stringContaining('Reverted to revision from')
       })
     });

--- a/src/integration/forum.integration.ts
+++ b/src/integration/forum.integration.ts
@@ -70,6 +70,7 @@ describe('createTopic', () => {
 describe('createPost + deletePost', () => {
   it('increments and decrements counters correctly', async () => {
     const author = await createAuthor();
+    const replier = await createAuthor();
     const forum = await createForum();
     const topic = await createTopic(forum.id, author.id, {
       title: 'Counter test',
@@ -86,7 +87,7 @@ describe('createPost + deletePost', () => {
     const reply = await createPost(
       forum.id,
       topic.id,
-      author.id,
+      replier.id,
       '<p>reply</p>'
     );
 
@@ -100,7 +101,7 @@ describe('createPost + deletePost', () => {
     });
     expect(forumAfterCreate.numPosts).toBe(forumBefore.numPosts + 1);
 
-    await deletePost(reply.id, topic.id, forum.id, author.id, false);
+    await deletePost(reply.id, topic.id, forum.id, replier.id, false);
 
     const topicAfterDelete = await testPrisma.forumTopic.findUniqueOrThrow({
       where: { id: topic.id }

--- a/src/ipBans.spec.ts
+++ b/src/ipBans.spec.ts
@@ -18,7 +18,9 @@ describe('POST /api/ip-bans', () => {
   });
 
   it('rejects invalid IPv4 octets', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank({ admin: true }));
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
 
     const res = await request(app).post('/api/ip-bans').send({
       fromIp: '999.2.3.4'
@@ -29,7 +31,9 @@ describe('POST /api/ip-bans', () => {
   });
 
   it('rejects inverted ranges', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank({ admin: true }));
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
 
     const res = await request(app).post('/api/ip-bans').send({
       fromIp: '10.0.0.10',
@@ -41,7 +45,9 @@ describe('POST /api/ip-bans', () => {
   });
 
   it('stores valid ranges and serializes them back to dotted IPv4', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank({ admin: true }));
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ admin: true })
+    );
     prismaMock.ipBan.create.mockResolvedValue({
       id: 5,
       fromIp: 167772161,

--- a/src/ipBans.spec.ts
+++ b/src/ipBans.spec.ts
@@ -1,0 +1,66 @@
+import {
+  request,
+  app,
+  prismaMock,
+  makeUserRank,
+  resetApiTestState
+} from './test/apiTestHarness';
+
+beforeEach(() => resetApiTestState());
+
+describe('POST /api/ip-bans', () => {
+  it('requires admin permission', async () => {
+    const res = await request(app).post('/api/ip-bans').send({
+      fromIp: '1.2.3.4'
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects invalid IPv4 octets', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank({ admin: true }));
+
+    const res = await request(app).post('/api/ip-bans').send({
+      fromIp: '999.2.3.4'
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.msg).toBe('Validation failed');
+  });
+
+  it('rejects inverted ranges', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank({ admin: true }));
+
+    const res = await request(app).post('/api/ip-bans').send({
+      fromIp: '10.0.0.10',
+      toIp: '10.0.0.1'
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.msg).toBe('Validation failed');
+  });
+
+  it('stores valid ranges and serializes them back to dotted IPv4', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank({ admin: true }));
+    prismaMock.ipBan.create.mockResolvedValue({
+      id: 5,
+      fromIp: 167772161,
+      toIp: 167772170
+    } as never);
+
+    const res = await request(app).post('/api/ip-bans').send({
+      fromIp: '10.0.0.1',
+      toIp: '10.0.0.10'
+    });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.ipBan.create).toHaveBeenCalledWith({
+      data: { fromIp: 167772161, toIp: 167772170 }
+    });
+    expect(res.body).toEqual({
+      id: 5,
+      fromIp: '10.0.0.1',
+      toIp: '10.0.0.10'
+    });
+  });
+});

--- a/src/modules/downloads.ts
+++ b/src/modules/downloads.ts
@@ -34,6 +34,8 @@ export const grantDownloadAccess = async (
       }
     });
     if (!contribution) throw new AppError(404, 'Contribution not found');
+    if (contribution.userId === consumerId)
+      throw new AppError(403, 'You cannot consume your own contribution');
 
     const consumer = await tx.user.findUnique({
       where: { id: consumerId },

--- a/src/modules/forum.spec.ts
+++ b/src/modules/forum.spec.ts
@@ -2,11 +2,13 @@ const mockTx = {
   forumTopic: {
     create: jest.fn(),
     update: jest.fn(),
-    updateMany: jest.fn()
+    updateMany: jest.fn(),
+    findUnique: jest.fn()
   },
   forumPost: {
     create: jest.fn(),
     update: jest.fn(),
+    findUnique: jest.fn(),
     count: jest.fn()
   },
   forum: {
@@ -169,6 +171,7 @@ describe('createPost', () => {
   });
 
   it('creates notifications for subscribers other than the author', async () => {
+    mockTx.forumTopic.findUnique.mockResolvedValue({ lastPostId: null });
     mockTx.forumPost.create.mockResolvedValue({ id: 31, forumTopicId: 44 });
     mockTx.forumTopic.update.mockResolvedValue(undefined);
     mockTx.forum.update.mockResolvedValue(undefined);
@@ -208,6 +211,7 @@ describe('createPost', () => {
   });
 
   it('skips notification writes when no other subscribers exist', async () => {
+    mockTx.forumTopic.findUnique.mockResolvedValue({ lastPostId: null });
     mockTx.forumPost.create.mockResolvedValue({ id: 32, forumTopicId: 44 });
     mockTx.forumTopic.update.mockResolvedValue(undefined);
     mockTx.forum.update.mockResolvedValue(undefined);
@@ -216,6 +220,45 @@ describe('createPost', () => {
     await createPost(9, 44, 7, 'Reply');
 
     expect(mockTx.notification.createMany).not.toHaveBeenCalled();
+  });
+
+  it('merges into last post when last post is by the same author', async () => {
+    mockTx.forumTopic.findUnique.mockResolvedValue({ lastPostId: 31 });
+    mockTx.forumPost.findUnique.mockResolvedValue({
+      id: 31,
+      authorId: 7,
+      body: '[html]Previous'
+    });
+    mockTx.forumPost.update.mockResolvedValue({
+      id: 31,
+      body: '[html]Previous\n\nReply'
+    });
+
+    const result = await createPost(9, 44, 7, 'Reply');
+
+    expect(mockTx.forumPost.update).toHaveBeenCalledWith({
+      where: { id: 31 },
+      data: { body: '[html][html]Previous\n\nReply' }
+    });
+    expect(mockTx.forumPost.create).not.toHaveBeenCalled();
+    expect(result.id).toBe(31);
+  });
+
+  it('creates a new post when last post is by a different author', async () => {
+    mockTx.forumTopic.findUnique.mockResolvedValue({ lastPostId: 30 });
+    mockTx.forumPost.findUnique.mockResolvedValue({
+      id: 30,
+      authorId: 99,
+      body: '[html]Other'
+    });
+    mockTx.forumPost.create.mockResolvedValue({ id: 31, forumTopicId: 44 });
+    mockTx.forumTopic.update.mockResolvedValue(undefined);
+    mockTx.forum.update.mockResolvedValue(undefined);
+    mockTx.subscription.findMany.mockResolvedValue([]);
+
+    await createPost(9, 44, 7, 'Reply');
+
+    expect(mockTx.forumPost.create).toHaveBeenCalled();
   });
 });
 

--- a/src/modules/forum.spec.ts
+++ b/src/modules/forum.spec.ts
@@ -231,15 +231,26 @@ describe('createPost', () => {
     });
     mockTx.forumPost.update.mockResolvedValue({
       id: 31,
-      body: '[html]Previous\n\nReply'
+      body: '[html]Previous\n\n[html]Reply'
     });
+    mockTx.forumTopic.update.mockResolvedValue(undefined);
+    mockTx.forum.update.mockResolvedValue(undefined);
 
     const result = await createPost(9, 44, 7, 'Reply');
 
     expect(mockTx.forumPost.update).toHaveBeenCalledWith({
       where: { id: 31 },
-      data: { body: '[html][html]Previous\n\nReply' }
+      data: { body: '[html]Previous\n\n[html]Reply' }
     });
+    expect(mockTx.forumTopic.update).toHaveBeenCalledWith({
+      where: { id: 44 },
+      data: { lastPostId: 31 }
+    });
+    expect(mockTx.forum.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: { lastTopicId: 44 }
+    });
+    expect(mockTx.notification.createMany).not.toHaveBeenCalled();
     expect(mockTx.forumPost.create).not.toHaveBeenCalled();
     expect(result.id).toBe(31);
   });

--- a/src/modules/forum.ts
+++ b/src/modules/forum.ts
@@ -87,6 +87,26 @@ export const createPost = async (
   body: string
 ) =>
   prisma.$transaction(async (tx) => {
+    // If the last post in this topic was made by the same author, append to it
+    // instead of creating a new post (prevents consecutive double-posting).
+    const topic = await tx.forumTopic.findUnique({
+      where: { id: forumTopicId },
+      select: { lastPostId: true }
+    });
+    if (topic?.lastPostId) {
+      const lastPost = await tx.forumPost.findUnique({
+        where: { id: topic.lastPostId, deletedAt: null },
+        select: { id: true, authorId: true, body: true }
+      });
+      if (lastPost && lastPost.authorId === authorId) {
+        const merged = await tx.forumPost.update({
+          where: { id: lastPost.id },
+          data: { body: sanitizeHtml(lastPost.body + '\n\n' + body) }
+        });
+        return merged;
+      }
+    }
+
     const post = await tx.forumPost.create({
       data: { forumTopicId, authorId, body: sanitizeHtml(body) }
     });

--- a/src/modules/forum.ts
+++ b/src/modules/forum.ts
@@ -87,6 +87,8 @@ export const createPost = async (
   body: string
 ) =>
   prisma.$transaction(async (tx) => {
+    const sanitizedBody = sanitizeHtml(body);
+
     // If the last post in this topic was made by the same author, append to it
     // instead of creating a new post (prevents consecutive double-posting).
     const topic = await tx.forumTopic.findUnique({
@@ -101,14 +103,24 @@ export const createPost = async (
       if (lastPost && lastPost.authorId === authorId) {
         const merged = await tx.forumPost.update({
           where: { id: lastPost.id },
-          data: { body: sanitizeHtml(lastPost.body + '\n\n' + body) }
+          data: { body: `${lastPost.body}\n\n${sanitizedBody}` }
         });
+
+        await tx.forumTopic.update({
+          where: { id: forumTopicId },
+          data: { lastPostId: lastPost.id }
+        });
+        await tx.forum.update({
+          where: { id: forumId },
+          data: { lastTopicId: forumTopicId }
+        });
+
         return merged;
       }
     }
 
     const post = await tx.forumPost.create({
-      data: { forumTopicId, authorId, body: sanitizeHtml(body) }
+      data: { forumTopicId, authorId, body: sanitizedBody }
     });
     await tx.forumTopic.update({
       where: { id: forumTopicId },

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -131,6 +131,14 @@ const summarizeReleaseChanges = (fields: string[]): string => {
   return `Updated ${labels.join(', ')}`;
 };
 
+const extractRevisionSnapshot = (
+  entry: { snapshot: Prisma.JsonValue | null; after: Prisma.JsonValue | null }
+): ReleaseSnapshot | null => {
+  const candidate = entry.snapshot ?? entry.after;
+  if (!candidate || typeof candidate !== 'object') return null;
+  return candidate as unknown as ReleaseSnapshot;
+};
+
 const buildReleaseTagPayload = (
   tags: Array<{ id: number; name: string; occurrences: number }>,
   releaseTags: Array<{
@@ -374,7 +382,12 @@ router.post(
         .json({ msg: 'Only edit revisions can be reverted' });
     }
 
-    const restoreState = targetEntry.before as unknown as ReleaseSnapshot;
+    const restoreState = extractRevisionSnapshot(targetEntry);
+    if (!restoreState) {
+      return res
+        .status(422)
+        .json({ msg: 'History entry does not contain a restorable snapshot' });
+    }
 
     const existing = await prisma.release.findFirst({
       where: { id, communityId },

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -131,9 +131,10 @@ const summarizeReleaseChanges = (fields: string[]): string => {
   return `Updated ${labels.join(', ')}`;
 };
 
-const extractRevisionSnapshot = (
-  entry: { snapshot: Prisma.JsonValue | null; after: Prisma.JsonValue | null }
-): ReleaseSnapshot | null => {
+const extractRevisionSnapshot = (entry: {
+  snapshot: Prisma.JsonValue | null;
+  after: Prisma.JsonValue | null;
+}): ReleaseSnapshot | null => {
   const candidate = entry.snapshot ?? entry.after;
   if (!candidate || typeof candidate !== 'object') return null;
   return candidate as unknown as ReleaseSnapshot;

--- a/src/routes/api/donations.ts
+++ b/src/routes/api/donations.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { prisma } from '../../lib/prisma';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { requirePermission } from '../../middleware/permissions';
-import { validate, parsedBody, validateParams, parsedParams } from '../../middleware/validate';
+import {
+  validate,
+  parsedBody,
+  validateParams,
+  parsedParams
+} from '../../middleware/validate';
 import { audit } from '../../lib/audit';
 import { parsePage, paginatedResponse } from '../../lib/pagination';
 
@@ -65,10 +70,17 @@ router.post(
       },
       include: { user: { select: { id: true, username: true } } }
     });
-    await audit(prisma, req.user.id, 'donation.create', 'Donation', donation.id, {
-      userId: input.userId,
-      amount: input.amount
-    });
+    await audit(
+      prisma,
+      req.user.id,
+      'donation.create',
+      'Donation',
+      donation.id,
+      {
+        userId: input.userId,
+        amount: input.amount
+      }
+    );
     res.status(201).json(donation);
   })
 );

--- a/src/routes/api/donations.ts
+++ b/src/routes/api/donations.ts
@@ -1,0 +1,91 @@
+import express, { Request, Response } from 'express';
+import { z } from 'zod';
+import { prisma } from '../../lib/prisma';
+import { asyncHandler, authHandler } from '../../modules/asyncHandler';
+import { requirePermission } from '../../middleware/permissions';
+import { validate, parsedBody, validateParams, parsedParams } from '../../middleware/validate';
+import { audit } from '../../lib/audit';
+import { parsePage, paginatedResponse } from '../../lib/pagination';
+
+const router = express.Router();
+
+const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+
+const createDonationSchema = z.object({
+  userId: z.number().int().positive(),
+  amount: z.number().positive(),
+  email: z.string().email(),
+  donatedAt: z.string().datetime(),
+  currency: z.string().default('USD'),
+  source: z.string().default(''),
+  reason: z.string().min(1, 'Reason is required')
+});
+
+type CreateDonationInput = z.infer<typeof createDonationSchema>;
+
+// GET /api/donations
+router.get(
+  '/',
+  ...requirePermission('admin'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const pg = parsePage(req);
+    const [rows, total] = await Promise.all([
+      prisma.donation.findMany({
+        orderBy: { donatedAt: 'desc' },
+        skip: pg.skip,
+        take: pg.limit,
+        include: {
+          user: { select: { id: true, username: true } }
+        }
+      }),
+      prisma.donation.count()
+    ]);
+    paginatedResponse(res, rows, total, pg);
+  })
+);
+
+// POST /api/donations — manual entry
+router.post(
+  '/',
+  ...requirePermission('admin'),
+  validate(createDonationSchema),
+  authHandler(async (req, res) => {
+    const input = parsedBody<CreateDonationInput>(res);
+    const user = await prisma.user.findUnique({ where: { id: input.userId } });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+    const donation = await prisma.donation.create({
+      data: {
+        userId: input.userId,
+        amount: input.amount,
+        email: input.email,
+        donatedAt: new Date(input.donatedAt),
+        currency: input.currency,
+        source: input.source,
+        reason: input.reason
+      },
+      include: { user: { select: { id: true, username: true } } }
+    });
+    await audit(prisma, req.user.id, 'donation.create', 'Donation', donation.id, {
+      userId: input.userId,
+      amount: input.amount
+    });
+    res.status(201).json(donation);
+  })
+);
+
+// DELETE /api/donations/:id
+router.delete(
+  '/:id',
+  ...requirePermission('admin'),
+  validateParams(idParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const donation = await prisma.donation.findUnique({ where: { id } });
+    if (!donation) return res.status(404).json({ msg: 'Donation not found' });
+    await prisma.donation.delete({ where: { id } });
+    await audit(prisma, req.user.id, 'donation.delete', 'Donation', id);
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/emailBlacklist.ts
+++ b/src/routes/api/emailBlacklist.ts
@@ -1,0 +1,85 @@
+import express from 'express';
+import { z } from 'zod';
+import { prisma } from '../../lib/prisma';
+import { authHandler } from '../../modules/asyncHandler';
+import { requirePermission } from '../../middleware/permissions';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../middleware/validate';
+import { audit } from '../../lib/audit';
+
+const router = express.Router();
+
+const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+
+const emailBlacklistSchema = z.object({
+  email: z.string().min(1, 'Email or domain is required'),
+  comment: z.string().min(1, 'Comment is required')
+});
+
+type EmailBlacklistInput = z.infer<typeof emailBlacklistSchema>;
+
+// GET /api/email-blacklist
+router.get(
+  '/',
+  ...requirePermission('admin'),
+  authHandler(async (_req, res) => {
+    const entries = await prisma.emailBlacklist.findMany({
+      orderBy: { addedAt: 'desc' }
+    });
+    res.json(entries);
+  })
+);
+
+// POST /api/email-blacklist
+router.post(
+  '/',
+  ...requirePermission('admin'),
+  validate(emailBlacklistSchema),
+  authHandler(async (req, res) => {
+    const { email, comment } = parsedBody<EmailBlacklistInput>(res);
+    const entry = await prisma.emailBlacklist.create({
+      data: {
+        userId: req.user.id,
+        email,
+        comment,
+        addedAt: new Date()
+      }
+    });
+    await audit(
+      prisma,
+      req.user.id,
+      'emailblacklist.create',
+      'EmailBlacklist',
+      entry.id,
+      { email }
+    );
+    res.status(201).json(entry);
+  })
+);
+
+// DELETE /api/email-blacklist/:id
+router.delete(
+  '/:id',
+  ...requirePermission('admin'),
+  validateParams(idParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const entry = await prisma.emailBlacklist.findUnique({ where: { id } });
+    if (!entry) return res.status(404).json({ msg: 'Entry not found' });
+    await prisma.emailBlacklist.delete({ where: { id } });
+    await audit(
+      prisma,
+      req.user.id,
+      'emailblacklist.delete',
+      'EmailBlacklist',
+      id
+    );
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/ipBans.ts
+++ b/src/routes/api/ipBans.ts
@@ -1,0 +1,119 @@
+import express from 'express';
+import { z } from 'zod';
+import { prisma } from '../../lib/prisma';
+import { authHandler } from '../../modules/asyncHandler';
+import { requirePermission } from '../../middleware/permissions';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../middleware/validate';
+import { audit } from '../../lib/audit';
+
+const router = express.Router();
+
+const ipBanIdParamsSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+const parseIpv4ToInt = (ip: string): number | null => {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  if (!parts.every((part) => /^\d{1,3}$/.test(part))) return null;
+
+  const octets = parts.map(Number);
+  if (octets.some((octet) => octet < 0 || octet > 255)) return null;
+
+  const [a, b, c, d] = octets;
+  return ((a * 16777216 + b * 65536 + c * 256 + d) | 0);
+};
+
+const ipBanSchema = z
+  .object({
+    fromIp: z.string().refine((value) => parseIpv4ToInt(value) !== null, {
+      message: 'Invalid IPv4 address'
+    }),
+    toIp: z
+      .string()
+      .refine((value) => parseIpv4ToInt(value) !== null, {
+        message: 'Invalid IPv4 address'
+      })
+      .optional()
+  })
+  .superRefine((value, ctx) => {
+    const fromInt = parseIpv4ToInt(value.fromIp);
+    const toInt = parseIpv4ToInt(value.toIp ?? value.fromIp);
+    if (fromInt === null || toInt === null) return;
+    if ((fromInt >>> 0) > (toInt >>> 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['toIp'],
+        message: '`toIp` must be greater than or equal to `fromIp`'
+      });
+    }
+  });
+
+type IpBanInput = z.infer<typeof ipBanSchema>;
+
+// Signed 32-bit int back to IPv4 string
+const intToIp = (n: number): string => {
+  const u = n >>> 0;
+  return [u >>> 24, (u >>> 16) & 0xff, (u >>> 8) & 0xff, u & 0xff].join('.');
+};
+
+const serializeBan = (ban: { id: number; fromIp: number; toIp: number }) => ({
+  id: ban.id,
+  fromIp: intToIp(ban.fromIp),
+  toIp: intToIp(ban.toIp)
+});
+
+// GET /api/ip-bans
+router.get(
+  '/',
+  ...requirePermission('admin'),
+  authHandler(async (_req, res) => {
+    const bans = await prisma.ipBan.findMany({ orderBy: { id: 'asc' } });
+    res.json(bans.map(serializeBan));
+  })
+);
+
+// POST /api/ip-bans
+router.post(
+  '/',
+  ...requirePermission('admin'),
+  validate(ipBanSchema),
+  authHandler(async (req, res) => {
+    const { fromIp, toIp } = parsedBody<IpBanInput>(res);
+    const fromInt = parseIpv4ToInt(fromIp);
+    const toInt = parseIpv4ToInt(toIp ?? fromIp);
+    if (fromInt === null || toInt === null) {
+      return res.status(400).json({ msg: 'Invalid IPv4 address' });
+    }
+    const ban = await prisma.ipBan.create({
+      data: { fromIp: fromInt, toIp: toInt }
+    });
+    await audit(prisma, req.user.id, 'ipban.create', 'IpBan', ban.id, {
+      fromIp,
+      toIp: toIp ?? fromIp
+    });
+    res.status(201).json(serializeBan(ban));
+  })
+);
+
+// DELETE /api/ip-bans/:id
+router.delete(
+  '/:id',
+  ...requirePermission('admin'),
+  validateParams(ipBanIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const ban = await prisma.ipBan.findUnique({ where: { id } });
+    if (!ban) return res.status(404).json({ msg: 'Ban not found' });
+    await prisma.ipBan.delete({ where: { id } });
+    await audit(prisma, req.user.id, 'ipban.delete', 'IpBan', id);
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/routes/api/ipBans.ts
+++ b/src/routes/api/ipBans.ts
@@ -26,7 +26,7 @@ const parseIpv4ToInt = (ip: string): number | null => {
   if (octets.some((octet) => octet < 0 || octet > 255)) return null;
 
   const [a, b, c, d] = octets;
-  return ((a * 16777216 + b * 65536 + c * 256 + d) | 0);
+  return (a * 16777216 + b * 65536 + c * 256 + d) | 0;
 };
 
 const ipBanSchema = z
@@ -45,7 +45,7 @@ const ipBanSchema = z
     const fromInt = parseIpv4ToInt(value.fromIp);
     const toInt = parseIpv4ToInt(value.toIp ?? value.fromIp);
     if (fromInt === null || toInt === null) return;
-    if ((fromInt >>> 0) > (toInt >>> 0)) {
+    if (fromInt >>> 0 > toInt >>> 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['toIp'],

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -292,6 +292,64 @@ router.delete(
   })
 );
 
+// GET /api/users/duplicate-ips — users sharing the same last-seen IP (must be before /:id)
+router.get(
+  '/duplicate-ips',
+  ...requirePermission('staff'),
+  authHandler(async (_req, res) => {
+    const dupes = await prisma.user.groupBy({
+      by: ['lastIp'],
+      where: { lastIp: { not: null } },
+      _count: { lastIp: true },
+      having: { lastIp: { _count: { gt: 1 } } },
+      orderBy: { _count: { lastIp: 'desc' } }
+    });
+    const result = await Promise.all(
+      dupes.map(async (d) => {
+        const users = await prisma.user.findMany({
+          where: { lastIp: d.lastIp! },
+          select: {
+            id: true,
+            username: true,
+            dateRegistered: true,
+            disabled: true,
+            lastLogin: true
+          }
+        });
+        return { ip: d.lastIp!, count: d._count.lastIp, users };
+      })
+    );
+    res.json(result);
+  })
+);
+
+// GET /api/users/registration-log — users ordered by registration date (must be before /:id)
+router.get(
+  '/registration-log',
+  ...requirePermission('staff'),
+  authHandler(async (req, res) => {
+    const pg = parsePage(req);
+    const [users, total] = await Promise.all([
+      prisma.user.findMany({
+        orderBy: { dateRegistered: 'desc' },
+        skip: pg.skip,
+        take: pg.limit,
+        select: {
+          id: true,
+          username: true,
+          email: true,
+          dateRegistered: true,
+          disabled: true,
+          lastIp: true,
+          userRank: { select: { id: true, name: true } }
+        }
+      }),
+      prisma.user.count()
+    ]);
+    paginatedResponse(res, users, total, pg);
+  })
+);
+
 // GET /api/users/:id/stats/history — user historical stats (own or staff)
 router.get(
   '/:id/stats/history',


### PR DESCRIPTION
## Summary

- **Self-download prevention**: users can no longer consume their own contributions
- **Forum post merging**: consecutive posts by the same author are appended rather than creating a new post
- **Warning datetime fix**: `datetime-local` input value is converted to UTC ISO before sending to the API
- **IP address bans**: full CRUD at `/api/ip-bans` with integer-encoded range storage
- **Email blacklist**: full CRUD at `/api/email-blacklist`
- **Donation log**: paginated list with manual entry and delete at `/api/donations`
- **Duplicate IP detection**: `/api/users/duplicate-ips` groups users by shared last-seen IP
- **Registration log**: paginated `/api/users/registration-log` ordered by registration date

## Test plan

- [ ] Attempt to download your own contribution — expect 403
- [ ] Post twice in a row in a forum topic — second post should merge into the first
- [ ] Warn a user with an expiry date set — should succeed without datetime error
- [ ] Add and remove an IP ban via `/api/ip-bans`
- [ ] Add and remove an email blacklist entry via `/api/email-blacklist`
- [ ] POST a manual donation and verify it appears in the paginated list
- [ ] `/api/users/duplicate-ips` returns only IPs shared by 2+ users
- [ ] `/api/users/registration-log` returns paginated users newest-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)