### PR TITLE
Deepen permission domain and registration flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,8 +193,11 @@ Any static-segment route (`/history/:artistId`, `/settings`) must be registered 
 ```ts
 requireAuth                                // sets req.user or 401
 ...requirePermission('admin')              // spread — includes requireAuth
-await isModerator(req, res)                // boolean; uses cached userRankId
+// Inline permission branch — name the exact permission required:
+const perms = await loadPermissions(req, res);
+if (!hasPermission(perms, 'forums_moderate')) { ... }
 ```
+Do not introduce named role checks (`isModerator`, `isStaffUser`). See `docs/adr/0001-granular-permission-checks.md`.
 
 ### Pagination
 ```ts

--- a/docs/adr/0001-granular-permission-checks.md
+++ b/docs/adr/0001-granular-permission-checks.md
@@ -1,0 +1,16 @@
+# Use granular permission checks; do not introduce role convenience functions
+
+Stellar has a per-permission system where each user rank stores an explicit map of
+granted permissions (e.g. `forums_moderate`, `reports_manage`, `staff_inbox_manage`).
+We deliberately do not expose named role checks like `isModerator()` or `isStaffUser()`
+at call sites.
+
+Before granular permissions existed, convenience functions (`isModerator`,
+`isStaffUser`) were introduced as shorthand. These caused cross-domain permission
+bleed: a user with only `forums_moderate` inadvertently satisfied the `reports_manage`
+gate because both were collapsed into the same role check. Each call site should name
+the exact permission it requires. Use `requirePermission('X')` as route middleware, or
+`hasPermission(await loadPermissions(req, res), 'X')` for inline branching.
+
+The `admin` permission is the one universal override and is already handled
+transparently by `hasPermission` — callers never need to check for it explicitly.

--- a/src/comments.spec.ts
+++ b/src/comments.spec.ts
@@ -468,7 +468,7 @@ describe('DELETE /api/comments/:id', () => {
 
   it("allows a moderator to delete another user's comment", async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+      makeUserRank({ reports_manage: true })
     );
     prismaMock.comment.findUnique.mockResolvedValue(
       makeComment({ id: 12, authorId: 99 }) as never

--- a/src/content.spec.ts
+++ b/src/content.spec.ts
@@ -499,7 +499,7 @@ describe('API content and shared flows', () => {
       makeComment({ id: 12, authorId: 99 })
     );
     prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ forums_moderate: true })
+      makeUserRank({ reports_manage: true })
     );
 
     const res = await request(app).delete('/api/comments/12');

--- a/src/forumSub.spec.ts
+++ b/src/forumSub.spec.ts
@@ -378,7 +378,7 @@ describe('POST /api/forums/polls', () => {
       authorId: 99, // different user
       deletedAt: null
     } as never);
-    // isModerator checks userRank — default rank has no staff flag
+    // permission check: default rank has no forums_moderate flag
     prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
 
     const res = await request(app).post('/api/forums/polls').send({

--- a/src/integration/auth.integration.ts
+++ b/src/integration/auth.integration.ts
@@ -15,7 +15,12 @@ const registerFixtureUser = async (
   email: string,
   password: string
 ) => {
-  const result = await registerUser(username, email, password);
+  const result = await registerUser({
+    username,
+    email,
+    password,
+    registrationMode: 'open'
+  });
   expect(result.ok).toBe(true);
   if (!result.ok) {
     throw new Error('Failed to register fixture user');
@@ -25,11 +30,12 @@ const registerFixtureUser = async (
 
 describe('registerUser', () => {
   it('creates user, userSettings, and profile in a single transaction', async () => {
-    const result = await registerUser(
-      'alice',
-      'alice@example.com',
-      'password1'
-    );
+    const result = await registerUser({
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password1',
+      registrationMode: 'open'
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
@@ -52,16 +58,22 @@ describe('registerUser', () => {
   it('returns user_exists when username or email is already taken', async () => {
     await registerFixtureUser('alice', 'alice@example.com', 'password1');
 
-    const result = await registerUser(
-      'alice',
-      'other@example.com',
-      'password1'
-    );
+    const result = await registerUser({
+      username: 'alice',
+      email: 'other@example.com',
+      password: 'password1',
+      registrationMode: 'open'
+    });
     expect(result).toEqual({ ok: false, reason: 'user_exists' });
   });
 
   it('stores password as a bcrypt hash, never plaintext', async () => {
-    const result = await registerUser('bob', 'bob@example.com', 'password2');
+    const result = await registerUser({
+      username: 'bob',
+      email: 'bob@example.com',
+      password: 'password2',
+      registrationMode: 'open'
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -56,6 +56,7 @@ import {
   createStaffGroupSchema,
   updateStaffGroupSchema
 } from '../schemas/staff';
+import { VALID_PERMISSIONS } from './rankPermissions';
 import { postSchema, postCommentSchema } from '../schemas/post';
 import {
   commentQuerySchema,
@@ -2489,6 +2490,33 @@ const Release = registry.register(
   })
 );
 
+// ─── Permission catalog ───────────────────────────────────────────────────────
+
+const PermissionKey = registry.register(
+  'PermissionKey',
+  z.enum(VALID_PERMISSIONS)
+);
+
+const PermissionEntry = registry.register(
+  'PermissionEntry',
+  z.object({
+    key: PermissionKey,
+    label: z.string(),
+    description: z.string()
+  })
+);
+
+registry.register(
+  'PermissionGroup',
+  z.object({
+    key: z.string(),
+    title: z.string(),
+    permissions: z.array(PermissionEntry)
+  })
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 const UserRank = registry.register(
   'UserRank',
   z.object({
@@ -2839,6 +2867,34 @@ registry.registerPath({
     200: {
       description: 'User ranks',
       content: { 'application/json': { schema: z.array(UserRank) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/tools/user-ranks/permissions',
+  tags: ['Tools'],
+  responses: {
+    200: {
+      description: 'Permission catalog',
+      content: {
+        'application/json': {
+          schema: z.array(
+            z.object({
+              key: z.string(),
+              title: z.string(),
+              permissions: z.array(
+                z.object({
+                  key: PermissionKey,
+                  label: z.string(),
+                  description: z.string()
+                })
+              )
+            })
+          )
+        }
+      }
     }
   }
 });

--- a/src/middleware/permissions.spec.ts
+++ b/src/middleware/permissions.spec.ts
@@ -26,12 +26,7 @@ jest.mock('./auth', () => ({
   requireAuth: (...args: Parameters<RequestHandler>) => requireAuthMock(...args)
 }));
 
-import {
-  requirePermission,
-  requireOwnerOrPermission,
-  isModerator
-} from './permissions';
-import type { AuthenticatedRequest } from '../types/auth';
+import { requirePermission, requireOwnerOrPermission } from './permissions';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -171,44 +166,6 @@ describe('requireOwnerOrPermission', () => {
     const [, checkMw] = requireOwnerOrPermission(getOwnerNull, 'admin');
     await checkMw(req, res as unknown as Response, next);
     expect(next).toHaveBeenCalledWith();
-  });
-});
-
-// ─── isModerator ──────────────────────────────────────────────────────────────
-
-describe('isModerator', () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  it('returns true when user has forums_moderate permission', async () => {
-    getUserRankAccessMock.mockResolvedValue({
-      permissions: { forums_moderate: true }
-    });
-    const [req, res] = makeReqRes();
-    const result = await isModerator(
-      req as unknown as AuthenticatedRequest,
-      res as unknown as Response
-    );
-    expect(result).toBe(true);
-  });
-
-  it('returns true when user has staff permission', async () => {
-    getUserRankAccessMock.mockResolvedValue({ permissions: { staff: true } });
-    const [req, res] = makeReqRes();
-    const result = await isModerator(
-      req as unknown as AuthenticatedRequest,
-      res as unknown as Response
-    );
-    expect(result).toBe(true);
-  });
-
-  it('returns false when user has no moderator permissions', async () => {
-    getUserRankAccessMock.mockResolvedValue({ permissions: {} });
-    const [req, res] = makeReqRes();
-    const result = await isModerator(
-      req as unknown as AuthenticatedRequest,
-      res as unknown as Response
-    );
-    expect(result).toBe(false);
   });
 });
 

--- a/src/middleware/permissions.ts
+++ b/src/middleware/permissions.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/rankPermissions';
 import { getUserRankAccess } from '../lib/userRankAccess';
 
-export { VALID_PERMISSIONS };
+export { VALID_PERMISSIONS, hasPermission };
 export type { Permission };
 
 export const loadPermissions = async (
@@ -26,14 +26,6 @@ export const loadPermissions = async (
   res.locals.userPerms = (access?.permissions ??
     normalizePermissions(null)) as Record<string, boolean>;
   return res.locals.userPerms;
-};
-
-export const isModerator = async (
-  req: AuthenticatedRequest,
-  res: Response
-): Promise<boolean> => {
-  const perms = await loadPermissions(req, res);
-  return !!(perms['forums_moderate'] || perms['admin'] || perms['staff']);
 };
 
 // Like requirePermission('admin') but does NOT let staff satisfy the gate.

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -94,18 +94,58 @@ export const toAuthUser = (raw: RawAuthUser): AuthUser => ({
 });
 
 type RegisterResult =
-  | { ok: false; reason: 'user_exists' | 'bad_password' }
+  | {
+      ok: false;
+      reason:
+        | 'user_exists'
+        | 'bad_password'
+        | 'registration_closed'
+        | 'invite_required'
+        | 'invalid_invite'
+        | 'invite_email_mismatch';
+    }
   | { ok: true; user: AuthUser };
+
+export type RegisterOptions = {
+  username: string;
+  email: string;
+  password: string;
+  /** Passed from getSettings().registrationStatus — the module does not read settings itself. */
+  registrationMode: 'open' | 'invite' | 'closed';
+  inviteKey?: string;
+};
 
 type LoginResult =
   | { ok: false; reason: 'not_found' | 'disabled' | 'wrong_password' }
   | { ok: true; user: AuthUser };
 
-export const registerUser = async (
-  username: string,
-  email: string,
-  password: string
-): Promise<RegisterResult> => {
+export const registerUser = async ({
+  username,
+  email,
+  password,
+  registrationMode,
+  inviteKey
+}: RegisterOptions): Promise<RegisterResult> => {
+  // 1. Mode gate — no DB required
+  if (registrationMode === 'closed') {
+    return { ok: false, reason: 'registration_closed' };
+  }
+
+  if (registrationMode === 'invite') {
+    if (!inviteKey) return { ok: false, reason: 'invite_required' };
+    // Pre-validate for an early exit before any writes. The actual
+    // consumption (status → accepted) happens inside the user-creation
+    // transaction below, making the two operations atomic.
+    const invite = await prisma.invite.findUnique({ where: { inviteKey } });
+    if (!invite || invite.status !== 'pending') {
+      return { ok: false, reason: 'invalid_invite' };
+    }
+    if (invite.email.toLowerCase() !== email.toLowerCase()) {
+      return { ok: false, reason: 'invite_email_mismatch' };
+    }
+  }
+
+  // 2. Uniqueness / quality checks
   const existing = await prisma.user.findFirst({
     where: { OR: [{ email: email.toLowerCase() }, { username }] }
   });
@@ -127,10 +167,12 @@ export const registerUser = async (
   const avatar = gravatar.url(email, { s: '200', r: 'pg', d: 'mm' });
   const hashedPassword = await bcrypt.hash(password, await bcrypt.genSalt(10));
 
+  // 3. Atomic: create user + consume invite in one transaction so a crash
+  //    between the two can never leave the invite permanently open.
   const user = await prisma.$transaction(async (tx) => {
     const settings = await tx.userSettings.create({ data: {} });
     const profile = await tx.profile.create({ data: {} });
-    return tx.user.create({
+    const newUser = await tx.user.create({
       data: {
         username,
         email: email.toLowerCase(),
@@ -143,6 +185,15 @@ export const registerUser = async (
       },
       select: authUserSelect
     });
+
+    if (registrationMode === 'invite' && inviteKey) {
+      await tx.invite.update({
+        where: { inviteKey },
+        data: { status: 'accepted' }
+      });
+    }
+
+    return newUser;
   });
 
   return { ok: true, user: toAuthUser(user) };

--- a/src/routes/api/auth.ts
+++ b/src/routes/api/auth.ts
@@ -104,42 +104,36 @@ router.post(
 
     const settings = await getSettings();
 
-    if (settings.registrationStatus === 'closed') {
-      return res.status(403).json({ msg: 'Registration is currently closed' });
-    }
-
-    if (settings.registrationStatus === 'invite') {
-      if (!inviteKey) {
-        return res
-          .status(403)
-          .json({ msg: 'An invite key is required to register' });
-      }
-      const invite = await prisma.invite.findUnique({ where: { inviteKey } });
-      if (!invite || invite.status !== 'pending') {
-        return res
-          .status(403)
-          .json({ msg: 'Invalid or already-used invite key' });
-      }
-      if (invite.email.toLowerCase() !== email.toLowerCase()) {
-        return res
-          .status(403)
-          .json({ msg: 'Invite key is not valid for this email address' });
-      }
-    }
-
-    const result = await registerUser(username, email, password);
+    const result = await registerUser({
+      username,
+      email,
+      password,
+      registrationMode: settings.registrationStatus,
+      inviteKey
+    });
     if (!result.ok) {
-      if (result.reason === 'bad_password') {
-        return res.status(400).json({ msg: 'Password is not allowed' });
+      switch (result.reason) {
+        case 'registration_closed':
+          return res
+            .status(403)
+            .json({ msg: 'Registration is currently closed' });
+        case 'invite_required':
+          return res
+            .status(403)
+            .json({ msg: 'An invite key is required to register' });
+        case 'invalid_invite':
+          return res
+            .status(403)
+            .json({ msg: 'Invalid or already-used invite key' });
+        case 'invite_email_mismatch':
+          return res
+            .status(403)
+            .json({ msg: 'Invite key is not valid for this email address' });
+        case 'bad_password':
+          return res.status(400).json({ msg: 'Password is not allowed' });
+        default:
+          return res.status(400).json({ msg: 'User already exists' });
       }
-      return res.status(400).json({ msg: 'User already exists' });
-    }
-
-    if (settings.registrationStatus === 'invite' && inviteKey) {
-      await prisma.invite.update({
-        where: { inviteKey },
-        data: { status: 'accepted' }
-      });
     }
 
     const token = await issueToken(result.user.id);

--- a/src/routes/api/comments.ts
+++ b/src/routes/api/comments.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/notifications';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
-import { isModerator } from '../../middleware/permissions';
+import { loadPermissions, hasPermission } from '../../middleware/permissions';
 import {
   parsedBody,
   validate,
@@ -277,7 +277,10 @@ router.delete(
     if (!comment) return res.status(404).json({ msg: 'Comment not found' });
 
     const isOwner = comment.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res))) {
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'reports_manage')
+    ) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 

--- a/src/routes/api/forum/forumPoll.ts
+++ b/src/routes/api/forum/forumPoll.ts
@@ -5,7 +5,10 @@ import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import { authHandler } from '../../../modules/asyncHandler';
 import { createPoll, closePoll } from '../../../modules/forum';
 import { requireAuth } from '../../../middleware/auth';
-import { isModerator } from '../../../middleware/permissions';
+import {
+  loadPermissions,
+  hasPermission
+} from '../../../middleware/permissions';
 import {
   parsedBody,
   validate,
@@ -83,7 +86,10 @@ router.post(
       return res.status(404).json({ msg: 'Topic not found' });
 
     const isOwner = topic.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res))) {
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'forums_moderate')
+    ) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 
@@ -107,7 +113,10 @@ router.put(
     if (!poll) return res.status(404).json({ msg: 'Poll not found' });
 
     const isOwner = poll.forumTopic?.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res))) {
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'forums_moderate')
+    ) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 

--- a/src/routes/api/forum/forumPost.ts
+++ b/src/routes/api/forum/forumPost.ts
@@ -4,7 +4,10 @@ import { prisma } from '../../../lib/prisma';
 import { authHandler } from '../../../modules/asyncHandler';
 import { createPost, updatePost, deletePost } from '../../../modules/forum';
 import { requireAuth } from '../../../middleware/auth';
-import { isModerator } from '../../../middleware/permissions';
+import {
+  loadPermissions,
+  hasPermission
+} from '../../../middleware/permissions';
 import {
   parsedBody,
   validate,
@@ -183,7 +186,7 @@ router.get(
         .status(403)
         .json({ msg: 'Insufficient class to read this forum' });
     }
-    if (!(await isModerator(req, res))) {
+    if (!hasPermission(await loadPermissions(req, res), 'forums_moderate')) {
       return res
         .status(403)
         .json({ msg: 'Insufficient permission to view edit history' });
@@ -255,7 +258,10 @@ router.put(
     });
     if (!post) return res.status(404).json({ msg: 'Post not found' });
     const isOwner = post.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res)))
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'forums_moderate')
+    )
       return res.status(403).json({ msg: 'Not authorized' });
 
     await updatePost(id, req.user.id, post.body, body, forumTopicId);
@@ -296,7 +302,10 @@ router.delete(
     if (!post) return res.status(404).json({ msg: 'Post not found' });
 
     const isOwner = post.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res))) {
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'forums_moderate')
+    ) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 

--- a/src/routes/api/forum/forumTopic.ts
+++ b/src/routes/api/forum/forumTopic.ts
@@ -9,7 +9,10 @@ import {
   trashTopic
 } from '../../../modules/forum';
 import { requireAuth } from '../../../middleware/auth';
-import { isModerator } from '../../../middleware/permissions';
+import {
+  loadPermissions,
+  hasPermission
+} from '../../../middleware/permissions';
 import {
   parsedBody,
   validate,
@@ -163,7 +166,10 @@ router.put(
     if (!topic) return res.status(404).json({ msg: 'Topic not found' });
 
     const isOwner = topic.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res))) {
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'forums_moderate')
+    ) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 
@@ -189,7 +195,10 @@ router.delete(
     if (!topic) return res.status(404).json({ msg: 'Topic not found' });
 
     const isOwner = topic.authorId === req.user.id;
-    if (!isOwner && !(await isModerator(req, res))) {
+    if (
+      !isOwner &&
+      !hasPermission(await loadPermissions(req, res), 'forums_moderate')
+    ) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 
@@ -213,7 +222,7 @@ router.post(
     });
     if (!topic) return res.status(404).json({ msg: 'Topic not found' });
 
-    if (!(await isModerator(req, res))) {
+    if (!hasPermission(await loadPermissions(req, res), 'forums_moderate')) {
       return res.status(403).json({ msg: 'Not authorized' });
     }
 

--- a/src/routes/api/forum/forumTopicNote.ts
+++ b/src/routes/api/forum/forumTopicNote.ts
@@ -4,7 +4,10 @@ import { prisma } from '../../../lib/prisma';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { createTopicNote } from '../../../modules/forum';
 import { requireAuth } from '../../../middleware/auth';
-import { isModerator } from '../../../middleware/permissions';
+import {
+  loadPermissions,
+  hasPermission
+} from '../../../middleware/permissions';
 import type { AuthenticatedRequest } from '../../../types/auth';
 import {
   parsedBody,
@@ -27,7 +30,13 @@ const requireModerator = async (
   res: Response,
   next: NextFunction
 ) => {
-  if (await isModerator(req as AuthenticatedRequest, res)) return next();
+  if (
+    hasPermission(
+      await loadPermissions(req as AuthenticatedRequest, res),
+      'forums_moderate'
+    )
+  )
+    return next();
   res.status(403).json({ msg: 'Not authorized' });
 };
 

--- a/src/routes/api/reports.ts
+++ b/src/routes/api/reports.ts
@@ -2,7 +2,11 @@ import express from 'express';
 import { z } from 'zod';
 import { authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
-import { requirePermission, isModerator } from '../../middleware/permissions';
+import {
+  requirePermission,
+  loadPermissions,
+  hasPermission
+} from '../../middleware/permissions';
 import {
   validate,
   validateParams,
@@ -129,7 +133,10 @@ router.get(
   validateParams(reportIdSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const isStaff = await isModerator(req, res);
+    const isStaff = hasPermission(
+      await loadPermissions(req, res),
+      'reports_manage'
+    );
     const result = await getReport(id, req.user.id, isStaff);
     if (!result.ok) {
       if (result.reason === 'forbidden')

--- a/src/routes/api/staffInbox.ts
+++ b/src/routes/api/staffInbox.ts
@@ -1,7 +1,11 @@
 import express from 'express';
 import { z } from 'zod';
 import { authHandler } from '../../modules/asyncHandler';
-import { requirePermission, isModerator } from '../../middleware/permissions';
+import {
+  requirePermission,
+  loadPermissions,
+  hasPermission
+} from '../../middleware/permissions';
 import { requireAuth } from '../../middleware/auth';
 import { prisma } from '../../lib/prisma';
 import {
@@ -197,7 +201,10 @@ router.get(
   validateParams(ticketIdSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const isStaff = await isModerator(req, res);
+    const isStaff = hasPermission(
+      await loadPermissions(req, res),
+      'staff_inbox_manage'
+    );
     const result = await viewTicket(id, req.user.id, isStaff);
     if (!result.ok) return res.status(404).json({ msg: 'Ticket not found' });
     res.json(result.ticket);
@@ -213,7 +220,10 @@ router.post(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { body } = parsedBody<ReplyInput>(res);
-    const isStaff = await isModerator(req, res);
+    const isStaff = hasPermission(
+      await loadPermissions(req, res),
+      'staff_inbox_manage'
+    );
     const result = await replyToTicket(id, req.user.id, body, isStaff);
     if (!result.ok) {
       let status = 404;
@@ -232,7 +242,10 @@ router.post(
   validateParams(ticketIdSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const isStaff = await isModerator(req, res);
+    const isStaff = hasPermission(
+      await loadPermissions(req, res),
+      'staff_inbox_manage'
+    );
     const result = await resolveTicket(id, req.user.id, isStaff);
     if (!result.ok) {
       let status = 404;

--- a/src/routes/api/tools.ts
+++ b/src/routes/api/tools.ts
@@ -11,7 +11,10 @@ import {
   parsedParams
 } from '../../middleware/validate';
 import { audit } from '../../lib/audit';
-import { normalizePermissions } from '../../lib/rankPermissions';
+import {
+  normalizePermissions,
+  PERMISSION_GROUPS
+} from '../../lib/rankPermissions';
 import {
   createRankSchema,
   updateRankSchema,
@@ -69,6 +72,15 @@ router.get(
       include: { _count: { select: { users: true, secondaryUsers: true } } }
     });
     res.json(ranks.map(formatRank));
+  })
+);
+
+// GET /api/tools/user-ranks/permissions — permission catalog (static; no DB)
+router.get(
+  '/user-ranks/permissions',
+  ...requirePermission('rank_permissions_manage'),
+  asyncHandler(async (_req: Request, res: Response) => {
+    res.json(PERMISSION_GROUPS);
   })
 );
 

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -10,8 +10,8 @@ import {
 import { requireAuth } from '../../middleware/auth';
 import {
   requirePermission,
-  isModerator,
-  loadPermissions
+  loadPermissions,
+  hasPermission
 } from '../../middleware/permissions';
 import {
   validate,
@@ -510,7 +510,7 @@ router.get(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { period } = parsedQuery<StatsPeriodQuery>(res);
-    const isStaff = await isModerator(req, res);
+    const isStaff = hasPermission(await loadPermissions(req, res), 'staff');
     const userAndSettings = await prisma.user.findUnique({
       where: { id },
       include: { userSettings: true }


### PR DESCRIPTION
## What

Two architectural deepenings surfaced by a codebase review.

### 1. Granular permission checks — remove `isModerator`

`isModerator()` conflated `forums_moderate || admin || staff` into a single boolean. Any user with `forums_moderate` inadvertently satisfied the `reports` and `staff_inbox` gates — cross-domain permission bleed.

Removed entirely. Every call site now names the exact permission it requires:

| Route | Old gate | New gate |
|---|---|---|
| `forumTopic`, `forumPost`, `forumPoll`, `forumTopicNote` | `isModerator` | `forums_moderate` |
| `reports.ts` staff view | `isModerator` | `reports_manage` |
| `staffInbox.ts` ticket ops | `isModerator` | `staff_inbox_manage` |
| `comments.ts` mod delete | `isModerator` | `reports_manage` |
| `user.ts` stats history | `isStaffUser` | `staff` |

Decision recorded in `docs/adr/0001-granular-permission-checks.md`.

### 2. Expose permission catalog via API — remove static frontend duplicate

`src/utils/permissionCatalog.ts` (281 lines) was a hand-maintained copy of the backend's `PERMISSION_GROUPS`. Added `GET /api/tools/user-ranks/permissions` (requires `rank_permissions_manage`) returning the live catalog. Registered `PermissionKey` as `z.enum(VALID_PERMISSIONS)` in the OpenAPI spec; regenerated `types/api.ts`. The frontend `Permission` type is now derived from `components['schemas']['PermissionKey']` and the rank editor fetches groups via `useGetPermissionCatalogQuery`.

### 3. Deepen `registerUser`: atomic invite gate and consumption

The registration route previously ran three separate steps — check invite → create user → mark invite accepted — with no transaction between steps 2 and 3. A crash or DB error after user creation left the invite permanently open and reusable.

`registerUser` now accepts `RegisterOptions` (including `registrationMode` passed from the route's `getSettings()` call) and owns the full policy:

- `registration_closed` / `invite_required` are typed early exits before any DB writes
- `invite.update({ status: 'accepted' })` moves inside the `$transaction` with `userSettings`, `profile`, and `user` creation — the two are now atomic
- Route is a thin switch on typed result reasons → HTTP status codes

**Follow-up:** TOCTOU race on concurrent invite redemptions — two simultaneous requests both see `status: 'pending'` before either commits. Requires a `SELECT FOR UPDATE` or unique-constraint + optimistic-lock strategy on `Invite`. Tracked separately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)