### PR TITLE
Add friends feature

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,6 +55,7 @@ import emailBlacklistRouter from './routes/api/emailBlacklist';
 import donationsRouter from './routes/api/donations';
 import staffRouter from './routes/api/staff';
 import rulesRouter from './routes/api/rules';
+import friendsRouter from './routes/api/friends';
 
 const log = getLogger('app');
 
@@ -121,6 +122,7 @@ export const createApp = () => {
   app.use('/api/donations', donationsRouter);
   app.use('/api/staff', staffRouter);
   app.use('/api/rules', rulesRouter);
+  app.use('/api/friends', friendsRouter);
 
   app.use(
     (

--- a/src/friends.spec.ts
+++ b/src/friends.spec.ts
@@ -1,0 +1,246 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock
+} from './test/apiTestHarness';
+import { Prisma } from '@prisma/client';
+
+beforeEach(() => resetApiTestState());
+
+// ─── GET /api/friends ─────────────────────────────────────────────────────────
+
+describe('GET /api/friends', () => {
+  it('returns paginated empty list when user has no friends', async () => {
+    prismaMock.friend.findMany.mockResolvedValue([]);
+    prismaMock.friend.count.mockResolvedValue(0);
+
+    const res = await request(app).get('/api/friends');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.total).toBe(0);
+  });
+
+  it('returns paginated friend list ordered by username', async () => {
+    const mockFriend = {
+      id: 1,
+      userId: 7,
+      friendId: 42,
+      comment: 'Good person',
+      friend: { id: 42, username: 'alice', avatar: null }
+    };
+    prismaMock.friend.findMany.mockResolvedValue([mockFriend] as never);
+    prismaMock.friend.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/friends');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].friend.username).toBe('alice');
+    expect(res.body.meta.total).toBe(1);
+    expect(res.body.meta).toHaveProperty('totalPages');
+  });
+});
+
+// ─── GET /api/friends/status/:userId ─────────────────────────────────────────
+
+describe('GET /api/friends/status/:userId', () => {
+  it('returns isFriend: false when not friends', async () => {
+    prismaMock.friend.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/friends/status/42');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ isFriend: false });
+  });
+
+  it('returns isFriend: true when friendship exists', async () => {
+    prismaMock.friend.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 7,
+      friendId: 42,
+      comment: ''
+    } as never);
+
+    const res = await request(app).get('/api/friends/status/42');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ isFriend: true });
+  });
+
+  it('rejects non-numeric userId with 400', async () => {
+    const res = await request(app).get('/api/friends/status/notanumber');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── POST /api/friends/:userId ────────────────────────────────────────────────
+
+describe('POST /api/friends/:userId', () => {
+  it('adds a friend and returns 201', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 42,
+      disabled: false
+    } as never);
+    prismaMock.friend.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/friends/42');
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.friend.create).toHaveBeenCalledWith({
+      data: { userId: 7, friendId: 42 }
+    });
+  });
+
+  it('returns 400 when adding self (actor id = 7)', async () => {
+    const res = await request(app).post('/api/friends/7');
+    expect(res.status).toBe(400);
+    expect(res.body.msg).toMatch(/yourself/i);
+  });
+
+  it('returns 404 when target user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).post('/api/friends/999');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when target user is disabled', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 999,
+      disabled: true
+    } as never);
+
+    const res = await request(app).post('/api/friends/999');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 on duplicate friendship (P2002)', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 42,
+      disabled: false
+    } as never);
+    prismaMock.friend.create.mockRejectedValue(
+      Object.assign(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '5.0.0'
+        }),
+        {}
+      )
+    );
+
+    const res = await request(app).post('/api/friends/42');
+
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 404 on FK violation (P2003 — user deleted between check and create)', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 42,
+      disabled: false
+    } as never);
+    prismaMock.friend.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError(
+        'Foreign key constraint failed',
+        {
+          code: 'P2003',
+          clientVersion: '5.0.0'
+        }
+      )
+    );
+
+    const res = await request(app).post('/api/friends/42');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects non-numeric userId with 400', async () => {
+    const res = await request(app).post('/api/friends/notanumber');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── DELETE /api/friends/:userId ──────────────────────────────────────────────
+
+describe('DELETE /api/friends/:userId', () => {
+  it('removes friendship and returns 204', async () => {
+    prismaMock.friend.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app).delete('/api/friends/42');
+
+    expect(res.status).toBe(204);
+    expect(prismaMock.friend.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 7, friendId: 42 }
+    });
+  });
+
+  it('returns 204 even when friendship does not exist (graceful)', async () => {
+    prismaMock.friend.deleteMany.mockResolvedValue({ count: 0 });
+
+    const res = await request(app).delete('/api/friends/999');
+
+    expect(res.status).toBe(204);
+  });
+
+  it('rejects non-numeric userId with 400', async () => {
+    const res = await request(app).delete('/api/friends/notanumber');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── PUT /api/friends/:userId/comment ────────────────────────────────────────
+
+describe('PUT /api/friends/:userId/comment', () => {
+  it('updates the comment and returns 200', async () => {
+    prismaMock.friend.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app)
+      .put('/api/friends/42/comment')
+      .send({ comment: 'Great contributor' });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.friend.updateMany).toHaveBeenCalledWith({
+      where: { userId: 7, friendId: 42 },
+      data: { comment: 'Great contributor' }
+    });
+  });
+
+  it('returns 404 when friendship does not exist', async () => {
+    prismaMock.friend.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await request(app)
+      .put('/api/friends/999/comment')
+      .send({ comment: 'Hello' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects comment longer than 500 chars with 400', async () => {
+    const res = await request(app)
+      .put('/api/friends/42/comment')
+      .send({ comment: 'x'.repeat(501) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts empty string as comment', async () => {
+    prismaMock.friend.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app)
+      .put('/api/friends/42/comment')
+      .send({ comment: '' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects non-numeric userId with 400', async () => {
+    const res = await request(app)
+      .put('/api/friends/notanumber/comment')
+      .send({ comment: 'Hi' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -4751,6 +4751,133 @@ registry.registerPath({
   }
 });
 
+// ─── Friends ──────────────────────────────────────────────────────────────────
+
+const FriendEntry = registry.register(
+  'FriendEntry',
+  z.object({
+    id: z.number(),
+    userId: z.number(),
+    friendId: z.number(),
+    comment: z.string(),
+    friend: z.object({
+      id: z.number(),
+      username: z.string(),
+      avatar: z.string().nullable()
+    })
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/friends',
+  tags: ['Friends'],
+  request: {
+    query: z.object({
+      page: z.coerce.number().int().positive().optional(),
+      limit: z.coerce.number().int().positive().optional()
+    })
+  },
+  responses: {
+    200: {
+      description: 'Paginated friends list',
+      content: {
+        'application/json': {
+          schema: z.object({ data: z.array(FriendEntry), meta: PaginationMeta })
+        }
+      }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/friends/status/{userId}',
+  tags: ['Friends'],
+  request: { params: z.object({ userId: z.string() }) },
+  responses: {
+    200: {
+      description: 'Friend status',
+      content: {
+        'application/json': {
+          schema: z.object({ isFriend: z.boolean() })
+        }
+      }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/friends/{userId}',
+  tags: ['Friends'],
+  request: { params: z.object({ userId: z.string() }) },
+  responses: {
+    201: { description: 'Friend added' },
+    400: {
+      description: 'Cannot add self',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'User not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    409: {
+      description: 'Already friends',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/friends/{userId}',
+  tags: ['Friends'],
+  request: { params: z.object({ userId: z.string() }) },
+  responses: {
+    204: { description: 'Friend removed' },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/friends/{userId}/comment',
+  tags: ['Friends'],
+  request: {
+    params: z.object({ userId: z.string() }),
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({ comment: z.string().max(500) })
+        }
+      }
+    }
+  },
+  responses: {
+    200: { description: 'Comment updated' },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    404: {
+      description: 'Friend not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 // ─── Document builder ─────────────────────────────────────────────────────────
 
 export function buildOpenApiDocument() {

--- a/src/routes/api/friends.ts
+++ b/src/routes/api/friends.ts
@@ -1,0 +1,131 @@
+import express from 'express';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { sanitizePlain } from '../../lib/sanitize';
+import { parsePage, paginatedResponse } from '../../lib/pagination';
+import { authHandler } from '../../modules/asyncHandler';
+import { requireAuth } from '../../middleware/auth';
+import {
+  validate,
+  validateParams,
+  parsedBody,
+  parsedParams
+} from '../../middleware/validate';
+
+const router = express.Router();
+
+const userIdParams = z.object({
+  userId: z.coerce.number().int().positive()
+});
+
+const commentSchema = z.object({
+  comment: z.string().max(500)
+});
+
+// GET /status/:userId before /:userId/* to avoid shadowing
+router.get(
+  '/status/:userId',
+  requireAuth,
+  validateParams(userIdParams),
+  authHandler(async (req, res) => {
+    const { userId: friendId } = parsedParams<{ userId: number }>(res);
+    const existing = await prisma.friend.findUnique({
+      where: { userId_friendId: { userId: req.user.id, friendId } }
+    });
+    res.json({ isFriend: existing !== null });
+  })
+);
+
+router.get(
+  '/',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const pg = parsePage(req);
+    const [friends, total] = await Promise.all([
+      prisma.friend.findMany({
+        where: { userId: req.user.id },
+        include: {
+          friend: { select: { id: true, username: true, avatar: true } }
+        },
+        orderBy: { friend: { username: 'asc' } },
+        skip: pg.skip,
+        take: pg.limit
+      }),
+      prisma.friend.count({ where: { userId: req.user.id } })
+    ]);
+    paginatedResponse(res, friends, total, pg);
+  })
+);
+
+router.post(
+  '/:userId',
+  requireAuth,
+  validateParams(userIdParams),
+  authHandler(async (req, res) => {
+    const { userId: friendId } = parsedParams<{ userId: number }>(res);
+
+    if (friendId === req.user.id) {
+      throw new AppError(400, 'Cannot add yourself as a friend');
+    }
+
+    const target = await prisma.user.findUnique({
+      where: { id: friendId },
+      select: { id: true, disabled: true }
+    });
+
+    if (!target || target.disabled) {
+      throw new AppError(404, 'User not found');
+    }
+
+    try {
+      await prisma.friend.create({ data: { userId: req.user.id, friendId } });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError) {
+        if (err.code === 'P2002') throw new AppError(409, 'Already friends');
+        if (err.code === 'P2003') throw new AppError(404, 'User not found');
+      }
+      throw err;
+    }
+
+    res.status(201).json({});
+  })
+);
+
+router.delete(
+  '/:userId',
+  requireAuth,
+  validateParams(userIdParams),
+  authHandler(async (req, res) => {
+    const { userId: friendId } = parsedParams<{ userId: number }>(res);
+    await prisma.friend.deleteMany({
+      where: { userId: req.user.id, friendId }
+    });
+    res.status(204).send();
+  })
+);
+
+router.put(
+  '/:userId/comment',
+  requireAuth,
+  validateParams(userIdParams),
+  validate(commentSchema),
+  authHandler(async (req, res) => {
+    const { userId: friendId } = parsedParams<{ userId: number }>(res);
+    const { comment } = parsedBody<{ comment: string }>(res);
+
+    const result = await prisma.friend.updateMany({
+      where: { userId: req.user.id, friendId },
+      data: { comment: sanitizePlain(comment) }
+    });
+
+    if (result.count === 0) {
+      throw new AppError(404, 'Friend not found');
+    }
+
+    res.json({});
+  })
+);
+
+export default router;


### PR DESCRIPTION
## Summary

- Unidirectional friendship model: users add others to a personal friends list with a private per-entry note
- Five endpoints under `/api/friends`: list (paginated), add, remove, update comment, friend-status check
- Self-friending rejected (400); disabled/missing user returns 404; duplicate add returns 409 (explicit P2002 catch); race-deleted user on create returns 404 (P2003 catch)
- Friends section registered in OpenAPI spec; `openapi.json` regenerated

## Intentional deviations from reference behavior

- Self-friend guard added (reference does not prevent this)
- Comment validated to 500 chars and sanitized via `sanitizePlain()`
- Staff view of another user's friends list deferred (no permission system mapping yet)
- Recommendations feature (uses friends as a gate in reference) deferred — out of scope

## Test plan

- [ ] `npx jest --runInBand "friends" --no-coverage` — 20 tests, all passing
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean on changed files
- [ ] POST `/api/friends/7` (self) → 400
- [ ] POST `/api/friends/:missingId` → 404
- [ ] POST `/api/friends/:id` twice → 409 on second call
- [ ] GET `/api/friends/status/:id` before and after add → `{ isFriend: false }` / `{ isFriend: true }`
- [ ] PUT `/api/friends/:id/comment` with 501-char body → 400
- [ ] DELETE `/api/friends/:nonExistentId` → 204 (graceful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)