### PR TITLE
Add donor system: self-service rewards, expiry job, and profile perk enforcement

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { http } from './modules/config';
 import { isInstalled } from './modules/installState';
 import { startLinkHealthJob } from './modules/linkHealthJob';
 import { startStatsJob } from './modules/statsJob';
+import { startDonorExpiryJob } from './modules/donorExpiryJob';
 
 import installRouter from './routes/api/install';
 import homeRouter from './routes/api/home';
@@ -154,6 +155,7 @@ export const createApp = () => {
 
   startLinkHealthJob();
   startStatsJob();
+  startDonorExpiryJob();
 
   return app;
 };

--- a/src/donations.spec.ts
+++ b/src/donations.spec.ts
@@ -1,0 +1,208 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock
+} from './test/apiTestHarness';
+import { makeUser } from './test/factories';
+
+beforeEach(() => resetApiTestState());
+
+const setAdmin = () =>
+  prismaMock.userRank.findUnique.mockResolvedValue({
+    id: 1,
+    name: 'Admin',
+    level: 1000,
+    color: '',
+    badge: '',
+    displayStaff: false,
+    permissions: {
+      admin: true,
+      staff: true,
+      forums_read: true,
+      forums_post: true
+    }
+  } as never);
+
+// ─── GET /api/donations ───────────────────────────────────────────────────────
+
+describe('GET /api/donations', () => {
+  it('returns 403 when user lacks admin permission (null rank)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(null);
+    const res = await request(app).get('/api/donations');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when user has non-admin rank', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue({
+      id: 1,
+      name: 'Member',
+      level: 10,
+      color: '',
+      badge: '',
+      displayStaff: false,
+      permissions: {}
+    } as never);
+    const res = await request(app).get('/api/donations');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns paginated donations', async () => {
+    setAdmin();
+    const donation = {
+      id: 1,
+      userId: 2,
+      amount: 25,
+      email: 'donor@test.com',
+      donatedAt: new Date('2026-01-01'),
+      currency: 'USD',
+      source: 'Staff PM',
+      reason: 'Thanks',
+      rank: 5,
+      addedBy: 7,
+      totalRank: 5,
+      user: { id: 2, username: 'supporter' }
+    };
+    prismaMock.donation.findMany.mockResolvedValue([donation] as never);
+    prismaMock.donation.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/donations');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.meta.total).toBe(1);
+  });
+
+  it('passes userId filter to both findMany and count', async () => {
+    setAdmin();
+    prismaMock.donation.findMany.mockResolvedValue([]);
+    prismaMock.donation.count.mockResolvedValue(0);
+
+    await request(app).get('/api/donations?userId=5');
+
+    expect(prismaMock.donation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 5 } })
+    );
+    expect(prismaMock.donation.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 5 } })
+    );
+  });
+
+  it('applies no where clause when userId is absent', async () => {
+    setAdmin();
+    prismaMock.donation.findMany.mockResolvedValue([]);
+    prismaMock.donation.count.mockResolvedValue(0);
+
+    await request(app).get('/api/donations');
+
+    expect(prismaMock.donation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined })
+    );
+  });
+
+  it('rejects non-integer userId', async () => {
+    setAdmin();
+    const res = await request(app).get('/api/donations?userId=abc');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── POST /api/donations ──────────────────────────────────────────────────────
+
+describe('POST /api/donations', () => {
+  beforeEach(() => setAdmin());
+
+  const validBody = {
+    userId: 2,
+    amount: 25,
+    email: 'donor@test.com',
+    donatedAt: '2026-01-01T00:00:00.000Z',
+    currency: 'USD',
+    source: 'Staff PM',
+    reason: 'General support'
+  };
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await request(app).post('/api/donations').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when reason is missing', async () => {
+    const res = await request(app)
+      .post('/api/donations')
+      .send({ ...validBody, reason: undefined });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when email is invalid', async () => {
+    const res = await request(app)
+      .post('/api/donations')
+      .send({ ...validBody, email: 'not-an-email' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    const res = await request(app).post('/api/donations').send(validBody);
+    expect(res.status).toBe(404);
+    expect(res.body.msg).toBe('User not found');
+  });
+
+  it('returns 201 with created donation and calls audit', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(makeUser({ id: 2 }) as never);
+    const created = {
+      id: 10,
+      userId: 2,
+      amount: 25,
+      email: 'donor@test.com',
+      donatedAt: new Date('2026-01-01'),
+      currency: 'USD',
+      source: 'Staff PM',
+      reason: 'General support',
+      rank: 0,
+      addedBy: 0,
+      totalRank: 0,
+      user: { id: 2, username: 'supporter' }
+    };
+    prismaMock.donation.create.mockResolvedValue(created as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).post('/api/donations').send(validBody);
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(10);
+    expect(prismaMock.auditLog.create).toHaveBeenCalled();
+  });
+});
+
+// ─── DELETE /api/donations/:id ────────────────────────────────────────────────
+
+describe('DELETE /api/donations/:id', () => {
+  beforeEach(() => setAdmin());
+
+  it('returns 404 when donation does not exist', async () => {
+    prismaMock.donation.findUnique.mockResolvedValue(null);
+    const res = await request(app).delete('/api/donations/99');
+    expect(res.status).toBe(404);
+    expect(res.body.msg).toBe('Donation not found');
+  });
+
+  it('returns 204 on success and calls audit', async () => {
+    prismaMock.donation.findUnique.mockResolvedValue({
+      id: 5,
+      userId: 2
+    } as never);
+    prismaMock.donation.delete.mockResolvedValue({} as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app).delete('/api/donations/5');
+    expect(res.status).toBe(204);
+    expect(prismaMock.donation.delete).toHaveBeenCalledWith({
+      where: { id: 5 }
+    });
+    expect(prismaMock.auditLog.create).toHaveBeenCalled();
+  });
+
+  it('returns 400 for non-integer id', async () => {
+    const res = await request(app).delete('/api/donations/abc');
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/donor.spec.ts
+++ b/src/donor.spec.ts
@@ -1,0 +1,57 @@
+jest.mock('./lib/sanitize', () => ({
+  sanitizeHtml: (v: string) => v,
+  sanitizePlain: (v: string) => v
+}));
+jest.mock('./lib/prisma', () => ({
+  prisma: {}
+}));
+
+import { parsePerks } from './modules/donor';
+
+// Unit tests for module-level logic that doesn't require DB access.
+// DB-dependent functions are covered via integration tests or via the route
+// spec tests (donorRewards.spec.ts) which mock the whole module.
+
+describe('parsePerks', () => {
+  it('returns the object as PerksMap when given a valid object', () => {
+    const raw = { customIcon: true, forumTitle: false };
+    expect(parsePerks(raw)).toEqual({ customIcon: true, forumTitle: false });
+  });
+
+  it('returns empty object for null', () => {
+    expect(parsePerks(null)).toEqual({});
+  });
+
+  it('returns empty object for undefined', () => {
+    expect(parsePerks(undefined)).toEqual({});
+  });
+
+  it('returns empty object for an array', () => {
+    expect(parsePerks(['customIcon', true])).toEqual({});
+  });
+
+  it('returns empty object for a string', () => {
+    expect(parsePerks('customIcon')).toEqual({});
+  });
+
+  it('returns empty object for an empty JSON object', () => {
+    expect(parsePerks({})).toEqual({});
+  });
+
+  it('preserves all perk keys when present', () => {
+    const raw = {
+      iconMouseOverText: true,
+      avatarMouseOverText: false,
+      customIconLink: true,
+      customIcon: true,
+      forumTitle: true,
+      secondAvatar: false,
+      profileInfo1: true,
+      profileInfo2: true,
+      profileInfo3: false,
+      profileInfo4: false
+    };
+    const result = parsePerks(raw);
+    expect(result).toEqual(raw);
+  });
+});

--- a/src/donorRewards.spec.ts
+++ b/src/donorRewards.spec.ts
@@ -1,0 +1,137 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  donorMock
+} from './test/apiTestHarness';
+import { AppError } from './lib/errors';
+
+beforeEach(() => resetApiTestState());
+
+const mockSettings = {
+  rewards: {
+    iconMouseOverText: '',
+    avatarMouseOverText: '',
+    customIcon: 'https://example.com/icon.png',
+    customIconLink: '',
+    secondAvatar: '',
+    profileInfo1: '',
+    profileInfoTitle1: '',
+    profileInfo2: '',
+    profileInfoTitle2: '',
+    profileInfo3: '',
+    profileInfoTitle3: '',
+    profileInfo4: '',
+    profileInfoTitle4: ''
+  },
+  perks: { customIcon: true, forumTitle: true },
+  forumTitle: { prefix: 'Gold', suffix: '', useComma: true }
+};
+
+// ─── GET /api/profile/me/donor-rewards ───────────────────────────────────────
+
+describe('GET /api/profile/me/donor-rewards', () => {
+  it('returns 404 when user has no active donor rank', async () => {
+    donorMock.getDonorSettings.mockResolvedValue(null);
+    const res = await request(app).get('/api/profile/me/donor-rewards');
+    expect(res.status).toBe(404);
+    expect(res.body.msg).toBe('No active donor rank');
+  });
+
+  it('returns 200 with rewards, perks, and forumTitle', async () => {
+    donorMock.getDonorSettings.mockResolvedValue(mockSettings);
+    const res = await request(app).get('/api/profile/me/donor-rewards');
+    expect(res.status).toBe(200);
+    expect(res.body.perks.customIcon).toBe(true);
+    expect(res.body.forumTitle.prefix).toBe('Gold');
+    expect(res.body.rewards.customIcon).toBe('https://example.com/icon.png');
+  });
+
+  it('returns forumTitle as null when perk is not enabled', async () => {
+    donorMock.getDonorSettings.mockResolvedValue({
+      ...mockSettings,
+      perks: { customIcon: true },
+      forumTitle: null
+    });
+    const res = await request(app).get('/api/profile/me/donor-rewards');
+    expect(res.status).toBe(200);
+    expect(res.body.forumTitle).toBeNull();
+  });
+});
+
+// ─── PUT /api/profile/me/donor-rewards ───────────────────────────────────────
+
+describe('PUT /api/profile/me/donor-rewards', () => {
+  it('returns 400 on invalid URL for customIcon', async () => {
+    const res = await request(app)
+      .put('/api/profile/me/donor-rewards')
+      .send({ customIcon: 'not-a-url' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with updated settings on success', async () => {
+    donorMock.updateDonorRewards.mockResolvedValue(mockSettings);
+    const res = await request(app)
+      .put('/api/profile/me/donor-rewards')
+      .send({ customIcon: 'https://example.com/new.png' });
+    expect(res.status).toBe(200);
+    expect(res.body.rewards).toBeDefined();
+  });
+
+  it('returns 403 when module throws AppError(403)', async () => {
+    donorMock.updateDonorRewards.mockRejectedValue(
+      new AppError(403, 'No active donor rank')
+    );
+    const res = await request(app)
+      .put('/api/profile/me/donor-rewards')
+      .send({ customIcon: '' });
+    expect(res.status).toBe(403);
+    expect(res.body.msg).toBe('No active donor rank');
+  });
+
+  it('accepts empty string to clear a URL field', async () => {
+    donorMock.updateDonorRewards.mockResolvedValue({
+      ...mockSettings,
+      rewards: { ...mockSettings.rewards, customIcon: '' }
+    });
+    const res = await request(app)
+      .put('/api/profile/me/donor-rewards')
+      .send({ customIcon: '' });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── PUT /api/profile/me/donor-title ─────────────────────────────────────────
+
+describe('PUT /api/profile/me/donor-title', () => {
+  it('returns 200 with updated title on success', async () => {
+    donorMock.updateDonorForumTitle.mockResolvedValue({
+      prefix: 'VIP',
+      suffix: '',
+      useComma: true
+    });
+    const res = await request(app)
+      .put('/api/profile/me/donor-title')
+      .send({ prefix: 'VIP', useComma: true });
+    expect(res.status).toBe(200);
+    expect(res.body.prefix).toBe('VIP');
+  });
+
+  it('returns 403 when module throws AppError(403)', async () => {
+    donorMock.updateDonorForumTitle.mockRejectedValue(
+      new AppError(403, 'Forum title perk not enabled')
+    );
+    const res = await request(app)
+      .put('/api/profile/me/donor-title')
+      .send({ prefix: 'VIP' });
+    expect(res.status).toBe(403);
+    expect(res.body.msg).toBe('Forum title perk not enabled');
+  });
+
+  it('returns 400 when prefix exceeds max length', async () => {
+    const res = await request(app)
+      .put('/api/profile/me/donor-title')
+      .send({ prefix: 'x'.repeat(65) });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -4,7 +4,12 @@ import {
   extendZodWithOpenApi
 } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
-import { profileUpdateSchema, inviteSchema } from '../schemas/profile';
+import {
+  profileUpdateSchema,
+  inviteSchema,
+  donorRewardUpdateSchema,
+  donorForumTitleUpdateSchema
+} from '../schemas/profile';
 import { adminCreateUserSchema, userSettingsSchema } from '../schemas/user';
 import {
   createContributionSchema,
@@ -431,6 +436,8 @@ const DonorPresentation = registry.register(
     customIcon: z.string().nullable(),
     customIconLink: z.string().nullable(),
     secondAvatar: z.string().nullable(),
+    iconMouseOverText: z.string().nullable(),
+    avatarMouseOverText: z.string().nullable(),
     profileBlocks: z.array(
       z.object({
         title: z.string(),
@@ -858,6 +865,124 @@ registry.registerPath({
     },
     409: {
       description: 'Invite already exists',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+// ─── Donor rewards (self-service) ────────────────────────────────────────────
+
+const DonorRewardsSchema = registry.register(
+  'DonorRewards',
+  z.object({
+    rewards: z.object({
+      iconMouseOverText: z.string(),
+      avatarMouseOverText: z.string(),
+      customIcon: z.string(),
+      customIconLink: z.string(),
+      secondAvatar: z.string(),
+      profileInfoTitle1: z.string(),
+      profileInfo1: z.string(),
+      profileInfoTitle2: z.string(),
+      profileInfo2: z.string(),
+      profileInfoTitle3: z.string(),
+      profileInfo3: z.string(),
+      profileInfoTitle4: z.string(),
+      profileInfo4: z.string()
+    }),
+    perks: z.record(z.string(), z.boolean()),
+    forumTitle: z
+      .object({
+        prefix: z.string(),
+        suffix: z.string(),
+        useComma: z.boolean()
+      })
+      .nullable()
+  })
+);
+
+const DonorForumTitleSchema = registry.register(
+  'DonorForumTitle',
+  z.object({
+    prefix: z.string(),
+    suffix: z.string(),
+    useComma: z.boolean()
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/profile/me/donor-rewards',
+  tags: ['Profile'],
+  responses: {
+    200: {
+      description: 'Donor reward settings and active perks',
+      content: { 'application/json': { schema: DonorRewardsSchema } }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'No active donor rank',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/profile/me/donor-rewards',
+  tags: ['Profile'],
+  request: {
+    body: {
+      content: { 'application/json': { schema: donorRewardUpdateSchema } }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Updated donor reward settings',
+      content: { 'application/json': { schema: DonorRewardsSchema } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    403: {
+      description: 'No active donor rank',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/profile/me/donor-title',
+  tags: ['Profile'],
+  request: {
+    body: {
+      content: { 'application/json': { schema: donorForumTitleUpdateSchema } }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Updated forum title',
+      content: { 'application/json': { schema: DonorForumTitleSchema } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    403: {
+      description: 'Perk not enabled for this rank',
       content: { 'application/json': { schema: MsgResponse } }
     }
   }

--- a/src/modules/donor.ts
+++ b/src/modules/donor.ts
@@ -1,0 +1,198 @@
+import { prisma } from '../lib/prisma';
+import { sanitizePlain } from '../lib/sanitize';
+import { AppError } from '../lib/errors';
+
+export type PerksMap = {
+  iconMouseOverText?: boolean;
+  avatarMouseOverText?: boolean;
+  customIconLink?: boolean;
+  customIcon?: boolean;
+  forumTitle?: boolean;
+  secondAvatar?: boolean;
+  profileInfo1?: boolean;
+  profileInfo2?: boolean;
+  profileInfo3?: boolean;
+  profileInfo4?: boolean;
+};
+
+export type DonorRewardFields = {
+  iconMouseOverText: string;
+  avatarMouseOverText: string;
+  customIcon: string;
+  customIconLink: string;
+  secondAvatar: string;
+  profileInfo1: string;
+  profileInfoTitle1: string;
+  profileInfo2: string;
+  profileInfoTitle2: string;
+  profileInfo3: string;
+  profileInfoTitle3: string;
+  profileInfo4: string;
+  profileInfoTitle4: string;
+};
+
+export type DonorForumTitle = {
+  prefix: string;
+  suffix: string;
+  useComma: boolean;
+};
+
+export type DonorSettings = {
+  rewards: DonorRewardFields;
+  perks: PerksMap;
+  forumTitle: DonorForumTitle | null;
+};
+
+// Maps each reward field to the perk key that unlocks it.
+// Title fields (profileInfoTitle*) share the same perk as their paired body field.
+const FIELD_PERK_MAP: Record<keyof DonorRewardFields, keyof PerksMap> = {
+  iconMouseOverText: 'iconMouseOverText',
+  avatarMouseOverText: 'avatarMouseOverText',
+  customIcon: 'customIcon',
+  customIconLink: 'customIconLink',
+  secondAvatar: 'secondAvatar',
+  profileInfo1: 'profileInfo1',
+  profileInfoTitle1: 'profileInfo1',
+  profileInfo2: 'profileInfo2',
+  profileInfoTitle2: 'profileInfo2',
+  profileInfo3: 'profileInfo3',
+  profileInfoTitle3: 'profileInfo3',
+  profileInfo4: 'profileInfo4',
+  profileInfoTitle4: 'profileInfo4'
+};
+
+export const parsePerks = (raw: unknown): PerksMap => {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as PerksMap;
+  }
+  return {};
+};
+
+const REWARD_DEFAULTS: DonorRewardFields = {
+  iconMouseOverText: '',
+  avatarMouseOverText: '',
+  customIcon: '',
+  customIconLink: '',
+  secondAvatar: '',
+  profileInfo1: '',
+  profileInfoTitle1: '',
+  profileInfo2: '',
+  profileInfoTitle2: '',
+  profileInfo3: '',
+  profileInfoTitle3: '',
+  profileInfo4: '',
+  profileInfoTitle4: ''
+};
+
+// Returns the user's active (non-expired) donor rank row, or null.
+// Using findFirst because UserDonorRank is unique on userId but we need the
+// expiry filter, which requires a WHERE clause Prisma only supports on findFirst.
+const getActiveRankRow = async (userId: number) => {
+  const now = new Date();
+  return prisma.userDonorRank.findFirst({
+    where: {
+      userId,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }]
+    },
+    select: {
+      donorRank: { select: { perks: true } }
+    }
+  });
+};
+
+export const getDonorSettings = async (
+  userId: number
+): Promise<DonorSettings | null> => {
+  const activeRank = await getActiveRankRow(userId);
+  if (!activeRank) return null;
+
+  const perks = parsePerks(activeRank.donorRank.perks);
+
+  const [rewardRow, titleRow] = await Promise.all([
+    prisma.donorReward.findUnique({ where: { userId } }),
+    perks.forumTitle
+      ? prisma.donorForumUsername.findUnique({ where: { userId } })
+      : Promise.resolve(null)
+  ]);
+
+  const rewards: DonorRewardFields = {
+    ...REWARD_DEFAULTS,
+    ...(rewardRow ?? {})
+  };
+
+  const forumTitle =
+    perks.forumTitle && titleRow
+      ? {
+          prefix: titleRow.prefix,
+          suffix: titleRow.suffix,
+          useComma: titleRow.useComma
+        }
+      : null;
+
+  return { rewards, perks, forumTitle };
+};
+
+export const updateDonorRewards = async (
+  userId: number,
+  fields: Partial<DonorRewardFields>
+): Promise<DonorSettings> => {
+  const activeRank = await getActiveRankRow(userId);
+  if (!activeRank) throw new AppError(403, 'No active donor rank');
+
+  const perks = parsePerks(activeRank.donorRank.perks);
+
+  // Only write fields whose perk is enabled
+  const allowed: Partial<Record<string, string>> = {};
+  for (const [field, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    const perkKey = FIELD_PERK_MAP[field as keyof DonorRewardFields];
+    if (perkKey && perks[perkKey]) {
+      allowed[field] = sanitizePlain(value as string);
+    }
+  }
+
+  if (Object.keys(allowed).length > 0) {
+    await prisma.donorReward.upsert({
+      where: { userId },
+      create: { userId, ...allowed },
+      update: allowed
+    });
+  }
+
+  const settings = await getDonorSettings(userId);
+  return settings!;
+};
+
+export const updateDonorForumTitle = async (
+  userId: number,
+  data: { prefix?: string; suffix?: string; useComma?: boolean }
+): Promise<DonorForumTitle> => {
+  const activeRank = await getActiveRankRow(userId);
+  if (!activeRank) throw new AppError(403, 'No active donor rank');
+
+  const perks = parsePerks(activeRank.donorRank.perks);
+  if (!perks.forumTitle)
+    throw new AppError(403, 'Forum title perk not enabled');
+
+  const sanitized = {
+    ...(data.prefix !== undefined && {
+      prefix: sanitizePlain(data.prefix).trim()
+    }),
+    ...(data.suffix !== undefined && {
+      suffix: sanitizePlain(data.suffix).trim()
+    }),
+    ...(data.useComma !== undefined && { useComma: data.useComma })
+  };
+
+  const updated = await prisma.donorForumUsername.upsert({
+    where: { userId },
+    create: { userId, prefix: '', suffix: '', useComma: true, ...sanitized },
+    update: sanitized
+  });
+
+  return {
+    prefix: updated.prefix,
+    suffix: updated.suffix,
+    useComma: updated.useComma
+  };
+};

--- a/src/modules/donorExpiryJob.ts
+++ b/src/modules/donorExpiryJob.ts
@@ -1,0 +1,55 @@
+import { prisma } from '../lib/prisma';
+import { getLogger } from './logging';
+
+const log = getLogger('donorExpiryJob');
+
+const INTERVAL_MS = 60 * 60 * 1000; // hourly
+const STARTUP_DELAY_MS = 30_000;
+
+const sweepExpiredDonors = async (): Promise<void> => {
+  const now = new Date();
+
+  // Delete by condition (not by userId) so a staff re-grant that creates a
+  // fresh non-expired row is never touched. The transaction ensures the
+  // isDonor cleanup sees the post-delete state.
+  await prisma.$transaction(async (tx) => {
+    const { count } = await tx.userDonorRank.deleteMany({
+      where: { expiresAt: { lte: now } }
+    });
+
+    if (count === 0) return;
+
+    // Only clear isDonor for users who now have no remaining active grant.
+    // If staff re-granted between the deleteMany and this update, the new
+    // row keeps the user's isDonor flag intact.
+    await tx.$executeRaw`
+      UPDATE "users"
+      SET "is_donor" = false
+      WHERE "is_donor" = true
+        AND NOT EXISTS (
+          SELECT 1 FROM "user_donor_ranks" WHERE "user_id" = "users"."id"
+        )
+    `;
+
+    log.info('Swept expired donor ranks', { count });
+  });
+};
+
+export const startDonorExpiryJob = (): void => {
+  const outer = setTimeout(() => {
+    sweepExpiredDonors().catch((err) =>
+      log.error('Donor expiry sweep failed', { err })
+    );
+    setInterval(() => {
+      sweepExpiredDonors().catch((err) =>
+        log.error('Donor expiry sweep failed', { err })
+      );
+    }, INTERVAL_MS).unref();
+  }, STARTUP_DELAY_MS);
+  outer.unref();
+
+  log.info('Donor expiry job scheduled', {
+    startupDelayMs: STARTUP_DELAY_MS,
+    intervalMs: INTERVAL_MS
+  });
+};

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -9,6 +9,7 @@ import { sanitizeHtml, sanitizePlain } from '../lib/sanitize';
 import { sendInviteEmail } from '../lib/mailer';
 import { getLogger } from './logging';
 import { computeRatio } from './ratio';
+import { parsePerks, type PerksMap } from './donor';
 
 const log = getLogger('profile');
 
@@ -89,6 +90,8 @@ type DonorPresentation = {
   customIcon: string | null;
   customIconLink: string | null;
   secondAvatar: string | null;
+  iconMouseOverText: string | null;
+  avatarMouseOverText: string | null;
   profileBlocks: Array<{ title: string; body: string }>;
 };
 
@@ -169,7 +172,8 @@ const PROFILE_BASE_SELECT = {
         select: {
           name: true,
           badge: true,
-          color: true
+          color: true,
+          perks: true
         }
       }
     }
@@ -179,6 +183,8 @@ const PROFILE_BASE_SELECT = {
       customIcon: true,
       customIconLink: true,
       secondAvatar: true,
+      iconMouseOverText: true,
+      avatarMouseOverText: true,
       profileInfoTitle1: true,
       profileInfo1: true,
       profileInfoTitle2: true,
@@ -485,40 +491,82 @@ const buildDonorPresentation = (
   const donorRank = user.donorRank;
   const donorReward = user.donorReward;
 
-  const profileBlocks = donorReward
-    ? [
-        {
-          title: donorReward.profileInfoTitle1,
-          body: donorReward.profileInfo1
-        },
-        {
-          title: donorReward.profileInfoTitle2,
-          body: donorReward.profileInfo2
-        },
-        {
-          title: donorReward.profileInfoTitle3,
-          body: donorReward.profileInfo3
-        },
-        {
-          title: donorReward.profileInfoTitle4,
-          body: donorReward.profileInfo4
-        }
-      ].filter((block) => block.title.trim() || block.body.trim())
-    : [];
+  // Enforce expiry: treat an expired grant as absent so stale rewards never
+  // render while the hourly sweep hasn't fired yet.
+  const now = new Date();
+  const activeRank =
+    donorRank && (donorRank.expiresAt === null || donorRank.expiresAt > now)
+      ? donorRank
+      : null;
+
+  const perks: PerksMap = activeRank
+    ? parsePerks(activeRank.donorRank.perks)
+    : {};
+
+  // Profile blocks filtered by per-block perks
+  const profileBlocks =
+    donorReward && activeRank
+      ? (
+          [
+            perks.profileInfo1
+              ? {
+                  title: donorReward.profileInfoTitle1,
+                  body: donorReward.profileInfo1
+                }
+              : null,
+            perks.profileInfo2
+              ? {
+                  title: donorReward.profileInfoTitle2,
+                  body: donorReward.profileInfo2
+                }
+              : null,
+            perks.profileInfo3
+              ? {
+                  title: donorReward.profileInfoTitle3,
+                  body: donorReward.profileInfo3
+                }
+              : null,
+            perks.profileInfo4
+              ? {
+                  title: donorReward.profileInfoTitle4,
+                  body: donorReward.profileInfo4
+                }
+              : null
+          ] as Array<{ title: string; body: string } | null>
+        ).filter(
+          (b): b is { title: string; body: string } =>
+            b !== null && !!(b.title.trim() || b.body.trim())
+        )
+      : [];
 
   const presentation: DonorPresentation = {
-    rank: donorRank
+    rank: activeRank
       ? {
-          name: donorRank.donorRank.name,
-          badge: donorRank.donorRank.badge,
-          color: donorRank.donorRank.color,
-          grantedAt: donorRank.grantedAt.toISOString(),
-          expiresAt: donorRank.expiresAt?.toISOString() ?? null
+          name: activeRank.donorRank.name,
+          badge: activeRank.donorRank.badge,
+          color: activeRank.donorRank.color,
+          grantedAt: activeRank.grantedAt.toISOString(),
+          expiresAt: activeRank.expiresAt?.toISOString() ?? null
         }
       : null,
-    customIcon: donorReward?.customIcon || null,
-    customIconLink: donorReward?.customIconLink || null,
-    secondAvatar: donorReward?.secondAvatar || null,
+    customIcon:
+      donorReward && perks.customIcon ? donorReward.customIcon || null : null,
+    customIconLink:
+      donorReward && perks.customIconLink
+        ? donorReward.customIconLink || null
+        : null,
+    secondAvatar:
+      donorReward && perks.secondAvatar
+        ? donorReward.secondAvatar || null
+        : null,
+    iconMouseOverText:
+      donorReward && perks.iconMouseOverText
+        ? donorReward.iconMouseOverText || null
+        : null,
+    avatarMouseOverText:
+      donorReward && perks.avatarMouseOverText
+        ? donorReward.avatarMouseOverText || null
+        : null,
     profileBlocks
   };
 
@@ -527,6 +575,8 @@ const buildDonorPresentation = (
     !presentation.customIcon &&
     !presentation.customIconLink &&
     !presentation.secondAvatar &&
+    !presentation.iconMouseOverText &&
+    !presentation.avatarMouseOverText &&
     !presentation.profileBlocks.length
   ) {
     return null;

--- a/src/routes/api/donations.ts
+++ b/src/routes/api/donations.ts
@@ -7,7 +7,9 @@ import {
   validate,
   parsedBody,
   validateParams,
-  parsedParams
+  parsedParams,
+  validateQuery,
+  parsedQuery
 } from '../../middleware/validate';
 import { audit } from '../../lib/audit';
 import { parsePage, paginatedResponse } from '../../lib/pagination';
@@ -15,6 +17,12 @@ import { parsePage, paginatedResponse } from '../../lib/pagination';
 const router = express.Router();
 
 const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+
+const donationsQuerySchema = z.object({
+  userId: z.coerce.number().int().positive().optional()
+});
+
+type DonationsQuery = z.infer<typeof donationsQuerySchema>;
 
 const createDonationSchema = z.object({
   userId: z.number().int().positive(),
@@ -32,10 +40,14 @@ type CreateDonationInput = z.infer<typeof createDonationSchema>;
 router.get(
   '/',
   ...requirePermission('admin'),
+  validateQuery(donationsQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
+    const { userId } = parsedQuery<DonationsQuery>(res);
+    const where = userId ? { userId } : undefined;
     const pg = parsePage(req);
     const [rows, total] = await Promise.all([
       prisma.donation.findMany({
+        where,
         orderBy: { donatedAt: 'desc' },
         skip: pg.skip,
         take: pg.limit,
@@ -43,7 +55,7 @@ router.get(
           user: { select: { id: true, username: true } }
         }
       }),
-      prisma.donation.count()
+      prisma.donation.count({ where })
     ]);
     paginatedResponse(res, rows, total, pg);
   })

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -15,9 +15,18 @@ import { validate, parsedBody } from '../../middleware/validate';
 import {
   profileUpdateSchema,
   inviteSchema,
+  donorRewardUpdateSchema,
+  donorForumTitleUpdateSchema,
   type ProfileUpdateInput,
-  type InviteInput
+  type InviteInput,
+  type DonorRewardUpdateInput,
+  type DonorForumTitleUpdateInput
 } from '../../schemas/profile';
+import {
+  getDonorSettings,
+  updateDonorRewards,
+  updateDonorForumTitle
+} from '../../modules/donor';
 
 const router = express.Router();
 // GET /api/profile/me
@@ -109,6 +118,41 @@ router.delete(
     );
     res.clearCookie('token');
     res.status(204).send();
+  })
+);
+
+// GET /api/profile/me/donor-rewards
+router.get(
+  '/me/donor-rewards',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const settings = await getDonorSettings(req.user.id);
+    if (!settings) return res.status(404).json({ msg: 'No active donor rank' });
+    res.json(settings);
+  })
+);
+
+// PUT /api/profile/me/donor-rewards
+router.put(
+  '/me/donor-rewards',
+  requireAuth,
+  validate(donorRewardUpdateSchema),
+  authHandler(async (req, res) => {
+    const fields = parsedBody<DonorRewardUpdateInput>(res);
+    const settings = await updateDonorRewards(req.user.id, fields);
+    res.json(settings);
+  })
+);
+
+// PUT /api/profile/me/donor-title
+router.put(
+  '/me/donor-title',
+  requireAuth,
+  validate(donorForumTitleUpdateSchema),
+  authHandler(async (req, res) => {
+    const data = parsedBody<DonorForumTitleUpdateInput>(res);
+    const title = await updateDonorForumTitle(req.user.id, data);
+    res.json(title);
   })
 );
 

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -726,6 +726,13 @@ router.post(
     if (!donorRank)
       return res.status(404).json({ msg: 'Donor rank not found' });
 
+    // Explicit expiresAt wins; fall back to the rank's expiresAfterDays if set
+    const computedExpiresAt = expiresAt
+      ? new Date(expiresAt)
+      : donorRank.expiresAfterDays != null
+      ? new Date(Date.now() + donorRank.expiresAfterDays * 86_400_000)
+      : null;
+
     await prisma.$transaction([
       prisma.userDonorRank.upsert({
         where: { userId: id },
@@ -733,15 +740,13 @@ router.post(
           userId: id,
           donorRankId,
           grantedById: req.user.id,
-          ...(expiresAt ? { expiresAt: new Date(expiresAt) } : {})
+          ...(computedExpiresAt ? { expiresAt: computedExpiresAt } : {})
         },
         update: {
           donorRankId,
           grantedAt: new Date(),
           grantedById: req.user.id,
-          ...(expiresAt
-            ? { expiresAt: new Date(expiresAt) }
-            : { expiresAt: null })
+          expiresAt: computedExpiresAt
         }
       }),
       prisma.user.update({ where: { id }, data: { isDonor: true } })

--- a/src/schemas/profile.ts
+++ b/src/schemas/profile.ts
@@ -26,3 +26,30 @@ export const inviteSchema = z.object({
 
 export type ProfileUpdateInput = z.infer<typeof profileUpdateSchema>;
 export type InviteInput = z.infer<typeof inviteSchema>;
+
+export const donorRewardUpdateSchema = z.object({
+  iconMouseOverText: z.string().max(256).optional(),
+  avatarMouseOverText: z.string().max(256).optional(),
+  customIcon: z.string().url().or(z.literal('')).optional(),
+  customIconLink: z.string().url().or(z.literal('')).optional(),
+  secondAvatar: z.string().url().or(z.literal('')).optional(),
+  profileInfoTitle1: z.string().max(128).optional(),
+  profileInfo1: z.string().max(5000).optional(),
+  profileInfoTitle2: z.string().max(128).optional(),
+  profileInfo2: z.string().max(5000).optional(),
+  profileInfoTitle3: z.string().max(128).optional(),
+  profileInfo3: z.string().max(5000).optional(),
+  profileInfoTitle4: z.string().max(128).optional(),
+  profileInfo4: z.string().max(5000).optional()
+});
+
+export const donorForumTitleUpdateSchema = z.object({
+  prefix: z.string().max(64).optional(),
+  suffix: z.string().max(64).optional(),
+  useComma: z.boolean().optional()
+});
+
+export type DonorRewardUpdateInput = z.infer<typeof donorRewardUpdateSchema>;
+export type DonorForumTitleUpdateInput = z.infer<
+  typeof donorForumTitleUpdateSchema
+>;

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -50,6 +50,16 @@ jest.mock('../modules/statsJob', () => ({
   startStatsJob: jest.fn()
 }));
 
+jest.mock('../modules/donorExpiryJob', () => ({
+  startDonorExpiryJob: jest.fn()
+}));
+
+jest.mock('../modules/donor', () => ({
+  getDonorSettings: jest.fn(),
+  updateDonorRewards: jest.fn(),
+  updateDonorForumTitle: jest.fn()
+}));
+
 jest.mock('../modules/artist', () => ({
   createArtist: jest.fn(),
   updateArtist: jest.fn(),
@@ -230,6 +240,7 @@ import {
 } from '../modules/downloads';
 import { fileReport } from '../modules/reports';
 import { recordContributionReport } from '../modules/linkHealth';
+import * as donorModule from '../modules/donor';
 
 const gravatar = jest.requireMock('gravatar') as { url: jest.Mock };
 import * as pmModule from '../modules/pm';
@@ -332,6 +343,7 @@ export const staffInboxMock = staffInboxModule as jest.Mocked<
   typeof staffInboxModule
 >;
 export const staffPmMock = staffPmModule as jest.Mocked<typeof staffPmModule>;
+export const donorMock = donorModule as jest.Mocked<typeof donorModule>;
 
 export const setCurrentUserRankLevel = (level: number): void => {
   currentUserRankLevel = level;


### PR DESCRIPTION
## Summary

- **Donor module** (`src/modules/donor.ts`): `getDonorSettings`, `updateDonorRewards`, `updateDonorForumTitle` — perk-gated field filtering, merged single-response shape (rewards + perks + forumTitle), expiry-aware active rank lookup
- **Expiry job** (`src/modules/donorExpiryJob.ts`): hourly sweep using condition-based `deleteMany` + raw SQL `NOT EXISTS` check for `isDonor` clear, preventing re-grant race conditions
- **Profile routes** (`GET/PUT /profile/me/donor-rewards`, `PUT /profile/me/donor-title`): authenticated self-service endpoints for donors to customize their rank presentation
- **Profile display** (`src/modules/profile.ts`): read-side perk enforcement in `buildDonorPresentation`; adds `iconMouseOverText` and `avatarMouseOverText` to the donor presentation response
- **Donations filter**: `GET /api/donations` now accepts optional `?userId` query param
- **Grant fix** (`src/routes/api/user.ts`): `expiresAt` is now auto-computed from `donorRank.expiresAfterDays` when not explicitly provided
- **OpenAPI**: registers `DonorRewards` schema and the four new profile routes
- **Spec tests**: 31 new tests across `donations.spec.ts`, `donorRewards.spec.ts`, `donor.spec.ts`

## Test plan

- [ ] `npx tsc --noEmit` — passes clean
- [ ] `npm run format && npm run lint` — no errors on changed files
- [ ] `npx jest --runInBand "donations|donorRewards|donor" --no-coverage` — 31/31 pass
- [ ] Full suite: `npx jest --runInBand --no-coverage` — 1181/1182 pass (pre-existing ordering flakiness in `moderation.spec.ts`, confirmed unrelated by isolating the suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)