### PR TITLE
Add dynamic rules page system

### DIFF
--- a/prisma/migrations/20260526014024_add_rules_pages/migration.sql
+++ b/prisma/migrations/20260526014024_add_rules_pages/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "rules_pages" (
+    "id" SERIAL NOT NULL,
+    "slug" VARCHAR(100) NOT NULL,
+    "title" VARCHAR(200) NOT NULL,
+    "body" TEXT NOT NULL,
+    "isMain" BOOLEAN NOT NULL DEFAULT false,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "authorId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rules_pages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rules_pages_slug_key" ON "rules_pages"("slug");
+
+-- CreateIndex
+CREATE INDEX "rules_pages_isMain_idx" ON "rules_pages"("isMain");
+
+-- CreateIndex
+CREATE INDEX "rules_pages_sortOrder_idx" ON "rules_pages"("sortOrder");
+
+-- AddForeignKey
+ALTER TABLE "rules_pages" ADD CONSTRAINT "rules_pages_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -421,6 +421,7 @@ model User {
   wikiPagesAuthored         WikiPage[]     @relation("WikiPageAuthor")
   wikiRevisionsAuthored     WikiRevision[] @relation("WikiRevisionAuthor")
   wikiAliasesCreated        WikiAlias[]    @relation("WikiAliasCreator")
+  rulesPagesAuthored        RulesPage[]    @relation("RulesPageAuthor")
   userStatSnapshots         UserStatSnapshot[]
 
   @@index([userRankId])
@@ -1974,6 +1975,28 @@ model WikiAlias {
 
   @@index([pageId])
   @@map("wiki_aliases")
+}
+
+// ─── Rules ────────────────────────────────────────────────────────────────────
+
+model RulesPage {
+  id        Int      @id @default(autoincrement())
+  slug      String   @unique @db.VarChar(100)
+  title     String   @db.VarChar(200)
+  body      String   @db.Text
+  // Only one row may have isMain = true; enforced at API layer within a transaction.
+  // Add DB-level partial unique after migration:
+  //   CREATE UNIQUE INDEX rules_pages_one_main ON rules_pages (is_main) WHERE is_main = true;
+  isMain    Boolean  @default(false)
+  sortOrder Int      @default(0)
+  authorId  Int
+  author    User     @relation("RulesPageAuthor", fields: [authorId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([isMain])
+  @@index([sortOrder])
+  @@map("rules_pages")
 }
 
 // ─── Top 10 ───────────────────────────────────────────────────────────────────

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,6 +54,7 @@ import ipBansRouter from './routes/api/ipBans';
 import emailBlacklistRouter from './routes/api/emailBlacklist';
 import donationsRouter from './routes/api/donations';
 import staffRouter from './routes/api/staff';
+import rulesRouter from './routes/api/rules';
 
 const log = getLogger('app');
 
@@ -119,6 +120,7 @@ export const createApp = () => {
   app.use('/api/email-blacklist', emailBlacklistRouter);
   app.use('/api/donations', donationsRouter);
   app.use('/api/staff', staffRouter);
+  app.use('/api/rules', rulesRouter);
 
   app.use(
     (

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -37,6 +37,7 @@ import {
   subscribeCommentsSchema
 } from '../schemas/subscription';
 import { announcementSchema } from '../schemas/announcement';
+import { createRulesPageSchema, updateRulesPageSchema } from '../schemas/rules';
 import { createRankSchema, updateRankSchema } from '../schemas/tools';
 import {
   createStaffGroupSchema,
@@ -4631,6 +4632,121 @@ registry.registerPath({
     200: {
       description: 'Snapshot created',
       content: { 'application/json': { schema: z.object({ msg: z.string() }) } }
+    }
+  }
+});
+
+// ─── Rules ────────────────────────────────────────────────────────────────────
+
+const RulesPage = registry.register(
+  'RulesPage',
+  z.object({
+    id: z.number(),
+    slug: z.string(),
+    title: z.string(),
+    body: z.string(),
+    isMain: z.boolean(),
+    sortOrder: z.number(),
+    authorId: z.number(),
+    author: z.object({ id: z.number(), username: z.string() }),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/rules',
+  tags: ['Rules'],
+  responses: {
+    200: {
+      description: 'Main rules page and sub-pages',
+      content: {
+        'application/json': {
+          schema: z.object({
+            main: RulesPage.nullable(),
+            pages: z.array(RulesPage)
+          })
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/rules/{slug}',
+  tags: ['Rules'],
+  request: { params: z.object({ slug: z.string() }) },
+  responses: {
+    200: {
+      description: 'Single rules page',
+      content: { 'application/json': { schema: RulesPage } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/rules',
+  tags: ['Rules'],
+  request: {
+    body: { content: { 'application/json': { schema: createRulesPageSchema } } }
+  },
+  responses: {
+    201: {
+      description: 'Page created',
+      content: { 'application/json': { schema: RulesPage } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    409: {
+      description: 'Conflict',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/rules/{id}',
+  tags: ['Rules'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: updateRulesPageSchema } } }
+  },
+  responses: {
+    200: {
+      description: 'Page updated',
+      content: { 'application/json': { schema: RulesPage } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/rules/{id}',
+  tags: ['Rules'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    204: { description: 'Page deleted' },
+    400: {
+      description: 'Cannot delete main page',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
     }
   }
 });

--- a/src/middleware/permissions.ts
+++ b/src/middleware/permissions.ts
@@ -18,6 +18,7 @@ export const VALID_PERMISSIONS = [
   'users_disable',
   'wiki_edit',
   'wiki_manage',
+  'rules_manage',
   'advanced_search',
   'users_search',
   'staff',

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -73,7 +73,7 @@ export const FORUM_STRUCTURE = [
       {
         sort: 10,
         name: 'Announcements',
-        description: 'Official site announcements.'
+        description: 'There are a terrible lot of lies going about the world and the worst of it is that half of them are true.'
       },
       {
         sort: 20,
@@ -82,80 +82,81 @@ export const FORUM_STRUCTURE = [
       },
       {
         sort: 30,
-        name: 'Bugs',
-        description: 'Report bugs and technical issues.'
-      },
-      {
-        sort: 40,
-        name: 'Projects',
-        description: 'Ongoing and upcoming projects.'
-      }
-    ]
-  },
-  {
-    name: 'Suggestions',
-    sort: 20,
-    forums: [
-      {
-        sort: 10,
-        name: 'The Laboratory',
-        description: 'Experimental ideas and early proposals.'
-      },
-      {
-        sort: 20,
-        name: 'Suggestions/Ideas',
-        description: 'Feature requests and suggestions.'
-      },
-      {
-        sort: 30,
         name: 'Contests & Designs',
         description: 'Community contests and design submissions.'
       },
       {
         sort: 40,
-        name: 'First Line Support',
-        description: 'Peer-to-peer support from the community.'
-      }
+        name: 'Projects',
+        description: 'Ongoing and upcoming projects.'
+      },
+      {
+        sort: 50,
+        name: 'The Laboratory',
+        description: 'I was working in the lab late one night when my eyes beheld an eerie sight.'
+      },
+      {
+        sort: 60,
+        name: 'Suggestions/Ideas',
+        description: 'Daring ideas are like chessmen moved forward, they may be beaten, but you may start a winning game.'
+      },
+      {
+        sort: 70,
+        name: 'Bugs',
+        description: 'Some days you are the bug and some days you are the windshield.'
+      },
     ]
   },
   {
     name: 'Community',
-    sort: 30,
+    sort: 20,
     forums: [
       {
         sort: 10,
         name: 'The Lounge',
-        description: 'General off-topic discussion.'
+        description: 'The only normal people you know are the ones you don\'t know very well.'
       },
       {
         sort: 20,
-        name: 'The Library',
-        description: 'Books, articles, and reading recommendations.'
+        name: 'The Lounge+',
+        description: 'There are points to be scored. There are games to be won.'
       },
       {
         sort: 30,
+        name: 'The Library',
+        description: 'The first sign of maturity is the discovery that the volume knob also turns to the left.'
+      },
+      {
+        sort: 40,
+        name: 'Concerts, Events & Meets',
+        description: 'No, it\'s just pure noise for the hell of it. The fun is in watching people\'s faces. That\'s why we light the audience up, to see their discomfort.'
+      },
+      {
+        sort: 50,
         name: 'Power User',
-        description: 'Power User discussion area.',
+        description: 'Destiny is not a matter of chance, it is a matter of choice. It is not a thing to be waited for, it is a thing to be achieved.',
         minClassRead: 200,
         minClassWrite: 200
       },
       {
-        sort: 40,
-        name: 'Technology',
-        description: 'Technology, software, and hardware.'
+        sort: 60,
+        name: 'Elite',
+        description: 'I don\'t believe in elitism, I don\'t think the audience is this dumb person lower than me. I am the audience.',
+        minClassRead: 300,
+        minClassWrite: 300
       },
       {
-        sort: 50,
-        name: 'Concerts & Events',
-        description: 'Live events, concerts, and meetups.'
+        sort: 70,
+        name: 'Technology',
+        description: 'The real danger is not that computers will begin to think like men, but men will begin to think like computers.'
       }
     ]
   },
   {
     name: 'Music',
-    sort: 40,
+    sort: 30,
     forums: [
-      { sort: 10, name: 'Music', description: 'General music discussion.' },
+      { sort: 10, name: 'Music', description: 'This witty remark only works with accompanied by the sweet harmonies of acoustic guitars.' },
       {
         sort: 20,
         name: 'Vanity House',
@@ -170,17 +171,27 @@ export const FORUM_STRUCTURE = [
         sort: 40,
         name: 'Offered',
         description: 'Share and exchange music recommendations.'
+      },
+      {
+        sort: 50,
+        name: 'Vinyl',
+        description: 'I don\'t think it\'s real unless you put it on an LP. CDs aren\'t real. Anybody can do that.'
       }
     ]
   },
   {
     name: 'Help',
-    sort: 50,
+    sort: 40,
     forums: [
       {
         sort: 10,
         name: 'Help',
-        description: 'Get help with site usage and your account.'
+        description: 'In helping others we shall help ourselves, for whatever good we give out completes the circle and comes back to us.'
+      },
+      {
+        sort: 20,
+        name: 'Tutorials',
+        description: 'He that gives good advice works with one hand, he who gives counsel and example builds with both.'
       }
     ]
   },

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -73,7 +73,8 @@ export const FORUM_STRUCTURE = [
       {
         sort: 10,
         name: 'Announcements',
-        description: 'There are a terrible lot of lies going about the world and the worst of it is that half of them are true.'
+        description:
+          'There are a terrible lot of lies going about the world and the worst of it is that half of them are true.'
       },
       {
         sort: 20,
@@ -93,18 +94,21 @@ export const FORUM_STRUCTURE = [
       {
         sort: 50,
         name: 'The Laboratory',
-        description: 'I was working in the lab late one night when my eyes beheld an eerie sight.'
+        description:
+          'I was working in the lab late one night when my eyes beheld an eerie sight.'
       },
       {
         sort: 60,
         name: 'Suggestions/Ideas',
-        description: 'Daring ideas are like chessmen moved forward, they may be beaten, but you may start a winning game.'
+        description:
+          'Daring ideas are like chessmen moved forward, they may be beaten, but you may start a winning game.'
       },
       {
         sort: 70,
         name: 'Bugs',
-        description: 'Some days you are the bug and some days you are the windshield.'
-      },
+        description:
+          'Some days you are the bug and some days you are the windshield.'
+      }
     ]
   },
   {
@@ -114,7 +118,8 @@ export const FORUM_STRUCTURE = [
       {
         sort: 10,
         name: 'The Lounge',
-        description: 'The only normal people you know are the ones you don\'t know very well.'
+        description:
+          "The only normal people you know are the ones you don't know very well."
       },
       {
         sort: 20,
@@ -124,31 +129,36 @@ export const FORUM_STRUCTURE = [
       {
         sort: 30,
         name: 'The Library',
-        description: 'The first sign of maturity is the discovery that the volume knob also turns to the left.'
+        description:
+          'The first sign of maturity is the discovery that the volume knob also turns to the left.'
       },
       {
         sort: 40,
         name: 'Concerts, Events & Meets',
-        description: 'No, it\'s just pure noise for the hell of it. The fun is in watching people\'s faces. That\'s why we light the audience up, to see their discomfort.'
+        description:
+          "No, it's just pure noise for the hell of it. The fun is in watching people's faces. That's why we light the audience up, to see their discomfort."
       },
       {
         sort: 50,
         name: 'Power User',
-        description: 'Destiny is not a matter of chance, it is a matter of choice. It is not a thing to be waited for, it is a thing to be achieved.',
+        description:
+          'Destiny is not a matter of chance, it is a matter of choice. It is not a thing to be waited for, it is a thing to be achieved.',
         minClassRead: 200,
         minClassWrite: 200
       },
       {
         sort: 60,
         name: 'Elite',
-        description: 'I don\'t believe in elitism, I don\'t think the audience is this dumb person lower than me. I am the audience.',
+        description:
+          "I don't believe in elitism, I don't think the audience is this dumb person lower than me. I am the audience.",
         minClassRead: 300,
         minClassWrite: 300
       },
       {
         sort: 70,
         name: 'Technology',
-        description: 'The real danger is not that computers will begin to think like men, but men will begin to think like computers.'
+        description:
+          'The real danger is not that computers will begin to think like men, but men will begin to think like computers.'
       }
     ]
   },
@@ -156,7 +166,12 @@ export const FORUM_STRUCTURE = [
     name: 'Music',
     sort: 30,
     forums: [
-      { sort: 10, name: 'Music', description: 'This witty remark only works with accompanied by the sweet harmonies of acoustic guitars.' },
+      {
+        sort: 10,
+        name: 'Music',
+        description:
+          'This witty remark only works with accompanied by the sweet harmonies of acoustic guitars.'
+      },
       {
         sort: 20,
         name: 'Vanity House',
@@ -175,7 +190,8 @@ export const FORUM_STRUCTURE = [
       {
         sort: 50,
         name: 'Vinyl',
-        description: 'I don\'t think it\'s real unless you put it on an LP. CDs aren\'t real. Anybody can do that.'
+        description:
+          "I don't think it's real unless you put it on an LP. CDs aren't real. Anybody can do that."
       }
     ]
   },
@@ -186,12 +202,14 @@ export const FORUM_STRUCTURE = [
       {
         sort: 10,
         name: 'Help',
-        description: 'In helping others we shall help ourselves, for whatever good we give out completes the circle and comes back to us.'
+        description:
+          'In helping others we shall help ourselves, for whatever good we give out completes the circle and comes back to us.'
       },
       {
         sort: 20,
         name: 'Tutorials',
-        description: 'He that gives good advice works with one hand, he who gives counsel and example builds with both.'
+        description:
+          'He that gives good advice works with one hand, he who gives counsel and example builds with both.'
       }
     ]
   },

--- a/src/routes/api/rules.ts
+++ b/src/routes/api/rules.ts
@@ -1,0 +1,201 @@
+import { Router } from 'express';
+import { prisma } from '../../lib/prisma';
+import { requireAuth } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/permissions';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../middleware/validate';
+import { authHandler } from '../../modules/asyncHandler';
+import { AppError } from '../../lib/errors';
+import { audit } from '../../lib/audit';
+import { sanitizeHtml } from '../../lib/sanitize';
+import {
+  createRulesPageSchema,
+  updateRulesPageSchema,
+  rulesPageParamsSchema,
+  rulesSlugParamsSchema,
+  normalizeRulesSlug,
+  type CreateRulesPageInput,
+  type UpdateRulesPageInput
+} from '../../schemas/rules';
+
+const router = Router();
+
+const pageSelect = {
+  id: true,
+  slug: true,
+  title: true,
+  body: true,
+  isMain: true,
+  sortOrder: true,
+  authorId: true,
+  author: { select: { id: true, username: true } },
+  createdAt: true,
+  updatedAt: true
+} as const;
+
+// GET / — list: { main, pages }
+router.get(
+  '/',
+  requireAuth,
+  authHandler(async (_req, res) => {
+    const [main, pages] = await Promise.all([
+      prisma.rulesPage.findFirst({
+        where: { isMain: true },
+        select: pageSelect
+      }),
+      prisma.rulesPage.findMany({
+        where: { isMain: false },
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+        select: pageSelect
+      })
+    ]);
+    res.json({ main, pages });
+  })
+);
+
+// GET /:slug — single page (static 'manager' would shadow this if registered after; frontend uses 'manager')
+router.get(
+  '/:slug',
+  requireAuth,
+  validateParams(rulesSlugParamsSchema),
+  authHandler(async (_req, res) => {
+    const { slug } = parsedParams<{ slug: string }>(res);
+    const page = await prisma.rulesPage.findUnique({
+      where: { slug },
+      select: pageSelect
+    });
+    if (!page) throw new AppError(404, 'Page not found');
+    res.json(page);
+  })
+);
+
+// POST / — create page
+router.post(
+  '/',
+  ...requirePermission('rules_manage'),
+  validate(createRulesPageSchema),
+  authHandler(async (req, res) => {
+    const input = parsedBody<CreateRulesPageInput>(res);
+    const slug = input.slug ?? normalizeRulesSlug(input.title);
+    const body = sanitizeHtml(input.body);
+
+    const page = await prisma.$transaction(async (tx) => {
+      if (input.isMain) {
+        const existing = await tx.rulesPage.findFirst({
+          where: { isMain: true },
+          select: { id: true }
+        });
+        if (existing)
+          throw new AppError(409, 'A main rules page already exists');
+      }
+
+      const existing = await tx.rulesPage.findUnique({
+        where: { slug },
+        select: { id: true }
+      });
+      if (existing)
+        throw new AppError(409, 'A page with this slug already exists');
+
+      const created = await tx.rulesPage.create({
+        data: {
+          slug,
+          title: input.title,
+          body,
+          isMain: input.isMain ?? false,
+          sortOrder: input.sortOrder ?? 0,
+          authorId: req.user.id
+        },
+        select: pageSelect
+      });
+
+      await audit(tx, req.user.id, 'rules.create', 'RulesPage', created.id, {
+        title: input.title,
+        slug,
+        isMain: created.isMain
+      });
+      return created;
+    });
+
+    res.status(201).json(page);
+  })
+);
+
+// PUT /:id — update page (slug is immutable after creation)
+router.put(
+  '/:id',
+  ...requirePermission('rules_manage'),
+  validateParams(rulesPageParamsSchema),
+  validate(updateRulesPageSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const input = parsedBody<UpdateRulesPageInput>(res);
+
+    const page = await prisma.$transaction(async (tx) => {
+      const existing = await tx.rulesPage.findUnique({
+        where: { id },
+        select: { id: true, isMain: true }
+      });
+      if (!existing) throw new AppError(404, 'Page not found');
+
+      if (input.isMain && !existing.isMain) {
+        const currentMain = await tx.rulesPage.findFirst({
+          where: { isMain: true },
+          select: { id: true }
+        });
+        if (currentMain)
+          throw new AppError(409, 'A main rules page already exists');
+      }
+
+      const updated = await tx.rulesPage.update({
+        where: { id },
+        data: {
+          ...(input.title !== undefined && { title: input.title }),
+          ...(input.body !== undefined && { body: sanitizeHtml(input.body) }),
+          ...(input.isMain !== undefined && { isMain: input.isMain }),
+          ...(input.sortOrder !== undefined && { sortOrder: input.sortOrder })
+        },
+        select: pageSelect
+      });
+
+      await audit(tx, req.user.id, 'rules.edit', 'RulesPage', id, {
+        title: updated.title
+      });
+      return updated;
+    });
+
+    res.json(page);
+  })
+);
+
+// DELETE /:id — delete page (cannot delete the main page)
+router.delete(
+  '/:id',
+  ...requirePermission('rules_manage'),
+  validateParams(rulesPageParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.rulesPage.findUnique({
+        where: { id },
+        select: { id: true, isMain: true, title: true }
+      });
+      if (!existing) throw new AppError(404, 'Page not found');
+      if (existing.isMain)
+        throw new AppError(400, 'Cannot delete the main rules page');
+
+      await tx.rulesPage.delete({ where: { id } });
+      await audit(tx, req.user.id, 'rules.delete', 'RulesPage', id, {
+        title: existing.title
+      });
+    });
+
+    res.status(204).send();
+  })
+);
+
+export default router;

--- a/src/rules.spec.ts
+++ b/src/rules.spec.ts
@@ -1,0 +1,266 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock,
+  makeUserRank
+} from './test/apiTestHarness';
+
+const makePage = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  slug: 'golden-rules',
+  title: 'Golden Rules',
+  body: '<p>Be excellent.</p>',
+  isMain: false,
+  sortOrder: 0,
+  authorId: 7,
+  author: { id: 7, username: 'testuser' },
+  createdAt: new Date('2026-01-15'),
+  updatedAt: new Date('2026-01-15'),
+  ...overrides
+});
+
+const makeMain = (overrides: Record<string, unknown> = {}) =>
+  makePage({ id: 2, slug: 'main', title: 'Rules', isMain: true, ...overrides });
+
+beforeEach(() => resetApiTestState());
+
+describe('GET /api/rules', () => {
+  it('returns main null and empty pages when none exist', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(null);
+    prismaMock.rulesPage.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/rules');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ main: null, pages: [] });
+  });
+
+  it('returns main page and sub-pages', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(makeMain() as never);
+    prismaMock.rulesPage.findMany.mockResolvedValue([makePage()] as never);
+
+    const res = await request(app).get('/api/rules');
+
+    expect(res.status).toBe(200);
+    expect(res.body.main.slug).toBe('main');
+    expect(res.body.pages).toHaveLength(1);
+    expect(res.body.pages[0].slug).toBe('golden-rules');
+  });
+});
+
+describe('GET /api/rules/:slug', () => {
+  it('returns page by slug', async () => {
+    prismaMock.rulesPage.findUnique.mockResolvedValue(makePage() as never);
+
+    const res = await request(app).get('/api/rules/golden-rules');
+
+    expect(res.status).toBe(200);
+    expect(res.body.slug).toBe('golden-rules');
+  });
+
+  it('returns 404 for unknown slug', async () => {
+    prismaMock.rulesPage.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/rules/no-such-page');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/rules', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ rules_manage: true })
+    );
+    prismaMock.$transaction.mockImplementation(
+      async (fn: (tx: typeof prismaMock) => unknown) => fn(prismaMock)
+    );
+  });
+
+  it('creates a sub-page and returns 201', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(null);
+    prismaMock.rulesPage.findUnique.mockResolvedValue(null);
+    prismaMock.rulesPage.create.mockResolvedValue(makePage() as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'Golden Rules', body: '<p>Be excellent.</p>' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.slug).toBe('golden-rules');
+  });
+
+  it('auto-derives slug from title', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(null);
+    prismaMock.rulesPage.findUnique.mockResolvedValue(null);
+    prismaMock.rulesPage.create.mockResolvedValue(
+      makePage({ slug: 'forum-rules', title: 'Forum Rules' }) as never
+    );
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'Forum Rules', body: 'Rules for the forum.' });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.rulesPage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ slug: 'forum-rules' })
+      })
+    );
+  });
+
+  it('creates the main page when isMain true and none exists', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(null);
+    prismaMock.rulesPage.findUnique.mockResolvedValue(null);
+    prismaMock.rulesPage.create.mockResolvedValue(makeMain() as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'Rules', body: '<p>Site rules.</p>', isMain: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.isMain).toBe(true);
+  });
+
+  it('returns 409 when a main page already exists', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(makeMain() as never);
+
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'Another Main', body: 'Body.', isMain: true });
+
+    expect(res.status).toBe(409);
+    expect(prismaMock.rulesPage.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when slug already exists', async () => {
+    prismaMock.rulesPage.findFirst.mockResolvedValue(null);
+    prismaMock.rulesPage.findUnique.mockResolvedValue(makePage() as never);
+
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'Golden Rules', body: 'Duplicate.' });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 403 without rules_manage permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'T', body: 'B' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when body is missing', async () => {
+    const res = await request(app)
+      .post('/api/rules')
+      .send({ title: 'Title only' });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('PUT /api/rules/:id', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ rules_manage: true })
+    );
+    prismaMock.$transaction.mockImplementation(
+      async (fn: (tx: typeof prismaMock) => unknown) => fn(prismaMock)
+    );
+  });
+
+  it('updates a page and returns it', async () => {
+    const updated = makePage({ title: 'Updated Title' });
+    prismaMock.rulesPage.findUnique.mockResolvedValue(makePage() as never);
+    prismaMock.rulesPage.update.mockResolvedValue(updated as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .put('/api/rules/1')
+      .send({ title: 'Updated Title' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Updated Title');
+  });
+
+  it('returns 404 when page does not exist', async () => {
+    prismaMock.rulesPage.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).put('/api/rules/999').send({ title: 'T' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 on non-numeric id', async () => {
+    const res = await request(app)
+      .put('/api/rules/notanumber')
+      .send({ title: 'T' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 without rules_manage permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app).put('/api/rules/1').send({ title: 'T' });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/rules/:id', () => {
+  beforeEach(() => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ rules_manage: true })
+    );
+    prismaMock.$transaction.mockImplementation(
+      async (fn: (tx: typeof prismaMock) => unknown) => fn(prismaMock)
+    );
+  });
+
+  it('deletes a sub-page and returns 204', async () => {
+    prismaMock.rulesPage.findUnique.mockResolvedValue(makePage() as never);
+    prismaMock.rulesPage.delete.mockResolvedValue(makePage() as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).delete('/api/rules/1');
+
+    expect(res.status).toBe(204);
+    expect(prismaMock.rulesPage.delete).toHaveBeenCalledWith({
+      where: { id: 1 }
+    });
+  });
+
+  it('returns 400 when trying to delete the main page', async () => {
+    prismaMock.rulesPage.findUnique.mockResolvedValue(makeMain() as never);
+
+    const res = await request(app).delete('/api/rules/2');
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.rulesPage.delete).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when page does not exist', async () => {
+    prismaMock.rulesPage.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).delete('/api/rules/999');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 without rules_manage permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app).delete('/api/rules/1');
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/schemas/rules.ts
+++ b/src/schemas/rules.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const normalizeRulesSlug = (s: string): string =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100);
+
+export const createRulesPageSchema = z.object({
+  title: z.string().min(1).max(200),
+  slug: z
+    .string()
+    .max(100)
+    .regex(/^[a-z0-9-]+$/, 'Slug must be lowercase alphanumeric with hyphens')
+    .optional(),
+  body: z.string().min(1),
+  isMain: z.boolean().optional().default(false),
+  sortOrder: z.number().int().min(0).optional().default(0)
+});
+
+export const updateRulesPageSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  body: z.string().min(1).optional(),
+  isMain: z.boolean().optional(),
+  sortOrder: z.number().int().min(0).optional()
+});
+
+export const rulesPageParamsSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+export const rulesSlugParamsSchema = z.object({
+  slug: z.string().min(1).max(100)
+});
+
+export type CreateRulesPageInput = z.infer<typeof createRulesPageSchema>;
+export type UpdateRulesPageInput = z.infer<typeof updateRulesPageSchema>;


### PR DESCRIPTION
## Summary

- Adds a `RulesPage` Prisma model and `/api/rules` REST endpoints for a database-driven site rules system
- Introduces a narrow `rules_manage` permission; write operations are gated to explicit grantees only (no staff passthrough)
- Single-main-page invariant enforced in transaction; body sanitized server-side via DOMPurify before persistence
- Forum structure and descriptions updated in `bootstrap.ts`

## Endpoints

| Method | Path | Auth |
|--------|------|------|
| GET | `/api/rules` | requireAuth |
| GET | `/api/rules/:slug` | requireAuth |
| POST | `/api/rules` | rules_manage |
| PUT | `/api/rules/:id` | rules_manage |
| DELETE | `/api/rules/:id` | rules_manage |

## Schema

New `rules_pages` table with `slug` (unique), `isMain` (bool), `sortOrder`, `authorId`, timestamps. Migration at `prisma/migrations/20260526014024_add_rules_pages/`.

> **Note:** A DB-level partial unique index (`WHERE is_main = true`) should be added to the migration SQL for full concurrency safety on the single-main invariant.

## Test plan

- [ ] `npx jest --runInBand "rules" --no-coverage` — 19 tests pass
- [ ] `npm run test --no-coverage` — full suite (1131 tests), no regressions
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean on changed files
- [ ] Manual: run migration, create main page via toolbox, create sub-page, verify public views render

🤖 Generated with [Claude Code](https://claude.com/claude-code)