### PR TITLE
Refactor release backend into workbench modules

### DIFF
--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -274,73 +274,33 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
     expect(res.status).toBe(404);
   });
 
-  it('updates mutable fields and tag sets', async () => {
+  it('updates mutable metadata fields', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
-    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce(makeRelease() as never)
+      .mockResolvedValueOnce(
+        makeRelease({ title: 'Updated', releaseTags: [] }) as never
+      );
     prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
     );
     prismaMock.release.update.mockResolvedValue(
-      makeRelease({
-        title: 'Updated',
-        releaseTags: [
-          {
-            tagId: 8,
-            tag: { id: 8, name: 'fusion', occurrences: 1 }
-          }
-        ]
-      }) as never
+      makeRelease({ title: 'Updated', releaseTags: [] }) as never
     );
-    prismaMock.tag.findMany.mockResolvedValue([
-      { id: 8, name: 'fusion' }
-    ] as never);
-    prismaMock.releaseTag.create.mockResolvedValue({ id: 99 } as never);
     prismaMock.release.findUniqueOrThrow.mockResolvedValue(
-      makeRelease({
-        title: 'Updated',
-        releaseTags: [
-          {
-            id: 81,
-            tagId: 8,
-            positiveVotes: 3,
-            negativeVotes: 1,
-            createdAt: new Date('2024-01-01T00:00:00Z'),
-            tag: { id: 8, name: 'fusion', occurrences: 1 },
-            user: { id: 7, username: 'user' },
-            votes: []
-          }
-        ]
-      }) as never
+      makeRelease({ title: 'Updated', releaseTags: [] }) as never
     );
 
     const res = await request(app)
       .put('/api/communities/1/releases/3')
-      .send({
-        title: 'Updated',
-        tagIds: [8]
-      });
+      .send({ title: 'Updated' });
 
     expect(res.status).toBe(200);
     expect(prismaMock.release.update).toHaveBeenCalledWith({
       where: { id: 3 },
-      data: {
-        title: 'Updated'
-      },
-      include: { artist: true, releaseTags: { include: { tag: true } } }
-    });
-    expect(prismaMock.releaseTag.deleteMany).toHaveBeenCalledWith({
-      where: { releaseId: 3, tagId: 7 }
-    });
-    expect(prismaMock.releaseTag.create).toHaveBeenCalledWith({
-      data: {
-        releaseId: 3,
-        tagId: 8,
-        userId: 7,
-        positiveVotes: 3,
-        negativeVotes: 1
-      }
+      data: { title: 'Updated' }
     });
     expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
@@ -364,7 +324,11 @@ describe('PUT /api/communities/:communityId/releases/:releaseId', () => {
   });
 
   it('allows a contributor without communities_manage to edit the release', async () => {
-    prismaMock.release.findFirst.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce(makeRelease() as never)
+      .mockResolvedValueOnce(
+        makeRelease({ title: 'Updated by Contributor' }) as never
+      );
     prismaMock.contribution.findFirst.mockResolvedValue({ id: 5 } as never);
     prismaMock.release.update.mockResolvedValue(
       makeRelease({ title: 'Updated by Contributor' }) as never
@@ -766,7 +730,9 @@ describe('DELETE /api/communities/:communityId/releases/:releaseId/tags/:tagId',
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
-    prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce({ id: 3 } as never)
+      .mockResolvedValueOnce(makeRelease() as never);
     prismaMock.tag.findUnique.mockResolvedValue({ name: 'jazz' } as never);
     prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
       (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)

--- a/src/modules/releaseBrowse.spec.ts
+++ b/src/modules/releaseBrowse.spec.ts
@@ -1,0 +1,50 @@
+const prismaMock = {
+  community: { findUnique: jest.fn() },
+  consumer: { findFirst: jest.fn() },
+  contributor: { findFirst: jest.fn() },
+  release: { findMany: jest.fn(), count: jest.fn() }
+};
+
+jest.mock('../lib/prisma', () => ({
+  prisma: prismaMock
+}));
+
+import { RegistrationStatus } from '@prisma/client';
+import { listCommunityReleases } from './releaseBrowse';
+
+describe('releaseBrowse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns paginated releases for accessible communities', async () => {
+    prismaMock.community.findUnique.mockResolvedValue({
+      registrationStatus: RegistrationStatus.open
+    } as never);
+    prismaMock.release.findMany.mockResolvedValue([
+      {
+        id: 3,
+        title: 'Kind of Blue',
+        releaseTags: [{ tag: { id: 7, name: 'jazz', occurrences: 9 } }]
+      }
+    ] as never);
+    prismaMock.release.count.mockResolvedValue(1);
+
+    const result = await listCommunityReleases({
+      actorId: 7,
+      communityId: 1,
+      page: 2,
+      limit: 25
+    });
+
+    expect(prismaMock.release.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { communityId: 1 },
+        skip: 25,
+        take: 25
+      })
+    );
+    expect(result.total).toBe(1);
+    expect(result.data[0].tags).toEqual([{ id: 7, name: 'jazz', occurrences: 9 }]);
+  });
+});

--- a/src/modules/releaseBrowse.spec.ts
+++ b/src/modules/releaseBrowse.spec.ts
@@ -45,6 +45,8 @@ describe('releaseBrowse', () => {
       })
     );
     expect(result.total).toBe(1);
-    expect(result.data[0].tags).toEqual([{ id: 7, name: 'jazz', occurrences: 9 }]);
+    expect(result.data[0].tags).toEqual([
+      { id: 7, name: 'jazz', occurrences: 9 }
+    ]);
   });
 });

--- a/src/modules/releaseBrowse.ts
+++ b/src/modules/releaseBrowse.ts
@@ -1,0 +1,72 @@
+import { RegistrationStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
+import { isCommunityMember } from '../routes/api/communities/communities';
+
+const buildPlainTags = (
+  releaseTags: Array<{ tag: { id: number; name: string; occurrences: number } }>
+) =>
+  releaseTags
+    .map((releaseTag) => releaseTag.tag)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+const getAccessibleCommunity = async (
+  communityId: number,
+  userId: number
+): Promise<{ registrationStatus: RegistrationStatus }> => {
+  const community = await prisma.community.findUnique({
+    where: { id: communityId },
+    select: { registrationStatus: true }
+  });
+  if (!community) throw new AppError(404, 'Community not found');
+
+  const isMember = await isCommunityMember(
+    communityId,
+    userId,
+    community.registrationStatus
+  );
+  if (!isMember) throw new AppError(403, 'Not a member of this community');
+  return community;
+};
+
+export const listCommunityReleases = async (input: {
+  actorId: number;
+  communityId: number;
+  page: number;
+  limit: number;
+}) => {
+  await getAccessibleCommunity(input.communityId, input.actorId);
+
+  const skip = (input.page - 1) * input.limit;
+  const [releases, total] = await Promise.all([
+    prisma.release.findMany({
+      where: { communityId: input.communityId },
+      skip,
+      take: input.limit,
+      include: {
+        artist: { select: { id: true, name: true } },
+        releaseTags: { include: { tag: true } },
+        _count: { select: { contributions: true } },
+        contributions: {
+          select: {
+            id: true,
+            type: true,
+            sizeInBytes: true,
+            linkStatus: true,
+            user: { select: { id: true, username: true } },
+            _count: { select: { consumers: true } }
+          }
+        }
+      }
+    }),
+    prisma.release.count({ where: { communityId: input.communityId } })
+  ]);
+
+  return {
+    data: releases.map((release) => ({
+      ...release,
+      tags: buildPlainTags(release.releaseTags)
+    })),
+    total
+  };
+};

--- a/src/modules/releaseLifecycle.spec.ts
+++ b/src/modules/releaseLifecycle.spec.ts
@@ -1,0 +1,108 @@
+const prismaMock = {
+  community: { findUnique: jest.fn() },
+  release: {
+    create: jest.fn(),
+    findUniqueOrThrow: jest.fn(),
+    findFirst: jest.fn(),
+    delete: jest.fn()
+  },
+  releaseTag: { create: jest.fn() },
+  releaseTagVote: { create: jest.fn() },
+  releaseHistory: { create: jest.fn() },
+  tag: {
+    findMany: jest.fn(),
+    update: jest.fn()
+  },
+  $transaction: jest.fn()
+};
+
+jest.mock('../lib/prisma', () => ({
+  prisma: prismaMock
+}));
+
+import { createCommunityRelease, deleteCommunityRelease } from './releaseLifecycle';
+
+const makeRelease = (overrides: Record<string, unknown> = {}) => ({
+  id: 3,
+  communityId: 1,
+  artistId: 2,
+  title: 'Kind of Blue',
+  description: 'Classic',
+  type: 'Music',
+  releaseType: 'Album',
+  year: 1959,
+  image: null,
+  isEdition: false,
+  edition: null,
+  artist: { id: 2, name: 'Miles Davis' },
+  releaseTags: [],
+  ...overrides
+});
+
+describe('releaseLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
+  });
+
+  it('creates community releases with initial tags and history', async () => {
+    prismaMock.community.findUnique.mockResolvedValue({ id: 1 } as never);
+    prismaMock.release.create.mockResolvedValue({ id: 3 } as never);
+    prismaMock.tag.findMany.mockResolvedValue([{ id: 7, name: 'jazz' }] as never);
+    prismaMock.releaseTag.create.mockResolvedValue({ id: 77 } as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease({
+        releaseTags: [{ tag: { id: 7, name: 'jazz', occurrences: 9 } }]
+      }) as never
+    );
+
+    const release = await createCommunityRelease({
+      actorId: 7,
+      communityId: 1,
+      data: {
+        artistId: 2,
+        title: 'Kind of Blue',
+        description: 'Classic',
+        type: 'Music' as never,
+        releaseType: 'Album' as never,
+        year: 1959,
+        tagIds: [7]
+      }
+    });
+
+    expect(release.id).toBe(3);
+    expect(prismaMock.release.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        artistId: 2,
+        communityId: 1,
+        image: null
+      })
+    });
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'created'
+      })
+    });
+  });
+
+  it('deletes community releases and decrements tag occurrences', async () => {
+    prismaMock.release.findFirst.mockResolvedValue({
+      id: 3,
+      releaseTags: [{ tagId: 7 }]
+    } as never);
+
+    await deleteCommunityRelease({ communityId: 1, releaseId: 3 });
+
+    expect(prismaMock.tag.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { occurrences: { decrement: 1 } }
+    });
+    expect(prismaMock.release.delete).toHaveBeenCalledWith({
+      where: { id: 3 }
+    });
+  });
+});

--- a/src/modules/releaseLifecycle.spec.ts
+++ b/src/modules/releaseLifecycle.spec.ts
@@ -20,7 +20,10 @@ jest.mock('../lib/prisma', () => ({
   prisma: prismaMock
 }));
 
-import { createCommunityRelease, deleteCommunityRelease } from './releaseLifecycle';
+import {
+  createCommunityRelease,
+  deleteCommunityRelease
+} from './releaseLifecycle';
 
 const makeRelease = (overrides: Record<string, unknown> = {}) => ({
   id: 3,
@@ -50,7 +53,9 @@ describe('releaseLifecycle', () => {
   it('creates community releases with initial tags and history', async () => {
     prismaMock.community.findUnique.mockResolvedValue({ id: 1 } as never);
     prismaMock.release.create.mockResolvedValue({ id: 3 } as never);
-    prismaMock.tag.findMany.mockResolvedValue([{ id: 7, name: 'jazz' }] as never);
+    prismaMock.tag.findMany.mockResolvedValue([
+      { id: 7, name: 'jazz' }
+    ] as never);
     prismaMock.releaseTag.create.mockResolvedValue({ id: 77 } as never);
     prismaMock.release.findUniqueOrThrow.mockResolvedValue(
       makeRelease({

--- a/src/modules/releaseLifecycle.ts
+++ b/src/modules/releaseLifecycle.ts
@@ -2,7 +2,10 @@ import { ReleaseHistoryAction, ReleaseTagVoteDirection } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import type { CreateGroupInput } from '../schemas/community';
-import { snapshotRelease, type ReleaseSnapshot } from './releaseWorkbench/snapshot';
+import {
+  snapshotRelease,
+  type ReleaseSnapshot
+} from './releaseWorkbench/snapshot';
 
 const buildPlainTags = (
   releaseTags: Array<{ tag: { id: number; name: string; occurrences: number } }>
@@ -12,10 +15,7 @@ const buildPlainTags = (
     .sort((a, b) => a.name.localeCompare(b.name));
 
 const attachTagWithVotes = async (
-  tx: Pick<
-    typeof prisma,
-    'releaseTag' | 'releaseTagVote' | 'releaseHistory'
-  >,
+  tx: Pick<typeof prisma, 'releaseTag' | 'releaseTagVote' | 'releaseHistory'>,
   releaseId: number,
   actorId: number,
   tag: { id: number; name: string },

--- a/src/modules/releaseLifecycle.ts
+++ b/src/modules/releaseLifecycle.ts
@@ -1,0 +1,160 @@
+import { ReleaseHistoryAction, ReleaseTagVoteDirection } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
+import type { CreateGroupInput } from '../schemas/community';
+import { snapshotRelease, type ReleaseSnapshot } from './releaseWorkbench/snapshot';
+
+const buildPlainTags = (
+  releaseTags: Array<{ tag: { id: number; name: string; occurrences: number } }>
+) =>
+  releaseTags
+    .map((releaseTag) => releaseTag.tag)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+const attachTagWithVotes = async (
+  tx: Pick<
+    typeof prisma,
+    'releaseTag' | 'releaseTagVote' | 'releaseHistory'
+  >,
+  releaseId: number,
+  actorId: number,
+  tag: { id: number; name: string },
+  writeHistory: boolean,
+  snapshot?: ReleaseSnapshot
+): Promise<void> => {
+  const releaseTag = await tx.releaseTag.create({
+    data: {
+      releaseId,
+      tagId: tag.id,
+      userId: actorId,
+      positiveVotes: 3,
+      negativeVotes: 1
+    }
+  });
+  await tx.releaseTagVote.create({
+    data: {
+      releaseTagId: releaseTag.id,
+      userId: actorId,
+      direction: ReleaseTagVoteDirection.up
+    }
+  });
+  if (writeHistory) {
+    await tx.releaseHistory.create({
+      data: {
+        releaseId,
+        actorId,
+        action: ReleaseHistoryAction.tag_added,
+        summary: `Tag "${tag.name}" added`,
+        changedFields: ['tags'],
+        before: { tagId: tag.id, name: tag.name, score: 0 } as never,
+        after: { tagId: tag.id, name: tag.name, score: 2 } as never,
+        ...(snapshot !== undefined && { snapshot: snapshot as never })
+      }
+    });
+  }
+};
+
+export const createCommunityRelease = async (input: {
+  actorId: number;
+  communityId: number;
+  data: CreateGroupInput;
+}) => {
+  const community = await prisma.community.findUnique({
+    where: { id: input.communityId }
+  });
+  if (!community) {
+    throw new AppError(404, 'Community not found');
+  }
+
+  const {
+    artistId,
+    title,
+    description,
+    type,
+    releaseType,
+    year,
+    image,
+    tagIds,
+    isEdition,
+    edition
+  } = input.data;
+  const uniqueTagIds = tagIds ? [...new Set(tagIds)] : [];
+
+  return prisma.$transaction(async (tx) => {
+    const created = await tx.release.create({
+      data: {
+        artistId,
+        communityId: input.communityId,
+        title,
+        description,
+        type,
+        releaseType,
+        year,
+        image: image ?? null,
+        isEdition: isEdition ?? false,
+        edition: (edition ?? undefined) as never
+      }
+    });
+
+    if (uniqueTagIds.length > 0) {
+      const tags = await tx.tag.findMany({
+        where: { id: { in: uniqueTagIds } },
+        select: { id: true, name: true }
+      });
+      for (const tag of tags) {
+        await tx.tag.update({
+          where: { id: tag.id },
+          data: { occurrences: { increment: 1 } }
+        });
+        await attachTagWithVotes(tx, created.id, input.actorId, tag, false);
+      }
+    }
+
+    const release = await tx.release.findUniqueOrThrow({
+      where: { id: created.id },
+      include: { artist: true, releaseTags: { include: { tag: true } } }
+    });
+    const createdSnapshot = snapshotRelease(release);
+    await tx.releaseHistory.create({
+      data: {
+        releaseId: release.id,
+        actorId: input.actorId,
+        action: ReleaseHistoryAction.created,
+        summary: 'Release created',
+        changedFields: [],
+        after: createdSnapshot as never,
+        snapshot: createdSnapshot as never
+      }
+    });
+
+    return {
+      ...release,
+      tags: buildPlainTags(release.releaseTags)
+    };
+  });
+};
+
+export const deleteCommunityRelease = async (input: {
+  communityId: number;
+  releaseId: number;
+}) => {
+  const existing = await prisma.release.findFirst({
+    where: { id: input.releaseId, communityId: input.communityId },
+    select: { id: true, releaseTags: { select: { tagId: true } } }
+  });
+  if (!existing) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await Promise.all(
+      existing.releaseTags.map((tag) =>
+        tx.tag.update({
+          where: { id: tag.tagId },
+          data: { occurrences: { decrement: 1 } }
+        })
+      )
+    );
+    await tx.release.delete({ where: { id: input.releaseId } });
+  });
+};

--- a/src/modules/releaseWorkbench.spec.ts
+++ b/src/modules/releaseWorkbench.spec.ts
@@ -1,0 +1,381 @@
+const prismaMock = {
+  community: { findUnique: jest.fn() },
+  consumer: { findFirst: jest.fn() },
+  contributor: { findFirst: jest.fn() },
+  contribution: { findFirst: jest.fn() },
+  release: {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    findUniqueOrThrow: jest.fn()
+  },
+  releaseVote: {
+    findUnique: jest.fn(),
+    upsert: jest.fn(),
+    deleteMany: jest.fn()
+  },
+  releaseVoteAggregate: { findUnique: jest.fn() },
+  releaseTag: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    findUniqueOrThrow: jest.fn(),
+    update: jest.fn(),
+    deleteMany: jest.fn()
+  },
+  releaseTagVote: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    delete: jest.fn()
+  },
+  releaseHistory: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn()
+  },
+  tag: {
+    upsert: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn()
+  },
+  tagAlias: { findUnique: jest.fn() },
+  artistSubscription: { findMany: jest.fn() },
+  notification: { createMany: jest.fn() },
+  siteSettings: { upsert: jest.fn() },
+  $transaction: jest.fn()
+};
+
+jest.mock('../lib/prisma', () => ({
+  prisma: prismaMock
+}));
+
+jest.mock('../lib/userRankAccess', () => ({
+  getUserRankAccess: jest.fn()
+}));
+
+jest.mock('./contribution', () => ({
+  addContributionToRelease: jest.fn()
+}));
+
+jest.mock('./settings', () => ({
+  getSettings: jest.fn()
+}));
+
+jest.mock('./top10', () => ({
+  recomputeVoteAggregate: jest.fn()
+}));
+
+import { RegistrationStatus, FileType } from '@prisma/client';
+import { releaseWorkbench } from './releaseWorkbench';
+import { getUserRankAccess } from '../lib/userRankAccess';
+import { addContributionToRelease } from './contribution';
+import { getSettings } from './settings';
+import { recomputeVoteAggregate } from './top10';
+
+const getUserRankAccessMock = getUserRankAccess as jest.MockedFunction<
+  typeof getUserRankAccess
+>;
+const addContributionToReleaseMock =
+  addContributionToRelease as jest.MockedFunction<typeof addContributionToRelease>;
+const getSettingsMock = getSettings as jest.MockedFunction<typeof getSettings>;
+const recomputeVoteAggregateMock =
+  recomputeVoteAggregate as jest.MockedFunction<typeof recomputeVoteAggregate>;
+
+const makeRelease = (overrides: Record<string, unknown> = {}) => ({
+  id: 3,
+  communityId: 1,
+  artistId: 2,
+  title: 'Kind of Blue',
+  description: 'Classic',
+  type: 'Music',
+  releaseType: 'Album',
+  year: 1959,
+  image: null,
+  isEdition: false,
+  edition: null,
+  artist: { id: 2, name: 'Miles Davis' },
+  releaseTags: [
+    {
+      id: 77,
+      tagId: 7,
+      positiveVotes: 3,
+      negativeVotes: 1,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      tag: { id: 7, name: 'jazz', occurrences: 9 },
+      user: { id: 9, username: 'tagger' },
+      votes: []
+    }
+  ],
+  voteAggregate: null,
+  contributions: [],
+  ...overrides
+});
+
+describe('releaseWorkbench session', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
+    prismaMock.community.findUnique.mockResolvedValue({
+      id: 1,
+      registrationStatus: RegistrationStatus.open
+    });
+    prismaMock.tagAlias.findUnique.mockResolvedValue(null as never);
+    prismaMock.artistSubscription.findMany.mockResolvedValue([] as never);
+    getUserRankAccessMock.mockResolvedValue({
+      userRankId: 1,
+      effectiveLevel: 1000,
+      permissions: {},
+      permittedForumIds: [],
+      secondaryRankIds: []
+    });
+    getSettingsMock.mockResolvedValue({
+      id: 1,
+      approvedDomains: [],
+      registrationStatus: 'open',
+      maxUsers: 7000,
+      dismissedLaunchChecklist: [],
+      updatedAt: new Date()
+    } as never);
+  });
+
+  it('maps release view state through the session seam', async () => {
+    prismaMock.release.findFirst.mockResolvedValue(
+      makeRelease({
+        releaseTags: [
+          {
+            id: 77,
+            tagId: 7,
+            positiveVotes: 5,
+            negativeVotes: 2,
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+            tag: { id: 7, name: 'jazz', occurrences: 9 },
+            user: { id: 9, username: 'tagger' },
+            votes: [{ direction: 'up' }]
+          }
+        ],
+        contributions: [{ id: 5, userId: 7 }]
+      }) as never
+    );
+    prismaMock.releaseVote.findUnique.mockResolvedValue({ positive: true } as never);
+
+    const session = await releaseWorkbench.open({
+      actorId: 7,
+      communityId: 1,
+      releaseId: 3
+    });
+    const view = await session.getView();
+
+    expect(view.myVote).toBe('up');
+    expect(view.isContributor).toBe(true);
+    expect(view.releaseTags[0]).toMatchObject({
+      name: 'jazz',
+      score: 3,
+      positiveVotes: 4,
+      negativeVotes: 1,
+      myVotes: { up: true, down: false }
+    });
+  });
+
+  it('updates metadata through the session seam', async () => {
+    prismaMock.contribution.findFirst.mockResolvedValue({ id: 5 } as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce(makeRelease() as never)
+      .mockResolvedValueOnce(makeRelease({ title: 'Updated' }) as never);
+    prismaMock.release.update.mockResolvedValue(
+      makeRelease({ title: 'Updated' }) as never
+    );
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease({ title: 'Updated' }) as never
+    );
+    prismaMock.releaseVote.findUnique.mockResolvedValue(null as never);
+
+    const session = await releaseWorkbench.open({
+      actorId: 7,
+      communityId: 1,
+      releaseId: 3
+    });
+    const view = await session.updateMetadata({ title: 'Updated' });
+
+    expect(view.release.title).toBe('Updated');
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'edit',
+        changedFields: ['title']
+      })
+    });
+  });
+
+  it('updates vote state through the session seam', async () => {
+    prismaMock.contribution.findFirst.mockResolvedValue(null as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce({ id: 3 } as never)
+      .mockResolvedValueOnce(makeRelease() as never);
+    prismaMock.releaseVote.upsert.mockResolvedValue({} as never);
+    prismaMock.releaseVote.findUnique.mockResolvedValue({ positive: true } as never);
+    prismaMock.releaseVoteAggregate.findUnique.mockResolvedValue({
+      releaseId: 3,
+      ups: 2,
+      total: 3,
+      score: 0.5
+    } as never);
+
+    const session = await releaseWorkbench.open({
+      actorId: 7,
+      communityId: 1,
+      releaseId: 3
+    });
+    const view = await session.vote({ direction: 'up' });
+
+    expect(recomputeVoteAggregateMock).toHaveBeenCalledWith(3);
+    expect(view.myVote).toBe('up');
+    expect(view.release.voteAggregate).toEqual({
+      releaseId: 3,
+      ups: 2,
+      total: 3,
+      score: 0.5
+    });
+  });
+
+  it('adds a tag through the session seam', async () => {
+    prismaMock.contribution.findFirst.mockResolvedValue(null as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce({ id: 3, releaseTags: [] } as never)
+      .mockResolvedValueOnce(
+        makeRelease({
+          releaseTags: [
+            {
+              id: 81,
+              tagId: 9,
+              positiveVotes: 3,
+              negativeVotes: 1,
+              createdAt: new Date('2024-01-01T00:00:00Z'),
+              tag: { id: 9, name: 'fusion', occurrences: 1 },
+              user: { id: 7, username: 'user' },
+              votes: []
+            }
+          ]
+        }) as never
+      );
+    prismaMock.tag.upsert.mockResolvedValue({ id: 9, name: 'fusion' } as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue({
+      id: 3,
+      title: 'Kind of Blue',
+      description: 'Classic',
+      image: null,
+      year: 1959,
+      isEdition: false,
+      edition: null,
+      releaseTags: []
+    } as never);
+    prismaMock.releaseTag.create.mockResolvedValue({ id: 81 } as never);
+    prismaMock.releaseVote.findUnique.mockResolvedValue(null as never);
+
+    const session = await releaseWorkbench.open({
+      actorId: 7,
+      communityId: 1,
+      releaseId: 3
+    });
+    const view = await session.addTag({ name: 'fusion' });
+
+    expect(view.releaseTags[0].name).toBe('fusion');
+    expect(prismaMock.releaseTagVote.create).toHaveBeenCalledWith({
+      data: { releaseTagId: 81, userId: 7, direction: 'up' }
+    });
+  });
+
+  it('reverts history through the session seam', async () => {
+    prismaMock.contribution.findFirst.mockResolvedValue(null as never);
+    prismaMock.releaseHistory.findFirst.mockResolvedValue({
+      id: 91,
+      releaseId: 3,
+      action: 'edit',
+      createdAt: new Date('2024-06-01T00:00:00Z'),
+      snapshot: {
+        title: 'Revision Title',
+        description: 'Classic',
+        image: null,
+        year: 1959,
+        isEdition: false,
+        edition: null,
+        tagIds: [7],
+        tagNames: ['jazz']
+      },
+      after: null
+    } as never);
+    prismaMock.release.findFirst
+      .mockResolvedValueOnce(makeRelease() as never)
+      .mockResolvedValueOnce(makeRelease({ title: 'Revision Title' }) as never);
+    prismaMock.release.update.mockResolvedValue(
+      makeRelease({ title: 'Revision Title' }) as never
+    );
+    prismaMock.releaseVote.findUnique.mockResolvedValue(null as never);
+
+    const session = await releaseWorkbench.open({
+      actorId: 7,
+      communityId: 1,
+      releaseId: 3,
+      permissions: { communities_manage: true }
+    });
+    const view = await session.revertHistory({ historyId: 91 });
+
+    expect(view.release.title).toBe('Revision Title');
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'edit'
+      })
+    });
+  });
+
+  it('attaches contributions through the session seam', async () => {
+    prismaMock.contribution.findFirst.mockResolvedValue(null as never);
+    prismaMock.community.findUnique.mockResolvedValueOnce({
+      id: 1,
+      registrationStatus: RegistrationStatus.open
+    } as never);
+    prismaMock.community.findUnique.mockResolvedValueOnce({
+      id: 1,
+      allowDuplicateFormats: true
+    } as never);
+    addContributionToReleaseMock.mockResolvedValue({
+      id: 15,
+      releaseId: 3,
+      userId: 7,
+      type: FileType.flac,
+      sizeInBytes: 1234,
+      user: { id: 7, username: 'user' },
+      release: { id: 3, title: 'Kind of Blue', communityId: 1, artistId: 5 }
+    } as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(makeRelease() as never);
+
+    const session = await releaseWorkbench.open({
+      actorId: 7,
+      communityId: 1,
+      releaseId: 3
+    });
+    const contribution = await session.attachContribution({
+      fileType: 'flac',
+      sizeInBytes: 1234,
+      downloadUrl: 'https://approved.example/file.zip',
+      releaseDescription: 'Seeded from archive',
+      bitrate: undefined,
+      media: undefined,
+      hasLog: false,
+      hasCue: false,
+      isScene: false
+    });
+
+    expect(contribution.id).toBe(15);
+    expect(prismaMock.releaseHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        releaseId: 3,
+        actorId: 7,
+        action: 'contribution_added'
+      })
+    });
+  });
+});

--- a/src/modules/releaseWorkbench.spec.ts
+++ b/src/modules/releaseWorkbench.spec.ts
@@ -75,7 +75,9 @@ const getUserRankAccessMock = getUserRankAccess as jest.MockedFunction<
   typeof getUserRankAccess
 >;
 const addContributionToReleaseMock =
-  addContributionToRelease as jest.MockedFunction<typeof addContributionToRelease>;
+  addContributionToRelease as jest.MockedFunction<
+    typeof addContributionToRelease
+  >;
 const getSettingsMock = getSettings as jest.MockedFunction<typeof getSettings>;
 const recomputeVoteAggregateMock =
   recomputeVoteAggregate as jest.MockedFunction<typeof recomputeVoteAggregate>;
@@ -157,7 +159,9 @@ describe('releaseWorkbench session', () => {
         contributions: [{ id: 5, userId: 7 }]
       }) as never
     );
-    prismaMock.releaseVote.findUnique.mockResolvedValue({ positive: true } as never);
+    prismaMock.releaseVote.findUnique.mockResolvedValue({
+      positive: true
+    } as never);
 
     const session = await releaseWorkbench.open({
       actorId: 7,
@@ -214,7 +218,9 @@ describe('releaseWorkbench session', () => {
       .mockResolvedValueOnce({ id: 3 } as never)
       .mockResolvedValueOnce(makeRelease() as never);
     prismaMock.releaseVote.upsert.mockResolvedValue({} as never);
-    prismaMock.releaseVote.findUnique.mockResolvedValue({ positive: true } as never);
+    prismaMock.releaseVote.findUnique.mockResolvedValue({
+      positive: true
+    } as never);
     prismaMock.releaseVoteAggregate.findUnique.mockResolvedValue({
       releaseId: 3,
       ups: 2,
@@ -350,7 +356,9 @@ describe('releaseWorkbench session', () => {
       user: { id: 7, username: 'user' },
       release: { id: 3, title: 'Kind of Blue', communityId: 1, artistId: 5 }
     } as never);
-    prismaMock.release.findUniqueOrThrow.mockResolvedValue(makeRelease() as never);
+    prismaMock.release.findUniqueOrThrow.mockResolvedValue(
+      makeRelease() as never
+    );
 
     const session = await releaseWorkbench.open({
       actorId: 7,

--- a/src/modules/releaseWorkbench/authority.ts
+++ b/src/modules/releaseWorkbench/authority.ts
@@ -1,0 +1,92 @@
+import { RegistrationStatus } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { getUserRankAccess } from '../../lib/userRankAccess';
+import type { ReleaseWorkbenchRef } from './types';
+
+export type ReleaseWorkbenchAuthority = {
+  actorId: number;
+  communityId: number;
+  releaseId: number;
+  canEditMetadata: boolean;
+  canManageTags: boolean;
+  canVote: boolean;
+  canAttachContribution: boolean;
+  canRevertHistory: boolean;
+};
+
+const isCommunityMember = async (
+  communityId: number,
+  userId: number,
+  registrationStatus: RegistrationStatus
+): Promise<boolean> => {
+  if (registrationStatus === RegistrationStatus.open) return true;
+  const [consumer, contributor] = await Promise.all([
+    prisma.consumer.findFirst({
+      where: { userId, communities: { some: { id: communityId } } }
+    }),
+    prisma.contributor.findFirst({ where: { userId, communityId } })
+  ]);
+  return !!(consumer || contributor);
+};
+
+const getAccessibleCommunity = async (
+  communityId: number,
+  userId: number
+): Promise<{ registrationStatus: RegistrationStatus }> => {
+  const community = await prisma.community.findUnique({
+    where: { id: communityId },
+    select: { registrationStatus: true }
+  });
+  if (!community) {
+    throw new AppError(404, 'Community not found');
+  }
+
+  const isMember = await isCommunityMember(
+    communityId,
+    userId,
+    community.registrationStatus
+  );
+  if (!isMember) {
+    throw new AppError(403, 'Not a member of this community');
+  }
+
+  return community;
+};
+
+export const loadReleaseWorkbenchAuthority = async (
+  ref: ReleaseWorkbenchRef,
+  options: { requireCommunityAccess?: boolean } = {}
+): Promise<ReleaseWorkbenchAuthority> => {
+  if (options.requireCommunityAccess ?? true) {
+    await getAccessibleCommunity(ref.communityId, ref.actorId);
+  }
+
+  const [access, contribution] = await Promise.all([
+    ref.permissions ? Promise.resolve(null) : getUserRankAccess(ref.actorId),
+    prisma.contribution.findFirst({
+      where: { releaseId: ref.releaseId, userId: ref.actorId },
+      select: { id: true }
+    })
+  ]);
+
+  const permissions = ref.permissions ?? access?.permissions ?? {};
+  const canModerateRelease =
+    !!permissions['communities_manage'] ||
+    !!permissions['admin'] ||
+    !!permissions['staff'];
+  const canManageTags =
+    !!permissions['communities_manage'] || !!permissions['admin'];
+  const isContributor = !!contribution;
+
+  return {
+    actorId: ref.actorId,
+    communityId: ref.communityId,
+    releaseId: ref.releaseId,
+    canEditMetadata: canModerateRelease || isContributor,
+    canManageTags,
+    canVote: true,
+    canAttachContribution: true,
+    canRevertHistory: canManageTags
+  };
+};

--- a/src/modules/releaseWorkbench/contributions.ts
+++ b/src/modules/releaseWorkbench/contributions.ts
@@ -1,0 +1,109 @@
+import { FileType, ReleaseHistoryAction } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { emitNotifications } from '../../lib/notifications';
+import { addContributionToRelease } from '../contribution';
+import { getSettings } from '../settings';
+import { loadReleaseWorkbenchAuthority } from './authority';
+import { snapshotRelease } from './snapshot';
+import type {
+  ReleaseContributionView,
+  ReleaseWorkbenchRef
+} from './types';
+import type { AddContributionToReleaseInput } from '../../schemas/contribution';
+
+export const attachReleaseWorkbenchContribution = async (
+  ref: ReleaseWorkbenchRef,
+  input: AddContributionToReleaseInput
+): Promise<ReleaseContributionView> => {
+  const authority = await loadReleaseWorkbenchAuthority(ref, {
+    requireCommunityAccess: false
+  });
+  if (!authority.canAttachContribution) {
+    throw new AppError(403, 'Not authorized');
+  }
+
+  const settings = await getSettings();
+  if (settings.approvedDomains.length > 0) {
+    let host: string;
+    try {
+      host = new URL(input.downloadUrl).hostname;
+    } catch {
+      throw new AppError(400, 'Invalid download URL');
+    }
+    if (!settings.approvedDomains.includes(host)) {
+      throw new AppError(
+        400,
+        `Domain '${host}' is not in the approved domains list`
+      );
+    }
+  }
+
+  const community = await prisma.community.findUnique({
+    where: { id: ref.communityId },
+    select: { allowDuplicateFormats: true }
+  });
+  if (!community) {
+    throw new AppError(404, 'Community not found');
+  }
+
+  if (!community.allowDuplicateFormats) {
+    const existing = await prisma.contribution.findFirst({
+      where: { releaseId: ref.releaseId, type: input.fileType as FileType }
+    });
+    if (existing) {
+      throw new AppError(
+        409,
+        `A ${input.fileType} contribution already exists for this release`
+      );
+    }
+  }
+
+  const contribution = await addContributionToRelease({
+    userId: ref.actorId,
+    communityId: ref.communityId,
+    releaseId: ref.releaseId,
+    input
+  });
+  if (!contribution) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const subs = await tx.artistSubscription.findMany({
+      where: { artistId: contribution.release.artistId },
+      select: { userId: true }
+    });
+    if (subs.length > 0) {
+      await emitNotifications(tx, {
+        userIds: subs.map((s) => s.userId),
+        type: 'artist_release',
+        actorId: ref.actorId,
+        page: 'contributions',
+        pageId: contribution.id
+      });
+    }
+    const releaseWithTags = await tx.release.findUniqueOrThrow({
+      where: { id: contribution.release.id },
+      include: { releaseTags: { include: { tag: true } } }
+    });
+    await tx.releaseHistory.create({
+      data: {
+        releaseId: contribution.release.id,
+        actorId: ref.actorId,
+        action: ReleaseHistoryAction.contribution_added,
+        summary: `${contribution.type} contribution added`,
+        changedFields: [],
+        after: {
+          contributionId: contribution.id,
+          type: contribution.type,
+          sizeInBytes: contribution.sizeInBytes ?? null,
+          contributor: contribution.user?.username ?? null
+        } as never,
+        snapshot: snapshotRelease(releaseWithTags) as never
+      }
+    });
+  });
+
+  return contribution as ReleaseContributionView;
+};

--- a/src/modules/releaseWorkbench/contributions.ts
+++ b/src/modules/releaseWorkbench/contributions.ts
@@ -6,10 +6,7 @@ import { addContributionToRelease } from '../contribution';
 import { getSettings } from '../settings';
 import { loadReleaseWorkbenchAuthority } from './authority';
 import { snapshotRelease } from './snapshot';
-import type {
-  ReleaseContributionView,
-  ReleaseWorkbenchRef
-} from './types';
+import type { ReleaseContributionView, ReleaseWorkbenchRef } from './types';
 import type { AddContributionToReleaseInput } from '../../schemas/contribution';
 
 export const attachReleaseWorkbenchContribution = async (

--- a/src/modules/releaseWorkbench/history.ts
+++ b/src/modules/releaseWorkbench/history.ts
@@ -1,0 +1,80 @@
+import { ReleaseHistoryAction } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { loadReleaseWorkbenchAuthority } from './authority';
+import { getReleaseWorkbenchView } from './load';
+import {
+  changedReleaseFields,
+  extractRevisionSnapshot,
+  snapshotRelease
+} from './snapshot';
+import type { ReleaseWorkbenchRef, ReleaseWorkbenchView } from './types';
+
+export const revertReleaseWorkbenchHistory = async (
+  ref: ReleaseWorkbenchRef,
+  input: { historyId: number }
+): Promise<ReleaseWorkbenchView> => {
+  const authority = await loadReleaseWorkbenchAuthority(ref);
+  if (!authority.canRevertHistory) {
+    throw new AppError(403, 'Permission denied');
+  }
+
+  const targetEntry = await prisma.releaseHistory.findFirst({
+    where: { id: input.historyId, releaseId: ref.releaseId }
+  });
+  if (!targetEntry) {
+    throw new AppError(404, 'History entry not found');
+  }
+  if (targetEntry.action !== ReleaseHistoryAction.edit) {
+    throw new AppError(422, 'Only edit revisions can be reverted');
+  }
+
+  const restoreState = extractRevisionSnapshot(targetEntry);
+  if (!restoreState) {
+    throw new AppError(422, 'History entry does not contain a restorable snapshot');
+  }
+
+  const existing = await prisma.release.findFirst({
+    where: { id: ref.releaseId, communityId: ref.communityId },
+    include: { releaseTags: { include: { tag: true } } }
+  });
+  if (!existing) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  const currentSnapshot = snapshotRelease(existing);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.release.update({
+      where: { id: ref.releaseId },
+      data: {
+        title: restoreState.title,
+        description: restoreState.description,
+        image: restoreState.image,
+        year: restoreState.year,
+        isEdition: restoreState.isEdition,
+        edition: (restoreState.edition ?? undefined) as never
+      }
+    });
+
+    const changedFields = changedReleaseFields(
+      currentSnapshot,
+      restoreState
+    ).filter((field) => field !== 'tags');
+
+    await tx.releaseHistory.create({
+      data: {
+        releaseId: ref.releaseId,
+        actorId: ref.actorId,
+        action: ReleaseHistoryAction.edit,
+        summary: `Reverted to revision from ${targetEntry.createdAt.toISOString()}`,
+        changedFields,
+        before: currentSnapshot as never,
+        after: restoreState as never,
+        snapshot: restoreState as never
+      }
+    });
+  });
+
+  return getReleaseWorkbenchView(ref);
+};

--- a/src/modules/releaseWorkbench/history.ts
+++ b/src/modules/releaseWorkbench/history.ts
@@ -31,7 +31,10 @@ export const revertReleaseWorkbenchHistory = async (
 
   const restoreState = extractRevisionSnapshot(targetEntry);
   if (!restoreState) {
-    throw new AppError(422, 'History entry does not contain a restorable snapshot');
+    throw new AppError(
+      422,
+      'History entry does not contain a restorable snapshot'
+    );
   }
 
   const existing = await prisma.release.findFirst({

--- a/src/modules/releaseWorkbench/index.ts
+++ b/src/modules/releaseWorkbench/index.ts
@@ -1,0 +1,50 @@
+import { AppError } from '../../lib/errors';
+import type {
+  ReleaseContributionView,
+  ReleaseTagView,
+  ReleaseWorkbenchModule,
+  ReleaseWorkbenchRef,
+  ReleaseWorkbenchSession,
+  ReleaseWorkbenchView,
+  UpdateReleaseMetadataInput
+} from './types';
+import {
+  getReleaseWorkbenchHistoryPage,
+  getReleaseWorkbenchView
+} from './load';
+import { updateReleaseWorkbenchMetadata } from './metadata';
+import { voteOnReleaseWorkbench } from './votes';
+import {
+  addReleaseWorkbenchTag,
+  removeReleaseWorkbenchTag,
+  voteOnReleaseWorkbenchTag
+} from './tags';
+import { attachReleaseWorkbenchContribution } from './contributions';
+import { revertReleaseWorkbenchHistory } from './history';
+
+const createSession = (ref: ReleaseWorkbenchRef): ReleaseWorkbenchSession => ({
+  getView: () => getReleaseWorkbenchView(ref),
+  getHistoryPage: (input) => getReleaseWorkbenchHistoryPage(ref, input),
+  updateMetadata: (input: UpdateReleaseMetadataInput): Promise<ReleaseWorkbenchView> =>
+    updateReleaseWorkbenchMetadata(ref, input),
+  vote: (input: {
+    direction: 'up' | 'down' | 'clear';
+  }): Promise<ReleaseWorkbenchView> => voteOnReleaseWorkbench(ref, input),
+  addTag: (input: { name: string }): Promise<ReleaseWorkbenchView> =>
+    addReleaseWorkbenchTag(ref, input),
+  voteTag: (input: {
+    tagId: number;
+    direction: 'up' | 'down';
+  }): Promise<ReleaseTagView> => voteOnReleaseWorkbenchTag(ref, input),
+  removeTag: (input: { tagId: number }): Promise<ReleaseWorkbenchView> =>
+    removeReleaseWorkbenchTag(ref, input),
+  attachContribution: (input): Promise<ReleaseContributionView> =>
+    attachReleaseWorkbenchContribution(ref, input),
+  revertHistory: (input: {
+    historyId: number;
+  }): Promise<ReleaseWorkbenchView> => revertReleaseWorkbenchHistory(ref, input)
+});
+
+export const releaseWorkbench: ReleaseWorkbenchModule = {
+  open: async (ref) => createSession(ref)
+};

--- a/src/modules/releaseWorkbench/index.ts
+++ b/src/modules/releaseWorkbench/index.ts
@@ -1,4 +1,3 @@
-import { AppError } from '../../lib/errors';
 import type {
   ReleaseContributionView,
   ReleaseTagView,
@@ -25,7 +24,9 @@ import { revertReleaseWorkbenchHistory } from './history';
 const createSession = (ref: ReleaseWorkbenchRef): ReleaseWorkbenchSession => ({
   getView: () => getReleaseWorkbenchView(ref),
   getHistoryPage: (input) => getReleaseWorkbenchHistoryPage(ref, input),
-  updateMetadata: (input: UpdateReleaseMetadataInput): Promise<ReleaseWorkbenchView> =>
+  updateMetadata: (
+    input: UpdateReleaseMetadataInput
+  ): Promise<ReleaseWorkbenchView> =>
     updateReleaseWorkbenchMetadata(ref, input),
   vote: (input: {
     direction: 'up' | 'down' | 'clear';

--- a/src/modules/releaseWorkbench/load.ts
+++ b/src/modules/releaseWorkbench/load.ts
@@ -1,0 +1,210 @@
+import { ReleaseTagVoteDirection } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import type {
+  ReleaseHistoryPage,
+  ReleaseTagView,
+  ReleaseWorkbenchRef,
+  ReleaseWorkbenchView
+} from './types';
+import { loadReleaseWorkbenchAuthority } from './authority';
+
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+
+const normalizePage = (page?: number, limit?: number) => {
+  const safePage = Math.max(1, page ?? 1);
+  const safeLimit = Math.min(MAX_PAGE_SIZE, Math.max(1, limit ?? DEFAULT_PAGE_SIZE));
+  return { page: safePage, limit: safeLimit, skip: (safePage - 1) * safeLimit };
+};
+
+const buildPlainTags = (
+  releaseTags: Array<{ tag: { id: number; name: string; occurrences: number } }>
+) =>
+  releaseTags
+    .map((releaseTag) => releaseTag.tag)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+const buildReleaseTagPayload = (
+  tags: Array<{ id: number; name: string; occurrences: number }>,
+  releaseTags: Array<{
+    id: number;
+    tagId: number;
+    positiveVotes: number;
+    negativeVotes: number;
+    createdAt: Date;
+    user: { id: number; username: string } | null;
+    votes: Array<{ direction: ReleaseTagVoteDirection }>;
+  }>
+): ReleaseTagView[] => {
+  const byTagId = new Map(
+    releaseTags.map((releaseTag) => [releaseTag.tagId, releaseTag])
+  );
+
+  return tags
+    .map((tag) => {
+      const releaseTag = byTagId.get(tag.id);
+      const positiveVotes = releaseTag?.positiveVotes ?? 1;
+      const negativeVotes = releaseTag?.negativeVotes ?? 1;
+
+      return {
+        id: releaseTag?.id ?? tag.id,
+        tagId: tag.id,
+        name: tag.name,
+        occurrences: tag.occurrences,
+        score: positiveVotes - negativeVotes,
+        positiveVotes: Math.max(0, positiveVotes - 1),
+        negativeVotes: Math.max(0, negativeVotes - 1),
+        addedBy: releaseTag?.user ?? null,
+        createdAt: releaseTag?.createdAt ?? null,
+        myVotes: {
+          up:
+            releaseTag?.votes.some(
+              (vote) => vote.direction === ReleaseTagVoteDirection.up
+            ) ?? false,
+          down:
+            releaseTag?.votes.some(
+              (vote) => vote.direction === ReleaseTagVoteDirection.down
+            ) ?? false
+        }
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+};
+
+export const getReleaseWorkbenchView = async (
+  ref: ReleaseWorkbenchRef,
+  options: { requireCommunityAccess?: boolean } = {}
+): Promise<ReleaseWorkbenchView> => {
+  const permissions = await loadReleaseWorkbenchAuthority(ref, {
+    requireCommunityAccess: options.requireCommunityAccess
+  });
+
+  const [release, myVoteRecord] = await Promise.all([
+    prisma.release.findFirst({
+      where: { id: ref.releaseId, communityId: ref.communityId },
+      include: {
+        artist: true,
+        releaseTags: {
+          include: {
+            tag: { select: { id: true, name: true, occurrences: true } },
+            votes: {
+              where: { userId: ref.actorId },
+              select: { direction: true }
+            },
+            user: { select: { id: true, username: true } }
+          }
+        },
+        voteAggregate: true,
+        contributions: {
+          select: {
+            id: true,
+            userId: true,
+            releaseId: true,
+            contributorId: true,
+            releaseDescription: true,
+            sizeInBytes: true,
+            approvedAccountingBytes: true,
+            linkStatus: true,
+            linkCheckedAt: true,
+            type: true,
+            createdAt: true,
+            updatedAt: true,
+            user: { select: { id: true, username: true } },
+            collaborators: true
+          }
+        }
+      }
+    }),
+    prisma.releaseVote.findUnique({
+      where: {
+        releaseId_userId: { releaseId: ref.releaseId, userId: ref.actorId }
+      },
+      select: { positive: true }
+    })
+  ]);
+
+  if (!release) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  const myVote = myVoteRecord ? (myVoteRecord.positive ? 'up' : 'down') : null;
+  const releaseTagsRaw = release.releaseTags ?? [];
+  const contributions = release.contributions ?? [];
+  const tags = buildPlainTags(releaseTagsRaw);
+  const releaseTags = buildReleaseTagPayload(
+    tags,
+    releaseTagsRaw.map((releaseTag) => ({
+      id: releaseTag.id,
+      tagId: releaseTag.tag.id,
+      positiveVotes: releaseTag.positiveVotes,
+      negativeVotes: releaseTag.negativeVotes,
+      createdAt: releaseTag.createdAt,
+      user: releaseTag.user ?? null,
+      votes: releaseTag.votes
+    }))
+  );
+  const isContributor = contributions.some(
+    (contribution) => contribution.userId === ref.actorId
+  );
+  const {
+    releaseTags: _releaseTags,
+    contributions: _contributions,
+    voteAggregate,
+    ...releaseView
+  } = release;
+
+  return {
+    release: {
+      ...releaseView,
+      contributions,
+      voteAggregate: voteAggregate ?? null
+    },
+    tags,
+    myVote,
+    releaseTags,
+    isContributor,
+    permissions: {
+      canEditMetadata: permissions.canEditMetadata,
+      canManageTags: permissions.canManageTags,
+      canVote: permissions.canVote,
+      canAttachContribution: permissions.canAttachContribution,
+      canRevertHistory: permissions.canRevertHistory
+    }
+  };
+};
+
+export const getReleaseWorkbenchHistoryPage = async (
+  ref: ReleaseWorkbenchRef,
+  input: { page?: number; limit?: number }
+): Promise<ReleaseHistoryPage> => {
+  await loadReleaseWorkbenchAuthority(ref);
+
+  const release = await prisma.release.findFirst({
+    where: { id: ref.releaseId, communityId: ref.communityId },
+    select: { id: true }
+  });
+  if (!release) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  const pg = normalizePage(input.page, input.limit);
+  const [entries, total] = await Promise.all([
+    prisma.releaseHistory.findMany({
+      where: { releaseId: ref.releaseId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      skip: pg.skip,
+      take: pg.limit,
+      include: { actor: { select: { id: true, username: true } } }
+    }),
+    prisma.releaseHistory.count({ where: { releaseId: ref.releaseId } })
+  ]);
+
+  return {
+    data: entries,
+    page: pg.page,
+    limit: pg.limit,
+    total,
+    totalPages: Math.ceil(total / pg.limit)
+  };
+};

--- a/src/modules/releaseWorkbench/load.ts
+++ b/src/modules/releaseWorkbench/load.ts
@@ -14,7 +14,10 @@ const MAX_PAGE_SIZE = 100;
 
 const normalizePage = (page?: number, limit?: number) => {
   const safePage = Math.max(1, page ?? 1);
-  const safeLimit = Math.min(MAX_PAGE_SIZE, Math.max(1, limit ?? DEFAULT_PAGE_SIZE));
+  const safeLimit = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(1, limit ?? DEFAULT_PAGE_SIZE)
+  );
   return { page: safePage, limit: safeLimit, skip: (safePage - 1) * safeLimit };
 };
 
@@ -147,18 +150,15 @@ export const getReleaseWorkbenchView = async (
   const isContributor = contributions.some(
     (contribution) => contribution.userId === ref.actorId
   );
-  const {
-    releaseTags: _releaseTags,
-    contributions: _contributions,
-    voteAggregate,
-    ...releaseView
-  } = release;
+  const releaseView = { ...release };
+  delete (releaseView as { releaseTags?: unknown }).releaseTags;
+  delete (releaseView as { contributions?: unknown }).contributions;
 
   return {
     release: {
       ...releaseView,
       contributions,
-      voteAggregate: voteAggregate ?? null
+      voteAggregate: release.voteAggregate ?? null
     },
     tags,
     myVote,

--- a/src/modules/releaseWorkbench/metadata.ts
+++ b/src/modules/releaseWorkbench/metadata.ts
@@ -2,7 +2,11 @@ import { prisma } from '../../lib/prisma';
 import { AppError } from '../../lib/errors';
 import { loadReleaseWorkbenchAuthority } from './authority';
 import { getReleaseWorkbenchView } from './load';
-import { changedReleaseFields, snapshotRelease, summarizeReleaseChanges } from './snapshot';
+import {
+  changedReleaseFields,
+  snapshotRelease,
+  summarizeReleaseChanges
+} from './snapshot';
 import type {
   ReleaseWorkbenchRef,
   ReleaseWorkbenchView,
@@ -28,7 +32,10 @@ export const updateReleaseWorkbenchMetadata = async (
     requireCommunityAccess: false
   });
   if (!authority.canEditMetadata) {
-    throw new AppError(403, 'Must be a contributor or staff to edit this release');
+    throw new AppError(
+      403,
+      'Must be a contributor or staff to edit this release'
+    );
   }
 
   const before = snapshotRelease(existing);
@@ -38,7 +45,9 @@ export const updateReleaseWorkbenchMetadata = async (
       where: { id: ref.releaseId },
       data: {
         ...(input.title !== undefined && { title: input.title }),
-        ...(input.description !== undefined && { description: input.description }),
+        ...(input.description !== undefined && {
+          description: input.description
+        }),
         ...(input.image !== undefined && { image: input.image }),
         ...(input.year !== undefined && { year: input.year }),
         ...(input.isEdition !== undefined && { isEdition: input.isEdition }),

--- a/src/modules/releaseWorkbench/metadata.ts
+++ b/src/modules/releaseWorkbench/metadata.ts
@@ -1,0 +1,77 @@
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { loadReleaseWorkbenchAuthority } from './authority';
+import { getReleaseWorkbenchView } from './load';
+import { changedReleaseFields, snapshotRelease, summarizeReleaseChanges } from './snapshot';
+import type {
+  ReleaseWorkbenchRef,
+  ReleaseWorkbenchView,
+  UpdateReleaseMetadataInput
+} from './types';
+import { ReleaseHistoryAction } from '@prisma/client';
+
+export const updateReleaseWorkbenchMetadata = async (
+  ref: ReleaseWorkbenchRef,
+  input: UpdateReleaseMetadataInput
+): Promise<ReleaseWorkbenchView> => {
+  const existing = await prisma.release.findFirst({
+    where: { id: ref.releaseId, communityId: ref.communityId },
+    include: {
+      releaseTags: { include: { tag: { select: { id: true, name: true } } } }
+    }
+  });
+  if (!existing) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  const authority = await loadReleaseWorkbenchAuthority(ref, {
+    requireCommunityAccess: false
+  });
+  if (!authority.canEditMetadata) {
+    throw new AppError(403, 'Must be a contributor or staff to edit this release');
+  }
+
+  const before = snapshotRelease(existing);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.release.update({
+      where: { id: ref.releaseId },
+      data: {
+        ...(input.title !== undefined && { title: input.title }),
+        ...(input.description !== undefined && { description: input.description }),
+        ...(input.image !== undefined && { image: input.image }),
+        ...(input.year !== undefined && { year: input.year }),
+        ...(input.isEdition !== undefined && { isEdition: input.isEdition }),
+        ...(input.edition !== undefined && { edition: input.edition as never })
+      }
+    });
+
+    const refreshed = await tx.release.findUniqueOrThrow({
+      where: { id: ref.releaseId },
+      include: { releaseTags: { include: { tag: true } } }
+    });
+
+    const after = snapshotRelease(refreshed);
+    const changedFields = changedReleaseFields(before, after).filter(
+      (field) => field !== 'tags'
+    );
+
+    if (changedFields.length > 0) {
+      await tx.releaseHistory.create({
+        data: {
+          releaseId: ref.releaseId,
+          actorId: ref.actorId,
+          action: ReleaseHistoryAction.edit,
+          summary:
+            input.editSummary?.trim() || summarizeReleaseChanges(changedFields),
+          changedFields,
+          before: before as never,
+          after: after as never,
+          snapshot: after as never
+        }
+      });
+    }
+  });
+
+  return getReleaseWorkbenchView(ref, { requireCommunityAccess: false });
+};

--- a/src/modules/releaseWorkbench/snapshot.ts
+++ b/src/modules/releaseWorkbench/snapshot.ts
@@ -1,0 +1,72 @@
+import type { Prisma } from '@prisma/client';
+
+export type ReleaseSnapshot = {
+  title: string;
+  description: string;
+  image: string | null;
+  year: number;
+  isEdition: boolean;
+  edition: unknown;
+  tagIds: number[];
+  tagNames: string[];
+};
+
+export const snapshotRelease = (release: {
+  title: string;
+  description: string;
+  image: string | null;
+  year: number;
+  isEdition: boolean;
+  edition: unknown;
+  releaseTags: Array<{ tag: { id: number; name: string } }>;
+}): ReleaseSnapshot => ({
+  title: release.title,
+  description: release.description,
+  image: release.image ?? null,
+  year: release.year,
+  isEdition: release.isEdition,
+  edition: release.edition ?? null,
+  tagIds: release.releaseTags.map((tag) => tag.tag.id).sort((a, b) => a - b),
+  tagNames: release.releaseTags.map((tag) => tag.tag.name).sort()
+});
+
+export const changedReleaseFields = (
+  before: ReleaseSnapshot,
+  after: ReleaseSnapshot
+): string[] => {
+  const changed: string[] = [];
+  if (before.title !== after.title) changed.push('title');
+  if (before.description !== after.description) changed.push('description');
+  if (before.image !== after.image) changed.push('image');
+  if (before.year !== after.year) changed.push('year');
+  if (before.isEdition !== after.isEdition) changed.push('isEdition');
+  if (JSON.stringify(before.edition) !== JSON.stringify(after.edition)) {
+    changed.push('edition');
+  }
+  if (JSON.stringify(before.tagIds) !== JSON.stringify(after.tagIds)) {
+    changed.push('tags');
+  }
+  return changed;
+};
+
+export const summarizeReleaseChanges = (fields: string[]): string => {
+  if (fields.length === 0) return 'Release metadata updated';
+  const labels = fields.map((field) => {
+    switch (field) {
+      case 'isEdition':
+        return 'edition flag';
+      default:
+        return field;
+    }
+  });
+  return `Updated ${labels.join(', ')}`;
+};
+
+export const extractRevisionSnapshot = (entry: {
+  snapshot: Prisma.JsonValue | null;
+  after: Prisma.JsonValue | null;
+}): ReleaseSnapshot | null => {
+  const candidate = entry.snapshot ?? entry.after;
+  if (!candidate || typeof candidate !== 'object') return null;
+  return candidate as unknown as ReleaseSnapshot;
+};

--- a/src/modules/releaseWorkbench/tags.ts
+++ b/src/modules/releaseWorkbench/tags.ts
@@ -1,4 +1,8 @@
-import { Prisma, ReleaseHistoryAction, ReleaseTagVoteDirection } from '@prisma/client';
+import {
+  Prisma,
+  ReleaseHistoryAction,
+  ReleaseTagVoteDirection
+} from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { AppError } from '../../lib/errors';
 import { resolveTagName } from '../tag';
@@ -131,10 +135,14 @@ export const addReleaseWorkbenchTag = async (
     });
     const postAddSnapshot: ReleaseSnapshot = {
       ...snapshotRelease(currentRelease),
-      tagIds: [...currentRelease.releaseTags.map((rt) => rt.tag.id), tag.id].sort(
-        (a, b) => a - b
-      ),
-      tagNames: [...currentRelease.releaseTags.map((rt) => rt.tag.name), tag.name].sort()
+      tagIds: [
+        ...currentRelease.releaseTags.map((rt) => rt.tag.id),
+        tag.id
+      ].sort((a, b) => a - b),
+      tagNames: [
+        ...currentRelease.releaseTags.map((rt) => rt.tag.name),
+        tag.name
+      ].sort()
     };
     await attachTagWithVotes(
       tx,
@@ -314,7 +322,9 @@ export const removeReleaseWorkbenchTag = async (
         action: ReleaseHistoryAction.tag_removed,
         summary: `Tag "${tag?.name ?? `#${input.tagId}`}" removed`,
         changedFields: ['tags'],
-        before: tag ? ({ tagId: input.tagId, name: tag.name } as never) : undefined,
+        before: tag
+          ? ({ tagId: input.tagId, name: tag.name } as never)
+          : undefined,
         snapshot: postRemovalSnapshot as never
       }
     });

--- a/src/modules/releaseWorkbench/tags.ts
+++ b/src/modules/releaseWorkbench/tags.ts
@@ -1,0 +1,324 @@
+import { Prisma, ReleaseHistoryAction, ReleaseTagVoteDirection } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { resolveTagName } from '../tag';
+import { loadReleaseWorkbenchAuthority } from './authority';
+import { getReleaseWorkbenchView } from './load';
+import { snapshotRelease, type ReleaseSnapshot } from './snapshot';
+import type {
+  ReleaseTagView,
+  ReleaseWorkbenchRef,
+  ReleaseWorkbenchView
+} from './types';
+
+const buildReleaseTagPayload = (
+  tags: Array<{ id: number; name: string; occurrences: number }>,
+  releaseTags: Array<{
+    id: number;
+    tagId: number;
+    positiveVotes: number;
+    negativeVotes: number;
+    createdAt: Date;
+    user: { id: number; username: string } | null;
+    votes: Array<{ direction: ReleaseTagVoteDirection }>;
+  }>
+): ReleaseTagView[] => {
+  const byTagId = new Map(
+    releaseTags.map((releaseTag) => [releaseTag.tagId, releaseTag])
+  );
+
+  return tags
+    .map((tag) => {
+      const releaseTag = byTagId.get(tag.id);
+      const positiveVotes = releaseTag?.positiveVotes ?? 1;
+      const negativeVotes = releaseTag?.negativeVotes ?? 1;
+
+      return {
+        id: releaseTag?.id ?? tag.id,
+        tagId: tag.id,
+        name: tag.name,
+        occurrences: tag.occurrences,
+        score: positiveVotes - negativeVotes,
+        positiveVotes: Math.max(0, positiveVotes - 1),
+        negativeVotes: Math.max(0, negativeVotes - 1),
+        addedBy: releaseTag?.user ?? null,
+        createdAt: releaseTag?.createdAt ?? null,
+        myVotes: {
+          up:
+            releaseTag?.votes.some(
+              (vote) => vote.direction === ReleaseTagVoteDirection.up
+            ) ?? false,
+          down:
+            releaseTag?.votes.some(
+              (vote) => vote.direction === ReleaseTagVoteDirection.down
+            ) ?? false
+        }
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+};
+
+const attachTagWithVotes = async (
+  tx: Prisma.TransactionClient,
+  releaseId: number,
+  actorId: number,
+  tag: { id: number; name: string },
+  writeHistory: boolean,
+  snapshot?: ReleaseSnapshot
+): Promise<void> => {
+  const releaseTag = await tx.releaseTag.create({
+    data: {
+      releaseId,
+      tagId: tag.id,
+      userId: actorId,
+      positiveVotes: 3,
+      negativeVotes: 1
+    }
+  });
+  await tx.releaseTagVote.create({
+    data: {
+      releaseTagId: releaseTag.id,
+      userId: actorId,
+      direction: ReleaseTagVoteDirection.up
+    }
+  });
+  if (writeHistory) {
+    await tx.releaseHistory.create({
+      data: {
+        releaseId,
+        actorId,
+        action: ReleaseHistoryAction.tag_added,
+        summary: `Tag "${tag.name}" added`,
+        changedFields: ['tags'],
+        before: { tagId: tag.id, name: tag.name, score: 0 } as never,
+        after: { tagId: tag.id, name: tag.name, score: 2 } as never,
+        ...(snapshot !== undefined && { snapshot: snapshot as never })
+      }
+    });
+  }
+};
+
+export const addReleaseWorkbenchTag = async (
+  ref: ReleaseWorkbenchRef,
+  input: { name: string }
+): Promise<ReleaseWorkbenchView> => {
+  await loadReleaseWorkbenchAuthority(ref);
+  const name = await resolveTagName(input.name);
+
+  const release = await prisma.release.findFirst({
+    where: { id: ref.releaseId, communityId: ref.communityId },
+    select: {
+      id: true,
+      releaseTags: { where: { tag: { name } }, select: { id: true } }
+    }
+  });
+  if (!release) {
+    throw new AppError(404, 'Release not found');
+  }
+  if (release.releaseTags.length > 0) {
+    throw new AppError(409, 'Release already has this tag');
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const tag = await tx.tag.upsert({
+      where: { name },
+      create: { name, occurrences: 1 },
+      update: { occurrences: { increment: 1 } }
+    });
+    const currentRelease = await tx.release.findUniqueOrThrow({
+      where: { id: ref.releaseId },
+      include: { releaseTags: { include: { tag: true } } }
+    });
+    const postAddSnapshot: ReleaseSnapshot = {
+      ...snapshotRelease(currentRelease),
+      tagIds: [...currentRelease.releaseTags.map((rt) => rt.tag.id), tag.id].sort(
+        (a, b) => a - b
+      ),
+      tagNames: [...currentRelease.releaseTags.map((rt) => rt.tag.name), tag.name].sort()
+    };
+    await attachTagWithVotes(
+      tx,
+      ref.releaseId,
+      ref.actorId,
+      tag,
+      true,
+      postAddSnapshot
+    );
+  });
+
+  return getReleaseWorkbenchView(ref);
+};
+
+export const voteOnReleaseWorkbenchTag = async (
+  ref: ReleaseWorkbenchRef,
+  input: { tagId: number; direction: 'up' | 'down' }
+): Promise<ReleaseTagView> => {
+  await loadReleaseWorkbenchAuthority(ref);
+
+  const releaseTag = await prisma.releaseTag.findFirst({
+    where: {
+      releaseId: ref.releaseId,
+      tagId: input.tagId,
+      release: { communityId: ref.communityId }
+    },
+    select: { id: true }
+  });
+  if (!releaseTag) {
+    throw new AppError(404, 'Release tag not found');
+  }
+
+  const direction = input.direction as ReleaseTagVoteDirection;
+  const oppositeDirection =
+    direction === ReleaseTagVoteDirection.up
+      ? ReleaseTagVoteDirection.down
+      : ReleaseTagVoteDirection.up;
+
+  const [existingVote, oppositeVote] = await Promise.all([
+    prisma.releaseTagVote.findUnique({
+      where: {
+        releaseTagId_userId_direction: {
+          releaseTagId: releaseTag.id,
+          userId: ref.actorId,
+          direction
+        }
+      }
+    }),
+    prisma.releaseTagVote.findUnique({
+      where: {
+        releaseTagId_userId_direction: {
+          releaseTagId: releaseTag.id,
+          userId: ref.actorId,
+          direction: oppositeDirection
+        }
+      }
+    })
+  ]);
+
+  if (!existingVote) {
+    await prisma.$transaction(async (tx) => {
+      await tx.releaseTagVote.create({
+        data: {
+          releaseTagId: releaseTag.id,
+          userId: ref.actorId,
+          direction
+        }
+      });
+      if (oppositeVote) {
+        await tx.releaseTagVote.delete({ where: { id: oppositeVote.id } });
+      }
+      await tx.releaseTag.update({
+        where: { id: releaseTag.id },
+        data:
+          direction === ReleaseTagVoteDirection.up
+            ? {
+                positiveVotes: { increment: 2 },
+                ...(oppositeVote ? { negativeVotes: { decrement: 1 } } : {})
+              }
+            : {
+                negativeVotes: { increment: 1 },
+                ...(oppositeVote ? { positiveVotes: { decrement: 1 } } : {})
+              }
+      });
+    });
+  }
+
+  const updated = await prisma.releaseTag.findUniqueOrThrow({
+    where: { id: releaseTag.id },
+    include: {
+      tag: true,
+      user: { select: { id: true, username: true } },
+      votes: {
+        where: { userId: ref.actorId },
+        select: { direction: true }
+      }
+    }
+  });
+
+  return buildReleaseTagPayload(
+    [
+      {
+        id: updated.tag.id,
+        name: updated.tag.name,
+        occurrences: updated.tag.occurrences
+      }
+    ],
+    [
+      {
+        id: updated.id,
+        tagId: updated.tag.id,
+        positiveVotes: updated.positiveVotes,
+        negativeVotes: updated.negativeVotes,
+        createdAt: updated.createdAt,
+        user: updated.user ?? null,
+        votes: updated.votes
+      }
+    ]
+  )[0];
+};
+
+export const removeReleaseWorkbenchTag = async (
+  ref: ReleaseWorkbenchRef,
+  input: { tagId: number }
+): Promise<ReleaseWorkbenchView> => {
+  const release = await prisma.release.findFirst({
+    where: {
+      id: ref.releaseId,
+      communityId: ref.communityId,
+      releaseTags: { some: { tagId: input.tagId } }
+    },
+    select: { id: true }
+  });
+  if (!release) {
+    throw new AppError(404, 'Release or tag not found');
+  }
+
+  const authority = await loadReleaseWorkbenchAuthority(ref, {
+    requireCommunityAccess: false
+  });
+  if (!authority.canManageTags) {
+    throw new AppError(403, 'Permission denied');
+  }
+
+  const tag = await prisma.tag.findUnique({
+    where: { id: input.tagId },
+    select: { name: true }
+  });
+
+  await prisma.$transaction(async (tx) => {
+    const currentRelease = await tx.release.findUniqueOrThrow({
+      where: { id: ref.releaseId },
+      include: { releaseTags: { include: { tag: true } } }
+    });
+    const postRemovalSnapshot: ReleaseSnapshot = {
+      ...snapshotRelease(currentRelease),
+      tagIds: currentRelease.releaseTags
+        .filter((rt) => rt.tag.id !== input.tagId)
+        .map((rt) => rt.tag.id)
+        .sort((a, b) => a - b),
+      tagNames: currentRelease.releaseTags
+        .filter((rt) => rt.tag.id !== input.tagId)
+        .map((rt) => rt.tag.name)
+        .sort()
+    };
+    await tx.releaseTag.deleteMany({
+      where: { releaseId: ref.releaseId, tagId: input.tagId }
+    });
+    await tx.tag.update({
+      where: { id: input.tagId },
+      data: { occurrences: { decrement: 1 } }
+    });
+    await tx.releaseHistory.create({
+      data: {
+        releaseId: ref.releaseId,
+        actorId: ref.actorId,
+        action: ReleaseHistoryAction.tag_removed,
+        summary: `Tag "${tag?.name ?? `#${input.tagId}`}" removed`,
+        changedFields: ['tags'],
+        before: tag ? ({ tagId: input.tagId, name: tag.name } as never) : undefined,
+        snapshot: postRemovalSnapshot as never
+      }
+    });
+  });
+
+  return getReleaseWorkbenchView(ref, { requireCommunityAccess: false });
+};

--- a/src/modules/releaseWorkbench/types.ts
+++ b/src/modules/releaseWorkbench/types.ts
@@ -1,0 +1,119 @@
+import type { Prisma } from '@prisma/client';
+import type { AddContributionToReleaseInput } from '../../schemas/contribution';
+
+export type ReleaseWorkbenchRef = {
+  actorId: number;
+  communityId: number;
+  releaseId: number;
+  permissions?: Record<string, boolean>;
+};
+
+export type ReleaseTagView = {
+  id: number;
+  tagId: number;
+  name: string;
+  occurrences: number;
+  score: number;
+  positiveVotes: number;
+  negativeVotes: number;
+  addedBy: { id: number; username: string } | null;
+  createdAt: Date | null;
+  myVotes: { up: boolean; down: boolean };
+};
+
+export type ReleaseContributionView = {
+  id: number;
+  userId: number;
+  releaseId: number;
+  contributorId: number;
+  releaseDescription: string | null;
+  sizeInBytes: number | null;
+  approvedAccountingBytes: bigint | null;
+  linkStatus: string | null;
+  linkCheckedAt: Date | null;
+  type: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user: { id: number; username: string } | null;
+  release: { id: number; title: string; communityId: number; artistId: number };
+  collaborators: Array<{ id: number; name: string }>;
+};
+
+export type ReleaseHistoryEntry = Prisma.ReleaseHistoryGetPayload<{
+  include: { actor: { select: { id: true; username: true } } };
+}>;
+
+export type ReleaseHistoryPage = {
+  data: ReleaseHistoryEntry[];
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+};
+
+export type ReleaseWorkbenchView = {
+  release: Prisma.ReleaseGetPayload<{
+    include: {
+      artist: true;
+      voteAggregate: true;
+      contributions: {
+        select: {
+          id: true;
+          userId: true;
+          releaseId: true;
+          contributorId: true;
+          releaseDescription: true;
+          sizeInBytes: true;
+          approvedAccountingBytes: true;
+          linkStatus: true;
+          linkCheckedAt: true;
+          type: true;
+          createdAt: true;
+          updatedAt: true;
+          user: { select: { id: true; username: true } };
+          collaborators: true;
+        };
+      };
+    };
+  }>;
+  tags: Array<{ id: number; name: string; occurrences: number }>;
+  myVote: 'up' | 'down' | null;
+  releaseTags: ReleaseTagView[];
+  isContributor: boolean;
+  permissions: {
+    canEditMetadata: boolean;
+    canManageTags: boolean;
+    canVote: boolean;
+    canAttachContribution: boolean;
+    canRevertHistory: boolean;
+  };
+};
+
+export type UpdateReleaseMetadataInput = {
+  title?: string;
+  description?: string;
+  image?: string;
+  year?: number;
+  isEdition?: boolean;
+  edition?: Record<string, unknown>;
+  editSummary?: string;
+};
+
+export type ReleaseWorkbenchSession = {
+  getView(): Promise<ReleaseWorkbenchView>;
+  getHistoryPage(input: { page?: number; limit?: number }): Promise<ReleaseHistoryPage>;
+  updateMetadata(input: UpdateReleaseMetadataInput): Promise<ReleaseWorkbenchView>;
+  vote(input: { direction: 'up' | 'down' | 'clear' }): Promise<ReleaseWorkbenchView>;
+  addTag(input: { name: string }): Promise<ReleaseWorkbenchView>;
+  voteTag(input: {
+    tagId: number;
+    direction: 'up' | 'down';
+  }): Promise<ReleaseTagView>;
+  removeTag(input: { tagId: number }): Promise<ReleaseWorkbenchView>;
+  attachContribution(input: AddContributionToReleaseInput): Promise<ReleaseContributionView>;
+  revertHistory(input: { historyId: number }): Promise<ReleaseWorkbenchView>;
+};
+
+export type ReleaseWorkbenchModule = {
+  open(ref: ReleaseWorkbenchRef): Promise<ReleaseWorkbenchSession>;
+};

--- a/src/modules/releaseWorkbench/types.ts
+++ b/src/modules/releaseWorkbench/types.ts
@@ -101,16 +101,25 @@ export type UpdateReleaseMetadataInput = {
 
 export type ReleaseWorkbenchSession = {
   getView(): Promise<ReleaseWorkbenchView>;
-  getHistoryPage(input: { page?: number; limit?: number }): Promise<ReleaseHistoryPage>;
-  updateMetadata(input: UpdateReleaseMetadataInput): Promise<ReleaseWorkbenchView>;
-  vote(input: { direction: 'up' | 'down' | 'clear' }): Promise<ReleaseWorkbenchView>;
+  getHistoryPage(input: {
+    page?: number;
+    limit?: number;
+  }): Promise<ReleaseHistoryPage>;
+  updateMetadata(
+    input: UpdateReleaseMetadataInput
+  ): Promise<ReleaseWorkbenchView>;
+  vote(input: {
+    direction: 'up' | 'down' | 'clear';
+  }): Promise<ReleaseWorkbenchView>;
   addTag(input: { name: string }): Promise<ReleaseWorkbenchView>;
   voteTag(input: {
     tagId: number;
     direction: 'up' | 'down';
   }): Promise<ReleaseTagView>;
   removeTag(input: { tagId: number }): Promise<ReleaseWorkbenchView>;
-  attachContribution(input: AddContributionToReleaseInput): Promise<ReleaseContributionView>;
+  attachContribution(
+    input: AddContributionToReleaseInput
+  ): Promise<ReleaseContributionView>;
   revertHistory(input: { historyId: number }): Promise<ReleaseWorkbenchView>;
 };
 

--- a/src/modules/releaseWorkbench/votes.ts
+++ b/src/modules/releaseWorkbench/votes.ts
@@ -1,0 +1,56 @@
+import { prisma } from '../../lib/prisma';
+import { AppError } from '../../lib/errors';
+import { recomputeVoteAggregate } from '../top10';
+import { loadReleaseWorkbenchAuthority } from './authority';
+import { getReleaseWorkbenchView } from './load';
+import type { ReleaseWorkbenchRef, ReleaseWorkbenchView } from './types';
+
+export const voteOnReleaseWorkbench = async (
+  ref: ReleaseWorkbenchRef,
+  input: { direction: 'up' | 'down' | 'clear' }
+): Promise<ReleaseWorkbenchView> => {
+  const authority = await loadReleaseWorkbenchAuthority(ref);
+  if (!authority.canVote) {
+    throw new AppError(403, 'Not authorized');
+  }
+
+  const exists = await prisma.release.findFirst({
+    where: { id: ref.releaseId, communityId: ref.communityId },
+    select: { id: true }
+  });
+  if (!exists) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  if (input.direction === 'clear') {
+    await prisma.releaseVote.deleteMany({
+      where: { releaseId: ref.releaseId, userId: ref.actorId }
+    });
+  } else {
+    await prisma.releaseVote.upsert({
+      where: {
+        releaseId_userId: { releaseId: ref.releaseId, userId: ref.actorId }
+      },
+      create: {
+        releaseId: ref.releaseId,
+        userId: ref.actorId,
+        positive: input.direction === 'up'
+      },
+      update: { positive: input.direction === 'up' }
+    });
+  }
+
+  await recomputeVoteAggregate(ref.releaseId);
+  const aggregate = await prisma.releaseVoteAggregate.findUnique({
+    where: { releaseId: ref.releaseId }
+  });
+  const view = await getReleaseWorkbenchView(ref);
+  return {
+    ...view,
+    myVote: input.direction === 'clear' ? null : input.direction,
+    release: {
+      ...view.release,
+      voteAggregate: aggregate
+    }
+  };
+};

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -88,7 +88,10 @@ router.get(
       communityId,
       releaseId
     });
-    const history = await session.getHistoryPage({ page: pg.page, limit: pg.limit });
+    const history = await session.getHistoryPage({
+      page: pg.page,
+      limit: pg.limit
+    });
     res.json({
       data: history.data,
       meta: {
@@ -276,7 +279,10 @@ router.delete(
       permissions: req.user.permissions
     });
     const view = await session.vote({ direction: 'clear' });
-    res.json({ myVote: view.myVote, voteAggregate: view.release.voteAggregate });
+    res.json({
+      myVote: view.myVote,
+      voteAggregate: view.release.voteAggregate
+    });
   })
 );
 

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -1,13 +1,8 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
-import { prisma } from '../../../lib/prisma';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { requireAuth } from '../../../middleware/auth';
-import {
-  requirePermission,
-  loadPermissions
-} from '../../../middleware/permissions';
-import { isCommunityMember } from './communities';
+import { requirePermission } from '../../../middleware/permissions';
 import {
   validate,
   validateParams,
@@ -30,19 +25,15 @@ import {
   addContributionToReleaseSchema,
   type AddContributionToReleaseInput
 } from '../../../schemas/contribution';
-import { addContributionToRelease } from '../../../modules/contribution';
 import { resolveTagName } from '../../../modules/tag';
-import { emitNotifications } from '../../../lib/notifications';
-import { recomputeVoteAggregate } from '../../../modules/top10';
-import { getSettings } from '../../../modules/settings';
-import {
-  FileType,
-  Prisma,
-  RegistrationStatus,
-  ReleaseHistoryAction,
-  ReleaseTagVoteDirection
-} from '@prisma/client';
 import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import { releaseWorkbench } from '../../../modules/releaseWorkbench';
+import type { ReleaseWorkbenchView } from '../../../modules/releaseWorkbench/types';
+import {
+  createCommunityRelease,
+  deleteCommunityRelease
+} from '../../../modules/releaseLifecycle';
+import { listCommunityReleases } from '../../../modules/releaseBrowse';
 
 const router = express.Router({ mergeParams: true });
 const communityIdParamsSchema = z.object({
@@ -53,213 +44,14 @@ const releaseParamsSchema = z.object({
   releaseId: z.coerce.number().int().positive()
 });
 
-type ReleaseSnapshot = {
-  title: string;
-  description: string;
-  image: string | null;
-  year: number;
-  isEdition: boolean;
-  edition: unknown;
-  tagIds: number[];
-  tagNames: string[];
-};
-
-const getAccessibleCommunity = async (
-  communityId: number,
-  userId: number
-): Promise<{ registrationStatus: RegistrationStatus } | null | 'forbidden'> => {
-  const community = await prisma.community.findUnique({
-    where: { id: communityId },
-    select: { registrationStatus: true }
-  });
-  if (!community) return null;
-  const isMember = await isCommunityMember(
-    communityId,
-    userId,
-    community.registrationStatus
-  );
-  return isMember ? community : 'forbidden';
-};
-
-const snapshotRelease = (release: {
-  title: string;
-  description: string;
-  image: string | null;
-  year: number;
-  isEdition: boolean;
-  edition: unknown;
-  releaseTags: Array<{ tag: { id: number; name: string } }>;
-}): ReleaseSnapshot => ({
-  title: release.title,
-  description: release.description,
-  image: release.image ?? null,
-  year: release.year,
-  isEdition: release.isEdition,
-  edition: release.edition ?? null,
-  tagIds: release.releaseTags.map((tag) => tag.tag.id).sort((a, b) => a - b),
-  tagNames: release.releaseTags.map((tag) => tag.tag.name).sort()
-});
-
-const changedReleaseFields = (
-  before: ReleaseSnapshot,
-  after: ReleaseSnapshot
-): string[] => {
-  const changed: string[] = [];
-  if (before.title !== after.title) changed.push('title');
-  if (before.description !== after.description) changed.push('description');
-  if (before.image !== after.image) changed.push('image');
-  if (before.year !== after.year) changed.push('year');
-  if (before.isEdition !== after.isEdition) changed.push('isEdition');
-  if (JSON.stringify(before.edition) !== JSON.stringify(after.edition)) {
-    changed.push('edition');
-  }
-  if (JSON.stringify(before.tagIds) !== JSON.stringify(after.tagIds)) {
-    changed.push('tags');
-  }
-  return changed;
-};
-
-const summarizeReleaseChanges = (fields: string[]): string => {
-  if (fields.length === 0) return 'Release metadata updated';
-  const labels = fields.map((field) => {
-    switch (field) {
-      case 'isEdition':
-        return 'edition flag';
-      default:
-        return field;
-    }
-  });
-  return `Updated ${labels.join(', ')}`;
-};
-
-const extractRevisionSnapshot = (entry: {
-  snapshot: Prisma.JsonValue | null;
-  after: Prisma.JsonValue | null;
-}): ReleaseSnapshot | null => {
-  const candidate = entry.snapshot ?? entry.after;
-  if (!candidate || typeof candidate !== 'object') return null;
-  return candidate as unknown as ReleaseSnapshot;
-};
-
-const buildReleaseTagPayload = (
-  tags: Array<{ id: number; name: string; occurrences: number }>,
-  releaseTags: Array<{
-    id: number;
-    tagId: number;
-    positiveVotes: number;
-    negativeVotes: number;
-    createdAt: Date;
-    user: { id: number; username: string } | null;
-    votes: Array<{ direction: ReleaseTagVoteDirection }>;
-  }>
-) => {
-  const byTagId = new Map(
-    releaseTags.map((releaseTag) => [releaseTag.tagId, releaseTag])
-  );
-
-  return tags
-    .map((tag) => {
-      const releaseTag = byTagId.get(tag.id);
-      const positiveVotes = releaseTag?.positiveVotes ?? 1;
-      const negativeVotes = releaseTag?.negativeVotes ?? 1;
-
-      return {
-        id: releaseTag?.id ?? tag.id,
-        tagId: tag.id,
-        name: tag.name,
-        occurrences: tag.occurrences,
-        score: positiveVotes - negativeVotes,
-        positiveVotes: Math.max(0, positiveVotes - 1),
-        negativeVotes: Math.max(0, negativeVotes - 1),
-        addedBy: releaseTag?.user ?? null,
-        createdAt: releaseTag?.createdAt ?? null,
-        myVotes: {
-          up:
-            releaseTag?.votes.some(
-              (vote) => vote.direction === ReleaseTagVoteDirection.up
-            ) ?? false,
-          down:
-            releaseTag?.votes.some(
-              (vote) => vote.direction === ReleaseTagVoteDirection.down
-            ) ?? false
-        }
-      };
-    })
-    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
-};
-
-const buildPlainTags = (
-  releaseTags: Array<{ tag: { id: number; name: string; occurrences: number } }>
-) =>
-  releaseTags
-    .map((releaseTag) => releaseTag.tag)
-    .sort((a, b) => a.name.localeCompare(b.name));
-
-const attachTagWithVotes = async (
-  tx: Prisma.TransactionClient,
-  releaseId: number,
-  actorId: number,
-  tag: { id: number; name: string },
-  writeHistory: boolean,
-  snapshot?: ReleaseSnapshot
-): Promise<void> => {
-  const releaseTag = await tx.releaseTag.create({
-    data: {
-      releaseId,
-      tagId: tag.id,
-      userId: actorId,
-      positiveVotes: 3,
-      negativeVotes: 1
-    }
-  });
-  await tx.releaseTagVote.create({
-    data: {
-      releaseTagId: releaseTag.id,
-      userId: actorId,
-      direction: ReleaseTagVoteDirection.up
-    }
-  });
-  if (writeHistory) {
-    await tx.releaseHistory.create({
-      data: {
-        releaseId,
-        actorId,
-        action: ReleaseHistoryAction.tag_added,
-        summary: `Tag "${tag.name}" added`,
-        changedFields: ['tags'],
-        before: { tagId: tag.id, name: tag.name, score: 0 } as never,
-        after: { tagId: tag.id, name: tag.name, score: 2 } as never,
-        ...(snapshot !== undefined && { snapshot: snapshot as never })
-      }
-    });
-  }
-};
-
-const detachTag = async (
-  tx: Prisma.TransactionClient,
-  releaseId: number,
-  actorId: number,
-  tag: { id: number; name?: string },
-  snapshot?: ReleaseSnapshot
-): Promise<void> => {
-  await tx.releaseTag.deleteMany({ where: { releaseId, tagId: tag.id } });
-  await tx.tag.update({
-    where: { id: tag.id },
-    data: { occurrences: { decrement: 1 } }
-  });
-  await tx.releaseHistory.create({
-    data: {
-      releaseId,
-      actorId,
-      action: ReleaseHistoryAction.tag_removed,
-      summary: `Tag "${tag.name ?? `#${tag.id}`}" removed`,
-      changedFields: ['tags'],
-      before: tag.name
-        ? ({ tagId: tag.id, name: tag.name } as never)
-        : undefined,
-      ...(snapshot !== undefined && { snapshot: snapshot as never })
-    }
-  });
+const serializeReleaseWorkbenchView = (view: ReleaseWorkbenchView) => {
+  return {
+    ...view.release,
+    tags: view.tags,
+    myVote: view.myVote,
+    releaseTags: view.releaseTags,
+    isContributor: view.isContributor
+  };
 };
 
 // GET /api/communities/:communityId/releases
@@ -269,44 +61,14 @@ router.get(
   validateParams(communityIdParamsSchema),
   authHandler(async (req, res) => {
     const { communityId } = parsedParams<{ communityId: number }>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
     const pg = parsePage(req);
-    const [releases, total] = await Promise.all([
-      prisma.release.findMany({
-        where: { communityId },
-        skip: pg.skip,
-        take: pg.limit,
-        include: {
-          artist: { select: { id: true, name: true } },
-          releaseTags: { include: { tag: true } },
-          _count: { select: { contributions: true } },
-          contributions: {
-            select: {
-              id: true,
-              type: true,
-              sizeInBytes: true,
-              linkStatus: true,
-              user: { select: { id: true, username: true } },
-              _count: { select: { consumers: true } }
-            }
-          }
-        }
-      }),
-      prisma.release.count({ where: { communityId } })
-    ]);
-    paginatedResponse(
-      res,
-      releases.map((release) => ({
-        ...release,
-        tags: buildPlainTags(release.releaseTags)
-      })),
-      total,
-      pg
-    );
+    const result = await listCommunityReleases({
+      actorId: req.user.id,
+      communityId,
+      page: pg.page,
+      limit: pg.limit
+    });
+    paginatedResponse(res, result.data, result.total, pg);
   })
 );
 
@@ -316,33 +78,26 @@ router.get(
   requireAuth,
   validateParams(releaseParamsSchema),
   authHandler(async (req, res) => {
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-    const release = await prisma.release.findFirst({
-      where: { id, communityId },
-      select: { id: true }
-    });
-    if (!release) return res.status(404).json({ msg: 'Release not found' });
-
     const pg = parsePage(req);
-    const [entries, total] = await Promise.all([
-      prisma.releaseHistory.findMany({
-        where: { releaseId: id },
-        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-        skip: pg.skip,
-        take: pg.limit,
-        include: { actor: { select: { id: true, username: true } } }
-      }),
-      prisma.releaseHistory.count({ where: { releaseId: id } })
-    ]);
-    paginatedResponse(res, entries, total, pg);
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId
+    });
+    const history = await session.getHistoryPage({ page: pg.page, limit: pg.limit });
+    res.json({
+      data: history.data,
+      meta: {
+        total: history.total,
+        page: history.page,
+        limit: history.limit,
+        totalPages: history.totalPages
+      }
+    });
   })
 );
 
@@ -367,81 +122,14 @@ router.post(
       releaseId: number;
       historyId: number;
     }>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-
-    const targetEntry = await prisma.releaseHistory.findFirst({
-      where: { id: historyId, releaseId: id }
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId: id,
+      permissions: req.user.permissions
     });
-    if (!targetEntry)
-      return res.status(404).json({ msg: 'History entry not found' });
-    if (targetEntry.action !== ReleaseHistoryAction.edit) {
-      return res
-        .status(422)
-        .json({ msg: 'Only edit revisions can be reverted' });
-    }
-
-    const restoreState = extractRevisionSnapshot(targetEntry);
-    if (!restoreState) {
-      return res
-        .status(422)
-        .json({ msg: 'History entry does not contain a restorable snapshot' });
-    }
-
-    const existing = await prisma.release.findFirst({
-      where: { id, communityId },
-      include: { releaseTags: { include: { tag: true } } }
-    });
-    if (!existing) return res.status(404).json({ msg: 'Release not found' });
-
-    const currentSnapshot = snapshotRelease(existing);
-
-    const release = await prisma.$transaction(async (tx) => {
-      await tx.release.update({
-        where: { id },
-        data: {
-          title: restoreState.title,
-          description: restoreState.description,
-          image: restoreState.image,
-          year: restoreState.year,
-          isEdition: restoreState.isEdition,
-          edition: (restoreState.edition ?? undefined) as never
-        }
-      });
-
-      const changedFields = changedReleaseFields(
-        currentSnapshot,
-        restoreState
-      ).filter((f) => f !== 'tags');
-
-      await tx.releaseHistory.create({
-        data: {
-          releaseId: id,
-          actorId: req.user.id,
-          action: ReleaseHistoryAction.edit,
-          summary: `Reverted to revision from ${targetEntry.createdAt.toISOString()}`,
-          changedFields,
-          before: currentSnapshot as never,
-          after: restoreState as never,
-          snapshot: restoreState as never
-        }
-      });
-
-      const refreshed = await tx.release.findUniqueOrThrow({
-        where: { id },
-        include: { artist: true, releaseTags: { include: { tag: true } } }
-      });
-
-      return {
-        ...refreshed,
-        tags: buildPlainTags(refreshed.releaseTags)
-      };
-    });
-
-    res.json(release);
+    const view = await session.revertHistory({ historyId });
+    res.json(serializeReleaseWorkbenchView(view));
   })
 );
 
@@ -451,86 +139,17 @@ router.get(
   requireAuth,
   validateParams(releaseParamsSchema),
   authHandler(async (req, res) => {
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-    const [release, myVoteRecord] = await Promise.all([
-      prisma.release.findFirst({
-        where: { id, communityId },
-        include: {
-          artist: true,
-          releaseTags: {
-            include: {
-              tag: { select: { id: true, name: true, occurrences: true } },
-              votes: {
-                where: { userId: req.user.id },
-                select: { direction: true }
-              },
-              user: { select: { id: true, username: true } }
-            }
-          },
-          voteAggregate: true,
-          contributions: {
-            select: {
-              id: true,
-              userId: true,
-              releaseId: true,
-              contributorId: true,
-              releaseDescription: true,
-              sizeInBytes: true,
-              approvedAccountingBytes: true,
-              linkStatus: true,
-              linkCheckedAt: true,
-              type: true,
-              createdAt: true,
-              updatedAt: true,
-              user: { select: { id: true, username: true } },
-              collaborators: true
-            }
-          }
-        }
-      }),
-      prisma.releaseVote.findUnique({
-        where: { releaseId_userId: { releaseId: id, userId: req.user.id } },
-        select: { positive: true }
-      })
-    ]);
-    if (!release) return res.status(404).json({ msg: 'Release not found' });
-    const myVote = myVoteRecord
-      ? myVoteRecord.positive
-        ? 'up'
-        : 'down'
-      : null;
-    const releaseTags = buildReleaseTagPayload(
-      buildPlainTags(release.releaseTags),
-      release.releaseTags.map((releaseTag) => ({
-        id: releaseTag.id,
-        tagId: releaseTag.tag.id,
-        positiveVotes: releaseTag.positiveVotes,
-        negativeVotes: releaseTag.negativeVotes,
-        createdAt: releaseTag.createdAt,
-        user: releaseTag.user ?? null,
-        votes: releaseTag.votes
-      }))
-    );
-
-    const isContributor = release.contributions.some(
-      (c) => c.userId === req.user.id
-    );
-
-    res.json({
-      ...release,
-      tags: buildPlainTags(release.releaseTags),
-      myVote,
-      releaseTags,
-      isContributor
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
     });
+    res.json(serializeReleaseWorkbenchView(await session.getView()));
   })
 );
 
@@ -542,75 +161,10 @@ router.post(
   validate(createGroupSchema),
   asyncHandler(async (req: Request, res: Response) => {
     const { communityId } = parsedParams<{ communityId: number }>(res);
-    const community = await prisma.community.findUnique({
-      where: { id: communityId }
-    });
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-
-    const {
-      artistId,
-      title,
-      description,
-      type,
-      releaseType,
-      year,
-      image,
-      tagIds,
-      isEdition,
-      edition
-    } = parsedBody<CreateGroupInput>(res);
-    const uniqueTagIds = tagIds ? [...new Set(tagIds)] : [];
-
-    const release = await prisma.$transaction(async (tx) => {
-      const created = await tx.release.create({
-        data: {
-          artistId,
-          communityId,
-          title,
-          description,
-          type,
-          releaseType,
-          year,
-          image: image ?? null,
-          isEdition: isEdition ?? false,
-          edition: (edition ?? undefined) as never
-        }
-      });
-
-      if (uniqueTagIds.length > 0) {
-        const tags = await tx.tag.findMany({
-          where: { id: { in: uniqueTagIds } },
-          select: { id: true, name: true }
-        });
-        for (const tag of tags) {
-          await tx.tag.update({
-            where: { id: tag.id },
-            data: { occurrences: { increment: 1 } }
-          });
-          await attachTagWithVotes(tx, created.id, req.user!.id, tag, false);
-        }
-      }
-
-      const release = await tx.release.findUniqueOrThrow({
-        where: { id: created.id },
-        include: { artist: true, releaseTags: { include: { tag: true } } }
-      });
-      const createdSnapshot = snapshotRelease(release);
-      await tx.releaseHistory.create({
-        data: {
-          releaseId: release.id,
-          actorId: req.user!.id,
-          action: ReleaseHistoryAction.created,
-          summary: 'Release created',
-          changedFields: [],
-          after: createdSnapshot as never,
-          snapshot: createdSnapshot as never
-        }
-      });
-      return {
-        ...release,
-        tags: buildPlainTags(release.releaseTags)
-      };
+    const release = await createCommunityRelease({
+      actorId: req.user!.id,
+      communityId,
+      data: parsedBody<CreateGroupInput>(res)
     });
     res.status(201).json(release);
   })
@@ -623,151 +177,28 @@ router.put(
   validateParams(releaseParamsSchema),
   validate(updateGroupSchema),
   authHandler(async (req, res) => {
-    const actorId = req.user.id;
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
-
-    const existing = await prisma.release.findFirst({
-      where: { id, communityId },
-      include: {
-        releaseTags: { include: { tag: { select: { id: true, name: true } } } }
-      }
+    const { title, description, image, year, isEdition, edition, editSummary } =
+      parsedBody<UpdateGroupInput>(res);
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
     });
-    if (!existing) return res.status(404).json({ msg: 'Release not found' });
-
-    const perms = await loadPermissions(req, res);
-    const canManage = !!(
-      perms['communities_manage'] ||
-      perms['admin'] ||
-      perms['staff']
-    );
-    if (!canManage) {
-      const contribution = await prisma.contribution.findFirst({
-        where: { releaseId: id, userId: actorId },
-        select: { id: true }
-      });
-      if (!contribution) {
-        return res
-          .status(403)
-          .json({ msg: 'Must be a contributor or staff to edit this release' });
-      }
-    }
-
-    const {
+    const view = await session.updateMetadata({
       title,
       description,
       image,
       year,
       isEdition,
       edition,
-      tagIds,
       editSummary
-    } = parsedBody<UpdateGroupInput>(res);
-    const before = snapshotRelease(existing);
-    const nextTagIds = tagIds
-      ? [...new Set(tagIds)].sort((a, b) => a - b)
-      : null;
-    const removedTagIds =
-      nextTagIds === null
-        ? []
-        : before.tagIds.filter((tagId) => !nextTagIds.includes(tagId));
-    const addedTagIds =
-      nextTagIds === null
-        ? []
-        : nextTagIds.filter((tagId) => !before.tagIds.includes(tagId));
-
-    const release = await prisma.$transaction(async (tx) => {
-      await tx.release.update({
-        where: { id },
-        data: {
-          ...(title !== undefined && { title }),
-          ...(description !== undefined && { description }),
-          ...(image !== undefined && { image }),
-          ...(year !== undefined && { year }),
-          ...(isEdition !== undefined && { isEdition }),
-          ...(edition !== undefined && { edition: edition as never })
-        },
-        include: { artist: true, releaseTags: { include: { tag: true } } }
-      });
-
-      let runningSnapshot = { ...before };
-
-      if (removedTagIds.length > 0) {
-        const existingTagMap = new Map(
-          existing.releaseTags.map((rt) => [rt.tag.id, rt.tag])
-        );
-        for (const tagId of removedTagIds) {
-          const tagName = existingTagMap.get(tagId)?.name;
-          runningSnapshot = {
-            ...runningSnapshot,
-            tagIds: runningSnapshot.tagIds.filter((tid) => tid !== tagId),
-            tagNames: runningSnapshot.tagNames.filter((n) => n !== tagName)
-          };
-          await detachTag(
-            tx,
-            id,
-            actorId,
-            { id: tagId, name: tagName },
-            runningSnapshot
-          );
-        }
-      }
-
-      if (addedTagIds.length > 0) {
-        const addedTags = await tx.tag.findMany({
-          where: { id: { in: addedTagIds } },
-          select: { id: true, name: true }
-        });
-        for (const tag of addedTags) {
-          await tx.tag.update({
-            where: { id: tag.id },
-            data: { occurrences: { increment: 1 } }
-          });
-          runningSnapshot = {
-            ...runningSnapshot,
-            tagIds: [...runningSnapshot.tagIds, tag.id].sort((a, b) => a - b),
-            tagNames: [...runningSnapshot.tagNames, tag.name].sort()
-          };
-          await attachTagWithVotes(tx, id, actorId, tag, true, runningSnapshot);
-        }
-      }
-
-      const refreshed = await tx.release.findUniqueOrThrow({
-        where: { id },
-        include: { artist: true, releaseTags: { include: { tag: true } } }
-      });
-
-      const after = snapshotRelease(refreshed);
-      // Tags are already covered by per-tag history entries; exclude from the
-      // edit entry so the summary reflects only metadata field changes.
-      const changedFields = changedReleaseFields(before, after).filter(
-        (f) => f !== 'tags'
-      );
-
-      if (changedFields.length > 0) {
-        await tx.releaseHistory.create({
-          data: {
-            releaseId: id,
-            actorId,
-            action: ReleaseHistoryAction.edit,
-            summary:
-              editSummary?.trim() || summarizeReleaseChanges(changedFields),
-            changedFields,
-            before: before as never,
-            after: after as never,
-            snapshot: after as never
-          }
-        });
-      }
-
-      return {
-        ...refreshed,
-        tags: buildPlainTags(refreshed.releaseTags)
-      };
     });
-    res.json(release);
+    res.json(serializeReleaseWorkbenchView(view));
   })
 );
 
@@ -783,84 +214,13 @@ router.post(
       releaseId: number;
     }>(res);
     const input = parsedBody<AddContributionToReleaseInput>(res);
-
-    const settings = await getSettings();
-    if (settings.approvedDomains.length > 0) {
-      let host: string;
-      try {
-        host = new URL(input.downloadUrl).hostname;
-      } catch {
-        return res.status(400).json({ msg: 'Invalid download URL' });
-      }
-      if (!settings.approvedDomains.includes(host)) {
-        return res.status(400).json({
-          msg: `Domain '${host}' is not in the approved domains list`
-        });
-      }
-    }
-
-    const community = await prisma.community.findUnique({
-      where: { id: communityId },
-      select: { allowDuplicateFormats: true }
-    });
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-
-    if (!community.allowDuplicateFormats) {
-      const existing = await prisma.contribution.findFirst({
-        where: { releaseId, type: input.fileType as FileType }
-      });
-      if (existing) {
-        return res.status(409).json({
-          msg: `A ${input.fileType} contribution already exists for this release`
-        });
-      }
-    }
-
-    const contribution = await addContributionToRelease({
-      userId: req.user.id,
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
       communityId,
       releaseId,
-      input
+      permissions: req.user.permissions
     });
-    if (!contribution)
-      return res.status(404).json({ msg: 'Release not found' });
-
-    await prisma.$transaction(async (tx) => {
-      const subs = await tx.artistSubscription.findMany({
-        where: { artistId: contribution.release.artistId },
-        select: { userId: true }
-      });
-      if (subs.length > 0) {
-        await emitNotifications(tx, {
-          userIds: subs.map((s) => s.userId),
-          type: 'artist_release',
-          actorId: req.user.id,
-          page: 'contributions',
-          pageId: contribution.id
-        });
-      }
-      const releaseWithTags = await tx.release.findUniqueOrThrow({
-        where: { id: contribution.release.id },
-        include: { releaseTags: { include: { tag: true } } }
-      });
-      await tx.releaseHistory.create({
-        data: {
-          releaseId: contribution.release.id,
-          actorId: req.user.id,
-          action: ReleaseHistoryAction.contribution_added,
-          summary: `${contribution.type} contribution added`,
-          changedFields: [],
-          after: {
-            contributionId: contribution.id,
-            type: contribution.type,
-            sizeInBytes: contribution.sizeInBytes ?? null,
-            contributor: contribution.user?.username ?? null
-          } as never,
-          snapshot: snapshotRelease(releaseWithTags) as never
-        }
-      });
-    });
-
+    const contribution = await session.attachContribution(input);
     res.status(201).json(contribution);
   })
 );
@@ -880,35 +240,22 @@ router.post(
   validateParams(releaseParamsSchema),
   validate(releaseVoteSchema),
   authHandler(async (req, res) => {
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
     const { positive } = parsedBody<ReleaseVoteInput>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-
-    const exists = await prisma.release.findFirst({
-      where: { id, communityId },
-      select: { id: true }
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
     });
-    if (!exists) return res.status(404).json({ msg: 'Release not found' });
-
-    await prisma.releaseVote.upsert({
-      where: { releaseId_userId: { releaseId: id, userId: req.user.id } },
-      create: { releaseId: id, userId: req.user.id, positive },
-      update: { positive }
+    const view = await session.vote({ direction: positive ? 'up' : 'down' });
+    res.json({
+      myVote: view.myVote,
+      voteAggregate: view.release.voteAggregate
     });
-
-    await recomputeVoteAggregate(id);
-
-    const aggregate = await prisma.releaseVoteAggregate.findUnique({
-      where: { releaseId: id }
-    });
-    res.json({ myVote: positive ? 'up' : 'down', voteAggregate: aggregate });
   })
 );
 
@@ -918,32 +265,18 @@ router.delete(
   requireAuth,
   validateParams(releaseParamsSchema),
   authHandler(async (req, res) => {
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-
-    const exists = await prisma.release.findFirst({
-      where: { id, communityId },
-      select: { id: true }
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
     });
-    if (!exists) return res.status(404).json({ msg: 'Release not found' });
-
-    await prisma.releaseVote.deleteMany({
-      where: { releaseId: id, userId: req.user.id }
-    });
-
-    await recomputeVoteAggregate(id);
-
-    const aggregate = await prisma.releaseVoteAggregate.findUnique({
-      where: { releaseId: id }
-    });
-    res.json({ myVote: null, voteAggregate: aggregate });
+    const view = await session.vote({ direction: 'clear' });
+    res.json({ myVote: view.myVote, voteAggregate: view.release.voteAggregate });
   })
 );
 
@@ -956,56 +289,21 @@ router.post(
   validateParams(releaseParamsSchema),
   validate(releaseTagSchema),
   authHandler(async (req, res) => {
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
     const { name: submittedName } = parsedBody<ReleaseTagInput>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-
     const name = await resolveTagName(submittedName);
-
-    const release = await prisma.release.findFirst({
-      where: { id, communityId },
-      select: {
-        id: true,
-        releaseTags: { where: { tag: { name } }, select: { id: true } }
-      }
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
     });
-    if (!release) return res.status(404).json({ msg: 'Release not found' });
-    if (release.releaseTags.length > 0)
-      return res.status(409).json({ msg: 'Release already has this tag' });
-
-    const tag = await prisma.$transaction(async (tx) => {
-      const t = await tx.tag.upsert({
-        where: { name },
-        create: { name, occurrences: 1 },
-        update: { occurrences: { increment: 1 } }
-      });
-      const currentRelease = await tx.release.findUniqueOrThrow({
-        where: { id },
-        include: { releaseTags: { include: { tag: true } } }
-      });
-      const postAddSnapshot: ReleaseSnapshot = {
-        ...snapshotRelease(currentRelease),
-        tagIds: [
-          ...currentRelease.releaseTags.map((rt) => rt.tag.id),
-          t.id
-        ].sort((a, b) => a - b),
-        tagNames: [
-          ...currentRelease.releaseTags.map((rt) => rt.tag.name),
-          t.name
-        ].sort()
-      };
-      await attachTagWithVotes(tx, id, req.user.id, t, true, postAddSnapshot);
-      return t;
-    });
-
-    res.status(201).json(tag);
+    const view = await session.addTag({ name: submittedName });
+    const tag = view.releaseTags.find((releaseTag) => releaseTag.name === name);
+    res.status(201).json(tag ?? view.releaseTags[0]);
   })
 );
 
@@ -1016,119 +314,19 @@ router.post(
   validateParams(tagParamsSchema),
   validate(releaseTagVoteSchema),
   authHandler(async (req, res) => {
-    const {
-      communityId,
-      releaseId: id,
-      tagId
-    } = parsedParams<{
+    const { communityId, releaseId, tagId } = parsedParams<{
       communityId: number;
       releaseId: number;
       tagId: number;
     }>(res);
     const { direction } = parsedBody<ReleaseTagVoteInput>(res);
-    const community = await getAccessibleCommunity(communityId, req.user.id);
-    if (!community) return res.status(404).json({ msg: 'Community not found' });
-    if (community === 'forbidden') {
-      return res.status(403).json({ msg: 'Not a member of this community' });
-    }
-
-    const releaseTag = await prisma.releaseTag.findFirst({
-      where: { releaseId: id, tagId, release: { communityId } },
-      select: { id: true, positiveVotes: true, negativeVotes: true }
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
     });
-    if (!releaseTag) {
-      return res.status(404).json({ msg: 'Release tag not found' });
-    }
-
-    const dir = direction as ReleaseTagVoteDirection;
-    const oppositeDir =
-      dir === ReleaseTagVoteDirection.up
-        ? ReleaseTagVoteDirection.down
-        : ReleaseTagVoteDirection.up;
-
-    const [existingVote, oppositeVote] = await Promise.all([
-      prisma.releaseTagVote.findUnique({
-        where: {
-          releaseTagId_userId_direction: {
-            releaseTagId: releaseTag.id,
-            userId: req.user.id,
-            direction: dir
-          }
-        }
-      }),
-      prisma.releaseTagVote.findUnique({
-        where: {
-          releaseTagId_userId_direction: {
-            releaseTagId: releaseTag.id,
-            userId: req.user.id,
-            direction: oppositeDir
-          }
-        }
-      })
-    ]);
-
-    if (!existingVote) {
-      await prisma.$transaction(async (tx) => {
-        await tx.releaseTagVote.create({
-          data: {
-            releaseTagId: releaseTag.id,
-            userId: req.user.id,
-            direction: dir
-          }
-        });
-        if (oppositeVote) {
-          await tx.releaseTagVote.delete({ where: { id: oppositeVote.id } });
-        }
-        await tx.releaseTag.update({
-          where: { id: releaseTag.id },
-          data:
-            dir === ReleaseTagVoteDirection.up
-              ? {
-                  positiveVotes: { increment: 2 },
-                  ...(oppositeVote ? { negativeVotes: { decrement: 1 } } : {})
-                }
-              : {
-                  negativeVotes: { increment: 1 },
-                  ...(oppositeVote ? { positiveVotes: { decrement: 1 } } : {})
-                }
-        });
-      });
-    }
-
-    const updated = await prisma.releaseTag.findUniqueOrThrow({
-      where: { id: releaseTag.id },
-      include: {
-        tag: true,
-        user: { select: { id: true, username: true } },
-        votes: {
-          where: { userId: req.user.id },
-          select: { direction: true }
-        }
-      }
-    });
-
-    res.json(
-      buildReleaseTagPayload(
-        [
-          {
-            id: updated.tag.id,
-            name: updated.tag.name,
-            occurrences: updated.tag.occurrences
-          }
-        ],
-        [
-          {
-            id: updated.id,
-            tagId: updated.tag.id,
-            positiveVotes: updated.positiveVotes,
-            negativeVotes: updated.negativeVotes,
-            createdAt: updated.createdAt,
-            user: updated.user ?? null,
-            votes: updated.votes
-          }
-        ]
-      )[0]
-    );
+    res.json(await session.voteTag({ tagId, direction }));
   })
 );
 
@@ -1150,54 +348,13 @@ router.delete(
       tagId: number;
     }>(res);
 
-    const release = await prisma.release.findFirst({
-      where: { id, communityId, releaseTags: { some: { tagId } } },
-      select: { id: true }
+    const session = await releaseWorkbench.open({
+      actorId,
+      communityId,
+      releaseId: id,
+      permissions: req.user.permissions
     });
-    if (!release)
-      return res.status(404).json({ msg: 'Release or tag not found' });
-
-    const tag = await prisma.tag.findUnique({
-      where: { id: tagId },
-      select: { name: true }
-    });
-
-    await prisma.$transaction(async (tx) => {
-      const currentRelease = await tx.release.findUniqueOrThrow({
-        where: { id },
-        include: { releaseTags: { include: { tag: true } } }
-      });
-      const postRemovalSnapshot: ReleaseSnapshot = {
-        ...snapshotRelease(currentRelease),
-        tagIds: currentRelease.releaseTags
-          .filter((rt) => rt.tag.id !== tagId)
-          .map((rt) => rt.tag.id)
-          .sort((a, b) => a - b),
-        tagNames: currentRelease.releaseTags
-          .filter((rt) => rt.tag.id !== tagId)
-          .map((rt) => rt.tag.name)
-          .sort()
-      };
-      await tx.releaseTag.deleteMany({
-        where: { releaseId: id, tagId }
-      });
-      await tx.tag.update({
-        where: { id: tagId },
-        data: { occurrences: { decrement: 1 } }
-      });
-      await tx.releaseHistory.create({
-        data: {
-          releaseId: id,
-          actorId,
-          action: ReleaseHistoryAction.tag_removed,
-          summary: `Tag "${tag?.name ?? `#${tagId}`}" removed`,
-          changedFields: ['tags'],
-          before: tag ? ({ tagId, name: tag.name } as never) : undefined,
-          snapshot: postRemovalSnapshot as never
-        }
-      });
-    });
-
+    await session.removeTag({ tagId });
     res.status(204).send();
   })
 );
@@ -1208,26 +365,11 @@ router.delete(
   ...requirePermission('communities_manage'),
   validateParams(releaseParamsSchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const { communityId, releaseId: id } = parsedParams<{
+    const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
-    const existing = await prisma.release.findFirst({
-      where: { id, communityId },
-      select: { id: true, releaseTags: { select: { tagId: true } } }
-    });
-    if (!existing) return res.status(404).json({ msg: 'Release not found' });
-    await prisma.$transaction(async (tx) => {
-      await Promise.all(
-        existing.releaseTags.map((tag) =>
-          tx.tag.update({
-            where: { id: tag.tagId },
-            data: { occurrences: { decrement: 1 } }
-          })
-        )
-      );
-      await tx.release.delete({ where: { id } });
-    });
+    await deleteCommunityRelease({ communityId, releaseId });
     res.status(204).send();
   })
 );


### PR DESCRIPTION
## Summary
- extract release browse, lifecycle, and workbench backend modules
- thin community release routes so they delegate to deep modules
- add direct module tests alongside updated route coverage

## Verification
- npm test -- --runInBand src/communityReleases.spec.ts src/modules/releaseWorkbench.spec.ts src/modules/releaseLifecycle.spec.ts src/modules/releaseBrowse.spec.ts
- npx tsc --noEmit --pretty false