### PR TITLE
Add rank permissions manager

### DIFF
--- a/prisma/migrations/20260526195000_rank_permissions_uniques/migration.sql
+++ b/prisma/migrations/20260526195000_rank_permissions_uniques/migration.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "user_ranks_level_key" ON "user_ranks"("level");
+CREATE UNIQUE INDEX "user_ranks_name_key" ON "user_ranks"("name");

--- a/prisma/migrations/20260526212000_secondary_ranks_and_forum_overrides/migration.sql
+++ b/prisma/migrations/20260526212000_secondary_ranks_and_forum_overrides/migration.sql
@@ -1,0 +1,26 @@
+ALTER TABLE "user_ranks"
+ADD COLUMN "secondary" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "permittedForumIds" INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[];
+
+CREATE TABLE "user_secondary_ranks" (
+  "userId" INTEGER NOT NULL,
+  "userRankId" INTEGER NOT NULL,
+  "assignedById" INTEGER,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "user_secondary_ranks_pkey" PRIMARY KEY ("userId", "userRankId")
+);
+
+CREATE INDEX "user_secondary_ranks_userRankId_idx" ON "user_secondary_ranks"("userRankId");
+CREATE INDEX "user_secondary_ranks_assignedById_idx" ON "user_secondary_ranks"("assignedById");
+
+ALTER TABLE "user_secondary_ranks"
+ADD CONSTRAINT "user_secondary_ranks_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "user_secondary_ranks"
+ADD CONSTRAINT "user_secondary_ranks_userRankId_fkey"
+FOREIGN KEY ("userRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "user_secondary_ranks"
+ADD CONSTRAINT "user_secondary_ranks_assignedById_fkey"
+FOREIGN KEY ("assignedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -278,6 +278,8 @@ model UserRank {
   level                Int
   name                 String
   permissions          Json
+  secondary            Boolean     @default(false)
+  permittedForumIds    Int[]       @default([])
   color                String      @default("")
   badge                String      @default("")
   uploadRequired       Int         @default(0)
@@ -286,9 +288,12 @@ model UserRank {
   staffGroupId         Int?
   staffGroup           StaffGroup? @relation(fields: [staffGroupId], references: [id], onDelete: SetNull)
   users                User[]
+  secondaryUsers       UserSecondaryRank[]
 
   @@index([displayStaff])
   @@index([staffGroupId])
+  @@unique([level])
+  @@unique([name])
   @@map("user_ranks")
 }
 
@@ -317,6 +322,7 @@ model User {
   avatar             String?
   userRankId         Int
   userRank           UserRank     @relation(fields: [userRankId], references: [id])
+  secondaryRanks     UserSecondaryRank[]
   userSettingsId     Int          @unique
   userSettings       UserSettings @relation(fields: [userSettingsId], references: [id])
   profileId          Int          @unique
@@ -414,6 +420,7 @@ model User {
   warningsIssued            UserWarning[]                    @relation("UserWarnedBy")
   moderationNotes           UserModerationNote[]             @relation("UserModerationNotes")
   moderationNotesAuthored   UserModerationNote[]             @relation("ModerationNoteAuthor")
+  secondaryRankAssignments  UserSecondaryRank[]              @relation("UserSecondaryRankAssignedBy")
   pmDrafts                  PmDraft[]
   massMessagesSent          MassMessage[]                    @relation("MassMessageSender")
   siteHistoryEntries        SiteHistory[]
@@ -432,6 +439,21 @@ model User {
 
   @@index([userRankId])
   @@map("users")
+}
+
+model UserSecondaryRank {
+  userId       Int
+  userRankId   Int
+  assignedById Int?
+  createdAt    DateTime @default(now())
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userRank     UserRank @relation(fields: [userRankId], references: [id], onDelete: Cascade)
+  assignedBy   User?    @relation("UserSecondaryRankAssignedBy", fields: [assignedById], references: [id], onDelete: SetNull)
+
+  @@id([userId, userRankId])
+  @@index([userRankId])
+  @@index([assignedById])
+  @@map("user_secondary_ranks")
 }
 
 model Invite {

--- a/src/dnc.spec.ts
+++ b/src/dnc.spec.ts
@@ -3,14 +3,15 @@ import {
   app,
   resetApiTestState,
   prismaMock,
-  makeUserRank
+  makeUserRank,
+  setCurrentUserPermissions
 } from './test/apiTestHarness';
 
 beforeEach(() => resetApiTestState());
 
 const setManager = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ communities_manage: true })
+  setCurrentUserPermissions(
+    makeUserRank({ dnc_manage: true }).permissions as Record<string, boolean>
   );
 
 const BASE = '/api/communities/5/dnc';
@@ -89,8 +90,10 @@ describe('POST /api/communities/:communityId/dnc', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 403 without communities_manage permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+  it('returns 403 without dnc_manage permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app)
       .post(BASE)
       .send({ name: 'Bad Label', comment: 'Do not contribute' });
@@ -127,8 +130,10 @@ describe('DELETE /api/communities/:communityId/dnc/:dncId', () => {
     expect(res.body.msg).toBe('DNC entry not found');
   });
 
-  it('returns 403 without communities_manage permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+  it('returns 403 without dnc_manage permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).delete(`${BASE}/3`);
     expect(res.status).toBe(403);
   });

--- a/src/forum.spec.ts
+++ b/src/forum.spec.ts
@@ -12,6 +12,7 @@ import {
   deleteForumMock,
   createTopicNoteMock,
   setCurrentUserRankLevel,
+  setCurrentUserPermissions,
   resetApiTestState
 } from './test/apiTestHarness';
 import {
@@ -165,8 +166,11 @@ describe('API forum flows', () => {
     prismaMock.forumPost.findFirst.mockResolvedValue(
       makeForumPost({ id: 21, forumTopicId: 44, authorId: 99 })
     );
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_moderate: true }).permissions as Record<
+        string,
+        boolean
+      >
     );
 
     const res = await request(app).delete('/api/forums/9/topics/44/posts/21');
@@ -187,8 +191,11 @@ describe('API forum flows', () => {
   });
 
   it('allows moderators to create topic notes', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_moderate: true }).permissions as Record<
+        string,
+        boolean
+      >
     );
     createTopicNoteMock.mockResolvedValue({
       id: 77,
@@ -241,8 +248,11 @@ describe('API forum flows', () => {
   });
 
   it('allows moderators to list topic notes for a topic', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_moderate: true }).permissions as Record<
+        string,
+        boolean
+      >
     );
     prismaMock.forumTopicNote.findMany.mockResolvedValue([
       {
@@ -269,11 +279,7 @@ describe('API forum flows', () => {
     const res = await request(app).get('/api/forums');
 
     expect(res.status).toBe(200);
-    expect(prismaMock.forum.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { minClassRead: { lte: 100 } }
-      })
-    );
+    expect(prismaMock.forum.findMany).toHaveBeenCalled();
     expect(res.body).toEqual([{ id: 1, name: 'Open Forum', minClassRead: 0 }]);
   });
 
@@ -368,8 +374,11 @@ describe('POST /api/forums/:id/catchup', () => {
 
 describe('POST /api/forums', () => {
   beforeEach(() =>
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_manage: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_manage: true }).permissions as Record<
+        string,
+        boolean
+      >
     )
   );
 
@@ -392,7 +401,9 @@ describe('POST /api/forums', () => {
   });
 
   it('returns 403 without forums_manage permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app).post('/api/forums').send({
       forumCategoryId: 1,
@@ -419,8 +430,11 @@ describe('POST /api/forums', () => {
 
 describe('PUT /api/forums/:id', () => {
   beforeEach(() =>
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_manage: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_manage: true }).permissions as Record<
+        string,
+        boolean
+      >
     )
   );
 
@@ -450,7 +464,9 @@ describe('PUT /api/forums/:id', () => {
   });
 
   it('returns 403 without forums_manage permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app)
       .put('/api/forums/9')
@@ -464,8 +480,11 @@ describe('PUT /api/forums/:id', () => {
 
 describe('DELETE /api/forums/:id', () => {
   beforeEach(() =>
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_manage: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_manage: true }).permissions as Record<
+        string,
+        boolean
+      >
     )
   );
 
@@ -513,7 +532,9 @@ describe('DELETE /api/forums/:id', () => {
   });
 
   it('returns 403 without forums_manage permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app).delete('/api/forums/9');
 
@@ -669,8 +690,11 @@ describe('DELETE /api/forums/:forumId/topics/:forumTopicId — success', () => {
   });
 
   it('moderator can delete any topic', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_moderate: true }).permissions as Record<
+        string,
+        boolean
+      >
     );
     prismaMock.forumTopic.findFirst.mockResolvedValue(
       makeForumTopic({ id: 44, forumId: 9, authorId: 99 })
@@ -807,8 +831,11 @@ describe('GET /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
 describe('GET /api/forums/:forumId/topics/:forumTopicId/posts/:id/edits', () => {
   it('returns moderator edit history newest first', async () => {
     prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_moderate: true }).permissions as Record<
+        string,
+        boolean
+      >
     );
     prismaMock.forumPost.findFirst.mockResolvedValue({
       ...makeForumPost({ id: 21, body: 'Current body' }),
@@ -900,8 +927,11 @@ describe('POST /api/forums/:forumId/topics/:forumTopicId/posts — error paths',
 
 describe('PUT /api/forums/:forumId/topics/:forumTopicId/posts/:id', () => {
   it('allows moderators to edit another user post', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+    setCurrentUserPermissions(
+      makeUserRank({ forums_moderate: true }).permissions as Record<
+        string,
+        boolean
+      >
     );
     prismaMock.forumPost.findFirst
       .mockResolvedValueOnce(

--- a/src/forumSub.spec.ts
+++ b/src/forumSub.spec.ts
@@ -4,6 +4,7 @@ import {
   resetApiTestState,
   prismaMock,
   makeUserRank,
+  setCurrentUserPermissions,
   createPollMock,
   closePollMock,
   castVoteMock
@@ -12,8 +13,11 @@ import {
 beforeEach(() => resetApiTestState());
 
 const setForumAdmin = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ forums_manage: true, staff: true })
+  setCurrentUserPermissions(
+    makeUserRank({
+      forums_manage: true,
+      staff: true
+    }).permissions as Record<string, boolean>
   );
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -45,6 +49,7 @@ describe('GET /api/forums/categories', () => {
   });
 
   it('returns all categories when ?all=true is passed', async () => {
+    setForumAdmin();
     prismaMock.forumCategory.findMany.mockResolvedValue([
       { id: 1, name: 'Hidden', sort: 0, forums: [] }
     ] as never);
@@ -126,7 +131,9 @@ describe('POST /api/forums/categories', () => {
   });
 
   it('returns 403 without forums_manage permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app)
       .post('/api/forums/categories')
       .send({ name: 'New' });

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -147,12 +147,15 @@ describe('API auth/profile/user flows', () => {
         dateRegistered: '2026-04-24T00:00:00.000Z',
         lastLogin: '2026-04-24T00:00:00.000Z',
         userRank: {
+          id: 1,
           level: 100,
           name: 'User',
           color: '',
           badge: '',
-          permissions: {}
-        }
+          permissions: {},
+          personalCollageLimit: 0
+        },
+        secondaryRanks: []
       })
     );
     prismaMock.invite.update.mockResolvedValueOnce({} as never);
@@ -201,12 +204,15 @@ describe('API auth/profile/user flows', () => {
       dateRegistered: '2026-04-24T00:00:00.000Z',
       lastLogin: '2026-04-24T00:00:00.000Z',
       userRank: {
+        id: 1,
         level: 100,
         name: 'User',
         color: '',
         badge: '',
-        permissions: {}
-      }
+        permissions: {},
+        personalCollageLimit: 0
+      },
+      secondaryRanks: []
     };
     prismaMock.user.findUnique.mockResolvedValue(
       makeUser({ password: 'hashed-password', disabled: false })
@@ -274,12 +280,15 @@ describe('API auth/profile/user flows', () => {
         dateRegistered: '2026-04-24T00:00:00.000Z',
         lastLogin: '2026-04-24T00:00:00.000Z',
         userRank: {
+          id: 1,
           level: 100,
           name: 'User',
           color: '',
           badge: '',
-          permissions: {}
-        }
+          permissions: {},
+          personalCollageLimit: 0
+        },
+        secondaryRanks: []
       })
     );
 

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -10,11 +10,15 @@ beforeEach(() => resetApiTestState());
 // Shared mock setup for a successful install with pre-seeded ranks/forums.
 // seedRanks/seedForums both no-op when counts > 0.
 function mockPreseededBootstrap() {
-  prismaMock.userRank.count.mockResolvedValue(4);
   prismaMock.forumCategory.count.mockResolvedValue(7);
   prismaMock.userRank.findFirst.mockResolvedValue({
     id: 13,
     level: 1000
+  } as never);
+  prismaMock.userRank.findUnique.mockResolvedValue({
+    id: 13,
+    level: 1000,
+    name: 'SysOp'
   } as never);
 }
 
@@ -38,12 +42,15 @@ function mockSysopTransaction() {
       consumed: 0n,
       ratio: 0,
       userRank: {
+        id: 13,
         level: 1000,
         name: 'SysOp',
         color: '#a0d468',
         badge: '',
-        permissions: { admin: true }
-      }
+        permissions: { admin: true },
+        personalCollageLimit: 0
+      },
+      secondaryRanks: []
     } as never);
     return (cb as (tx: typeof prismaMock) => Promise<unknown>)(tx);
   });
@@ -232,8 +239,12 @@ describe('POST /api/install', () => {
     prismaMock.user.count.mockResolvedValue(0);
     prismaMock.user.findFirst.mockResolvedValue(null);
 
-    // seedRanks: no existing ranks → creates 4
-    prismaMock.userRank.count.mockResolvedValue(0);
+    // seedRanks checks canonical levels individually.
+    prismaMock.userRank.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
     prismaMock.userRank.create
       .mockResolvedValueOnce({ id: 10, level: 100 } as never)
       .mockResolvedValueOnce({ id: 11, level: 200 } as never)

--- a/src/ipBans.spec.ts
+++ b/src/ipBans.spec.ts
@@ -3,13 +3,21 @@ import {
   app,
   prismaMock,
   makeUserRank,
-  resetApiTestState
+  resetApiTestState,
+  setCurrentUserPermissions
 } from './test/apiTestHarness';
+
+const setIpBanManager = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      ip_bans_manage: true
+    }).permissions as Record<string, boolean>
+  );
 
 beforeEach(() => resetApiTestState());
 
 describe('POST /api/ip-bans', () => {
-  it('requires admin permission', async () => {
+  it('requires ip_bans_manage permission', async () => {
     const res = await request(app).post('/api/ip-bans').send({
       fromIp: '1.2.3.4'
     });
@@ -18,9 +26,7 @@ describe('POST /api/ip-bans', () => {
   });
 
   it('rejects invalid IPv4 octets', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
-    );
+    setIpBanManager();
 
     const res = await request(app).post('/api/ip-bans').send({
       fromIp: '999.2.3.4'
@@ -31,9 +37,7 @@ describe('POST /api/ip-bans', () => {
   });
 
   it('rejects inverted ranges', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
-    );
+    setIpBanManager();
 
     const res = await request(app).post('/api/ip-bans').send({
       fromIp: '10.0.0.10',
@@ -45,9 +49,7 @@ describe('POST /api/ip-bans', () => {
   });
 
   it('stores valid ranges and serializes them back to dotted IPv4', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
-    );
+    setIpBanManager();
     prismaMock.ipBan.create.mockResolvedValue({
       id: 5,
       fromIp: 167772161,

--- a/src/lib/rankPermissions.ts
+++ b/src/lib/rankPermissions.ts
@@ -1,0 +1,329 @@
+export const PERMISSION_GROUPS = [
+  {
+    key: 'discovery',
+    title: 'Discovery',
+    permissions: [
+      {
+        key: 'advanced_search',
+        label: 'Advanced search',
+        description: 'Access advanced search and broader discovery tools.'
+      },
+      {
+        key: 'users_search',
+        label: 'Search users',
+        description: 'Access elevated user search tooling.'
+      }
+    ]
+  },
+  {
+    key: 'forums',
+    title: 'Forums',
+    permissions: [
+      {
+        key: 'forums_read',
+        label: 'Read forums',
+        description: 'Browse forum categories and topics.'
+      },
+      {
+        key: 'forums_post',
+        label: 'Post in forums',
+        description: 'Create and reply to forum topics.'
+      },
+      {
+        key: 'forums_moderate',
+        label: 'Moderate forums',
+        description: 'Edit, lock, move, and otherwise moderate forum content.'
+      },
+      {
+        key: 'forums_manage',
+        label: 'Manage forums',
+        description: 'Manage forum categories, forums, and forum settings.'
+      }
+    ]
+  },
+  {
+    key: 'communities',
+    title: 'Communities',
+    permissions: [
+      {
+        key: 'communities_manage',
+        label: 'Manage communities',
+        description: 'Create and manage communities and related metadata.'
+      },
+      {
+        key: 'contributions_manage',
+        label: 'Manage contributions',
+        description:
+          'Moderate releases, contributions, and related community content.'
+      },
+      {
+        key: 'dnc_manage',
+        label: 'Manage DNC',
+        description: 'Manage the Do Not Contribute list.'
+      }
+    ]
+  },
+  {
+    key: 'collages',
+    title: 'Collages',
+    permissions: [
+      {
+        key: 'collages_create',
+        label: 'Create collages',
+        description: 'Create new collages, including personal collages.'
+      },
+      {
+        key: 'collages_manage',
+        label: 'Manage collages',
+        description: 'Edit owned collages and manage collage entries.'
+      },
+      {
+        key: 'collages_moderate',
+        label: 'Moderate collages',
+        description: 'Recover, delete, and fully moderate collages.'
+      }
+    ]
+  },
+  {
+    key: 'requests',
+    title: 'Requests',
+    permissions: [
+      {
+        key: 'requests_create',
+        label: 'Create requests',
+        description: 'Submit new requests.'
+      },
+      {
+        key: 'requests_moderate',
+        label: 'Moderate requests',
+        description:
+          'Edit, fill, unfill, and delete requests outside ownership.'
+      }
+    ]
+  },
+  {
+    key: 'wiki',
+    title: 'Wiki',
+    permissions: [
+      {
+        key: 'wiki_edit',
+        label: 'Edit wiki',
+        description: 'Create and edit wiki pages.'
+      },
+      {
+        key: 'wiki_manage',
+        label: 'Manage wiki',
+        description: 'Manage restricted wiki operations and revision tools.'
+      }
+    ]
+  },
+  {
+    key: 'content',
+    title: 'Content',
+    permissions: [
+      {
+        key: 'news_manage',
+        label: 'Manage news',
+        description: 'Manage announcements, blog posts, and featured albums.'
+      },
+      {
+        key: 'rules_manage',
+        label: 'Manage rules',
+        description: 'Manage rules pages.'
+      },
+      {
+        key: 'tags_manage',
+        label: 'Manage tags',
+        description: 'Manage tag aliases and related tag tooling.'
+      },
+      {
+        key: 'reports_manage',
+        label: 'Manage reports',
+        description: 'Work reports queues and report resolution flows.'
+      },
+      {
+        key: 'staff_inbox_manage',
+        label: 'Manage staff inbox',
+        description: 'Work staff inbox queues, tickets, and canned responses.'
+      }
+    ]
+  },
+  {
+    key: 'users',
+    title: 'Users',
+    permissions: [
+      {
+        key: 'users_edit',
+        label: 'Edit users',
+        description: 'Create users and manage user account state.'
+      },
+      {
+        key: 'users_warn',
+        label: 'Warn users',
+        description: 'Issue and remove user warnings.'
+      },
+      {
+        key: 'users_disable',
+        label: 'Disable users',
+        description: 'Enable or disable user accounts.'
+      },
+      {
+        key: 'users_view_ips',
+        label: 'View IP history',
+        description: 'View per-user IP history.'
+      },
+      {
+        key: 'users_view_email',
+        label: 'View email history',
+        description: 'View per-user email history.'
+      },
+      {
+        key: 'recovery_manage',
+        label: 'Manage recovery',
+        description:
+          'Manage account recovery requests and trigger recovery emails.'
+      },
+      {
+        key: 'invites_manage',
+        label: 'Manage invites',
+        description: 'Access invite pool and invite tree tools.'
+      },
+      {
+        key: 'ratio_policy_manage',
+        label: 'Manage ratio policy',
+        description: 'Manage ratio policy tools and ratio watch.'
+      }
+    ]
+  },
+  {
+    key: 'operations',
+    title: 'Operations',
+    permissions: [
+      {
+        key: 'site_history_manage',
+        label: 'Manage site history',
+        description: 'Manage site history entries.'
+      },
+      {
+        key: 'ip_bans_manage',
+        label: 'Manage IP bans',
+        description: 'Manage IP ban ranges.'
+      },
+      {
+        key: 'email_blacklist_manage',
+        label: 'Manage email blacklist',
+        description: 'Manage blacklisted email domains and addresses.'
+      },
+      {
+        key: 'donor_ranks_manage',
+        label: 'Manage donor ranks',
+        description: 'Manage donor ranks and donor assignments.'
+      },
+      {
+        key: 'donation_log_view',
+        label: 'View donation log',
+        description: 'Access donation log and related finance read tools.'
+      },
+      {
+        key: 'messages_mass_pm',
+        label: 'Send mass PMs',
+        description: 'Send site-wide mass private messages.'
+      }
+    ]
+  },
+  {
+    key: 'staffTools',
+    title: 'Staff Tools',
+    permissions: [
+      {
+        key: 'login_watch_view',
+        label: 'View login watch',
+        description: 'Access login watch session tools.'
+      },
+      {
+        key: 'duplicate_ips_view',
+        label: 'View duplicate IPs',
+        description: 'Access duplicate IP reports.'
+      },
+      {
+        key: 'registration_log_view',
+        label: 'View registration log',
+        description: 'Access registration logs.'
+      },
+      {
+        key: 'staff',
+        label: 'General staff',
+        description:
+          'Access general staff-only surfaces not broken out further.'
+      }
+    ]
+  },
+  {
+    key: 'administration',
+    title: 'Administration',
+    permissions: [
+      {
+        key: 'rank_permissions_manage',
+        label: 'Manage rank permissions',
+        description: 'Create, edit, and delete user ranks and permission sets.'
+      },
+      {
+        key: 'staff_groups_manage',
+        label: 'Manage staff groups',
+        description: 'Create, edit, and delete staff groups.'
+      },
+      {
+        key: 'admin',
+        label: 'Administrator',
+        description: 'Global administrative override.'
+      }
+    ]
+  }
+] as const;
+
+type PermissionEntry =
+  (typeof PERMISSION_GROUPS)[number]['permissions'][number];
+
+export const VALID_PERMISSIONS = PERMISSION_GROUPS.flatMap((group) =>
+  group.permissions.map((permission) => permission.key)
+) as [PermissionEntry['key'], ...PermissionEntry['key'][]];
+
+export type Permission = (typeof VALID_PERMISSIONS)[number];
+
+export type PermissionMap = Partial<Record<Permission, boolean>>;
+
+export const permissionLabelByKey = Object.fromEntries(
+  PERMISSION_GROUPS.flatMap((group) =>
+    group.permissions.map((permission) => [permission.key, permission.label])
+  )
+) as Record<Permission, string>;
+
+export const ALL_PERMISSIONS = Object.fromEntries(
+  VALID_PERMISSIONS.map((permission) => [permission, true])
+) as Record<Permission, true>;
+
+export const normalizePermissions = (
+  permissions: Record<string, boolean> | null | undefined
+): PermissionMap => {
+  const normalized: PermissionMap = {};
+  if (!permissions) return normalized;
+  for (const key of VALID_PERMISSIONS) {
+    if (permissions[key]) normalized[key] = true;
+  }
+  return normalized;
+};
+
+export const hasPermission = (
+  permissions: Record<string, boolean> | null | undefined,
+  permission: Permission
+): boolean => {
+  if (!permissions) return false;
+  if (permissions.admin) return true;
+  return !!permissions[permission];
+};
+
+export const hasAnyPermission = (
+  permissions: Record<string, boolean> | null | undefined,
+  required: Permission[]
+): boolean =>
+  required.some((permission) => hasPermission(permissions, permission));

--- a/src/lib/userRankAccess.ts
+++ b/src/lib/userRankAccess.ts
@@ -1,0 +1,109 @@
+import { prisma } from './prisma';
+import { normalizePermissions, type PermissionMap } from './rankPermissions';
+
+type RankSlice = {
+  id: number;
+  level: number;
+  permissions: unknown;
+  permittedForumIds: number[];
+};
+
+type UserRankAccessRow = {
+  userRankId: number;
+  userRank: RankSlice | null;
+  secondaryRanks: Array<{
+    userRankId: number;
+    userRank: RankSlice;
+  }>;
+};
+
+export type UserRankAccess = {
+  userRankId: number;
+  effectiveLevel: number;
+  permissions: PermissionMap;
+  permittedForumIds: number[];
+  secondaryRankIds: number[];
+};
+
+const mergeRankPermissions = (ranks: RankSlice[]): PermissionMap => {
+  const merged: PermissionMap = {};
+  for (const rank of ranks) {
+    Object.assign(
+      merged,
+      normalizePermissions(rank.permissions as Record<string, boolean> | null)
+    );
+  }
+  return merged;
+};
+
+export const computeUserRankAccess = (
+  user: UserRankAccessRow
+): UserRankAccess => {
+  const primary = user.userRank;
+  const secondary = user.secondaryRanks.map((entry) => entry.userRank);
+  const allRanks = [primary, ...secondary].filter(Boolean) as RankSlice[];
+
+  const effectiveLevel = allRanks.reduce(
+    (maxLevel, rank) => Math.max(maxLevel, rank.level),
+    0
+  );
+
+  const permittedForumIds = [
+    ...new Set(allRanks.flatMap((rank) => rank.permittedForumIds ?? []))
+  ].sort((a, b) => a - b);
+
+  return {
+    userRankId: user.userRankId,
+    effectiveLevel,
+    permissions: mergeRankPermissions(allRanks),
+    permittedForumIds,
+    secondaryRankIds: user.secondaryRanks.map((entry) => entry.userRankId)
+  };
+};
+
+export const getUserRankAccess = async (
+  userId: number
+): Promise<UserRankAccess | null> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      userRankId: true,
+      userRank: {
+        select: {
+          id: true,
+          level: true,
+          permissions: true,
+          permittedForumIds: true
+        }
+      },
+      secondaryRanks: {
+        select: {
+          userRankId: true,
+          userRank: {
+            select: {
+              id: true,
+              level: true,
+              permissions: true,
+              permittedForumIds: true
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!user) return null;
+  return computeUserRankAccess(user);
+};
+
+export const canAccessForumLevel = (
+  user:
+    | { userRankLevel: number; permittedForumIds?: number[] }
+    | null
+    | undefined,
+  forumId: number,
+  requiredLevel: number | null | undefined
+): boolean =>
+  !!user &&
+  (user.userRankLevel >= (requiredLevel ?? 0) ||
+    !!user.permittedForumIds?.includes(forumId));

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { auth as authConfig } from '../modules/config';
 import { prisma } from '../lib/prisma';
+import { computeUserRankAccess } from '../lib/userRankAccess';
 
 interface JwtPayload {
   user: { id: number; sessionId?: string };
@@ -25,7 +26,27 @@ export const requireAuth = async (
         id: true,
         userRankId: true,
         disabled: true,
-        userRank: { select: { level: true } }
+        userRank: {
+          select: {
+            id: true,
+            level: true,
+            permissions: true,
+            permittedForumIds: true
+          }
+        },
+        secondaryRanks: {
+          select: {
+            userRankId: true,
+            userRank: {
+              select: {
+                id: true,
+                level: true,
+                permissions: true,
+                permittedForumIds: true
+              }
+            }
+          }
+        }
       }
     });
     if (!user || user.disabled) {
@@ -60,10 +81,15 @@ export const requireAuth = async (
         .catch(() => undefined);
     }
 
+    const rankAccess = computeUserRankAccess(user);
+
     req.user = {
       id: user.id,
       userRankId: user.userRankId,
-      userRankLevel: user.userRank?.level ?? 0
+      userRankLevel: rankAccess.effectiveLevel,
+      secondaryRankIds: rankAccess.secondaryRankIds,
+      permittedForumIds: rankAccess.permittedForumIds,
+      permissions: rankAccess.permissions as Record<string, boolean>
     };
     next();
   } catch {

--- a/src/middleware/permissions.spec.ts
+++ b/src/middleware/permissions.spec.ts
@@ -5,12 +5,10 @@
 
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 
-const findUniqueMock = jest.fn();
+const getUserRankAccessMock = jest.fn();
 
-jest.mock('../lib/prisma', () => ({
-  prisma: {
-    userRank: { findUnique: (...args: unknown[]) => findUniqueMock(...args) }
-  }
+jest.mock('../lib/userRankAccess', () => ({
+  getUserRankAccess: (...args: unknown[]) => getUserRankAccessMock(...args)
 }));
 
 const requireAuthMock = jest.fn(
@@ -62,7 +60,9 @@ describe('requirePermission', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('calls next() when user has the required permission', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: { wiki_edit: true } });
+    getUserRankAccessMock.mockResolvedValue({
+      permissions: { wiki_edit: true }
+    });
     const [req, res, next] = makeReqRes();
     const [, checkMw] = requirePermission('wiki_edit');
     await checkMw(req, res as unknown as Response, next);
@@ -71,7 +71,7 @@ describe('requirePermission', () => {
   });
 
   it('returns 403 when user lacks the required permission', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: {} });
+    getUserRankAccessMock.mockResolvedValue({ permissions: {} });
     const [req, res, next] = makeReqRes();
     const [, checkMw] = requirePermission('wiki_edit');
     await checkMw(req, res as unknown as Response, next);
@@ -80,25 +80,36 @@ describe('requirePermission', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('staff permission satisfies admin gate', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: { staff: true } });
+  it('admin permission satisfies any delegated gate', async () => {
+    getUserRankAccessMock.mockResolvedValue({ permissions: { admin: true } });
     const [req, res, next] = makeReqRes();
-    const [, checkMw] = requirePermission('admin');
+    const [, checkMw] = requirePermission('rank_permissions_manage');
     await checkMw(req, res as unknown as Response, next);
     expect(next).toHaveBeenCalledWith();
   });
 
   it('accepts any of multiple permissions (first match)', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: { forums_manage: true } });
+    getUserRankAccessMock.mockResolvedValue({
+      permissions: { forums_manage: true }
+    });
     const [req, res, next] = makeReqRes();
     const [, checkMw] = requirePermission('admin', 'forums_manage');
     await checkMw(req, res as unknown as Response, next);
     expect(next).toHaveBeenCalledWith();
   });
 
+  it('does not treat staff as an implicit login-watch permission', async () => {
+    getUserRankAccessMock.mockResolvedValue({ permissions: { staff: true } });
+    const [req, res, next] = makeReqRes();
+    const [, checkMw] = requirePermission('login_watch_view');
+    await checkMw(req, res as unknown as Response, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('propagates errors from loadPermissions via next(err)', async () => {
     const dbError = new Error('DB connection lost');
-    findUniqueMock.mockRejectedValue(dbError);
+    getUserRankAccessMock.mockRejectedValue(dbError);
     const [req, res, next] = makeReqRes();
     const [, checkMw] = requirePermission('admin');
     await checkMw(req, res as unknown as Response, next);
@@ -121,11 +132,11 @@ describe('requireOwnerOrPermission', () => {
     const [, checkMw] = requireOwnerOrPermission(getOwnerId, 'admin');
     await checkMw(req, res as unknown as Response, next);
     expect(next).toHaveBeenCalledWith();
-    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(getUserRankAccessMock).not.toHaveBeenCalled();
   });
 
   it('calls next() when user has the required permission (non-owner)', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: { admin: true } });
+    getUserRankAccessMock.mockResolvedValue({ permissions: { admin: true } });
     const [req, res, next] = makeReqRes(7);
     (req as unknown as { ownerId: number }).ownerId = 99; // different owner
     const [, checkMw] = requireOwnerOrPermission(getOwnerId, 'admin');
@@ -134,7 +145,7 @@ describe('requireOwnerOrPermission', () => {
   });
 
   it('returns 403 when non-owner lacks permission', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: {} });
+    getUserRankAccessMock.mockResolvedValue({ permissions: {} });
     const [req, res, next] = makeReqRes(7);
     (req as unknown as { ownerId: number }).ownerId = 99;
     const [, checkMw] = requireOwnerOrPermission(getOwnerId, 'admin');
@@ -145,7 +156,7 @@ describe('requireOwnerOrPermission', () => {
 
   it('propagates errors via next(err)', async () => {
     const dbError = new Error('DB down');
-    findUniqueMock.mockRejectedValue(dbError);
+    getUserRankAccessMock.mockRejectedValue(dbError);
     const [req, res, next] = makeReqRes(7);
     (req as unknown as { ownerId: number }).ownerId = 99;
     const [, checkMw] = requireOwnerOrPermission(getOwnerId, 'admin');
@@ -154,7 +165,7 @@ describe('requireOwnerOrPermission', () => {
   });
 
   it('treats null ownerId as non-owner and falls through to permission check', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: { admin: true } });
+    getUserRankAccessMock.mockResolvedValue({ permissions: { admin: true } });
     const getOwnerNull = (_req: Request) => null;
     const [req, res, next] = makeReqRes(7);
     const [, checkMw] = requireOwnerOrPermission(getOwnerNull, 'admin');
@@ -169,7 +180,7 @@ describe('isModerator', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('returns true when user has forums_moderate permission', async () => {
-    findUniqueMock.mockResolvedValue({
+    getUserRankAccessMock.mockResolvedValue({
       permissions: { forums_moderate: true }
     });
     const [req, res] = makeReqRes();
@@ -181,7 +192,7 @@ describe('isModerator', () => {
   });
 
   it('returns true when user has staff permission', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: { staff: true } });
+    getUserRankAccessMock.mockResolvedValue({ permissions: { staff: true } });
     const [req, res] = makeReqRes();
     const result = await isModerator(
       req as unknown as AuthenticatedRequest,
@@ -191,7 +202,7 @@ describe('isModerator', () => {
   });
 
   it('returns false when user has no moderator permissions', async () => {
-    findUniqueMock.mockResolvedValue({ permissions: {} });
+    getUserRankAccessMock.mockResolvedValue({ permissions: {} });
     const [req, res] = makeReqRes();
     const result = await isModerator(
       req as unknown as AuthenticatedRequest,

--- a/src/middleware/permissions.ts
+++ b/src/middleware/permissions.ts
@@ -1,51 +1,30 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
-import { prisma } from '../lib/prisma';
 import { requireAuth } from './auth';
 import type { AuthenticatedRequest } from '../types/auth';
+import {
+  type Permission,
+  hasPermission,
+  normalizePermissions,
+  VALID_PERMISSIONS
+} from '../lib/rankPermissions';
+import { getUserRankAccess } from '../lib/userRankAccess';
 
-export const VALID_PERMISSIONS = [
-  'forums_read',
-  'forums_post',
-  'forums_moderate',
-  'forums_manage',
-  'communities_manage',
-  'collages_manage',
-  'collages_moderate',
-  'news_manage',
-  'invites_manage',
-  'users_edit',
-  'users_warn',
-  'users_disable',
-  'wiki_edit',
-  'wiki_manage',
-  'rules_manage',
-  'advanced_search',
-  'users_search',
-  'staff',
-  'admin'
-] as const;
-
-export type Permission = (typeof VALID_PERMISSIONS)[number];
-
-const hasPermission = (
-  perms: Record<string, boolean>,
-  permission: Permission
-): boolean => {
-  // staff permission also satisfies admin gates
-  if (permission === 'admin') return !!(perms['admin'] || perms['staff']);
-  return !!perms[permission];
-};
+export { VALID_PERMISSIONS };
+export type { Permission };
 
 export const loadPermissions = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<Record<string, boolean>> => {
   if (res.locals.userPerms) return res.locals.userPerms;
-  const rank = await prisma.userRank.findUnique({
-    where: { id: req.user.userRankId },
-    select: { permissions: true }
-  });
-  res.locals.userPerms = (rank?.permissions ?? {}) as Record<string, boolean>;
+  if (req.user.permissions) {
+    res.locals.userPerms = req.user.permissions;
+    return res.locals.userPerms;
+  }
+
+  const access = await getUserRankAccess(req.user.id);
+  res.locals.userPerms = (access?.permissions ??
+    normalizePermissions(null)) as Record<string, boolean>;
   return res.locals.userPerms;
 };
 

--- a/src/moderation.spec.ts
+++ b/src/moderation.spec.ts
@@ -29,6 +29,14 @@ const setStaff = () =>
     }).permissions as Record<string, boolean>
   );
 
+const setUserHistoryViewer = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      users_view_ips: true,
+      users_view_email: true
+    }).permissions as Record<string, boolean>
+  );
+
 const setAdmin = () =>
   setCurrentUserPermissions(
     makeUserRank({
@@ -37,6 +45,20 @@ const setAdmin = () =>
       users_warn: true,
       users_disable: true,
       users_edit: true
+    }).permissions as Record<string, boolean>
+  );
+
+const setDonorRankManager = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      donor_ranks_manage: true
+    }).permissions as Record<string, boolean>
+  );
+
+const setRecoveryManager = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      recovery_manage: true
     }).permissions as Record<string, boolean>
   );
 
@@ -282,7 +304,7 @@ describe('PUT /api/users/:id/rank', () => {
     expect(res.body.msg).toBe('Rank updated');
   });
 
-  it('returns 403 without admin permission', async () => {
+  it('returns 403 without users_edit permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -301,7 +323,7 @@ describe('PUT /api/users/:id/rank', () => {
 // ─── IP history ───────────────────────────────────────────────────────────────
 
 describe('GET /api/users/:id/ip-history', () => {
-  beforeEach(() => setStaff());
+  beforeEach(() => setUserHistoryViewer());
 
   it('returns session IP history for the target user', async () => {
     prismaMock.userSession.findMany.mockResolvedValue([
@@ -386,7 +408,7 @@ describe('GET /api/users/:id/ip-history', () => {
     expect(res.body).toHaveLength(1);
   });
 
-  it('returns 403 without staff permission', async () => {
+  it('returns 403 without users_view_ips permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -396,7 +418,7 @@ describe('GET /api/users/:id/ip-history', () => {
 });
 
 describe('GET /api/users/:id/email-history', () => {
-  beforeEach(() => setStaff());
+  beforeEach(() => setUserHistoryViewer());
 
   it('returns email history entries in the frontend contract shape', async () => {
     prismaMock.userEmailHistory.findMany.mockResolvedValue([
@@ -419,6 +441,14 @@ describe('GET /api/users/:id/email-history', () => {
         changedAt: '2026-05-01T00:00:00.000Z'
       }
     ]);
+  });
+
+  it('returns 403 without users_view_email permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
+    const res = await request(app).get('/api/users/9/email-history');
+    expect(res.status).toBe(403);
   });
 });
 
@@ -444,7 +474,7 @@ describe('GET /api/users/donor-ranks', () => {
 });
 
 describe('POST /api/users/donor-ranks', () => {
-  beforeEach(() => setAdmin());
+  beforeEach(() => setDonorRankManager());
 
   it('creates a donor rank and returns 201', async () => {
     prismaMock.donorRank.create.mockResolvedValue({
@@ -491,7 +521,7 @@ describe('POST /api/users/donor-ranks', () => {
     expect(res.body.badge).toBe('plat');
   });
 
-  it('returns 403 without admin permission', async () => {
+  it('returns 403 without donor_ranks_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -773,7 +803,7 @@ describe('DELETE /api/users/:id/warnings/:warnId', () => {
 // ─── Donor rank update and deletion ──────────────────────────────────────────
 
 describe('PUT /api/users/donor-ranks/:rankId', () => {
-  beforeEach(() => setAdmin());
+  beforeEach(() => setDonorRankManager());
 
   it('updates a donor rank and returns it', async () => {
     const existing = { id: 2, name: 'Silver', minDonation: 2000 };
@@ -828,7 +858,7 @@ describe('PUT /api/users/donor-ranks/:rankId', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 403 without admin permission', async () => {
+  it('returns 403 without donor_ranks_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -842,7 +872,7 @@ describe('PUT /api/users/donor-ranks/:rankId', () => {
 });
 
 describe('DELETE /api/users/donor-ranks/:rankId', () => {
-  beforeEach(() => setAdmin());
+  beforeEach(() => setDonorRankManager());
 
   it('deletes a donor rank and returns 204', async () => {
     prismaMock.donorRank.findUnique.mockResolvedValue({ id: 2 } as never);
@@ -1092,14 +1122,8 @@ describe('POST /api/users/:id/donor with expiresAt', () => {
 
 // ─── Staff recovery queue ─────────────────────────────────────────────────────
 
-const setUsersEdit = () =>
-  setCurrentUserPermissions(
-    makeUserRank({ users_edit: true, staff: true, admin: true })
-      .permissions as Record<string, boolean>
-  );
-
 describe('GET /api/users/recovery-requests', () => {
-  beforeEach(() => setUsersEdit());
+  beforeEach(() => setRecoveryManager());
 
   it('returns paginated pending recovery requests', async () => {
     prismaMock.accountRecovery.findMany.mockResolvedValue([
@@ -1123,7 +1147,7 @@ describe('GET /api/users/recovery-requests', () => {
     expect(res.body.meta.total).toBe(1);
   });
 
-  it('returns 403 without users_edit permission', async () => {
+  it('returns 403 without recovery_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -1133,7 +1157,7 @@ describe('GET /api/users/recovery-requests', () => {
 });
 
 describe('DELETE /api/users/recovery-requests/:reqId', () => {
-  beforeEach(() => setUsersEdit());
+  beforeEach(() => setRecoveryManager());
 
   it('deletes a pending recovery request and audits', async () => {
     prismaMock.accountRecovery.findUnique.mockResolvedValue({
@@ -1164,7 +1188,7 @@ describe('DELETE /api/users/recovery-requests/:reqId', () => {
     expect(res.status).toBe(409);
   });
 
-  it('returns 403 without users_edit permission', async () => {
+  it('returns 403 without recovery_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -1174,7 +1198,7 @@ describe('DELETE /api/users/recovery-requests/:reqId', () => {
 });
 
 describe('POST /api/users/:id/recovery', () => {
-  beforeEach(() => setUsersEdit());
+  beforeEach(() => setRecoveryManager());
 
   it('sends a recovery email and audits', async () => {
     sendRecoveryEmailMock.mockResolvedValue(true);
@@ -1208,7 +1232,7 @@ describe('POST /api/users/:id/recovery', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 403 without users_edit permission', async () => {
+  it('returns 403 without recovery_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );

--- a/src/moderation.spec.ts
+++ b/src/moderation.spec.ts
@@ -4,6 +4,7 @@ import {
   resetApiTestState,
   prismaMock,
   makeUserRank,
+  setCurrentUserPermissions,
   getUserSettingsMock,
   updateUserSettingsMock,
   createUserMock
@@ -18,19 +19,25 @@ beforeEach(() => resetApiTestState());
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const setStaff = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true, users_warn: true, users_disable: true })
+  setCurrentUserPermissions(
+    makeUserRank({
+      staff: true,
+      users_warn: true,
+      users_disable: true,
+      users_edit: true,
+      donor_ranks_manage: true
+    }).permissions as Record<string, boolean>
   );
 
 const setAdmin = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
+  setCurrentUserPermissions(
     makeUserRank({
       admin: true,
       staff: true,
       users_warn: true,
       users_disable: true,
       users_edit: true
-    })
+    }).permissions as Record<string, boolean>
   );
 
 const mockTargetUser = (overrides = {}) =>
@@ -64,7 +71,9 @@ describe('GET /api/users/:id/warnings', () => {
   });
 
   it('returns 403 without staff permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).get('/api/users/9/warnings');
     expect(res.status).toBe(403);
   });
@@ -251,23 +260,32 @@ describe('PUT /api/users/:id/rank', () => {
 
   it('updates the user rank and returns a msg', async () => {
     mockTargetUser();
-    // Second findUnique call is for the rank lookup
     prismaMock.userRank.findUnique
       .mockResolvedValueOnce(makeUserRank({ admin: true })) // permission check
-      .mockResolvedValueOnce(makeUserRank()); // rank existence check
-    prismaMock.user.update.mockResolvedValue(makeUser());
+      .mockResolvedValueOnce(null);
+    prismaMock.userRank.findMany.mockResolvedValue([
+      { id: 2, secondary: false },
+      { id: 5, secondary: true }
+    ] as never);
+    prismaMock.$transaction.mockResolvedValue([
+      makeUser(),
+      {},
+      { count: 1 }
+    ] as never);
     prismaMock.auditLog.create.mockResolvedValue({} as never);
 
     const res = await request(app)
       .put('/api/users/9/rank')
-      .send({ userRankId: 2 });
+      .send({ userRankId: 2, secondaryRankIds: [5] });
 
     expect(res.status).toBe(200);
     expect(res.body.msg).toBe('Rank updated');
   });
 
   it('returns 403 without admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app)
       .put('/api/users/9/rank')
       .send({ userRankId: 2 });
@@ -369,7 +387,9 @@ describe('GET /api/users/:id/ip-history', () => {
   });
 
   it('returns 403 without staff permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).get('/api/users/9/ip-history');
     expect(res.status).toBe(403);
   });
@@ -472,7 +492,9 @@ describe('POST /api/users/donor-ranks', () => {
   });
 
   it('returns 403 without admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app)
       .post('/api/users/donor-ranks')
       .send({ name: 'Gold', minDonation: 5000 });
@@ -668,7 +690,9 @@ describe('POST /api/users', () => {
   });
 
   it('returns 403 without users_edit permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app).post('/api/users').send({
       username: 'newuser',
@@ -805,7 +829,9 @@ describe('PUT /api/users/donor-ranks/:rankId', () => {
   });
 
   it('returns 403 without admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app)
       .put('/api/users/donor-ranks/2')
@@ -935,7 +961,9 @@ describe('GET /api/users/:id/snatch-list', () => {
   });
 
   it('returns 403 without staff permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).get('/api/users/9/snatch-list');
     expect(res.status).toBe(403);
   });
@@ -1002,7 +1030,8 @@ describe('PUT /api/users/:id/rank — rank not found', () => {
     prismaMock.user.findUnique.mockResolvedValue(makeUser({ id: 9 }) as never);
     prismaMock.userRank.findUnique
       .mockResolvedValueOnce(makeUserRank({ admin: true, users_edit: true })) // permission check
-      .mockResolvedValueOnce(null); // rank existence check → not found
+      .mockResolvedValueOnce(null);
+    prismaMock.userRank.findMany.mockResolvedValue([] as never);
 
     const res = await request(app)
       .put('/api/users/9/rank')
@@ -1021,6 +1050,24 @@ describe('PUT /api/users/:id/rank — rank not found', () => {
 
     expect(res.status).toBe(404);
     expect(res.body.msg).toBe('User not found');
+  });
+
+  it('returns 422 when a non-secondary rank is assigned as a secondary class', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(makeUser({ id: 9 }) as never);
+    prismaMock.userRank.findUnique
+      .mockResolvedValueOnce(makeUserRank({ admin: true, users_edit: true }))
+      .mockResolvedValueOnce(null);
+    prismaMock.userRank.findMany.mockResolvedValue([
+      { id: 2, secondary: false },
+      { id: 6, secondary: false }
+    ] as never);
+
+    const res = await request(app)
+      .put('/api/users/9/rank')
+      .send({ userRankId: 2, secondaryRankIds: [6] });
+
+    expect(res.status).toBe(422);
+    expect(res.body.msg).toMatch(/secondary-class ranks/);
   });
 });
 
@@ -1046,8 +1093,9 @@ describe('POST /api/users/:id/donor with expiresAt', () => {
 // ─── Staff recovery queue ─────────────────────────────────────────────────────
 
 const setUsersEdit = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
+  setCurrentUserPermissions(
     makeUserRank({ users_edit: true, staff: true, admin: true })
+      .permissions as Record<string, boolean>
   );
 
 describe('GET /api/users/recovery-requests', () => {
@@ -1076,7 +1124,9 @@ describe('GET /api/users/recovery-requests', () => {
   });
 
   it('returns 403 without users_edit permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).get('/api/users/recovery-requests');
     expect(res.status).toBe(403);
   });
@@ -1115,7 +1165,9 @@ describe('DELETE /api/users/recovery-requests/:reqId', () => {
   });
 
   it('returns 403 without users_edit permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).delete('/api/users/recovery-requests/5');
     expect(res.status).toBe(403);
   });
@@ -1157,7 +1209,9 @@ describe('POST /api/users/:id/recovery', () => {
   });
 
   it('returns 403 without users_edit permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
     const res = await request(app).post('/api/users/9/recovery');
     expect(res.status).toBe(403);
   });
@@ -1180,9 +1234,12 @@ describe('PUT /api/users/:id/staff-bio', () => {
   });
 
   it('allows a staff-listed user to edit their own bio', async () => {
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(makeUserRank() as never)
-      .mockResolvedValueOnce({ displayStaff: true } as never);
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
+    prismaMock.userRank.findUnique.mockResolvedValueOnce({
+      displayStaff: true
+    } as never);
     prismaMock.user.findUnique.mockResolvedValue({ id: 7 } as never);
     prismaMock.user.update.mockResolvedValue(makeUser({ id: 7 }) as never);
     prismaMock.auditLog.create.mockResolvedValue({} as never);
@@ -1199,9 +1256,12 @@ describe('PUT /api/users/:id/staff-bio', () => {
   });
 
   it('returns 403 when a non-staff-listed user edits their own bio', async () => {
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(makeUserRank() as never)
-      .mockResolvedValueOnce({ displayStaff: false } as never);
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
+    prismaMock.userRank.findUnique.mockResolvedValueOnce({
+      displayStaff: false
+    } as never);
 
     const res = await request(app)
       .put('/api/users/7/staff-bio')
@@ -1211,7 +1271,9 @@ describe('PUT /api/users/:id/staff-bio', () => {
   });
 
   it('returns 403 when a non-admin edits another user bio', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app)
       .put('/api/users/9/staff-bio')

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import { computeRatio } from './ratio';
+import { computeUserRankAccess } from '../lib/userRankAccess';
 
 export const isPasswordBanned = async (password: string): Promise<boolean> => {
   const found = await prisma.badPassword.findFirst({ where: { password } });
@@ -26,12 +27,27 @@ export const authUserSelect = {
   ratio: true,
   userRank: {
     select: {
+      id: true,
       level: true,
       name: true,
       color: true,
       badge: true,
       permissions: true,
       personalCollageLimit: true
+    }
+  },
+  secondaryRanks: {
+    select: {
+      userRankId: true,
+      userRank: {
+        select: {
+          id: true,
+          level: true,
+          permissions: true,
+          permittedForumIds: true,
+          personalCollageLimit: true
+        }
+      }
     }
   }
 } as const;
@@ -45,6 +61,33 @@ export type AuthUser = Omit<RawAuthUser, 'contributed' | 'consumed'> & {
 
 export const toAuthUser = (raw: RawAuthUser): AuthUser => ({
   ...raw,
+  userRank: {
+    ...raw.userRank,
+    permissions: computeUserRankAccess({
+      userRankId: raw.userRank.id,
+      userRank: {
+        id: raw.userRank.id,
+        level: raw.userRank.level,
+        permissions: raw.userRank.permissions,
+        permittedForumIds: []
+      },
+      secondaryRanks: raw.secondaryRanks.map((entry) => ({
+        userRankId: entry.userRankId,
+        userRank: {
+          id: entry.userRank.id,
+          level: entry.userRank.level,
+          permissions: entry.userRank.permissions,
+          permittedForumIds: entry.userRank.permittedForumIds
+        }
+      }))
+    }).permissions,
+    personalCollageLimit: Math.max(
+      raw.userRank.personalCollageLimit ?? 0,
+      ...raw.secondaryRanks.map(
+        (entry) => entry.userRank.personalCollageLimit ?? 0
+      )
+    )
+  },
   ratio: computeRatio(raw.contributed, raw.consumed),
   contributed: raw.contributed.toString(),
   consumed: raw.consumed.toString()

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -3,27 +3,48 @@
  * Each function is a no-op when the relevant rows already exist.
  */
 import { PrismaClient } from '@prisma/client';
+import { ALL_PERMISSIONS } from '../lib/rankPermissions';
 
 export const DEFAULT_RANKS = [
   {
     level: 100,
     name: 'User',
+    secondary: false,
+    permittedForumIds: [],
     color: '',
     badge: '',
     personalCollageLimit: 1,
-    permissions: { forums_read: true, forums_post: true }
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      collages_create: true,
+      requests_create: true,
+      wiki_edit: true
+    }
   },
   {
     level: 200,
     name: 'Power User',
+    secondary: false,
+    permittedForumIds: [],
     color: '#e2a822',
     badge: '',
     personalCollageLimit: 2,
-    permissions: { forums_read: true, forums_post: true }
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
   },
   {
     level: 500,
     name: 'Staff',
+    secondary: false,
+    permittedForumIds: [],
     color: '#e22a2a',
     badge: '',
     personalCollageLimit: 3,
@@ -33,34 +54,35 @@ export const DEFAULT_RANKS = [
       forums_moderate: true,
       forums_manage: true,
       communities_manage: true,
+      contributions_manage: true,
+      collages_create: true,
+      collages_manage: true,
+      collages_moderate: true,
       news_manage: true,
+      requests_create: true,
+      requests_moderate: true,
+      reports_manage: true,
+      staff_inbox_manage: true,
+      tags_manage: true,
       invites_manage: true,
+      recovery_manage: true,
       users_edit: true,
       users_warn: true,
       users_disable: true,
+      users_view_ips: true,
+      users_view_email: true,
       staff: true
     }
   },
   {
     level: 1000,
     name: 'SysOp',
+    secondary: false,
+    permittedForumIds: [],
     color: '#a0d468',
     badge: '',
     personalCollageLimit: 4,
-    permissions: {
-      forums_read: true,
-      forums_post: true,
-      forums_moderate: true,
-      forums_manage: true,
-      communities_manage: true,
-      news_manage: true,
-      invites_manage: true,
-      users_edit: true,
-      users_warn: true,
-      users_disable: true,
-      staff: true,
-      admin: true
-    }
+    permissions: ALL_PERMISSIONS
   }
 ] as const;
 
@@ -254,10 +276,35 @@ type ForumEntry = {
 };
 
 export async function seedRanks(client: PrismaClient): Promise<void> {
-  const existing = await client.userRank.count();
-  if (existing > 0) return;
   for (const rank of DEFAULT_RANKS) {
-    await client.userRank.create({ data: rank });
+    const existing = await client.userRank.findUnique({
+      where: { level: rank.level }
+    });
+
+    if (!existing) {
+      await client.userRank.create({
+        data: {
+          ...rank,
+          permittedForumIds: [...rank.permittedForumIds]
+        }
+      });
+      continue;
+    }
+
+    if (existing.name !== rank.name) continue;
+
+    await client.userRank.update({
+      where: { id: existing.id },
+      data: {
+        name: rank.name,
+        secondary: rank.secondary,
+        permittedForumIds: [...rank.permittedForumIds],
+        color: rank.color,
+        badge: rank.badge,
+        personalCollageLimit: rank.personalCollageLimit,
+        permissions: rank.permissions
+      }
+    });
   }
 }
 

--- a/src/modules/forum.ts
+++ b/src/modules/forum.ts
@@ -320,13 +320,27 @@ export const closePoll = async (id: number) =>
 
 export const castVote = async (
   forumPollId: number,
-  user: {
-    id: number;
-    userRankLevel: number;
-    permittedForumIds?: number[];
-  },
-  vote: number
+  userOrId:
+    | {
+        id: number;
+        userRankLevel: number;
+        permittedForumIds?: number[];
+      }
+    | number,
+  userRankLevelOrVote: number,
+  maybeVote?: number
 ): Promise<CastVoteResult> => {
+  const user =
+    typeof userOrId === 'number'
+      ? {
+          id: userOrId,
+          userRankLevel: userRankLevelOrVote,
+          permittedForumIds: []
+        }
+      : userOrId;
+  const vote =
+    typeof userOrId === 'number' ? maybeVote ?? 0 : userRankLevelOrVote;
+
   const poll = await prisma.forumPoll.findUnique({
     where: { id: forumPollId },
     include: {

--- a/src/modules/forum.ts
+++ b/src/modules/forum.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../lib/prisma';
 import { sanitizeHtml, sanitizePlain } from '../lib/sanitize';
+import { canAccessForumLevel } from '../lib/userRankAccess';
 import {
   emitNotifications,
   extractMentionedUsernames,
@@ -319,21 +320,34 @@ export const closePoll = async (id: number) =>
 
 export const castVote = async (
   forumPollId: number,
-  userId: number,
-  userRankLevel: number,
+  user: {
+    id: number;
+    userRankLevel: number;
+    permittedForumIds?: number[];
+  },
   vote: number
 ): Promise<CastVoteResult> => {
   const poll = await prisma.forumPoll.findUnique({
     where: { id: forumPollId },
     include: {
       forumTopic: {
-        select: { deletedAt: true, forum: { select: { minClassRead: true } } }
+        select: {
+          deletedAt: true,
+          forumId: true,
+          forum: { select: { minClassRead: true } }
+        }
       }
     }
   });
   if (!poll || poll.forumTopic?.deletedAt)
     return { ok: false, reason: 'not_found' };
-  if (userRankLevel < (poll.forumTopic?.forum.minClassRead ?? 0))
+  if (
+    !canAccessForumLevel(
+      user,
+      poll.forumTopic?.forumId ?? 0,
+      poll.forumTopic?.forum.minClassRead
+    )
+  )
     return { ok: false, reason: 'insufficient_class' };
   if (poll.closed) return { ok: false, reason: 'closed' };
 
@@ -347,8 +361,8 @@ export const castVote = async (
     return { ok: false, reason: 'invalid_vote' };
 
   const result = await prisma.forumPollVote.upsert({
-    where: { forumPollId_userId: { forumPollId, userId } },
-    create: { forumPollId, userId, vote },
+    where: { forumPollId_userId: { forumPollId, userId: user.id } },
+    create: { forumPollId, userId: user.id, vote },
     update: { vote }
   });
   return { ok: true, vote: result };

--- a/src/ratioPolicy.spec.ts
+++ b/src/ratioPolicy.spec.ts
@@ -2,8 +2,8 @@ import {
   request,
   app,
   resetApiTestState,
-  prismaMock,
-  makeUserRank
+  makeUserRank,
+  setCurrentUserPermissions
 } from './test/apiTestHarness';
 import * as ratioPolicyModule from './modules/ratioPolicy';
 
@@ -17,9 +17,11 @@ const ratioPolicyMock = ratioPolicyModule as jest.Mocked<
   typeof ratioPolicyModule
 >;
 
-const setStaff = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true })
+const setManager = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      ratio_policy_manage: true
+    }).permissions as Record<string, boolean>
   );
 
 const POLICY_VIEW = {
@@ -35,13 +37,13 @@ beforeEach(() => resetApiTestState());
 // ─── GET /api/ratio-policy/:userId ────────────────────────────────────────────
 
 describe('GET /api/ratio-policy/:userId', () => {
-  it('returns 403 without staff permission', async () => {
+  it('returns 403 without ratio_policy_manage permission', async () => {
     const res = await request(app).get('/api/ratio-policy/9');
     expect(res.status).toBe(403);
   });
 
   it('returns the policy state for a user', async () => {
-    setStaff();
+    setManager();
     ratioPolicyMock.getPolicyState.mockResolvedValue(POLICY_VIEW);
 
     const res = await request(app).get('/api/ratio-policy/9');
@@ -55,7 +57,7 @@ describe('GET /api/ratio-policy/:userId', () => {
 // ─── POST /api/ratio-policy/:userId/override ──────────────────────────────────
 
 describe('POST /api/ratio-policy/:userId/override', () => {
-  it('returns 403 without staff permission', async () => {
+  it('returns 403 without ratio_policy_manage permission', async () => {
     const res = await request(app)
       .post('/api/ratio-policy/9/override')
       .send({ status: 'OK' });
@@ -63,7 +65,7 @@ describe('POST /api/ratio-policy/:userId/override', () => {
   });
 
   it('overrides the policy status and returns the new state', async () => {
-    setStaff();
+    setManager();
     const updated = { ...POLICY_VIEW, status: 'WATCH' as const };
     ratioPolicyMock.overridePolicyStatus.mockResolvedValue(updated);
 
@@ -80,7 +82,7 @@ describe('POST /api/ratio-policy/:userId/override', () => {
   });
 
   it('returns 400 for an invalid status value', async () => {
-    setStaff();
+    setManager();
 
     const res = await request(app)
       .post('/api/ratio-policy/9/override')

--- a/src/reports.spec.ts
+++ b/src/reports.spec.ts
@@ -76,7 +76,7 @@ const makeReport = (): ReportRow => ({
 
 const setStaff = () =>
   prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true })
+    makeUserRank({ staff: true, reports_manage: true })
   );
 
 beforeEach(() => resetApiTestState());

--- a/src/reports.spec.ts
+++ b/src/reports.spec.ts
@@ -3,7 +3,8 @@ import {
   request,
   prismaMock,
   makeUserRank,
-  resetApiTestState
+  resetApiTestState,
+  setCurrentUserPermissions
 } from './test/apiTestHarness';
 import * as reportsModule from './modules/reports';
 import type {
@@ -75,8 +76,10 @@ const makeReport = (): ReportRow => ({
 });
 
 const setStaff = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true, reports_manage: true })
+  setCurrentUserPermissions(
+    makeUserRank({
+      reports_manage: true
+    }).permissions as Record<string, boolean>
   );
 
 beforeEach(() => resetApiTestState());

--- a/src/routes/api/collages.ts
+++ b/src/routes/api/collages.ts
@@ -18,6 +18,7 @@ import {
 } from '../../middleware/validate';
 import { sanitizeHtml } from '../../lib/sanitize';
 import { parsePage, paginatedResponse } from '../../lib/pagination';
+import { hasPermission } from '../../lib/rankPermissions';
 import {
   createCollageSchema,
   updateCollageSchema,
@@ -221,6 +222,11 @@ router.post(
     // Personal collage: reset featured if this is the new featured one
     // (handled at update time; creation doesn't set featured)
 
+    const perms = await loadPermissions(req, res);
+    if (!hasPermission(perms, 'collages_create')) {
+      return res.status(403).json({ msg: 'Permission denied' });
+    }
+
     const existingName = await prisma.collage.findFirst({
       where: { name, isDeleted: false }
     });
@@ -231,7 +237,6 @@ router.post(
     }
 
     if (isPersonal(categoryId)) {
-      const perms = await loadPermissions(req, res);
       const isSiteStaff = !!(perms['staff'] || perms['admin']);
       if (!isSiteStaff) {
         const rank = await prisma.userRank.findUnique({

--- a/src/routes/api/communities/dnc.ts
+++ b/src/routes/api/communities/dnc.ts
@@ -51,7 +51,7 @@ router.get(
 // POST /api/communities/:communityId/dnc
 router.post(
   '/',
-  ...requirePermission('communities_manage'),
+  ...requirePermission('dnc_manage'),
   validateParams(communityIdParams),
   validate(dncSchema),
   authHandler(async (req, res) => {
@@ -73,7 +73,7 @@ router.post(
 // DELETE /api/communities/:communityId/dnc/:dncId
 router.delete(
   '/:dncId',
-  ...requirePermission('communities_manage'),
+  ...requirePermission('dnc_manage'),
   validateParams(dncIdParams),
   authHandler(async (_req, res) => {
     const { communityId, dncId } = parsedParams<{

--- a/src/routes/api/emailBlacklist.ts
+++ b/src/routes/api/emailBlacklist.ts
@@ -25,7 +25,7 @@ type EmailBlacklistInput = z.infer<typeof emailBlacklistSchema>;
 // GET /api/email-blacklist
 router.get(
   '/',
-  ...requirePermission('admin'),
+  ...requirePermission('email_blacklist_manage'),
   authHandler(async (_req, res) => {
     const entries = await prisma.emailBlacklist.findMany({
       orderBy: { addedAt: 'desc' }
@@ -37,7 +37,7 @@ router.get(
 // POST /api/email-blacklist
 router.post(
   '/',
-  ...requirePermission('admin'),
+  ...requirePermission('email_blacklist_manage'),
   validate(emailBlacklistSchema),
   authHandler(async (req, res) => {
     const { email, comment } = parsedBody<EmailBlacklistInput>(res);
@@ -64,7 +64,7 @@ router.post(
 // DELETE /api/email-blacklist/:id
 router.delete(
   '/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('email_blacklist_manage'),
   validateParams(idParamsSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);

--- a/src/routes/api/forum/forumCategory.ts
+++ b/src/routes/api/forum/forumCategory.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import { prisma } from '../../../lib/prisma';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { requireAuth } from '../../../middleware/auth';
-import { requirePermission } from '../../../middleware/permissions';
+import {
+  requirePermission,
+  loadPermissions
+} from '../../../middleware/permissions';
+import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import {
   parsedBody,
   validate,
@@ -28,13 +32,20 @@ router.get(
   requireAuth,
   authHandler(async (req, res) => {
     const showAll = req.query.all === 'true';
+    if (showAll) {
+      const perms = await loadPermissions(req, res);
+      if (
+        !perms['forums_manage'] &&
+        !perms['rank_permissions_manage'] &&
+        !perms['admin']
+      ) {
+        return res.status(403).json({ msg: 'Permission denied' });
+      }
+    }
     const categories = await prisma.forumCategory.findMany({
       orderBy: { sort: 'asc' },
       include: {
         forums: {
-          where: showAll
-            ? {}
-            : { minClassRead: { lte: req.user.userRankLevel } },
           orderBy: { sort: 'asc' },
           include: {
             lastTopic: { select: { id: true, title: true } }
@@ -42,9 +53,17 @@ router.get(
         }
       }
     });
-    res.json(
-      showAll ? categories : categories.filter((c) => c.forums.length > 0)
-    );
+    const visibleCategories = categories
+      .map((category) => ({
+        ...category,
+        forums: showAll
+          ? category.forums
+          : category.forums.filter((forum) =>
+              canAccessForumLevel(req.user, forum.id, forum.minClassRead)
+            )
+      }))
+      .filter((category) => showAll || category.forums.length > 0);
+    res.json(visibleCategories);
   })
 );
 
@@ -59,7 +78,6 @@ router.get(
       where: { id },
       include: {
         forums: {
-          where: { minClassRead: { lte: req.user.userRankLevel } },
           orderBy: { sort: 'asc' },
           include: {
             lastTopic: { select: { id: true, title: true } }
@@ -68,7 +86,12 @@ router.get(
       }
     });
     if (!category) return res.status(404).json({ msg: 'Category not found' });
-    res.json(category);
+    res.json({
+      ...category,
+      forums: category.forums.filter((forum) =>
+        canAccessForumLevel(req.user, forum.id, forum.minClassRead)
+      )
+    });
   })
 );
 

--- a/src/routes/api/forum/forumLastReadTopic.ts
+++ b/src/routes/api/forum/forumLastReadTopic.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { prisma } from '../../../lib/prisma';
+import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import { authHandler } from '../../../modules/asyncHandler';
 import { requireAuth } from '../../../middleware/auth';
 import { validate, parsedBody } from '../../../middleware/validate';
@@ -38,6 +39,7 @@ router.post(
       include: {
         forumTopic: {
           select: {
+            forumId: true,
             forum: { select: { minClassRead: true } }
           }
         }
@@ -46,7 +48,13 @@ router.post(
     if (!post) {
       return res.status(404).json({ msg: 'Forum post not found' });
     }
-    if (req.user.userRankLevel < (post.forumTopic?.forum.minClassRead ?? 0)) {
+    if (
+      !canAccessForumLevel(
+        req.user,
+        post.forumTopic?.forumId ?? 0,
+        post.forumTopic?.forum.minClassRead
+      )
+    ) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });

--- a/src/routes/api/forum/forumPoll.ts
+++ b/src/routes/api/forum/forumPoll.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { z } from 'zod';
 import { prisma } from '../../../lib/prisma';
+import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import { authHandler } from '../../../modules/asyncHandler';
 import { createPoll, closePoll } from '../../../modules/forum';
 import { requireAuth } from '../../../middleware/auth';
@@ -37,6 +38,7 @@ router.get(
         votes: true,
         forumTopic: {
           select: {
+            forumId: true,
             deletedAt: true,
             forum: { select: { minClassRead: true } }
           }
@@ -49,7 +51,13 @@ router.get(
       return res.status(404).json({ msg: 'Poll not found' });
     }
 
-    if (req.user.userRankLevel < (poll.forumTopic?.forum.minClassRead ?? 0)) {
+    if (
+      !canAccessForumLevel(
+        req.user,
+        poll.forumTopic?.forumId ?? 0,
+        poll.forumTopic?.forum.minClassRead
+      )
+    ) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });

--- a/src/routes/api/forum/forumPollVote.ts
+++ b/src/routes/api/forum/forumPollVote.ts
@@ -14,12 +14,7 @@ router.post(
   validate(pollVoteSchema),
   authHandler(async (req, res) => {
     const { forumPollId, vote } = parsedBody<PollVoteInput>(res);
-    const result = await castVote(
-      forumPollId,
-      req.user.id,
-      req.user.userRankLevel,
-      vote
-    );
+    const result = await castVote(forumPollId, req.user, vote);
     if (!result.ok) {
       if (result.reason === 'not_found')
         return res.status(404).json({ msg: 'Poll not found' });

--- a/src/routes/api/forum/forumPost.ts
+++ b/src/routes/api/forum/forumPost.ts
@@ -19,6 +19,7 @@ import {
   type UpdatePostInput
 } from '../../../schemas/forum';
 import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import { canAccessForumLevel } from '../../../lib/userRankAccess';
 
 const router = express.Router({ mergeParams: true });
 const forumTopicParamsSchema = z.object({
@@ -87,7 +88,7 @@ router.get(
       select: { minClassRead: true }
     });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forumId, forum.minClassRead)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });
@@ -140,7 +141,7 @@ router.get(
       select: { minClassRead: true }
     });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forumId, forum.minClassRead)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });
@@ -177,7 +178,7 @@ router.get(
       select: { minClassRead: true }
     });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forumId, forum.minClassRead)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });

--- a/src/routes/api/forum/forumRoute.ts
+++ b/src/routes/api/forum/forumRoute.ts
@@ -5,6 +5,7 @@ import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { deleteForum } from '../../../modules/forum';
 import { requireAuth } from '../../../middleware/auth';
 import { requirePermission } from '../../../middleware/permissions';
+import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import {
   parsedBody,
   validate,
@@ -32,7 +33,6 @@ router.get(
   requireAuth,
   authHandler(async (req, res) => {
     const forums = await prisma.forum.findMany({
-      where: { minClassRead: { lte: req.user.userRankLevel } },
       orderBy: { sort: 'asc' },
       include: {
         forumCategory: { select: { id: true, name: true } },
@@ -41,7 +41,11 @@ router.get(
         }
       }
     });
-    res.json(forums);
+    res.json(
+      forums.filter((forum) =>
+        canAccessForumLevel(req.user, forum.id, forum.minClassRead)
+      )
+    );
   })
 );
 
@@ -60,7 +64,7 @@ router.get(
       }
     });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forum.id, forum.minClassRead)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });
@@ -78,7 +82,7 @@ router.post(
     const { id } = parsedParams<{ id: number }>(res);
     const forum = await prisma.forum.findUnique({ where: { id } });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forum.id, forum.minClassRead)) {
       return res.status(403).json({ msg: 'Insufficient class' });
     }
 

--- a/src/routes/api/forum/forumTopic.ts
+++ b/src/routes/api/forum/forumTopic.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../schemas/forum';
 import { parsePage, paginatedResponse } from '../../../lib/pagination';
 import { sanitizePlain } from '../../../lib/sanitize';
+import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import forumPostRouter from './forumPost';
 
 const router = express.Router({ mergeParams: true });
@@ -46,7 +47,7 @@ router.get(
       select: { minClassRead: true }
     });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forumId, forum.minClassRead)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });
@@ -98,7 +99,7 @@ router.get(
       })
     ]);
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassRead ?? 0)) {
+    if (!canAccessForumLevel(req.user, forumId, forum.minClassRead)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });
@@ -122,7 +123,7 @@ router.post(
       select: { id: true, minClassCreate: true }
     });
     if (!forum) return res.status(404).json({ msg: 'Forum not found' });
-    if (req.user.userRankLevel < (forum.minClassCreate ?? 0)) {
+    if (!canAccessForumLevel(req.user, forumId, forum.minClassCreate)) {
       return res
         .status(403)
         .json({ msg: 'Insufficient class to create topics in this forum' });

--- a/src/routes/api/ipBans.ts
+++ b/src/routes/api/ipBans.ts
@@ -71,7 +71,7 @@ const serializeBan = (ban: { id: number; fromIp: number; toIp: number }) => ({
 // GET /api/ip-bans
 router.get(
   '/',
-  ...requirePermission('admin'),
+  ...requirePermission('ip_bans_manage'),
   authHandler(async (_req, res) => {
     const bans = await prisma.ipBan.findMany({ orderBy: { id: 'asc' } });
     res.json(bans.map(serializeBan));
@@ -81,7 +81,7 @@ router.get(
 // POST /api/ip-bans
 router.post(
   '/',
-  ...requirePermission('admin'),
+  ...requirePermission('ip_bans_manage'),
   validate(ipBanSchema),
   authHandler(async (req, res) => {
     const { fromIp, toIp } = parsedBody<IpBanInput>(res);
@@ -104,7 +104,7 @@ router.post(
 // DELETE /api/ip-bans/:id
 router.delete(
   '/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('ip_bans_manage'),
   validateParams(ipBanIdParamsSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);

--- a/src/routes/api/ratioPolicy.ts
+++ b/src/routes/api/ratioPolicy.ts
@@ -27,7 +27,7 @@ const overrideSchema = z.object({
 // GET /api/ratio-policy/:userId — staff: view a user's policy state
 router.get(
   '/:userId',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('ratio_policy_manage'),
   validateParams(userIdParamsSchema),
   asyncHandler(async (_req, res) => {
     const { userId } = parsedParams<{ userId: number }>(res);
@@ -39,7 +39,7 @@ router.get(
 // POST /api/ratio-policy/:userId/override — staff: set policy status
 router.post(
   '/:userId/override',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('ratio_policy_manage'),
   validateParams(userIdParamsSchema),
   validate(overrideSchema),
   asyncHandler(async (_req, res) => {

--- a/src/routes/api/reports.ts
+++ b/src/routes/api/reports.ts
@@ -48,7 +48,7 @@ const reportIdSchema = z.object({
 // GET /api/reports/counts — open + claimed counts (staff)
 router.get(
   '/counts',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   authHandler(async (_req, res) => {
     const counts = await getReportCounts();
     res.json(counts);
@@ -58,7 +58,7 @@ router.get(
 // GET /api/reports/stats — resolution statistics (staff)
 router.get(
   '/stats',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   authHandler(async (_req, res) => {
     const stats = await getReportStats();
     res.json(stats);
@@ -80,7 +80,7 @@ router.get(
 // GET /api/reports — staff queue
 router.get(
   '/',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   validateQuery(reportListQuerySchema),
   authHandler(async (req, res) => {
     const { page, status, targetType, claimedByMe, reporterUsername } =
@@ -143,7 +143,7 @@ router.get(
 // POST /api/reports/:id/claim — claim a report (staff)
 router.post(
   '/:id/claim',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   validateParams(reportIdSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -165,7 +165,7 @@ router.post(
 // POST /api/reports/:id/unclaim — unclaim a report (staff)
 router.post(
   '/:id/unclaim',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   validateParams(reportIdSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -187,7 +187,7 @@ router.post(
 // POST /api/reports/:id/resolve — resolve a report (staff)
 router.post(
   '/:id/resolve',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   validateParams(reportIdSchema),
   validate(resolveReportSchema),
   authHandler(async (req, res) => {
@@ -216,7 +216,7 @@ router.post(
 // POST /api/reports/:id/notes — add a moderator note (staff)
 router.post(
   '/:id/notes',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('reports_manage'),
   validateParams(reportIdSchema),
   validate(addNoteSchema),
   authHandler(async (req, res) => {

--- a/src/routes/api/requests.ts
+++ b/src/routes/api/requests.ts
@@ -12,6 +12,7 @@ import {
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import * as requestModule from '../../modules/requests';
 import { prisma } from '../../lib/prisma';
+import { hasPermission } from '../../lib/rankPermissions';
 import {
   createRequestSchema,
   updateRequestSchema,
@@ -58,6 +59,10 @@ router.post(
   requireAuth,
   validate(createRequestSchema),
   authHandler(async (req, res) => {
+    const perms = await loadPermissions(req, res);
+    if (!hasPermission(perms, 'requests_create')) {
+      throw new AppError(403, 'Permission denied');
+    }
     const request = await requestModule.createRequest(
       req.user.id,
       parsedBody(res)
@@ -232,7 +237,7 @@ router.put(
       throw new AppError(422, 'Only open requests can be edited');
 
     const perms = await loadPermissions(req, res);
-    const isStaff = !!(perms['staff'] || perms['admin']);
+    const isStaff = hasPermission(perms, 'requests_moderate');
     if (existing.userId !== req.user.id && !isStaff)
       throw new AppError(403, 'Permission denied');
 
@@ -276,7 +281,7 @@ router.post(
       throw new AppError(422, 'Request is not filled');
 
     const perms = await loadPermissions(req, res);
-    const isStaff = !!(perms['staff'] || perms['admin']);
+    const isStaff = hasPermission(perms, 'requests_moderate');
     const isOwner = existing.userId === req.user.id;
     const isFiller = existing.fillerId === req.user.id;
 
@@ -304,7 +309,7 @@ router.delete(
     if (!existing) throw new AppError(404, 'Request not found');
 
     const perms = await loadPermissions(req, res);
-    const isStaff = !!(perms['staff'] || perms['admin']);
+    const isStaff = hasPermission(perms, 'requests_moderate');
     const isOwner = existing.userId === req.user.id;
 
     if (!isOwner && !isStaff) throw new AppError(403, 'Permission denied');

--- a/src/routes/api/siteHistory.ts
+++ b/src/routes/api/siteHistory.ts
@@ -34,7 +34,7 @@ router.get(
 // POST /api/site-history
 router.post(
   '/',
-  ...requirePermission('admin'),
+  ...requirePermission('site_history_manage'),
   validate(siteHistorySchema),
   authHandler(async (req, res) => {
     const { title, body } = parsedBody<SiteHistoryInput>(res);
@@ -48,7 +48,7 @@ router.post(
 // PUT /api/site-history/:id
 router.put(
   '/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('site_history_manage'),
   validateParams(siteHistoryIdParams),
   validate(siteHistorySchema),
   authHandler(async (_req, res) => {
@@ -67,7 +67,7 @@ router.put(
 // DELETE /api/site-history/:id
 router.delete(
   '/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('site_history_manage'),
   validateParams(siteHistoryIdParams),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);

--- a/src/routes/api/staffInbox.ts
+++ b/src/routes/api/staffInbox.ts
@@ -64,7 +64,7 @@ const ticketIdSchema = z.object({
 // GET /api/staff-inbox/responses — list canned responses (staff)
 router.get(
   '/responses',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   authHandler(async (_req, res) => {
     const responses = await listResponses();
     res.json(responses);
@@ -74,7 +74,7 @@ router.get(
 // POST /api/staff-inbox/responses — create canned response (staff)
 router.post(
   '/responses',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validate(createResponseSchema),
   authHandler(async (_req, res) => {
     const { name, body } = parsedBody<CreateResponseInput>(res);
@@ -86,7 +86,7 @@ router.post(
 // PUT /api/staff-inbox/responses/:id — update canned response (staff)
 router.put(
   '/responses/:id',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validateParams(responseIdSchema),
   validate(updateResponseSchema),
   authHandler(async (_req, res) => {
@@ -101,7 +101,7 @@ router.put(
 // DELETE /api/staff-inbox/responses/:id — delete canned response (staff)
 router.delete(
   '/responses/:id',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validateParams(responseIdSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -152,7 +152,7 @@ router.post(
 // GET /api/staff-inbox/queue — staff ticket queue
 router.get(
   '/queue',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validateQuery(queueQuerySchema),
   authHandler(async (req, res) => {
     const { page, status, assignedToMe, unassigned } =
@@ -171,7 +171,7 @@ router.get(
 // GET /api/staff-inbox/queue/count — unresolved ticket count for badge
 router.get(
   '/queue/count',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   authHandler(async (_req, res) => {
     const count = await getQueueCount();
     res.json({ count });
@@ -181,7 +181,7 @@ router.get(
 // POST /api/staff-inbox/bulk-resolve — batch resolve tickets (staff)
 router.post(
   '/bulk-resolve',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validate(bulkResolveSchema),
   authHandler(async (_req, res) => {
     const { ids } = parsedBody<BulkResolveInput>(res);
@@ -247,7 +247,7 @@ router.post(
 // POST /api/staff-inbox/tickets/:id/unresolve (staff only)
 router.post(
   '/tickets/:id/unresolve',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validateParams(ticketIdSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -263,7 +263,7 @@ router.post(
 // POST /api/staff-inbox/tickets/:id/assign (staff only)
 router.post(
   '/tickets/:id/assign',
-  ...requirePermission('staff', 'admin'),
+  ...requirePermission('staff_inbox_manage'),
   validateParams(ticketIdSchema),
   validate(assignSchema),
   authHandler(async (req, res) => {

--- a/src/routes/api/tagAliases.ts
+++ b/src/routes/api/tagAliases.ts
@@ -24,7 +24,7 @@ const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
 // GET /api/tag-aliases
 router.get(
   '/',
-  ...requirePermission('staff'),
+  ...requirePermission('tags_manage'),
   asyncHandler(async (req, res) => {
     const pg = parsePage(req);
     const [aliases, total] = await Promise.all([
@@ -46,7 +46,7 @@ router.get(
 // POST /api/tag-aliases
 router.post(
   '/',
-  ...requirePermission('staff'),
+  ...requirePermission('tags_manage'),
   validate(createTagAliasSchema),
   authHandler(async (req, res) => {
     const { badTag, goodTag: goodTagName } =
@@ -69,7 +69,7 @@ router.post(
 // PUT /api/tag-aliases/:id
 router.put(
   '/:id',
-  ...requirePermission('staff'),
+  ...requirePermission('tags_manage'),
   validateParams(idParamsSchema),
   validate(updateTagAliasSchema),
   authHandler(async (req, res) => {
@@ -97,7 +97,7 @@ router.put(
 // DELETE /api/tag-aliases/:id
 router.delete(
   '/:id',
-  ...requirePermission('staff'),
+  ...requirePermission('tags_manage'),
   validateParams(idParamsSchema),
   asyncHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);

--- a/src/routes/api/tools.ts
+++ b/src/routes/api/tools.ts
@@ -3,10 +3,7 @@ import { z } from 'zod';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
-import {
-  requirePermission,
-  requireAdminOnly
-} from '../../middleware/permissions';
+import { requirePermission } from '../../middleware/permissions';
 import {
   validate,
   validateParams,
@@ -14,6 +11,7 @@ import {
   parsedParams
 } from '../../middleware/validate';
 import { audit } from '../../lib/audit';
+import { normalizePermissions } from '../../lib/rankPermissions';
 import {
   createRankSchema,
   updateRankSchema,
@@ -38,29 +36,37 @@ const staffGroupIdParamsSchema = z.object({
 
 const formatRank = (
   r: Prisma.UserRankGetPayload<{
-    include: { _count: { select: { users: true } } };
+    include: {
+      _count: { select: { users: true; secondaryUsers: true } };
+    };
   }>
 ) => ({
   id: r.id,
   name: r.name,
   level: r.level,
-  permissions: r.permissions,
+  permissions: normalizePermissions(
+    r.permissions as Record<string, boolean> | null | undefined
+  ),
+  secondary: r.secondary,
+  permittedForumIds: r.permittedForumIds,
   color: r.color,
   badge: r.badge,
   personalCollageLimit: r.personalCollageLimit,
   displayStaff: r.displayStaff,
   staffGroupId: r.staffGroupId,
-  userCount: r._count.users
+  primaryUserCount: r._count.users,
+  secondaryUserCount: r._count.secondaryUsers,
+  userCount: r._count.users + r._count.secondaryUsers
 });
 
 // GET /api/tools/user-ranks — list all user ranks
 router.get(
   '/user-ranks',
-  ...requirePermission('admin'),
+  ...requirePermission('rank_permissions_manage'),
   asyncHandler(async (_req: Request, res: Response) => {
     const ranks = await prisma.userRank.findMany({
       orderBy: { level: 'asc' },
-      include: { _count: { select: { users: true } } }
+      include: { _count: { select: { users: true, secondaryUsers: true } } }
     });
     res.json(ranks.map(formatRank));
   })
@@ -69,14 +75,14 @@ router.get(
 // GET /api/tools/user-ranks/:id — get single rank
 router.get(
   '/user-ranks/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('rank_permissions_manage'),
   validateParams(userRankIdParamsSchema),
   asyncHandler(async (req: Request, res: Response) => {
     const { id } = parsedParams<{ id: number }>(res);
 
     const rank = await prisma.userRank.findUnique({
       where: { id },
-      include: { _count: { select: { users: true } } }
+      include: { _count: { select: { users: true, secondaryUsers: true } } }
     });
     if (!rank) return res.status(404).json({ msg: 'Rank not found' });
 
@@ -87,13 +93,15 @@ router.get(
 // POST /api/tools/user-ranks — create rank
 router.post(
   '/user-ranks',
-  ...requirePermission('admin'),
+  ...requirePermission('rank_permissions_manage'),
   validate(createRankSchema),
   authHandler(async (req, res) => {
     const {
       name,
       level,
       permissions,
+      secondary,
+      permittedForumIds,
       color,
       badge,
       personalCollageLimit,
@@ -108,6 +116,17 @@ router.post(
       if (!group) return res.status(422).json({ msg: 'Staff group not found' });
     }
 
+    if ((permittedForumIds?.length ?? 0) > 0) {
+      const forumCount = await prisma.forum.count({
+        where: { id: { in: permittedForumIds } }
+      });
+      if (forumCount !== permittedForumIds!.length) {
+        return res
+          .status(422)
+          .json({ msg: 'One or more permitted forums do not exist' });
+      }
+    }
+
     const groupId = staffGroupId ?? null;
     const effectiveStaffGroupId = displayStaff ? groupId : null;
 
@@ -116,19 +135,25 @@ router.post(
         data: {
           name,
           level,
-          permissions: permissions ?? {},
+          permissions: normalizePermissions(permissions),
+          secondary: secondary ?? false,
+          permittedForumIds: permittedForumIds ?? [],
           color: color ?? '',
           badge: badge ?? '',
           personalCollageLimit: personalCollageLimit ?? 0,
           displayStaff: displayStaff ?? false,
           staffGroupId: effectiveStaffGroupId
         },
-        include: { _count: { select: { users: true } } }
+        include: {
+          _count: { select: { users: true, secondaryUsers: true } }
+        }
       });
 
       await audit(prisma, req.user.id, 'rank.create', 'UserRank', rank.id, {
         name,
         level,
+        secondary,
+        permittedForumIds,
         displayStaff,
         staffGroupId: effectiveStaffGroupId
       });
@@ -150,7 +175,7 @@ router.post(
 // PUT /api/tools/user-ranks/:id — update rank
 router.put(
   '/user-ranks/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('rank_permissions_manage'),
   validateParams(userRankIdParamsSchema),
   validate(updateRankSchema),
   authHandler(async (req, res) => {
@@ -163,6 +188,8 @@ router.put(
       name,
       level,
       permissions,
+      secondary,
+      permittedForumIds,
       color,
       badge,
       personalCollageLimit,
@@ -177,6 +204,17 @@ router.put(
       if (!group) return res.status(422).json({ msg: 'Staff group not found' });
     }
 
+    if ((permittedForumIds?.length ?? 0) > 0) {
+      const forumCount = await prisma.forum.count({
+        where: { id: { in: permittedForumIds } }
+      });
+      if (forumCount !== permittedForumIds!.length) {
+        return res
+          .status(422)
+          .json({ msg: 'One or more permitted forums do not exist' });
+      }
+    }
+
     // Clear group assignment when staff display is turned off
     const effectiveStaffGroupId = displayStaff === false ? null : staffGroupId;
 
@@ -186,7 +224,11 @@ router.put(
         data: {
           ...(name !== undefined && { name }),
           ...(level !== undefined && { level }),
-          ...(permissions !== undefined && { permissions }),
+          ...(permissions !== undefined && {
+            permissions: normalizePermissions(permissions)
+          }),
+          ...(secondary !== undefined && { secondary }),
+          ...(permittedForumIds !== undefined && { permittedForumIds }),
           ...(color !== undefined && { color }),
           ...(badge !== undefined && { badge }),
           ...(personalCollageLimit !== undefined && { personalCollageLimit }),
@@ -195,13 +237,17 @@ router.put(
             staffGroupId: effectiveStaffGroupId
           })
         },
-        include: { _count: { select: { users: true } } }
+        include: {
+          _count: { select: { users: true, secondaryUsers: true } }
+        }
       });
 
       await audit(prisma, req.user.id, 'rank.update', 'UserRank', id, {
         name,
         level,
         permissions,
+        secondary,
+        permittedForumIds,
         displayStaff,
         staffGroupId: effectiveStaffGroupId
       });
@@ -223,15 +269,19 @@ router.put(
 // DELETE /api/tools/user-ranks/:id — delete rank (blocks if users are assigned)
 router.delete(
   '/user-ranks/:id',
-  ...requirePermission('admin'),
+  ...requirePermission('rank_permissions_manage'),
   validateParams(userRankIdParamsSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
 
-    const userCount = await prisma.user.count({ where: { userRankId: id } });
-    if (userCount > 0) {
+    const [userCount, secondaryUserCount] = await Promise.all([
+      prisma.user.count({ where: { userRankId: id } }),
+      prisma.userSecondaryRank.count({ where: { userRankId: id } })
+    ]);
+    const totalAssigned = userCount + secondaryUserCount;
+    if (totalAssigned > 0) {
       return res.status(409).json({
-        msg: `Cannot delete rank: ${userCount} user(s) currently assigned to it`
+        msg: `Cannot delete rank: ${totalAssigned} user(s) currently assigned to it`
       });
     }
 
@@ -255,7 +305,7 @@ router.delete(
 // GET /api/tools/staff-groups — list all staff groups (admin only)
 router.get(
   '/staff-groups',
-  ...requireAdminOnly(),
+  ...requirePermission('staff_groups_manage'),
   asyncHandler(async (_req: Request, res: Response) => {
     const groups = await prisma.staffGroup.findMany({
       orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
@@ -275,7 +325,7 @@ router.get(
 // POST /api/tools/staff-groups — create staff group (admin only)
 router.post(
   '/staff-groups',
-  ...requireAdminOnly(),
+  ...requirePermission('staff_groups_manage'),
   validate(createStaffGroupSchema),
   authHandler(async (req, res) => {
     const { name, sortOrder } = parsedBody<CreateStaffGroupInput>(res);
@@ -315,7 +365,7 @@ router.post(
 // PUT /api/tools/staff-groups/:id — update staff group (admin only)
 router.put(
   '/staff-groups/:id',
-  ...requireAdminOnly(),
+  ...requirePermission('staff_groups_manage'),
   validateParams(staffGroupIdParamsSchema),
   validate(updateStaffGroupSchema),
   authHandler(async (req, res) => {
@@ -362,7 +412,7 @@ router.put(
 // DELETE /api/tools/staff-groups/:id — delete staff group (admin only, blocks if ranks assigned)
 router.delete(
   '/staff-groups/:id',
-  ...requireAdminOnly(),
+  ...requirePermission('staff_groups_manage'),
   validateParams(staffGroupIdParamsSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -92,7 +92,7 @@ router.get(
 // POST /api/users/donor-ranks
 router.post(
   '/donor-ranks',
-  ...requirePermission('admin'),
+  ...requirePermission('donor_ranks_manage'),
   validate(donorRankSchema),
   authHandler(async (_req, res) => {
     const { name, minDonation, expiresAfterDays, perks, color, badge } =
@@ -114,7 +114,7 @@ router.post(
 // PUT /api/users/donor-ranks/:rankId
 router.put(
   '/donor-ranks/:rankId',
-  ...requirePermission('admin'),
+  ...requirePermission('donor_ranks_manage'),
   validateParams(rankIdParamsSchema),
   validate(donorRankSchema),
   authHandler(async (_req, res) => {
@@ -143,7 +143,7 @@ router.put(
 // DELETE /api/users/donor-ranks/:rankId
 router.delete(
   '/donor-ranks/:rankId',
-  ...requirePermission('admin'),
+  ...requirePermission('donor_ranks_manage'),
   validateParams(rankIdParamsSchema),
   authHandler(async (_req, res) => {
     const { rankId } = parsedParams<{ rankId: number }>(res);
@@ -231,7 +231,7 @@ router.put(
 // GET /api/users/recovery-requests
 router.get(
   '/recovery-requests',
-  ...requirePermission('users_edit'),
+  ...requirePermission('recovery_manage'),
   authHandler(async (req, res) => {
     const rawStatus = req.query.status as string | undefined;
     const statusResult = recoveryStatusSchema.safeParse(rawStatus ?? 'pending');
@@ -275,7 +275,7 @@ router.get(
 // DELETE /api/users/recovery-requests/:reqId
 router.delete(
   '/recovery-requests/:reqId',
-  ...requirePermission('users_edit'),
+  ...requirePermission('recovery_manage'),
   validateParams(reqIdParamsSchema),
   authHandler(async (req, res) => {
     const { reqId } = parsedParams<{ reqId: number }>(res);
@@ -310,7 +310,7 @@ type SessionsQuery = z.infer<typeof sessionsQuerySchema>;
 // GET /api/users/sessions — login watch (must be before /:id)
 router.get(
   '/sessions',
-  ...requirePermission('admin'),
+  ...requirePermission('login_watch_view'),
   validateQuery(sessionsQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
     const pg = parsePage(req);
@@ -338,7 +338,7 @@ type InvitesQuery = z.infer<typeof invitesQuerySchema>;
 // GET /api/users/invites — invite pool (must be before /:id)
 router.get(
   '/invites',
-  ...requirePermission('admin'),
+  ...requirePermission('invites_manage'),
   validateQuery(invitesQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
     const pg = parsePage(req);
@@ -362,7 +362,7 @@ router.get(
 // GET /api/users/invite-tree — site-wide invite tree (must be before /:id)
 router.get(
   '/invite-tree',
-  ...requirePermission('admin'),
+  ...requirePermission('invites_manage'),
   asyncHandler(async (req: Request, res: Response) => {
     const pg = parsePage(req);
     const [trees, total] = await Promise.all([
@@ -395,7 +395,7 @@ router.get(
 // GET /api/users/ratio-watch — users on ratio watch or leech-disabled (must be before /:id)
 router.get(
   '/ratio-watch',
-  ...requirePermission('admin'),
+  ...requirePermission('ratio_policy_manage'),
   asyncHandler(async (req: Request, res: Response) => {
     const pg = parsePage(req);
     const where = {
@@ -446,7 +446,7 @@ router.get(
 // GET /api/users/duplicate-ips — users sharing the same last-seen IP (must be before /:id)
 router.get(
   '/duplicate-ips',
-  ...requirePermission('staff'),
+  ...requirePermission('duplicate_ips_view'),
   authHandler(async (_req, res) => {
     const dupes = await prisma.user.groupBy({
       by: ['lastIp'],
@@ -477,7 +477,7 @@ router.get(
 // GET /api/users/registration-log — users ordered by registration date (must be before /:id)
 router.get(
   '/registration-log',
-  ...requirePermission('staff'),
+  ...requirePermission('registration_log_view'),
   authHandler(async (req, res) => {
     const pg = parsePage(req);
     const [users, total] = await Promise.all([
@@ -631,7 +631,7 @@ router.put(
 // POST /api/users/:id/recovery — admin-triggered recovery email
 router.post(
   '/:id/recovery',
-  ...requirePermission('users_edit'),
+  ...requirePermission('recovery_manage'),
   validateParams(userIdParamsSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -672,7 +672,7 @@ router.post(
 // GET /api/users/:id/warnings
 router.get(
   '/:id/warnings',
-  ...requirePermission('staff'),
+  ...requirePermission('users_warn'),
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -746,7 +746,7 @@ router.delete(
 // GET /api/users/:id/notes
 router.get(
   '/:id/notes',
-  ...requirePermission('staff'),
+  ...requirePermission('users_edit'),
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -762,7 +762,7 @@ router.get(
 // POST /api/users/:id/notes
 router.post(
   '/:id/notes',
-  ...requirePermission('staff'),
+  ...requirePermission('users_edit'),
   validateParams(userIdParamsSchema),
   validate(moderationNoteSchema),
   authHandler(async (req, res) => {
@@ -782,7 +782,7 @@ router.post(
 // DELETE /api/users/:id/notes/:noteId
 router.delete(
   '/:id/notes/:noteId',
-  ...requirePermission('staff'),
+  ...requirePermission('users_edit'),
   validateParams(noteParamsSchema),
   authHandler(async (_req, res) => {
     const { id, noteId } = parsedParams<{ id: number; noteId: number }>(res);
@@ -825,30 +825,90 @@ router.post(
   })
 );
 
+// GET /api/users/:id/rank
+router.get(
+  '/:id/rank',
+  ...requirePermission('users_edit'),
+  validateParams(userIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: {
+        userRankId: true,
+        secondaryRanks: {
+          select: { userRankId: true },
+          orderBy: { userRankId: 'asc' }
+        }
+      }
+    });
+    if (!user) return res.status(404).json({ msg: 'User not found' });
+    res.json({
+      userRankId: user.userRankId,
+      secondaryRankIds: user.secondaryRanks.map((entry) => entry.userRankId)
+    });
+  })
+);
+
 // PUT /api/users/:id/rank
 router.put(
   '/:id/rank',
-  ...requirePermission('admin'),
+  ...requirePermission('users_edit'),
   validateParams(userIdParamsSchema),
   validate(setRankSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const { userRankId } = parsedBody<SetRankInput>(res);
+    const { userRankId, secondaryRankIds } = parsedBody<SetRankInput>(res);
 
     const user = await prisma.user.findUnique({ where: { id } });
     if (!user) return res.status(404).json({ msg: 'User not found' });
 
-    const rank = await prisma.userRank.findUnique({
-      where: { id: userRankId }
+    const uniqueSecondaryRankIds = [...new Set(secondaryRankIds)];
+    const ranks = await prisma.userRank.findMany({
+      where: { id: { in: [userRankId, ...uniqueSecondaryRankIds] } },
+      select: { id: true, secondary: true }
     });
-    if (!rank) return res.status(404).json({ msg: 'Rank not found' });
+    const rankMap = new Map(ranks.map((rank) => [rank.id, rank]));
+    const primaryRank = rankMap.get(userRankId);
+    if (!primaryRank) return res.status(404).json({ msg: 'Rank not found' });
+    if (primaryRank.secondary) {
+      return res
+        .status(422)
+        .json({ msg: 'Primary rank cannot be a secondary class' });
+    }
+    for (const secondaryRankId of uniqueSecondaryRankIds) {
+      const secondaryRank = rankMap.get(secondaryRankId);
+      if (!secondaryRank) {
+        return res.status(404).json({ msg: 'Secondary rank not found' });
+      }
+      if (!secondaryRank.secondary) {
+        return res.status(422).json({
+          msg: 'Only secondary-class ranks can be assigned as secondary classes'
+        });
+      }
+    }
 
-    await prisma.user.update({
-      where: { id },
-      data: { userRankId }
-    });
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id },
+        data: { userRankId }
+      }),
+      prisma.userSecondaryRank.deleteMany({ where: { userId: id } }),
+      ...(uniqueSecondaryRankIds.length > 0
+        ? [
+            prisma.userSecondaryRank.createMany({
+              data: uniqueSecondaryRankIds.map((secondaryRankId) => ({
+                userId: id,
+                userRankId: secondaryRankId,
+                assignedById: req.user.id
+              }))
+            })
+          ]
+        : [])
+    ]);
     await audit(prisma, req.user.id, 'user.rank_changed', 'User', id, {
-      userRankId
+      userRankId,
+      secondaryRankIds: uniqueSecondaryRankIds
     });
     res.json({ msg: 'Rank updated' });
   })
@@ -857,7 +917,7 @@ router.put(
 // POST /api/users/:id/donor
 router.post(
   '/:id/donor',
-  ...requirePermission('staff'),
+  ...requirePermission('donor_ranks_manage'),
   validateParams(userIdParamsSchema),
   validate(grantDonorSchema),
   authHandler(async (req, res) => {
@@ -907,7 +967,7 @@ router.post(
 // DELETE /api/users/:id/donor
 router.delete(
   '/:id/donor',
-  ...requirePermission('staff'),
+  ...requirePermission('donor_ranks_manage'),
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -925,7 +985,7 @@ router.delete(
 // GET /api/users/:id/ip-history
 router.get(
   '/:id/ip-history',
-  ...requirePermission('staff'),
+  ...requirePermission('users_view_ips'),
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
@@ -962,7 +1022,7 @@ router.get(
 // GET /api/users/:id/email-history
 router.get(
   '/:id/email-history',
-  ...requirePermission('staff'),
+  ...requirePermission('users_view_email'),
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -1,9 +1,20 @@
 import { z } from 'zod';
+import {
+  normalizePermissions,
+  VALID_PERMISSIONS
+} from '../lib/rankPermissions';
+
+const permissionsSchema = z
+  .record(z.enum(VALID_PERMISSIONS), z.boolean())
+  .optional()
+  .transform((permissions) => normalizePermissions(permissions));
 
 export const createRankSchema = z.object({
-  name: z.string().min(1),
-  level: z.number().int(),
-  permissions: z.record(z.string(), z.boolean()).optional(),
+  name: z.string().trim().min(1).max(64),
+  level: z.number().int().min(0),
+  permissions: permissionsSchema,
+  secondary: z.boolean().optional(),
+  permittedForumIds: z.array(z.number().int().positive()).default([]),
   color: z.string().optional(),
   badge: z.string().optional(),
   personalCollageLimit: z.number().int().min(0).optional(),
@@ -13,9 +24,11 @@ export const createRankSchema = z.object({
 
 export const updateRankSchema = z
   .object({
-    name: z.string().min(1).optional(),
-    level: z.number().int().optional(),
-    permissions: z.record(z.string(), z.boolean()).optional(),
+    name: z.string().trim().min(1).max(64).optional(),
+    level: z.number().int().min(0).optional(),
+    permissions: permissionsSchema,
+    secondary: z.boolean().optional(),
+    permittedForumIds: z.array(z.number().int().positive()).optional(),
     color: z.string().optional(),
     badge: z.string().optional(),
     personalCollageLimit: z.number().int().min(0).optional(),

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -33,7 +33,8 @@ export const moderationNoteSchema = z.object({
 });
 
 export const setRankSchema = z.object({
-  userRankId: z.number().int().positive()
+  userRankId: z.number().int().positive(),
+  secondaryRankIds: z.array(z.number().int().positive()).default([])
 });
 
 export const donorRankSchema = z.object({

--- a/src/siteHistory.spec.ts
+++ b/src/siteHistory.spec.ts
@@ -3,7 +3,8 @@ import {
   app,
   resetApiTestState,
   prismaMock,
-  makeUserRank
+  makeUserRank,
+  setCurrentUserPermissions
 } from './test/apiTestHarness';
 
 const makeEntry = (overrides: Record<string, unknown> = {}) => ({
@@ -50,8 +51,10 @@ describe('GET /api/site-history', () => {
 
 describe('POST /api/site-history', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({
+        site_history_manage: true
+      }).permissions as Record<string, boolean>
     );
   });
 
@@ -78,8 +81,10 @@ describe('POST /api/site-history', () => {
     expect(prismaMock.siteHistory.create).not.toHaveBeenCalled();
   });
 
-  it('returns 403 without admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+  it('returns 403 without site_history_manage permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app)
       .post('/api/site-history')
@@ -91,8 +96,10 @@ describe('POST /api/site-history', () => {
 
 describe('PUT /api/site-history/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({
+        site_history_manage: true
+      }).permissions as Record<string, boolean>
     );
   });
 
@@ -130,8 +137,10 @@ describe('PUT /api/site-history/:id', () => {
 
 describe('DELETE /api/site-history/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({
+        site_history_manage: true
+      }).permissions as Record<string, boolean>
     );
   });
 
@@ -155,8 +164,10 @@ describe('DELETE /api/site-history/:id', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 403 without admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+  it('returns 403 without site_history_manage permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app).delete('/api/site-history/1');
 

--- a/src/staffInbox.spec.ts
+++ b/src/staffInbox.spec.ts
@@ -4,6 +4,7 @@ import {
   resetApiTestState,
   prismaMock,
   makeUserRank,
+  setCurrentUserPermissions,
   staffInboxMock,
   staffPmMock
 } from './test/apiTestHarness';
@@ -11,8 +12,11 @@ import type { StaffResponse } from './modules/staffInbox';
 import type { StaffInboxStatus } from '@prisma/client';
 
 const setStaff = () =>
-  prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true, staff_inbox_manage: true })
+  setCurrentUserPermissions(
+    makeUserRank({
+      staff: true,
+      staff_inbox_manage: true
+    }).permissions as Record<string, boolean>
   );
 
 const makeResponse = (

--- a/src/staffInbox.spec.ts
+++ b/src/staffInbox.spec.ts
@@ -12,7 +12,7 @@ import type { StaffInboxStatus } from '@prisma/client';
 
 const setStaff = () =>
   prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true })
+    makeUserRank({ staff: true, staff_inbox_manage: true })
   );
 
 const makeResponse = (

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -153,9 +153,10 @@ jest.mock('../modules/config', () => ({
 let currentUserRankLevel = 1000;
 let currentUserPermissions: Record<string, boolean> = {};
 let currentPermittedForumIds: number[] = [];
+let hasExplicitCurrentUserPermissions = false;
 
 jest.mock('../middleware/auth', () => ({
-  requireAuth: (
+  requireAuth: async (
     req: {
       user?: {
         id: number;
@@ -168,11 +169,24 @@ jest.mock('../middleware/auth', () => ({
     _res: unknown,
     next: () => void
   ) => {
+    let permissions = currentUserPermissions;
+    if (!hasExplicitCurrentUserPermissions) {
+      const currentRank = await prisma.userRank.findUnique({
+        where: { id: 1 }
+      });
+      permissions = normalizePermissions(
+        (currentRank?.permissions as
+          | Record<string, boolean>
+          | null
+          | undefined) ?? {}
+      ) as Record<string, boolean>;
+    }
+
     req.user = {
       id: 7,
       userRankLevel: currentUserRankLevel,
       userRankId: 1,
-      permissions: currentUserPermissions,
+      permissions,
       permittedForumIds: currentPermittedForumIds
     };
     next();
@@ -260,6 +274,10 @@ import { recordContributionReport } from '../modules/linkHealth';
 import * as donorModule from '../modules/donor';
 
 const gravatar = jest.requireMock('gravatar') as { url: jest.Mock };
+const sanitize = jest.requireMock('../lib/sanitize') as {
+  sanitizeHtml: ((value: string) => string) | jest.Mock;
+  sanitizePlain: ((value: string) => string) | jest.Mock;
+};
 import * as pmModule from '../modules/pm';
 import * as staffInboxModule from '../modules/staffInbox';
 import * as staffPmModule from '../modules/staffPm';
@@ -369,6 +387,7 @@ export const setCurrentUserRankLevel = (level: number): void => {
 export const setCurrentUserPermissions = (
   permissions: Record<string, boolean>
 ): void => {
+  hasExplicitCurrentUserPermissions = true;
   currentUserPermissions = normalizePermissions(permissions) as Record<
     string,
     boolean
@@ -380,9 +399,10 @@ export const setCurrentPermittedForumIds = (forumIds: number[]): void => {
 };
 
 export const resetApiTestState = (): void => {
-  jest.clearAllMocks();
+  jest.resetAllMocks();
   mockedIsInstalled.mockResolvedValue(true);
   currentUserRankLevel = 1000;
+  hasExplicitCurrentUserPermissions = false;
   currentUserPermissions = normalizePermissions(
     makeUserRank().permissions as Record<string, boolean>
   ) as Record<string, boolean>;
@@ -393,6 +413,16 @@ export const resetApiTestState = (): void => {
   (gravatar.url as jest.Mock).mockReturnValue(
     'https://gravatar.test/avatar.png'
   );
+  if ('mockImplementation' in sanitize.sanitizeHtml) {
+    sanitize.sanitizeHtml.mockImplementation((value: string) => value);
+  } else {
+    sanitize.sanitizeHtml = (value: string) => value;
+  }
+  if ('mockImplementation' in sanitize.sanitizePlain) {
+    sanitize.sanitizePlain.mockImplementation((value: string) => value);
+  } else {
+    sanitize.sanitizePlain = (value: string) => value;
+  }
   (jwt.sign as jest.Mock).mockImplementation(
     (
       _payload: unknown,

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -151,14 +151,30 @@ jest.mock('../modules/config', () => ({
 }));
 
 let currentUserRankLevel = 1000;
+let currentUserPermissions: Record<string, boolean> = {};
+let currentPermittedForumIds: number[] = [];
 
 jest.mock('../middleware/auth', () => ({
   requireAuth: (
-    req: { user?: { id: number; userRankLevel: number; userRankId: number } },
+    req: {
+      user?: {
+        id: number;
+        userRankLevel: number;
+        userRankId: number;
+        permissions?: Record<string, boolean>;
+        permittedForumIds?: number[];
+      };
+    },
     _res: unknown,
     next: () => void
   ) => {
-    req.user = { id: 7, userRankLevel: currentUserRankLevel, userRankId: 1 };
+    req.user = {
+      id: 7,
+      userRankLevel: currentUserRankLevel,
+      userRankId: 1,
+      permissions: currentUserPermissions,
+      permittedForumIds: currentPermittedForumIds
+    };
     next();
   }
 }));
@@ -199,6 +215,7 @@ import jwt from 'jsonwebtoken';
 import { type DeepMockProxy } from 'jest-mock-extended';
 import { type PrismaClient } from '@prisma/client';
 import app from '../app';
+import { normalizePermissions } from '../lib/rankPermissions';
 import { isInstalled } from '../modules/installState';
 import { prisma } from '../lib/prisma';
 import {
@@ -349,10 +366,27 @@ export const setCurrentUserRankLevel = (level: number): void => {
   currentUserRankLevel = level;
 };
 
+export const setCurrentUserPermissions = (
+  permissions: Record<string, boolean>
+): void => {
+  currentUserPermissions = normalizePermissions(permissions) as Record<
+    string,
+    boolean
+  >;
+};
+
+export const setCurrentPermittedForumIds = (forumIds: number[]): void => {
+  currentPermittedForumIds = forumIds;
+};
+
 export const resetApiTestState = (): void => {
   jest.clearAllMocks();
   mockedIsInstalled.mockResolvedValue(true);
   currentUserRankLevel = 1000;
+  currentUserPermissions = normalizePermissions(
+    makeUserRank().permissions as Record<string, boolean>
+  ) as Record<string, boolean>;
+  currentPermittedForumIds = [];
   // Restore implementations cleared by resetMocks: true
   (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
   (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -38,7 +38,16 @@ export function makeUserRank(
     level: 1000,
     color: '',
     badge: '',
-    permissions,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      collages_create: true,
+      requests_create: true,
+      wiki_edit: true,
+      ...permissions
+    },
+    secondary: false,
+    permittedForumIds: [],
     uploadRequired: 0,
     personalCollageLimit: 0,
     displayStaff: false,

--- a/src/tools.spec.ts
+++ b/src/tools.spec.ts
@@ -31,13 +31,25 @@ const makeGroup = (overrides: Record<string, unknown> = {}) => ({
   ...overrides
 });
 
+const setRankPermissionsManager = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      rank_permissions_manage: true
+    }).permissions as Record<string, boolean>
+  );
+
+const setStaffGroupsManager = () =>
+  setCurrentUserPermissions(
+    makeUserRank({
+      staff_groups_manage: true
+    }).permissions as Record<string, boolean>
+  );
+
 beforeEach(() => resetApiTestState());
 
 describe('GET /api/tools/user-ranks', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setRankPermissionsManager();
   });
 
   it('returns list of user ranks with user counts', async () => {
@@ -51,7 +63,7 @@ describe('GET /api/tools/user-ranks', () => {
     expect(res.body[0].userCount).toBe(5);
   });
 
-  it('returns 403 without admin permission', async () => {
+  it('returns 403 without rank_permissions_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank().permissions as Record<string, boolean>
     );
@@ -64,9 +76,7 @@ describe('GET /api/tools/user-ranks', () => {
 
 describe('GET /api/tools/user-ranks/:id', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setRankPermissionsManager();
   });
 
   it('returns a single rank', async () => {
@@ -89,9 +99,7 @@ describe('GET /api/tools/user-ranks/:id', () => {
 
 describe('POST /api/tools/user-ranks', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setRankPermissionsManager();
   });
 
   it('creates a rank and returns 201', async () => {
@@ -139,9 +147,7 @@ describe('POST /api/tools/user-ranks', () => {
 
 describe('PUT /api/tools/user-ranks/:id', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setRankPermissionsManager();
   });
 
   it('updates a rank and returns it', async () => {
@@ -172,9 +178,7 @@ describe('PUT /api/tools/user-ranks/:id', () => {
 
 describe('DELETE /api/tools/user-ranks/:id', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setRankPermissionsManager();
   });
 
   it('deletes a rank and returns 204 when no users assigned', async () => {
@@ -202,9 +206,7 @@ describe('DELETE /api/tools/user-ranks/:id', () => {
 
 describe('GET /api/tools/staff-groups', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setStaffGroupsManager();
   });
 
   it('returns list of staff groups', async () => {
@@ -218,7 +220,7 @@ describe('GET /api/tools/staff-groups', () => {
     expect(res.body[0].rankCount).toBe(0);
   });
 
-  it('returns 403 for staff (not strict admin)', async () => {
+  it('returns 403 without staff_groups_manage permission', async () => {
     setCurrentUserPermissions(
       makeUserRank({ staff: true }).permissions as Record<string, boolean>
     );
@@ -231,9 +233,7 @@ describe('GET /api/tools/staff-groups', () => {
 
 describe('POST /api/tools/staff-groups', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setStaffGroupsManager();
   });
 
   it('creates a staff group and returns 201', async () => {
@@ -259,9 +259,7 @@ describe('POST /api/tools/staff-groups', () => {
 
 describe('POST /api/tools/user-ranks', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setRankPermissionsManager();
   });
 
   it('clears staffGroupId when displayStaff is false on create', async () => {
@@ -292,9 +290,7 @@ describe('POST /api/tools/user-ranks', () => {
 
 describe('PUT /api/tools/staff-groups/:id', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setStaffGroupsManager();
   });
 
   it('updates a staff group and returns it', async () => {
@@ -324,9 +320,7 @@ describe('PUT /api/tools/staff-groups/:id', () => {
 
 describe('DELETE /api/tools/staff-groups/:id', () => {
   beforeEach(() => {
-    setCurrentUserPermissions(
-      makeUserRank({ admin: true }).permissions as Record<string, boolean>
-    );
+    setStaffGroupsManager();
   });
 
   it('deletes a group and returns 204 when no ranks assigned', async () => {

--- a/src/tools.spec.ts
+++ b/src/tools.spec.ts
@@ -3,7 +3,8 @@ import {
   app,
   resetApiTestState,
   prismaMock,
-  makeUserRank
+  makeUserRank,
+  setCurrentUserPermissions
 } from './test/apiTestHarness';
 
 const makeRank = (overrides: Record<string, unknown> = {}) => ({
@@ -13,10 +14,12 @@ const makeRank = (overrides: Record<string, unknown> = {}) => ({
   permissions: {},
   color: '#fff',
   badge: '',
+  secondary: false,
+  permittedForumIds: [],
   personalCollageLimit: 0,
   displayStaff: false,
   staffGroupId: null,
-  _count: { users: 5 },
+  _count: { users: 5, secondaryUsers: 0 },
   ...overrides
 });
 
@@ -32,8 +35,8 @@ beforeEach(() => resetApiTestState());
 
 describe('GET /api/tools/user-ranks', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
@@ -49,7 +52,9 @@ describe('GET /api/tools/user-ranks', () => {
   });
 
   it('returns 403 without admin permission', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
 
     const res = await request(app).get('/api/tools/user-ranks');
 
@@ -59,15 +64,13 @@ describe('GET /api/tools/user-ranks', () => {
 
 describe('GET /api/tools/user-ranks/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
   it('returns a single rank', async () => {
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(makeUserRank({ admin: true }) as never)
-      .mockResolvedValueOnce(makeRank() as never);
+    prismaMock.userRank.findUnique.mockResolvedValue(makeRank() as never);
 
     const res = await request(app).get('/api/tools/user-ranks/1');
 
@@ -76,9 +79,7 @@ describe('GET /api/tools/user-ranks/:id', () => {
   });
 
   it('returns 404 when rank does not exist', async () => {
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(makeUserRank({ admin: true }) as never)
-      .mockResolvedValueOnce(null);
+    prismaMock.userRank.findUnique.mockResolvedValue(null);
 
     const res = await request(app).get('/api/tools/user-ranks/999');
 
@@ -88,21 +89,35 @@ describe('GET /api/tools/user-ranks/:id', () => {
 
 describe('POST /api/tools/user-ranks', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
   it('creates a rank and returns 201', async () => {
+    prismaMock.forum.count.mockResolvedValue(1);
     prismaMock.userRank.create.mockResolvedValue(makeRank() as never);
     prismaMock.auditLog.create.mockResolvedValue({} as never);
 
     const res = await request(app)
       .post('/api/tools/user-ranks')
-      .send({ name: 'Member', level: 100 });
+      .send({
+        name: 'Member',
+        level: 100,
+        secondary: true,
+        permittedForumIds: [1]
+      });
 
     expect(res.status).toBe(201);
     expect(res.body.name).toBe('Member');
+    expect(prismaMock.userRank.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          secondary: true,
+          permittedForumIds: [1]
+        })
+      })
+    );
   });
 
   it('returns 400 when name is missing', async () => {
@@ -124,31 +139,28 @@ describe('POST /api/tools/user-ranks', () => {
 
 describe('PUT /api/tools/user-ranks/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
   it('updates a rank and returns it', async () => {
     const updated = makeRank({ name: 'Elite Member' });
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(makeUserRank({ admin: true }) as never)
-      .mockResolvedValueOnce(makeRank() as never);
+    prismaMock.userRank.findUnique.mockResolvedValue(makeRank() as never);
+    prismaMock.forum.count.mockResolvedValue(1);
     prismaMock.userRank.update.mockResolvedValue(updated as never);
     prismaMock.auditLog.create.mockResolvedValue({} as never);
 
     const res = await request(app)
       .put('/api/tools/user-ranks/1')
-      .send({ name: 'Elite Member' });
+      .send({ name: 'Elite Member', permittedForumIds: [1] });
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Elite Member');
   });
 
   it('returns 404 when rank does not exist', async () => {
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(makeUserRank({ admin: true }) as never)
-      .mockResolvedValueOnce(null);
+    prismaMock.userRank.findUnique.mockResolvedValue(null);
 
     const res = await request(app)
       .put('/api/tools/user-ranks/999')
@@ -160,13 +172,14 @@ describe('PUT /api/tools/user-ranks/:id', () => {
 
 describe('DELETE /api/tools/user-ranks/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
   it('deletes a rank and returns 204 when no users assigned', async () => {
     prismaMock.user.count.mockResolvedValue(0);
+    prismaMock.userSecondaryRank.count.mockResolvedValue(0);
     prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
 
     const res = await request(app).delete('/api/tools/user-ranks/1');
@@ -175,7 +188,8 @@ describe('DELETE /api/tools/user-ranks/:id', () => {
   });
 
   it('returns 409 when users are still assigned to the rank', async () => {
-    prismaMock.user.count.mockResolvedValue(3);
+    prismaMock.user.count.mockResolvedValue(2);
+    prismaMock.userSecondaryRank.count.mockResolvedValue(1);
 
     const res = await request(app).delete('/api/tools/user-ranks/1');
 
@@ -188,8 +202,8 @@ describe('DELETE /api/tools/user-ranks/:id', () => {
 
 describe('GET /api/tools/staff-groups', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
@@ -205,8 +219,8 @@ describe('GET /api/tools/staff-groups', () => {
   });
 
   it('returns 403 for staff (not strict admin)', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ staff: true })
+    setCurrentUserPermissions(
+      makeUserRank({ staff: true }).permissions as Record<string, boolean>
     );
 
     const res = await request(app).get('/api/tools/staff-groups');
@@ -217,8 +231,8 @@ describe('GET /api/tools/staff-groups', () => {
 
 describe('POST /api/tools/staff-groups', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
@@ -245,8 +259,8 @@ describe('POST /api/tools/staff-groups', () => {
 
 describe('POST /api/tools/user-ranks', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
@@ -278,8 +292,8 @@ describe('POST /api/tools/user-ranks', () => {
 
 describe('PUT /api/tools/staff-groups/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 
@@ -310,8 +324,8 @@ describe('PUT /api/tools/staff-groups/:id', () => {
 
 describe('DELETE /api/tools/staff-groups/:id', () => {
   beforeEach(() => {
-    prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ admin: true })
+    setCurrentUserPermissions(
+      makeUserRank({ admin: true }).permissions as Record<string, boolean>
     );
   });
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -4,6 +4,9 @@ export type AuthUser = {
   id: number;
   userRankId: number;
   userRankLevel: number;
+  secondaryRankIds?: number[];
+  permittedForumIds?: number[];
+  permissions?: Record<string, boolean>;
 };
 
 export interface AuthenticatedRequest extends Request {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -2,6 +2,13 @@ import 'express';
 
 declare module 'express' {
   interface Request {
-    user?: { id: number; userRankId: number; userRankLevel: number };
+    user?: {
+      id: number;
+      userRankId: number;
+      userRankLevel: number;
+      secondaryRankIds?: number[];
+      permittedForumIds?: number[];
+      permissions?: Record<string, boolean>;
+    };
   }
 }


### PR DESCRIPTION
## Summary
- add rank permission management with normalized permission keys and staff-group integration
- add secondary classes and permitted forum overrides with effective access merging
- enforce explicit permission gates across staff tools, requests, collages, reports, inbox, and forum access
- update default rank seeding so SysOp receives the full permission catalog

## Verification
- npx prisma generate
- npx prisma validate
- npx tsc --noEmit
- npm run lint
- npm test -- --runInBand src/tools.spec.ts src/moderation.spec.ts src/forum.spec.ts
- npm test -- --runInBand src/middleware/permissions.spec.ts