### PR TITLE
Deepen pagination module: paginationBase, parsedPage, validateQuery on all list routes

### DIFF
--- a/src/comments.spec.ts
+++ b/src/comments.spec.ts
@@ -108,7 +108,9 @@ describe('GET /api/comments', () => {
   });
 
   it('returns 400 for an invalid page filter', async () => {
-    const res = await request(app).get('/api/comments?context=bad-page&pageId=1');
+    const res = await request(app).get(
+      '/api/comments?context=bad-page&pageId=1'
+    );
 
     expect(res.status).toBe(400);
     expect(prismaMock.comment.findMany).not.toHaveBeenCalled();

--- a/src/comments.spec.ts
+++ b/src/comments.spec.ts
@@ -37,7 +37,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=communities&pageId=5');
+    await request(app).get('/api/comments?context=communities&pageId=5');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({ page: 'communities', communityId: 5 });
@@ -47,7 +47,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=artist&pageId=3');
+    await request(app).get('/api/comments?context=artist&pageId=3');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({ page: 'artist', artistId: 3 });
@@ -57,7 +57,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=collages&pageId=2');
+    await request(app).get('/api/comments?context=collages&pageId=2');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({ page: 'collages', collageId: 2 });
@@ -67,7 +67,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=contributions&pageId=1');
+    await request(app).get('/api/comments?context=contributions&pageId=1');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({
@@ -80,7 +80,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=requests&pageId=4');
+    await request(app).get('/api/comments?context=requests&pageId=4');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({ page: 'requests', requestId: 4 });
@@ -90,7 +90,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=release&pageId=7');
+    await request(app).get('/api/comments?context=release&pageId=7');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({ page: 'release', releaseId: 7 });
@@ -100,7 +100,7 @@ describe('GET /api/comments', () => {
     prismaMock.comment.findMany.mockResolvedValue([]);
     prismaMock.comment.count.mockResolvedValue(0);
 
-    await request(app).get('/api/comments?page=artist');
+    await request(app).get('/api/comments?context=artist');
 
     const call = prismaMock.comment.findMany.mock.calls[0][0];
     expect(call?.where).toMatchObject({ page: 'artist', deletedAt: null });
@@ -108,7 +108,7 @@ describe('GET /api/comments', () => {
   });
 
   it('returns 400 for an invalid page filter', async () => {
-    const res = await request(app).get('/api/comments?page=bad-page&pageId=1');
+    const res = await request(app).get('/api/comments?context=bad-page&pageId=1');
 
     expect(res.status).toBe(400);
     expect(prismaMock.comment.findMany).not.toHaveBeenCalled();

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,4 +1,5 @@
-import { Request, Response } from 'express';
+import { z } from 'zod';
+import type { Response } from 'express';
 
 const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 100;
@@ -9,13 +10,29 @@ export interface PageParams {
   skip: number;
 }
 
-export const parsePage = (req: Request): PageParams => {
-  const page = Math.max(1, parseInt(req.query.page as string) || 1);
-  const limit = Math.min(
-    MAX_PAGE_SIZE,
-    Math.max(1, parseInt(req.query.limit as string) || DEFAULT_PAGE_SIZE)
-  );
-  return { page, limit, skip: (page - 1) * limit };
+/**
+ * Spread into any Zod query schema to add validated, bounded page/limit fields.
+ * Use with validateQuery() then read back with parsedPage(res).
+ */
+export const paginationBase = {
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_PAGE_SIZE)
+    .optional()
+    .default(DEFAULT_PAGE_SIZE)
+};
+
+/**
+ * Derive PageParams from a query already validated by validateQuery().
+ * The calling route MUST have run validateQuery() with a schema that
+ * spreads paginationBase before calling this.
+ */
+export const parsedPage = (res: Response): PageParams => {
+  const q = res.locals.parsedQuery as { page: number; limit: number };
+  return { page: q.page, limit: q.limit, skip: (q.page - 1) * q.limit };
 };
 
 export const paginatedResponse = (

--- a/src/routes/api/collages.ts
+++ b/src/routes/api/collages.ts
@@ -17,7 +17,11 @@ import {
   parsedQuery
 } from '../../middleware/validate';
 import { sanitizeHtml } from '../../lib/sanitize';
-import { parsePage, paginatedResponse } from '../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../lib/pagination';
 import { hasPermission } from '../../lib/rankPermissions';
 import {
   createCollageSchema,
@@ -59,13 +63,16 @@ const collageInclude = {
 // Personal collages: categoryId === 0
 const isPersonal = (categoryId: number) => categoryId === 0;
 
+const deletedCollagesQuerySchema = z.object({ ...paginationBase });
+
 // ─── GET /api/collages/deleted — staff recovery list (before /:id) ───────────
 
 router.get(
   '/deleted',
   ...requirePermission('collages_moderate'),
+  validateQuery(deletedCollagesQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [collages, total] = await Promise.all([
       prisma.collage.findMany({
         where: { isDeleted: true, categoryId: { gt: 0 } },
@@ -92,7 +99,7 @@ router.get(
     const authReq = req as AuthenticatedRequest;
     const { search, categoryId, userId, bookmarked, orderBy, order } =
       parsedQuery<CollageQueryInput>(res);
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
 
     const sortField = orderBy ?? 'createdAt';
     const sortDir = order ?? 'desc';

--- a/src/routes/api/comments.ts
+++ b/src/routes/api/comments.ts
@@ -19,7 +19,7 @@ import {
   parsedQuery
 } from '../../middleware/validate';
 import { sanitizeHtml } from '../../lib/sanitize';
-import { parsePage, paginatedResponse } from '../../lib/pagination';
+import { parsedPage, paginatedResponse } from '../../lib/pagination';
 import {
   commentQuerySchema,
   createCommentSchema,
@@ -40,20 +40,19 @@ router.get(
   '/',
   validateQuery(commentQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const { page, pageId } = parsedQuery<CommentQueryInput>(res);
+    const { context, pageId } = parsedQuery<CommentQueryInput>(res);
+    const pg = parsedPage(res);
     const where: Record<string, unknown> = {};
-    if (page) where.page = page as CommentPage;
-    if (page && pageId) {
-      if (page === CommentPage.communities) where.communityId = pageId;
-      else if (page === CommentPage.artist) where.artistId = pageId;
-      else if (page === CommentPage.collages) where.collageId = pageId;
-      else if (page === CommentPage.contributions)
+    if (context) where.page = context as CommentPage;
+    if (context && pageId) {
+      if (context === CommentPage.communities) where.communityId = pageId;
+      else if (context === CommentPage.artist) where.artistId = pageId;
+      else if (context === CommentPage.collages) where.collageId = pageId;
+      else if (context === CommentPage.contributions)
         where.contributionId = pageId;
-      else if (page === CommentPage.requests) where.requestId = pageId;
-      else if (page === CommentPage.release) where.releaseId = pageId;
+      else if (context === CommentPage.requests) where.requestId = pageId;
+      else if (context === CommentPage.release) where.releaseId = pageId;
     }
-
-    const pg = parsePage(req);
     const [comments, total] = await Promise.all([
       prisma.comment.findMany({
         where: { ...where, deletedAt: null },

--- a/src/routes/api/communities/artist.ts
+++ b/src/routes/api/communities/artist.ts
@@ -14,9 +14,14 @@ import {
   parsedBody,
   validate,
   validateParams,
+  validateQuery,
   parsedParams
 } from '../../../middleware/validate';
-import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../../lib/pagination';
 import {
   artistSchema,
   updateArtistSchema,
@@ -40,13 +45,15 @@ const artistHistoryParamsSchema = z.object({
 const artistRevertParamsSchema = z.object({
   historyId: z.coerce.number().int().positive()
 });
+const artistsQuerySchema = z.object({ ...paginationBase });
 
 // GET /api/artists
 router.get(
   '/',
   requireAuth,
+  validateQuery(artistsQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [artists, total] = await Promise.all([
       prisma.artist.findMany({
         skip: pg.skip,
@@ -64,8 +71,9 @@ router.get(
 router.get(
   '/vanity-house',
   ...requirePermission('admin'),
+  validateQuery(artistsQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [artists, total] = await Promise.all([
       prisma.artist.findMany({
         where: { vanityHouse: true },

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -12,6 +12,7 @@ import {
   parsedBody,
   validate,
   validateParams,
+  validateQuery,
   parsedParams
 } from '../../../middleware/validate';
 import {
@@ -20,7 +21,11 @@ import {
   type CreateCommunityInput,
   type UpdateCommunityInput
 } from '../../../schemas/community';
-import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../../lib/pagination';
 import releaseRouter from './release';
 
 const router = express.Router();
@@ -36,6 +41,8 @@ const addMemberSchema = z.object({
 });
 
 router.use('/:communityId/releases', releaseRouter);
+
+const communitiesQuerySchema = z.object({ ...paginationBase });
 
 export async function isCommunityMember(
   communityId: number,
@@ -56,8 +63,9 @@ export async function isCommunityMember(
 router.get(
   '/',
   requireAuth,
+  validateQuery(communitiesQuerySchema),
   authHandler(async (req, res) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const userId = req.user.id;
     const memberFilter = {
       OR: [

--- a/src/routes/api/communities/contributions.ts
+++ b/src/routes/api/communities/contributions.ts
@@ -11,9 +11,14 @@ import {
   parsedBody,
   validate,
   validateParams,
+  validateQuery,
   parsedParams
 } from '../../../middleware/validate';
-import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../../lib/pagination';
 import {
   createContributionSchema,
   type CreateContributionInput
@@ -28,13 +33,15 @@ const contributionIdParamsSchema = z.object({
 const reportSchema = z.object({
   reason: z.string().min(1).max(1000)
 });
+const contributionsQuerySchema = z.object({ ...paginationBase });
 
 // GET /api/contributions
 router.get(
   '/',
   requireAuth,
+  validateQuery(contributionsQuerySchema),
   authHandler(async (req, res) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const where = { userId: req.user.id };
     const [contributions, total] = await Promise.all([
       prisma.contribution.findMany({

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -6,6 +6,7 @@ import { requirePermission } from '../../../middleware/permissions';
 import {
   validate,
   validateParams,
+  validateQuery,
   parsedParams,
   parsedBody
 } from '../../../middleware/validate';
@@ -26,7 +27,11 @@ import {
   type AddContributionToReleaseInput
 } from '../../../schemas/contribution';
 import { resolveTagName } from '../../../modules/tag';
-import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../../lib/pagination';
 import { releaseWorkbench } from '../../../modules/releaseWorkbench';
 import type { ReleaseWorkbenchView } from '../../../modules/releaseWorkbench/types';
 import {
@@ -39,6 +44,8 @@ const router = express.Router({ mergeParams: true });
 const communityIdParamsSchema = z.object({
   communityId: z.coerce.number().int().positive()
 });
+const releasesQuerySchema = z.object({ ...paginationBase });
+const releaseHistoryQuerySchema = z.object({ ...paginationBase });
 const releaseParamsSchema = z.object({
   communityId: z.coerce.number().int().positive(),
   releaseId: z.coerce.number().int().positive()
@@ -59,9 +66,10 @@ router.get(
   '/',
   requireAuth,
   validateParams(communityIdParamsSchema),
+  validateQuery(releasesQuerySchema),
   authHandler(async (req, res) => {
     const { communityId } = parsedParams<{ communityId: number }>(res);
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const result = await listCommunityReleases({
       actorId: req.user.id,
       communityId,
@@ -77,12 +85,13 @@ router.get(
   '/:releaseId/history',
   requireAuth,
   validateParams(releaseParamsSchema),
+  validateQuery(releaseHistoryQuerySchema),
   authHandler(async (req, res) => {
     const { communityId, releaseId } = parsedParams<{
       communityId: number;
       releaseId: number;
     }>(res);
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const session = await releaseWorkbench.open({
       actorId: req.user.id,
       communityId,

--- a/src/routes/api/donations.ts
+++ b/src/routes/api/donations.ts
@@ -12,13 +12,18 @@ import {
   parsedQuery
 } from '../../middleware/validate';
 import { audit } from '../../lib/audit';
-import { parsePage, paginatedResponse } from '../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../lib/pagination';
 
 const router = express.Router();
 
 const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
 
 const donationsQuerySchema = z.object({
+  ...paginationBase,
   userId: z.coerce.number().int().positive().optional()
 });
 
@@ -44,7 +49,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const { userId } = parsedQuery<DonationsQuery>(res);
     const where = userId ? { userId } : undefined;
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [rows, total] = await Promise.all([
       prisma.donation.findMany({
         where,

--- a/src/routes/api/forum/forumPost.ts
+++ b/src/routes/api/forum/forumPost.ts
@@ -12,6 +12,7 @@ import {
   parsedBody,
   validate,
   validateParams,
+  validateQuery,
   parsedParams
 } from '../../../middleware/validate';
 import { writeLimiter } from '../../../middleware/rateLimiter';
@@ -21,7 +22,11 @@ import {
   type CreatePostInput,
   type UpdatePostInput
 } from '../../../schemas/forum';
-import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../../lib/pagination';
 import { canAccessForumLevel } from '../../../lib/userRankAccess';
 
 const router = express.Router({ mergeParams: true });
@@ -34,6 +39,8 @@ const forumPostParamsSchema = z.object({
   forumTopicId: z.coerce.number().int().positive(),
   id: z.coerce.number().int().positive()
 });
+
+const forumPostsQuerySchema = z.object({ ...paginationBase });
 
 const publicPostInclude = {
   author: { select: { id: true, username: true, avatar: true } },
@@ -80,6 +87,7 @@ router.get(
   '/',
   requireAuth,
   validateParams(forumTopicParamsSchema),
+  validateQuery(forumPostsQuerySchema),
   authHandler(async (req, res) => {
     const { forumId, forumTopicId } = parsedParams<{
       forumId: number;
@@ -97,7 +105,7 @@ router.get(
         .json({ msg: 'Insufficient class to read this forum' });
     }
 
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [posts, total] = await Promise.all([
       prisma.forumPost.findMany({
         where: {

--- a/src/routes/api/forum/forumTopic.ts
+++ b/src/routes/api/forum/forumTopic.ts
@@ -17,6 +17,7 @@ import {
   parsedBody,
   validate,
   validateParams,
+  validateQuery,
   parsedParams
 } from '../../../middleware/validate';
 import { writeLimiter } from '../../../middleware/rateLimiter';
@@ -26,7 +27,11 @@ import {
   type CreateTopicInput,
   type UpdateTopicInput
 } from '../../../schemas/forum';
-import { parsePage, paginatedResponse } from '../../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../../lib/pagination';
 import { sanitizePlain } from '../../../lib/sanitize';
 import { canAccessForumLevel } from '../../../lib/userRankAccess';
 import forumPostRouter from './forumPost';
@@ -42,11 +47,14 @@ const forumTopicParamsSchema = z.object({
 
 router.use('/:forumTopicId/posts', forumPostRouter);
 
+const forumTopicsQuerySchema = z.object({ ...paginationBase });
+
 // GET /api/forums/:forumId/topics
 router.get(
   '/',
   requireAuth,
   validateParams(forumIdParamsSchema),
+  validateQuery(forumTopicsQuerySchema),
   authHandler(async (req, res) => {
     const { forumId } = parsedParams<{ forumId: number }>(res);
 
@@ -61,7 +69,7 @@ router.get(
         .json({ msg: 'Insufficient class to read this forum' });
     }
 
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [topics, total] = await Promise.all([
       prisma.forumTopic.findMany({
         where: { forumId, deletedAt: null },

--- a/src/routes/api/friends.ts
+++ b/src/routes/api/friends.ts
@@ -4,17 +4,24 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { AppError } from '../../lib/errors';
 import { sanitizePlain } from '../../lib/sanitize';
-import { parsePage, paginatedResponse } from '../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../lib/pagination';
 import { authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
 import {
   validate,
   validateParams,
+  validateQuery,
   parsedBody,
   parsedParams
 } from '../../middleware/validate';
 
 const router = express.Router();
+
+const friendsQuerySchema = z.object({ ...paginationBase });
 
 const userIdParams = z.object({
   userId: z.coerce.number().int().positive()
@@ -41,8 +48,9 @@ router.get(
 router.get(
   '/',
   requireAuth,
+  validateQuery(friendsQuerySchema),
   authHandler(async (req, res) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [friends, total] = await Promise.all([
       prisma.friend.findMany({
         where: { userId: req.user.id },

--- a/src/routes/api/search.ts
+++ b/src/routes/api/search.ts
@@ -3,7 +3,7 @@ import { prisma } from '../../lib/prisma';
 import { requireAuth } from '../../middleware/auth';
 import { asyncHandler } from '../../modules/asyncHandler';
 import { validateQuery, parsedQuery } from '../../middleware/validate';
-import { paginatedResponse } from '../../lib/pagination';
+import { parsedPage, paginatedResponse } from '../../lib/pagination';
 import {
   searchReleasesQuerySchema,
   searchArtistsQuerySchema,
@@ -54,10 +54,6 @@ function buildArtistTagWhere(
     : { tags: { some: { tag: { name: { in: names } } } } };
 }
 
-function toPageParams(q: { page: number; limit: number }) {
-  return { page: q.page, limit: q.limit, skip: (q.page - 1) * q.limit };
-}
-
 // ─── GET /api/search/releases ─────────────────────────────────────────────────
 
 const RELEASE_SELECT = {
@@ -82,7 +78,7 @@ router.get(
   validateQuery(searchReleasesQuerySchema),
   asyncHandler(async (req, res) => {
     const q = parsedQuery<SearchReleasesQuery>(res);
-    const pg = toPageParams(q);
+    const pg = parsedPage(res);
 
     const communityIds = q.communityId
       ? Array.isArray(q.communityId)
@@ -206,7 +202,7 @@ router.get(
   validateQuery(searchArtistsQuerySchema),
   asyncHandler(async (req, res) => {
     const q = parsedQuery<SearchArtistsQuery>(res);
-    const pg = toPageParams(q);
+    const pg = parsedPage(res);
 
     const tagPredicate = buildArtistTagWhere(q.tags, q.tagMode);
 
@@ -282,7 +278,7 @@ router.get(
   validateQuery(searchRequestsQuerySchema),
   asyncHandler(async (req, res) => {
     const q = parsedQuery<SearchRequestsQuery>(res);
-    const pg = toPageParams(q);
+    const pg = parsedPage(res);
 
     const where: Record<string, unknown> = { deletedAt: null };
     if (q.q) {
@@ -370,7 +366,7 @@ router.get(
   validateQuery(searchLogQuerySchema),
   asyncHandler(async (req, res) => {
     const q = parsedQuery<SearchLogQuery>(res);
-    const pg = toPageParams(q);
+    const pg = parsedPage(res);
 
     const topicWhere: Record<string, unknown> = { deletedAt: null };
     const postWhere: Record<string, unknown> = { deletedAt: null };
@@ -481,7 +477,7 @@ router.get(
   validateQuery(searchUsersQuerySchema),
   asyncHandler(async (req, res) => {
     const q = parsedQuery<SearchUsersQuery>(res);
-    const pg = toPageParams(q);
+    const pg = parsedPage(res);
     const authedReq = req as AuthenticatedRequest;
 
     const rank = await prisma.userRank.findUnique({

--- a/src/routes/api/tagAliases.ts
+++ b/src/routes/api/tagAliases.ts
@@ -6,10 +6,15 @@ import { requirePermission } from '../../middleware/permissions';
 import {
   validate,
   validateParams,
+  validateQuery,
   parsedBody,
   parsedParams
 } from '../../middleware/validate';
-import { parsePage, paginatedResponse } from '../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../lib/pagination';
 import {
   createTagAliasSchema,
   updateTagAliasSchema,
@@ -20,13 +25,15 @@ import { AppError } from '../../lib/errors';
 
 const router = express.Router();
 const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+const tagAliasesQuerySchema = z.object({ ...paginationBase });
 
 // GET /api/tag-aliases
 router.get(
   '/',
   ...requirePermission('tags_manage'),
+  validateQuery(tagAliasesQuerySchema),
   asyncHandler(async (req, res) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [aliases, total] = await Promise.all([
       prisma.tagAlias.findMany({
         include: {

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -39,7 +39,11 @@ import {
   type GrantDonorInput
 } from '../../schemas/user';
 import { audit } from '../../lib/audit';
-import { parsePage, paginatedResponse } from '../../lib/pagination';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../lib/pagination';
 import { sendRecoveryEmail } from '../../lib/mailer';
 import { email as emailConfig } from '../../modules/config';
 import {
@@ -67,13 +71,21 @@ const warningParamsSchema = z.object({
 const reqIdParamsSchema = z.object({
   reqId: z.coerce.number().int().positive()
 });
-const recoveryStatusSchema = z
-  .enum(['pending', 'used', 'expired'])
-  .default('pending');
 const warningsQuerySchema = z.object({
+  ...paginationBase,
   userId: z.coerce.number().int().positive().optional()
 });
 type WarningsQuery = z.infer<typeof warningsQuerySchema>;
+
+const recoveryRequestsQuerySchema = z.object({
+  ...paginationBase,
+  status: z.enum(['pending', 'used', 'expired']).optional().default('pending')
+});
+type RecoveryRequestsQuery = z.infer<typeof recoveryRequestsQuerySchema>;
+
+const inviteTreeQuerySchema = z.object({ ...paginationBase });
+const ratioWatchQuerySchema = z.object({ ...paginationBase });
+const registrationLogQuerySchema = z.object({ ...paginationBase });
 
 // ─── Donor ranks (static paths — must come before /:id) ──────────────────────
 
@@ -232,10 +244,10 @@ router.put(
 router.get(
   '/recovery-requests',
   ...requirePermission('recovery_manage'),
+  validateQuery(recoveryRequestsQuerySchema),
   authHandler(async (req, res) => {
-    const rawStatus = req.query.status as string | undefined;
-    const statusResult = recoveryStatusSchema.safeParse(rawStatus ?? 'pending');
-    const status = statusResult.success ? statusResult.data : 'pending';
+    const { status } = parsedQuery<RecoveryRequestsQuery>(res);
+    const pg = parsedPage(res);
 
     const now = new Date();
     const where =
@@ -244,8 +256,6 @@ router.get(
         : status === 'used'
         ? { usedAt: { not: null } }
         : { usedAt: null, expiresAt: { lte: now } };
-
-    const pg = parsePage(req);
     const [records, total] = await Promise.all([
       prisma.accountRecovery.findMany({
         where,
@@ -303,6 +313,7 @@ router.delete(
 // ─── Login Watch / Invite Pool / Invite Tree / Ratio Watch (static — before /:id) ───
 
 const sessionsQuerySchema = z.object({
+  ...paginationBase,
   userId: z.coerce.number().int().positive().optional()
 });
 type SessionsQuery = z.infer<typeof sessionsQuerySchema>;
@@ -313,7 +324,7 @@ router.get(
   ...requirePermission('login_watch_view'),
   validateQuery(sessionsQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const { userId } = parsedQuery<SessionsQuery>(res);
     const where = userId ? { userId } : {};
     const [sessions, total] = await Promise.all([
@@ -331,6 +342,7 @@ router.get(
 );
 
 const invitesQuerySchema = z.object({
+  ...paginationBase,
   status: z.string().optional()
 });
 type InvitesQuery = z.infer<typeof invitesQuerySchema>;
@@ -341,7 +353,7 @@ router.get(
   ...requirePermission('invites_manage'),
   validateQuery(invitesQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const { status } = parsedQuery<InvitesQuery>(res);
     const where = status ? { status: status as never } : {};
     const [invites, total] = await Promise.all([
@@ -363,8 +375,9 @@ router.get(
 router.get(
   '/invite-tree',
   ...requirePermission('invites_manage'),
+  validateQuery(inviteTreeQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [trees, total] = await Promise.all([
       prisma.inviteTree.findMany({
         include: { user: { select: { id: true, username: true } } },
@@ -396,8 +409,9 @@ router.get(
 router.get(
   '/ratio-watch',
   ...requirePermission('ratio_policy_manage'),
+  validateQuery(ratioWatchQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const where = {
       status: {
         in: [RatioPolicyStatus.WATCH, RatioPolicyStatus.LEECH_DISABLED]
@@ -423,7 +437,7 @@ router.get(
   ...requirePermission('admin'),
   validateQuery(warningsQuerySchema),
   authHandler(async (req, res) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const { userId } = parsedQuery<WarningsQuery>(res);
     const where = userId ? { userId } : {};
     const [warnings, total] = await Promise.all([
@@ -478,8 +492,9 @@ router.get(
 router.get(
   '/registration-log',
   ...requirePermission('registration_log_view'),
+  validateQuery(registrationLogQuerySchema),
   authHandler(async (req, res) => {
-    const pg = parsePage(req);
+    const pg = parsedPage(res);
     const [users, total] = await Promise.all([
       prisma.user.findMany({
         orderBy: { dateRegistered: 'desc' },

--- a/src/schemas/collage.ts
+++ b/src/schemas/collage.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { paginationBase } from '../lib/pagination';
 
 export const createCollageSchema = z.object({
   name: z.string().min(3, 'Name must be at least 3 characters').max(100),
@@ -21,8 +22,7 @@ export const updateCollageSchema = z.object({
 });
 
 export const collageQuerySchema = z.object({
-  page: z.coerce.number().int().positive().optional(),
-  limit: z.coerce.number().int().positive().max(100).optional(),
+  ...paginationBase,
   search: z.string().max(200).optional(),
   categoryId: z.coerce.number().int().min(0).max(6).optional(),
   userId: z.coerce.number().int().positive().optional(),

--- a/src/schemas/comment.ts
+++ b/src/schemas/comment.ts
@@ -1,5 +1,6 @@
 import { CommentPage } from '@prisma/client';
 import { z } from 'zod';
+import { paginationBase } from '../lib/pagination';
 
 const commentPageEnum = z.enum(
   Object.values(CommentPage) as [CommentPage, ...CommentPage[]]
@@ -8,7 +9,8 @@ const commentPageEnum = z.enum(
 const pageIdSchema = z.number().int().positive();
 
 export const commentQuerySchema = z.object({
-  page: commentPageEnum.optional(),
+  ...paginationBase,
+  context: commentPageEnum.optional(),
   pageId: z.coerce.number().int().positive().optional()
 });
 

--- a/src/schemas/search.ts
+++ b/src/schemas/search.ts
@@ -5,6 +5,7 @@ import {
   RequestStatus
 } from '@prisma/client';
 import { z } from 'zod';
+import { paginationBase } from '../lib/pagination';
 
 const releaseTypeEnum = z.enum(
   Object.values(ReleaseType) as [ReleaseType, ...ReleaseType[]]
@@ -18,11 +19,6 @@ const fileTypeEnum = z.enum(
 const requestStatusEnum = z.enum(
   Object.values(RequestStatus) as [RequestStatus, ...RequestStatus[]]
 );
-
-const paginationBase = {
-  page: z.coerce.number().int().positive().optional().default(1),
-  limit: z.coerce.number().int().min(1).max(100).optional().default(25)
-};
 
 export const searchReleasesQuerySchema = z.object({
   ...paginationBase,


### PR DESCRIPTION
## What

Promotes the pagination module from a shallow utility into a deep seam with a single authoritative source of truth for validated, bounded page/limit fields.

### pagination.ts — new interface
- Export `paginationBase`: a Zod schema object fragment to spread into any query schema. Coerces, bounds (1–100), and defaults page/limit at the Zod layer.
- Export `parsedPage(res)`: reads from `res.locals.parsedQuery` (set by `validateQuery`). Replaces the unvalidated `parsePage(req)` which used raw `parseInt` on `req.query`.
- Remove `parsePage` — callers that needed it now use `validateQuery` + `parsedPage`.

### 13 route files updated
Every list endpoint that was calling `parsePage(req)` now uses `validateQuery(schema)` + `parsedPage(res)`:

| Route file | Schema change |
|---|---|
| `comments.ts` | Rename enum filter `page` → `context` (frees up `page` for numeric offset); add `paginationBase` |
| `collages.ts` | Replace hand-rolled `page`/`limit` with `paginationBase`; add schema for `/deleted` route |
| `donations.ts` | Add `paginationBase` to inline schema |
| `friends.ts` | New inline `friendsQuerySchema` with `paginationBase` |
| `tagAliases.ts` | New inline schema |
| `communities/communities.ts` | New inline schema |
| `communities/artist.ts` | New inline schema (shared by `/` and `/vanity-house`) |
| `communities/release.ts` | New schemas for list and history endpoints |
| `communities/contributions.ts` | New inline schema |
| `forum/forumPost.ts` | New inline schema |
| `forum/forumTopic.ts` | New inline schema |
| `search.ts` | Remove local `toPageParams` function; `paginationBase` now imported from pagination module |
| `user.ts` | Add `paginationBase` to sessions/invites/warnings schemas; new schemas for recovery-requests, invite-tree, ratio-watch, registration-log; fold `recoveryStatusSchema` + manual `safeParse` into `recoveryRequestsQuerySchema` |

### Schema consolidation
- `src/schemas/search.ts`: remove local `paginationBase` const, import from `pagination.ts`
- `src/schemas/comment.ts`: rename `page` → `context`, add `paginationBase`
- `src/schemas/collage.ts`: replace hand-rolled fields with `paginationBase`
- OpenAPI spec regenerated; `context` field now visible in `/comments` GET query params

## What wasn't changed

`GET /api/search/log` with `type=all` still hand-rolls its multi-key response (`{ topics: { data, meta }, posts: { data, meta } }`) — this shape diverges from `paginatedResponse` and is the only instance of that pattern. Intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)