### PR TITLE
Deepen requestLifecycle: move detail, vote, history, and auth into module

### DIFF
--- a/src/modules.spec.ts
+++ b/src/modules.spec.ts
@@ -899,9 +899,9 @@ describe('ratioPolicy.getPolicyState', () => {
 
 // ─── requests module ──────────────────────────────────────────────────────────
 
-import type * as RequestsModule from './modules/requests';
+import type * as RequestsModule from './modules/requestLifecycle';
 const { createRequest, unfillRequest, serializeRequest, listRequests } =
-  jest.requireActual<typeof RequestsModule>('./modules/requests');
+  jest.requireActual<typeof RequestsModule>('./modules/requestLifecycle');
 
 describe('requests.createRequest', () => {
   it('includes artist associations when artists array is provided', async () => {
@@ -960,9 +960,9 @@ describe('requests.unfillRequest', () => {
       bounties: []
     } as never);
 
-    await expect(unfillRequest(7, 1)).rejects.toThrow(
-      'Filled request has no fillerId'
-    );
+    await expect(
+      unfillRequest({ requestId: 1, actorId: 7, canModerateRequests: true })
+    ).rejects.toThrow('Filled request has no fillerId');
   });
 
   it('claws back bounty from filler when bounties exist', async () => {
@@ -991,7 +991,11 @@ describe('requests.unfillRequest', () => {
     prismaMock.request.update.mockResolvedValueOnce({} as never);
     prismaMock.requestAction.create.mockResolvedValueOnce({} as never);
 
-    await unfillRequest(7, 1);
+    await unfillRequest({
+      requestId: 1,
+      actorId: 7,
+      canModerateRequests: true
+    });
 
     expect(prismaMock.user.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/modules/requestLifecycle.spec.ts
+++ b/src/modules/requestLifecycle.spec.ts
@@ -1,8 +1,8 @@
 /**
- * Service-level unit tests for the requests module.
+ * Service-level unit tests for the requestLifecycle module.
  *
  * Prisma is mocked at the lib/prisma boundary so we can test business logic,
- * error paths, and transaction behavior without a real database.
+ * authorization rules, error paths, and transaction behavior without a real DB.
  */
 
 import { ReleaseType, RequestStatus } from '@prisma/client';
@@ -42,7 +42,24 @@ jest.mock('../lib/prisma', () => ({
     $transaction: mockTransaction,
     request: {
       findMany: jest.fn(),
-      count: jest.fn()
+      count: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn()
+    },
+    requestBounty: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn()
+    },
+    requestAction: {
+      create: jest.fn(),
+      findMany: jest.fn()
+    },
+    requestVote: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn()
     }
   }
 }));
@@ -59,8 +76,12 @@ import {
   deleteRequest,
   listRequests,
   MINIMUM_BOUNTY,
-  serializeRequest
-} from './requests';
+  serializeRequest,
+  getRequestDetail,
+  getBountyHistory,
+  toggleVote,
+  updateRequest
+} from './requestLifecycle';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -87,6 +108,7 @@ const makeRequest = (overrides = {}) => ({
   createdAt: new Date(),
   updatedAt: new Date(),
   deletedAt: null,
+  voteCount: 0,
   bounties: [
     {
       id: 1,
@@ -111,6 +133,38 @@ beforeEach(() => {
   mockTransaction.mockImplementation(
     (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)
   );
+});
+
+// ─── serializeRequest ─────────────────────────────────────────────────────────
+
+describe('serializeRequest', () => {
+  it('sums bounty totals and stringifies individual amounts', () => {
+    const result = serializeRequest({
+      ...makeRequest(),
+      bounties: [
+        {
+          id: 1,
+          requestId: 10,
+          userId: 1,
+          amount: BigInt('104857600'),
+          createdAt: new Date()
+        },
+        {
+          id: 2,
+          requestId: 10,
+          userId: 2,
+          amount: BigInt('52428800'),
+          createdAt: new Date()
+        }
+      ]
+    } as Parameters<typeof serializeRequest>[0]);
+
+    expect(result.totalBounty).toBe('157286400');
+    expect(result.bounties?.map((b) => b.amount)).toEqual([
+      '104857600',
+      '52428800'
+    ]);
+  });
 });
 
 // ─── createRequest ─────────────────────────────────────────────────────────────
@@ -198,38 +252,6 @@ describe('createRequest', () => {
       })
     );
     expect(result.totalBounty).toBe(MINIMUM_BOUNTY.toString());
-  });
-});
-
-// ─── fillRequest ──────────────────────────────────────────────────────────────
-
-describe('serializeRequest', () => {
-  it('sums bounty totals and stringifies individual amounts', () => {
-    const result = serializeRequest({
-      ...makeRequest(),
-      bounties: [
-        {
-          id: 1,
-          requestId: 10,
-          userId: 1,
-          amount: BigInt('104857600'),
-          createdAt: new Date()
-        },
-        {
-          id: 2,
-          requestId: 10,
-          userId: 2,
-          amount: BigInt('52428800'),
-          createdAt: new Date()
-        }
-      ]
-    } as Parameters<typeof serializeRequest>[0]);
-
-    expect(result.totalBounty).toBe('157286400');
-    expect(result.bounties?.map((b) => b.amount)).toEqual([
-      '104857600',
-      '52428800'
-    ]);
   });
 });
 
@@ -344,6 +366,8 @@ describe('addBounty', () => {
   });
 });
 
+// ─── fillRequest ──────────────────────────────────────────────────────────────
+
 describe('fillRequest', () => {
   it('throws 404 when contribution not found', async () => {
     mockTx.contribution.findUnique.mockResolvedValue(null);
@@ -442,8 +466,6 @@ describe('fillRequest', () => {
   });
 
   it('notifies requester and bounty holders, excluding the filler', async () => {
-    // makeRequest(): userId=1, bounties=[{userId:1}]
-    // filler is userId=1 → should be excluded (actor === recipient)
     const requestWithBounties = makeRequest({
       userId: 2, // requester
       bounties: [
@@ -536,16 +558,112 @@ describe('fillRequest', () => {
 // ─── unfillRequest ─────────────────────────────────────────────────────────────
 
 describe('unfillRequest', () => {
-  it('throws 404 if request is not filled', async () => {
+  it('throws 404 if request is not found', async () => {
     mockTx.request.findUnique.mockResolvedValue(null);
-    await expect(unfillRequest(99, 10, 'reason')).rejects.toMatchObject({
-      statusCode: 404
-    });
+    await expect(
+      unfillRequest({
+        requestId: 10,
+        actorId: 99,
+        canModerateRequests: true,
+        reason: 'reason'
+      })
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 
-  it('claws back bounty from filler and records audit with moderatorId', async () => {
+  it('throws 422 if request is not filled', async () => {
+    mockTx.request.findUnique.mockResolvedValue(
+      makeRequest({ status: 'open', userId: 99, fillerId: null })
+    );
+    await expect(
+      unfillRequest({ requestId: 10, actorId: 99, canModerateRequests: true })
+    ).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  it('throws 403 when caller is not owner, filler, or moderator', async () => {
+    mockTx.request.findUnique.mockResolvedValue(
+      makeRequest({ status: 'filled', userId: 88, fillerId: 77 })
+    );
+    await expect(
+      unfillRequest({ requestId: 10, actorId: 1, canModerateRequests: false })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('allows the request owner to unfill', async () => {
     const filledReq = makeRequest({
       status: 'filled',
+      userId: 1,
+      fillerId: 77
+    });
+    const openReq = { ...filledReq, status: 'open', fillerId: null };
+    mockTx.request.findUnique
+      .mockResolvedValueOnce(filledReq)
+      .mockResolvedValueOnce(openReq);
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('209715200')
+    });
+    mockTx.user.update.mockResolvedValue(undefined);
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.request.update.mockResolvedValue(undefined);
+    mockTx.requestAction.create.mockResolvedValue(undefined);
+
+    await expect(
+      unfillRequest({ requestId: 10, actorId: 1, canModerateRequests: false })
+    ).resolves.toBeDefined();
+  });
+
+  it('allows the filler to unfill their own fill', async () => {
+    const filledReq = makeRequest({
+      status: 'filled',
+      userId: 88,
+      fillerId: 1
+    });
+    const openReq = { ...filledReq, status: 'open', fillerId: null };
+    mockTx.request.findUnique
+      .mockResolvedValueOnce(filledReq)
+      .mockResolvedValueOnce(openReq);
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('209715200')
+    });
+    mockTx.user.update.mockResolvedValue(undefined);
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.request.update.mockResolvedValue(undefined);
+    mockTx.requestAction.create.mockResolvedValue(undefined);
+
+    await expect(
+      unfillRequest({ requestId: 10, actorId: 1, canModerateRequests: false })
+    ).resolves.toBeDefined();
+  });
+
+  it('allows a moderator to unfill any filled request', async () => {
+    const filledReq = makeRequest({
+      status: 'filled',
+      userId: 88,
+      fillerId: 77
+    });
+    const openReq = { ...filledReq, status: 'open', fillerId: null };
+    mockTx.request.findUnique
+      .mockResolvedValueOnce(filledReq)
+      .mockResolvedValueOnce(openReq);
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('209715200')
+    });
+    mockTx.user.update.mockResolvedValue(undefined);
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.request.update.mockResolvedValue(undefined);
+    mockTx.requestAction.create.mockResolvedValue(undefined);
+
+    await expect(
+      unfillRequest({ requestId: 10, actorId: 99, canModerateRequests: true })
+    ).resolves.toBeDefined();
+  });
+
+  it('claws back bounty from filler and records audit with actorId', async () => {
+    const filledReq = makeRequest({
+      status: 'filled',
+      userId: 88,
       fillerId: 7,
       bounties: [
         {
@@ -558,8 +676,8 @@ describe('unfillRequest', () => {
       ]
     });
     mockTx.request.findUnique
-      .mockResolvedValueOnce(filledReq) // initial fetch
-      .mockResolvedValueOnce({ ...filledReq, status: 'open', fillerId: null }); // final fetch
+      .mockResolvedValueOnce(filledReq)
+      .mockResolvedValueOnce({ ...filledReq, status: 'open', fillerId: null });
     mockTx.user.findUniqueOrThrow.mockResolvedValue({
       consumed: BigInt(0),
       contributed: BigInt('209715200')
@@ -569,7 +687,12 @@ describe('unfillRequest', () => {
     mockTx.request.update.mockResolvedValue(undefined);
     mockTx.requestAction.create.mockResolvedValue(undefined);
 
-    await unfillRequest(99, 10, 'Incorrect fill');
+    await unfillRequest({
+      requestId: 10,
+      actorId: 99,
+      canModerateRequests: true,
+      reason: 'Incorrect fill'
+    });
 
     expect(mockTx.user.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -605,18 +728,47 @@ describe('unfillRequest', () => {
 describe('deleteRequest', () => {
   it('throws 404 when request not found', async () => {
     mockTx.request.findUnique.mockResolvedValue(null);
-    await expect(deleteRequest(1, 10, false)).rejects.toMatchObject({
-      statusCode: 404
-    });
+    await expect(
+      deleteRequest({ requestId: 10, actorId: 1, canModerateRequests: false })
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 
-  it('throws 403 when non-staff tries to delete a filled request', async () => {
+  it('throws 403 when non-owner non-moderator tries to delete', async () => {
+    mockTx.request.findUnique.mockResolvedValue(makeRequest({ userId: 99 }));
+    await expect(
+      deleteRequest({ requestId: 10, actorId: 1, canModerateRequests: false })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('throws 403 when owner tries to delete a filled request without moderation', async () => {
     mockTx.request.findUnique.mockResolvedValue(
-      makeRequest({ status: 'filled' })
+      makeRequest({ userId: 1, status: 'filled' })
     );
-    await expect(deleteRequest(1, 10, false)).rejects.toMatchObject({
-      statusCode: 403
+    await expect(
+      deleteRequest({ requestId: 10, actorId: 1, canModerateRequests: false })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('allows moderator to delete a filled request without refunding', async () => {
+    mockTx.request.findUnique.mockResolvedValue(
+      makeRequest({ userId: 99, status: 'filled', bounties: [] })
+    );
+    mockTx.request.update.mockResolvedValue(undefined);
+    mockTx.requestAction.create.mockResolvedValue(undefined);
+
+    await deleteRequest({
+      requestId: 10,
+      actorId: 1,
+      canModerateRequests: true
     });
+
+    expect(mockTx.user.update).not.toHaveBeenCalled();
+    expect(mockTx.economyTransaction.create).not.toHaveBeenCalled();
+    expect(mockTx.requestAction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'DELETE' })
+      })
+    );
   });
 
   it('refunds all bounties when deleting an open request', async () => {
@@ -639,7 +791,11 @@ describe('deleteRequest', () => {
     mockTx.request.update.mockResolvedValue(undefined);
     mockTx.requestAction.create.mockResolvedValue(undefined);
 
-    await deleteRequest(1, 10, false);
+    await deleteRequest({
+      requestId: 10,
+      actorId: 1,
+      canModerateRequests: false
+    });
 
     expect(mockTx.user.update).toHaveBeenCalledTimes(2);
     expect(mockTx.user.update).toHaveBeenNthCalledWith(
@@ -672,20 +828,266 @@ describe('deleteRequest', () => {
     ).toBe(true);
   });
 
-  it('does not refund bounties when staff deletes a filled request', async () => {
+  it('does not refund bounties when moderator deletes a filled request', async () => {
     mockTx.request.findUnique.mockResolvedValue(
-      makeRequest({ status: 'filled' })
+      makeRequest({ status: 'filled', bounties: [] })
     );
     mockTx.request.update.mockResolvedValue(undefined);
     mockTx.requestAction.create.mockResolvedValue(undefined);
 
-    await deleteRequest(99, 10, true); // isStaff = true
+    await deleteRequest({
+      requestId: 10,
+      actorId: 99,
+      canModerateRequests: true
+    });
 
     expect(mockTx.user.update).not.toHaveBeenCalled();
     expect(mockTx.economyTransaction.create).not.toHaveBeenCalled();
     expect(mockTx.requestAction.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ action: 'DELETE' })
+      })
+    );
+  });
+});
+
+// ─── getRequestDetail ─────────────────────────────────────────────────────────
+
+describe('getRequestDetail', () => {
+  it('throws 404 when request is not found', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(getRequestDetail(999)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('returns serialized request with voteCount and votes', async () => {
+    const { prisma } = await import('../lib/prisma');
+    const rawRequest = {
+      ...makeRequest({
+        bounties: [
+          {
+            id: 1,
+            requestId: 10,
+            userId: 1,
+            amount: BigInt('104857600'),
+            createdAt: new Date(),
+            user: { id: 1, username: 'testuser' }
+          }
+        ]
+      }),
+      user: { id: 1, username: 'testuser' },
+      filler: null,
+      community: { id: 1, name: 'Jazz' },
+      artists: [],
+      filledContribution: null,
+      votes: [{ userId: 1 }],
+      voteCount: 1
+    };
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce(rawRequest);
+
+    const result = await getRequestDetail(10);
+
+    expect(result.totalBounty).toBe('104857600');
+    expect(result.voteCount).toBe(1);
+    expect(result.votes).toEqual([{ userId: 1 }]);
+  });
+});
+
+// ─── getBountyHistory ─────────────────────────────────────────────────────────
+
+describe('getBountyHistory', () => {
+  it('throws 404 when request is not found', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(getBountyHistory(999)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('returns bounties and actions for the request', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({ id: 10 });
+    (prisma.requestBounty.findMany as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 1,
+        requestId: 10,
+        userId: 1,
+        amount: BigInt('104857600'),
+        createdAt: new Date(),
+        user: { id: 1, username: 'testuser' }
+      }
+    ]);
+    (prisma.requestAction.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    const result = await getBountyHistory(10);
+
+    expect(result.bounties).toHaveLength(1);
+    expect(result.actions).toHaveLength(0);
+  });
+});
+
+// ─── toggleVote ───────────────────────────────────────────────────────────────
+
+describe('toggleVote', () => {
+  it('throws 404 when request is not found', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(toggleVote(999, 1)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('adds a vote and returns { voted: true } when no existing vote', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({ id: 10 });
+    (prisma.requestVote.findUnique as jest.Mock).mockResolvedValueOnce(null);
+    (prisma.requestVote.create as jest.Mock).mockReturnValue({} as never);
+    (prisma.request.update as jest.Mock).mockReturnValue({} as never);
+    mockTransaction.mockResolvedValueOnce([{}, {}]);
+
+    const result = await toggleVote(10, 1);
+
+    expect(result).toEqual({ voted: true });
+  });
+
+  it('removes a vote and returns { voted: false } when vote exists', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({ id: 10 });
+    (prisma.requestVote.findUnique as jest.Mock).mockResolvedValueOnce({
+      requestId: 10,
+      userId: 1
+    });
+    (prisma.requestVote.delete as jest.Mock).mockReturnValue({} as never);
+    (prisma.request.update as jest.Mock).mockReturnValue({} as never);
+    mockTransaction.mockResolvedValueOnce([{}, {}]);
+
+    const result = await toggleVote(10, 1);
+
+    expect(result).toEqual({ voted: false });
+  });
+});
+
+// ─── updateRequest ────────────────────────────────────────────────────────────
+
+describe('updateRequest', () => {
+  it('throws 404 when request is not found', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(
+      updateRequest({
+        requestId: 10,
+        actorId: 1,
+        canModerateRequests: false,
+        input: { image: undefined }
+      })
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('throws 422 when request is not open', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({
+      userId: 1,
+      status: 'filled'
+    });
+
+    await expect(
+      updateRequest({
+        requestId: 10,
+        actorId: 1,
+        canModerateRequests: false,
+        input: { image: undefined }
+      })
+    ).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  it('throws 403 when non-owner non-moderator edits', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({
+      userId: 99,
+      status: 'open'
+    });
+
+    await expect(
+      updateRequest({
+        requestId: 10,
+        actorId: 1,
+        canModerateRequests: false,
+        input: { image: undefined }
+      })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('allows owner to update an open request', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({
+      userId: 1,
+      status: 'open'
+    });
+    (prisma.request.update as jest.Mock).mockResolvedValueOnce({
+      ...makeRequest({ title: 'Updated', userId: 1 }),
+      bounties: [],
+      user: { id: 1, username: 'testuser' }
+    });
+
+    const result = await updateRequest({
+      requestId: 10,
+      actorId: 1,
+      canModerateRequests: false,
+      input: { title: 'Updated', image: undefined }
+    });
+
+    expect(result.title).toBe('Updated');
+  });
+
+  it('allows moderator to update any open request', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({
+      userId: 99,
+      status: 'open'
+    });
+    (prisma.request.update as jest.Mock).mockResolvedValueOnce({
+      ...makeRequest({ title: 'Mod Edit', userId: 99 }),
+      bounties: [],
+      user: { id: 99, username: 'other' }
+    });
+
+    const result = await updateRequest({
+      requestId: 10,
+      actorId: 1,
+      canModerateRequests: true,
+      input: { title: 'Mod Edit', image: undefined }
+    });
+
+    expect(result.title).toBe('Mod Edit');
+  });
+
+  it('shapes update data correctly, excluding undefined fields', async () => {
+    const { prisma } = await import('../lib/prisma');
+    (prisma.request.findUnique as jest.Mock).mockResolvedValueOnce({
+      userId: 1,
+      status: 'open'
+    });
+    (prisma.request.update as jest.Mock).mockResolvedValueOnce({
+      ...makeRequest({ title: 'New Title', image: null, userId: 1 }),
+      bounties: [],
+      user: { id: 1, username: 'testuser' }
+    });
+
+    await updateRequest({
+      requestId: 10,
+      actorId: 1,
+      canModerateRequests: false,
+      input: { title: 'New Title', image: null as string | null | undefined }
+    });
+
+    expect(prisma.request.update as jest.Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 10 },
+        data: { title: 'New Title', image: null }
       })
     );
   });

--- a/src/modules/requestLifecycle.ts
+++ b/src/modules/requestLifecycle.ts
@@ -3,10 +3,22 @@ import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import { economy } from './config';
 import { computeRatio } from './ratio';
-import { CreateRequestInput } from '../schemas/requests';
+import { CreateRequestInput, UpdateRequestInput } from '../schemas/requests';
 import { emitNotifications } from '../lib/notifications';
 
 export const MINIMUM_BOUNTY = BigInt(economy.minimumBounty);
+
+// ─── Capability types ─────────────────────────────────────────────────────────
+
+export type RequestActor = {
+  actorId: number;
+  canModerateRequests: boolean;
+};
+
+export type OptionalRequestActor = {
+  actorId?: number;
+  canModerateRequests?: boolean;
+};
 
 // ─── DTO serialization ────────────────────────────────────────────────────────
 
@@ -81,6 +93,151 @@ export function serializeRequest(request: {
       amount: b.amount.toString()
     }))
   };
+}
+
+// ─── getRequestDetail ─────────────────────────────────────────────────────────
+
+export async function getRequestDetail(requestId: number): Promise<
+  SerializedRequest & {
+    voteCount: number;
+    votes: Array<{ userId: number }>;
+  }
+> {
+  const request = await prisma.request.findUnique({
+    where: { id: requestId, deletedAt: null },
+    include: {
+      user: { select: { id: true, username: true } },
+      filler: { select: { id: true, username: true } },
+      community: { select: { id: true, name: true } },
+      artists: { include: { artist: true } },
+      bounties: {
+        include: { user: { select: { id: true, username: true } } }
+      },
+      filledContribution: {
+        include: {
+          release: { select: { id: true, title: true } },
+          user: { select: { id: true, username: true } }
+        }
+      },
+      votes: { select: { userId: true } }
+    }
+  });
+  if (!request) throw new AppError(404, 'Request not found');
+
+  const serialized = serializeRequest(request);
+  return {
+    ...serialized,
+    voteCount: request.voteCount,
+    votes: request.votes
+  };
+}
+
+// ─── getBountyHistory ─────────────────────────────────────────────────────────
+
+export async function getBountyHistory(requestId: number) {
+  const request = await prisma.request.findUnique({
+    where: { id: requestId, deletedAt: null },
+    select: { id: true }
+  });
+  if (!request) throw new AppError(404, 'Request not found');
+
+  const [bounties, actions] = await Promise.all([
+    prisma.requestBounty.findMany({
+      where: { requestId },
+      include: { user: { select: { id: true, username: true } } },
+      orderBy: { createdAt: 'desc' }
+    }),
+    prisma.requestAction.findMany({
+      where: { requestId },
+      orderBy: { createdAt: 'desc' }
+    })
+  ]);
+
+  return { bounties, actions };
+}
+
+// ─── toggleVote ───────────────────────────────────────────────────────────────
+
+export async function toggleVote(
+  requestId: number,
+  userId: number
+): Promise<{ voted: boolean }> {
+  const request = await prisma.request.findUnique({
+    where: { id: requestId, deletedAt: null },
+    select: { id: true }
+  });
+  if (!request) throw new AppError(404, 'Request not found');
+
+  const existing = await prisma.requestVote.findUnique({
+    where: { requestId_userId: { requestId, userId } }
+  });
+
+  if (existing) {
+    await prisma.$transaction([
+      prisma.requestVote.delete({
+        where: { requestId_userId: { requestId, userId } }
+      }),
+      prisma.request.update({
+        where: { id: requestId },
+        data: { voteCount: { decrement: 1 } }
+      })
+    ]);
+    return { voted: false };
+  }
+
+  await prisma.$transaction([
+    prisma.requestVote.create({
+      data: { requestId, userId }
+    }),
+    prisma.request.update({
+      where: { id: requestId },
+      data: { voteCount: { increment: 1 } }
+    })
+  ]);
+  return { voted: true };
+}
+
+// ─── updateRequest ────────────────────────────────────────────────────────────
+
+export async function updateRequest({
+  requestId,
+  actorId,
+  canModerateRequests,
+  input
+}: {
+  requestId: number;
+  actorId: number;
+  canModerateRequests: boolean;
+  input: UpdateRequestInput;
+}): Promise<SerializedRequest> {
+  const existing = await prisma.request.findUnique({
+    where: { id: requestId, deletedAt: null },
+    select: { userId: true, status: true }
+  });
+  if (!existing) throw new AppError(404, 'Request not found');
+  if (existing.status !== 'open')
+    throw new AppError(422, 'Only open requests can be edited');
+
+  if (existing.userId !== actorId && !canModerateRequests)
+    throw new AppError(403, 'Permission denied');
+
+  const updated = await prisma.request.update({
+    where: { id: requestId },
+    data: {
+      ...(input.title !== undefined && { title: input.title }),
+      ...(input.description !== undefined && {
+        description: input.description
+      }),
+      ...(input.type !== undefined && { type: input.type }),
+      ...(input.year !== undefined && { year: input.year }),
+      ...(input.image !== undefined && { image: input.image })
+    },
+    include: {
+      user: { select: { id: true, username: true } },
+      bounties: true
+    }
+  });
+  return serializeRequest(updated);
 }
 
 // ─── createRequest ─────────────────────────────────────────────────────────────
@@ -385,20 +542,34 @@ export async function fillRequest(
 }
 
 // ─── unfillRequest ────────────────────────────────────────────────────────────
-// Staff action. Claws back bounty from the filler and re-opens the request.
+// Now owns authorization: owner, filler, or moderator may unfill.
+// Claws back bounty from the filler and re-opens the request.
 
-export async function unfillRequest(
-  moderatorId: number,
-  requestId: number,
-  reason?: string
-) {
+export async function unfillRequest({
+  requestId,
+  actorId,
+  canModerateRequests,
+  reason
+}: {
+  requestId: number;
+  actorId: number;
+  canModerateRequests: boolean;
+  reason?: string;
+}): Promise<SerializedRequest> {
   return await prisma.$transaction(async (tx) => {
     const request = await tx.request.findUnique({
-      where: { id: requestId, status: 'filled' },
+      where: { id: requestId, deletedAt: null },
       include: { bounties: true }
     });
-    if (!request)
-      throw new AppError(404, 'Request not found or not currently filled');
+    if (!request) throw new AppError(404, 'Request not found');
+    if (request.status !== 'filled')
+      throw new AppError(422, 'Request is not filled');
+
+    const isOwner = request.userId === actorId;
+    const isFiller = request.fillerId === actorId;
+    if (!canModerateRequests && !isOwner && !isFiller)
+      throw new AppError(403, 'Permission denied');
+
     if (!request.fillerId)
       throw new AppError(500, 'Filled request has no fillerId');
 
@@ -432,7 +603,7 @@ export async function unfillRequest(
           reason: 'REQUEST_UNFILL',
           contextId: requestId,
           contextType: 'request',
-          actorUserId: moderatorId
+          actorUserId: actorId
         }
       });
     }
@@ -450,7 +621,7 @@ export async function unfillRequest(
     await tx.requestAction.create({
       data: {
         requestId,
-        actorId: moderatorId,
+        actorId,
         action: 'UNFILL',
         metadata: {
           previousFillerId: request.fillerId,
@@ -468,14 +639,19 @@ export async function unfillRequest(
 }
 
 // ─── deleteRequest ────────────────────────────────────────────────────────────
+// Now owns authorization: owner (open only) or moderator (any status) may delete.
 // Soft-deletes a request. Only refunds bounties when the request is still open
 // (filled requests have already paid out; staff may delete them without refund).
 
-export async function deleteRequest(
-  actorId: number,
-  requestId: number,
-  isStaff: boolean
-) {
+export async function deleteRequest({
+  requestId,
+  actorId,
+  canModerateRequests
+}: {
+  requestId: number;
+  actorId: number;
+  canModerateRequests: boolean;
+}) {
   return await prisma.$transaction(async (tx) => {
     const request = await tx.request.findUnique({
       where: { id: requestId, deletedAt: null },
@@ -483,7 +659,11 @@ export async function deleteRequest(
     });
     if (!request) throw new AppError(404, 'Request not found');
 
-    if (request.status === 'filled' && !isStaff) {
+    const isOwner = request.userId === actorId;
+    if (!isOwner && !canModerateRequests)
+      throw new AppError(403, 'Permission denied');
+
+    if (request.status === 'filled' && !canModerateRequests) {
       throw new AppError(403, 'Only staff can delete a filled request');
     }
 

--- a/src/requests.spec.ts
+++ b/src/requests.spec.ts
@@ -2,10 +2,10 @@
  * Route-level tests for the requests API.
  *
  * These verify: auth enforcement, permission gates, validation, and that the
- * correct module functions are invoked with the right arguments.
+ * correct lifecycle functions are invoked with the right arguments.
  *
  * For deeper service-logic tests (atomic fill, ledger correctness, refund
- * flows) see src/modules/requests.spec.ts.
+ * flows, authorization rules) see src/modules/requestLifecycle.spec.ts.
  */
 
 import {
@@ -15,30 +15,29 @@ import {
   prismaMock,
   makeUserRank
 } from './test/apiTestHarness';
-import { makeRequest } from './test/factories';
-import * as requestModule from './modules/requests';
-import { RequestStatus } from '@prisma/client';
+import * as requestLifecycle from './modules/requestLifecycle';
 
-jest.mock('./modules/requests', () => ({
-  ...jest.requireActual('./modules/requests'),
+jest.mock('./modules/requestLifecycle', () => ({
+  ...jest.requireActual('./modules/requestLifecycle'),
   createRequest: jest.fn(),
   addBounty: jest.fn(),
   fillRequest: jest.fn(),
   unfillRequest: jest.fn(),
   deleteRequest: jest.fn(),
-  listRequests: jest.fn()
+  listRequests: jest.fn(),
+  getRequestDetail: jest.fn(),
+  getBountyHistory: jest.fn(),
+  toggleVote: jest.fn(),
+  updateRequest: jest.fn()
 }));
 
-const mod = requestModule as jest.Mocked<typeof requestModule>;
+const mod = requestLifecycle as jest.Mocked<typeof requestLifecycle>;
 
 // Grant staff+admin permissions so permission-gated routes pass in most tests
 const setStaffPerms = () =>
   prismaMock.userRank.findUnique.mockResolvedValue(
-    makeUserRank({ staff: true, admin: true })
+    makeUserRank({ staff: true, admin: true, requests_moderate: true })
   );
-
-const setDefaultRequest = (overrides: Parameters<typeof makeRequest>[0] = {}) =>
-  prismaMock.request.findUnique.mockResolvedValue(makeRequest(overrides));
 
 const OPEN_REQUEST = {
   id: 1,
@@ -115,10 +114,7 @@ describe('GET /api/requests', () => {
 });
 
 describe('POST /api/requests', () => {
-  beforeEach(() => {
-    resetApiTestState();
-    // create uses requireAuth only (no permission gate beyond being logged in)
-  });
+  beforeEach(() => resetApiTestState());
 
   it('returns 201 with valid payload and coerces bounty to BigInt', async () => {
     mod.createRequest.mockResolvedValue(OPEN_REQUEST);
@@ -164,9 +160,7 @@ describe('POST /api/requests', () => {
 });
 
 describe('POST /api/requests/:id/fill', () => {
-  beforeEach(() => {
-    resetApiTestState();
-  });
+  beforeEach(() => resetApiTestState());
 
   it('calls fillRequest with caller userId, requestId, and contributionId', async () => {
     mod.fillRequest.mockResolvedValue({
@@ -213,67 +207,64 @@ describe('POST /api/requests/:id/fill', () => {
 });
 
 describe('POST /api/requests/:id/unfill', () => {
-  // A filled request owned by someone other than the test user (id 7),
-  // so only staff permission (not ownership) grants access in most tests.
-  const FILLED_REQUEST_MOCK = makeRequest({
-    userId: 99,
-    fillerId: 88,
-    status: RequestStatus.filled
-  });
-
   beforeEach(() => {
     resetApiTestState();
     setStaffPerms();
-    prismaMock.request.findUnique.mockResolvedValue(FILLED_REQUEST_MOCK);
   });
 
-  it('calls unfillRequest when caller is staff', async () => {
+  it('calls unfillRequest with options object when caller is staff', async () => {
     mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
     const res = await request(app)
       .post('/api/requests/1/unfill')
       .send({ reason: 'Incorrect fill' });
     expect(res.status).toBe(200);
-    expect(mod.unfillRequest).toHaveBeenCalledWith(7, 1, 'Incorrect fill');
+    expect(mod.unfillRequest).toHaveBeenCalledWith({
+      requestId: 1,
+      actorId: 7,
+      canModerateRequests: true,
+      reason: 'Incorrect fill'
+    });
   });
 
   it('allows unfill with no reason body', async () => {
     mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
     const res = await request(app).post('/api/requests/1/unfill').send({});
     expect(res.status).toBe(200);
-    expect(mod.unfillRequest).toHaveBeenCalledWith(7, 1, undefined);
+    expect(mod.unfillRequest).toHaveBeenCalledWith({
+      requestId: 1,
+      actorId: 7,
+      canModerateRequests: true,
+      reason: undefined
+    });
   });
 
-  it('allows owner to unfill their own request', async () => {
-    // Reset to a filled request owned by the test user (id 7)
-    prismaMock.request.findUnique.mockResolvedValue(
-      makeRequest({ userId: 7, fillerId: 88, status: RequestStatus.filled })
-    );
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
-    mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
-    const res = await request(app)
-      .post('/api/requests/1/unfill')
-      .send({ reason: 'Changed my mind' });
-    expect(res.status).toBe(200);
-  });
-
-  it('allows filler to unfill their own fill', async () => {
-    // Reset to a filled request where filler is the test user (id 7)
-    prismaMock.request.findUnique.mockResolvedValue(
-      makeRequest({ userId: 99, fillerId: 7, status: RequestStatus.filled })
-    );
+  it('passes canModerateRequests: false for non-staff user', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
     mod.unfillRequest.mockResolvedValue(OPEN_REQUEST);
     const res = await request(app).post('/api/requests/1/unfill').send({});
     expect(res.status).toBe(200);
+    expect(mod.unfillRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ canModerateRequests: false })
+    );
   });
 
-  it('returns 403 when user is not staff, owner, or filler', async () => {
+  it('propagates 403 from module when not authorized', async () => {
+    const { AppError } = await import('./lib/errors');
     prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
+    mod.unfillRequest.mockRejectedValue(new AppError(403, 'Permission denied'));
     const res = await request(app)
       .post('/api/requests/1/unfill')
       .send({ reason: 'test' });
     expect(res.status).toBe(403);
-    expect(mod.unfillRequest).not.toHaveBeenCalled();
+  });
+
+  it('propagates 422 from module when request is not filled', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.unfillRequest.mockRejectedValue(
+      new AppError(422, 'Request is not filled')
+    );
+    const res = await request(app).post('/api/requests/1/unfill').send({});
+    expect(res.status).toBe(422);
   });
 });
 
@@ -281,38 +272,48 @@ describe('DELETE /api/requests/:id', () => {
   beforeEach(() => {
     resetApiTestState();
     setStaffPerms();
-    setDefaultRequest(); // userId: 7 = authenticated user
   });
 
-  it('allows owner to delete their own open request and returns 204', async () => {
+  it('calls deleteRequest with correct options and returns 204', async () => {
     mod.deleteRequest.mockResolvedValue(undefined);
     const res = await request(app).delete('/api/requests/1');
     expect(res.status).toBe(204);
-    expect(mod.deleteRequest).toHaveBeenCalledWith(7, 1, expect.any(Boolean));
+    expect(mod.deleteRequest).toHaveBeenCalledWith({
+      requestId: 1,
+      actorId: 7,
+      canModerateRequests: true
+    });
   });
 
-  it('returns 403 when non-owner non-staff tries to delete', async () => {
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
-    prismaMock.request.findUnique.mockResolvedValue(
-      makeRequest({ userId: 99 })
-    );
+  it('passes canModerateRequests: false for non-staff user', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
+    mod.deleteRequest.mockResolvedValue(undefined);
+    const res = await request(app).delete('/api/requests/1');
+    expect(res.status).toBe(204);
+    expect(mod.deleteRequest).toHaveBeenCalledWith({
+      requestId: 1,
+      actorId: 7,
+      canModerateRequests: false
+    });
+  });
+
+  it('propagates 403 from module when not authorized', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.deleteRequest.mockRejectedValue(new AppError(403, 'Permission denied'));
     const res = await request(app).delete('/api/requests/1');
     expect(res.status).toBe(403);
-    expect(mod.deleteRequest).not.toHaveBeenCalled();
   });
 
-  it('returns 404 for non-existent or already-deleted request', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(null);
+  it('propagates 404 from module when request not found', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.deleteRequest.mockRejectedValue(new AppError(404, 'Request not found'));
     const res = await request(app).delete('/api/requests/999');
     expect(res.status).toBe(404);
-    expect(mod.deleteRequest).not.toHaveBeenCalled();
   });
 });
 
 describe('POST /api/requests/:id/bounty', () => {
-  beforeEach(() => {
-    resetApiTestState();
-  });
+  beforeEach(() => resetApiTestState());
 
   it('calls addBounty with correct args', async () => {
     mod.addBounty.mockResolvedValue(OPEN_REQUEST);
@@ -347,8 +348,11 @@ describe('POST /api/requests/:id/bounty', () => {
 describe('GET /api/requests/:id', () => {
   beforeEach(() => resetApiTestState());
 
-  it('returns 404 when the request is missing', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(null);
+  it('returns 404 when the module throws not found', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.getRequestDetail.mockRejectedValue(
+      new AppError(404, 'Request not found')
+    );
 
     const res = await request(app).get('/api/requests/999');
 
@@ -356,26 +360,12 @@ describe('GET /api/requests/:id', () => {
   });
 
   it('returns serialized request detail with vote metadata', async () => {
-    prismaMock.request.findUnique.mockResolvedValue({
-      ...makeRequest(),
-      bounties: [
-        {
-          id: 1,
-          requestId: 1,
-          userId: 7,
-          amount: BigInt('104857600'),
-          createdAt: new Date(),
-          user: { id: 7, username: 'testuser' }
-        }
-      ],
-      user: { id: 7, username: 'testuser' },
-      filler: null,
-      community: { id: 1, name: 'Jazz' },
-      artists: [],
-      filledContribution: null,
-      votes: [{ userId: 7 }],
-      voteCount: 1
-    } as never);
+    mod.getRequestDetail.mockResolvedValue({
+      ...OPEN_REQUEST,
+      totalBounty: '104857600',
+      voteCount: 1,
+      votes: [{ userId: 7 }]
+    } as unknown as Awaited<ReturnType<typeof mod.getRequestDetail>>);
 
     const res = await request(app).get('/api/requests/1');
 
@@ -384,67 +374,31 @@ describe('GET /api/requests/:id', () => {
     expect(res.body.voteCount).toBe(1);
     expect(res.body.votes).toEqual([{ userId: 7 }]);
   });
+
+  it('calls getRequestDetail with the parsed request id', async () => {
+    mod.getRequestDetail.mockResolvedValue({
+      ...OPEN_REQUEST,
+      voteCount: 0,
+      votes: []
+    } as unknown as Awaited<ReturnType<typeof mod.getRequestDetail>>);
+
+    await request(app).get('/api/requests/42');
+
+    expect(mod.getRequestDetail).toHaveBeenCalledWith(42);
+  });
 });
 
 describe('PUT /api/requests/:id', () => {
-  beforeEach(() => resetApiTestState());
-
-  it('returns 404 when the request does not exist', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(null);
-
-    const res = await request(app).put('/api/requests/1').send({
-      title: 'Updated'
-    });
-
-    expect(res.status).toBe(404);
+  beforeEach(() => {
+    resetApiTestState();
+    setStaffPerms();
   });
 
-  it('returns 422 when editing a non-open request', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(
-      makeRequest({ status: RequestStatus.filled, userId: 7 }) as never
-    );
-
-    const res = await request(app).put('/api/requests/1').send({
+  it('calls updateRequest with correct options including canModerateRequests', async () => {
+    mod.updateRequest.mockResolvedValue({
+      ...OPEN_REQUEST,
       title: 'Updated'
-    });
-
-    expect(res.status).toBe(422);
-  });
-
-  it('returns 403 when a non-owner non-staff edits the request', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(
-      makeRequest({ status: RequestStatus.open, userId: 99 }) as never
-    );
-    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
-
-    const res = await request(app).put('/api/requests/1').send({
-      title: 'Updated'
-    });
-
-    expect(res.status).toBe(403);
-  });
-
-  it('allows owners to update open requests and serializes response', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(
-      makeRequest({ status: RequestStatus.open, userId: 7 }) as never
-    );
-    prismaMock.request.update.mockResolvedValue({
-      ...makeRequest({
-        title: 'Updated',
-        status: RequestStatus.open,
-        userId: 7
-      }),
-      bounties: [
-        {
-          id: 1,
-          requestId: 1,
-          userId: 7,
-          amount: BigInt('104857600'),
-          createdAt: new Date()
-        }
-      ],
-      user: { id: 7, username: 'testuser' }
-    } as never);
+    } as unknown as Awaited<ReturnType<typeof mod.updateRequest>>);
 
     const res = await request(app).put('/api/requests/1').send({
       title: 'Updated',
@@ -452,39 +406,72 @@ describe('PUT /api/requests/:id', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(prismaMock.request.update).toHaveBeenCalledWith({
-      where: { id: 1 },
-      data: { title: 'Updated', image: null },
-      include: {
-        user: { select: { id: true, username: true } },
-        bounties: true
-      }
+    expect(mod.updateRequest).toHaveBeenCalledWith({
+      requestId: 1,
+      actorId: 7,
+      canModerateRequests: true,
+      input: { title: 'Updated', image: null } // image '' → null via Zod transform
     });
-    expect(res.body.totalBounty).toBe('104857600');
+  });
+
+  it('passes canModerateRequests: false for non-staff user', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank()); // no staff
+    mod.updateRequest.mockResolvedValue(
+      OPEN_REQUEST as unknown as Awaited<ReturnType<typeof mod.updateRequest>>
+    );
+
+    await request(app).put('/api/requests/1').send({ title: 'T' });
+
+    expect(mod.updateRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ canModerateRequests: false })
+    );
+  });
+
+  it('propagates 404 from module when request not found', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.updateRequest.mockRejectedValue(new AppError(404, 'Request not found'));
+
+    const res = await request(app).put('/api/requests/1').send({ title: 'T' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('propagates 422 from module when editing a non-open request', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.updateRequest.mockRejectedValue(
+      new AppError(422, 'Only open requests can be edited')
+    );
+
+    const res = await request(app).put('/api/requests/1').send({ title: 'T' });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('propagates 403 from module when not authorized', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.updateRequest.mockRejectedValue(new AppError(403, 'Permission denied'));
+
+    const res = await request(app).put('/api/requests/1').send({ title: 'T' });
+
+    expect(res.status).toBe(403);
   });
 });
 
 describe('POST /api/requests/:id/vote', () => {
   beforeEach(() => resetApiTestState());
 
-  it('adds a vote when none exists and returns voted: true', async () => {
-    prismaMock.request.findUnique.mockResolvedValue({ id: 1 } as never);
-    prismaMock.requestVote.findUnique.mockResolvedValue(null);
-    prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
+  it('calls toggleVote and returns voted: true', async () => {
+    mod.toggleVote.mockResolvedValue({ voted: true });
 
     const res = await request(app).post('/api/requests/1/vote');
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ voted: true });
+    expect(mod.toggleVote).toHaveBeenCalledWith(1, 7);
   });
 
-  it('removes a vote when one exists and returns voted: false', async () => {
-    prismaMock.request.findUnique.mockResolvedValue({ id: 1 } as never);
-    prismaMock.requestVote.findUnique.mockResolvedValue({
-      requestId: 1,
-      userId: 7
-    } as never);
-    prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
+  it('calls toggleVote and returns voted: false when removing a vote', async () => {
+    mod.toggleVote.mockResolvedValue({ voted: false });
 
     const res = await request(app).post('/api/requests/1/vote');
 
@@ -492,8 +479,9 @@ describe('POST /api/requests/:id/vote', () => {
     expect(res.body).toEqual({ voted: false });
   });
 
-  it('returns 404 when the request does not exist', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(null);
+  it('returns 404 when module throws not found', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.toggleVote.mockRejectedValue(new AppError(404, 'Request not found'));
 
     const res = await request(app).post('/api/requests/999/vote');
 
@@ -504,19 +492,20 @@ describe('POST /api/requests/:id/vote', () => {
 describe('GET /api/requests/:id/bounty-history', () => {
   beforeEach(() => resetApiTestState());
 
-  it('returns bounties and actions for the request', async () => {
-    prismaMock.request.findUnique.mockResolvedValue({ id: 1 } as never);
-    prismaMock.requestBounty.findMany.mockResolvedValue([
-      {
-        id: 1,
-        requestId: 1,
-        userId: 7,
-        amount: BigInt('104857600'),
-        createdAt: new Date(),
-        user: { id: 7, username: 'testuser' }
-      } as never
-    ]);
-    prismaMock.requestAction.findMany.mockResolvedValue([]);
+  it('calls getBountyHistory and returns bounties and actions', async () => {
+    mod.getBountyHistory.mockResolvedValue({
+      bounties: [
+        {
+          id: 1,
+          requestId: 1,
+          userId: 7,
+          amount: BigInt('104857600'),
+          createdAt: new Date(),
+          user: { id: 7, username: 'testuser' }
+        }
+      ],
+      actions: []
+    } as unknown as Awaited<ReturnType<typeof mod.getBountyHistory>>);
 
     const res = await request(app).get('/api/requests/1/bounty-history');
 
@@ -524,10 +513,14 @@ describe('GET /api/requests/:id/bounty-history', () => {
     expect(res.body).toHaveProperty('bounties');
     expect(res.body).toHaveProperty('actions');
     expect(res.body.bounties).toHaveLength(1);
+    expect(mod.getBountyHistory).toHaveBeenCalledWith(1);
   });
 
-  it('returns 404 when the request does not exist or is deleted', async () => {
-    prismaMock.request.findUnique.mockResolvedValue(null);
+  it('returns 404 when module throws not found', async () => {
+    const { AppError } = await import('./lib/errors');
+    mod.getBountyHistory.mockRejectedValue(
+      new AppError(404, 'Request not found')
+    );
 
     const res = await request(app).get('/api/requests/999/bounty-history');
 

--- a/src/routes/api/requests.ts
+++ b/src/routes/api/requests.ts
@@ -10,8 +10,7 @@ import {
   parsedParams
 } from '../../middleware/validate';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
-import * as requestModule from '../../modules/requests';
-import { prisma } from '../../lib/prisma';
+import * as requestLifecycle from '../../modules/requestLifecycle';
 import { hasPermission } from '../../lib/rankPermissions';
 import {
   createRequestSchema,
@@ -25,7 +24,6 @@ import {
   type UpdateRequestInput
 } from '../../schemas/requests';
 import { AppError } from '../../lib/errors';
-import type { AuthenticatedRequest } from '../../types/auth';
 
 const router = Router();
 
@@ -36,7 +34,7 @@ router.get(
   validateQuery(listRequestsQuerySchema),
   asyncHandler(async (req, res) => {
     const q = parsedQuery<ListRequestsQuery>(res);
-    const result = await requestModule.listRequests({
+    const result = await requestLifecycle.listRequests({
       q: q.q,
       artist: q.artist,
       type: q.type,
@@ -63,7 +61,7 @@ router.post(
     if (!hasPermission(perms, 'requests_create')) {
       throw new AppError(403, 'Permission denied');
     }
-    const request = await requestModule.createRequest(
+    const request = await requestLifecycle.createRequest(
       req.user.id,
       parsedBody(res)
     );
@@ -76,34 +74,10 @@ router.post(
 router.get(
   '/:id',
   validateParams(requestIdParamsSchema),
-  asyncHandler(async (req, res) => {
+  asyncHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const request = await prisma.request.findUnique({
-      where: { id, deletedAt: null },
-      include: {
-        user: { select: { id: true, username: true } },
-        filler: { select: { id: true, username: true } },
-        community: { select: { id: true, name: true } },
-        artists: { include: { artist: true } },
-        bounties: {
-          include: { user: { select: { id: true, username: true } } }
-        },
-        filledContribution: {
-          include: {
-            release: { select: { id: true, title: true } },
-            user: { select: { id: true, username: true } }
-          }
-        },
-        votes: { select: { userId: true } }
-      }
-    });
-    if (!request) throw new AppError(404, 'Request not found');
-    const serialized = requestModule.serializeRequest(request);
-    res.json({
-      ...serialized,
-      voteCount: request.voteCount,
-      votes: request.votes
-    });
+    const result = await requestLifecycle.getRequestDetail(id);
+    res.json(result);
   })
 );
 
@@ -115,40 +89,8 @@ router.post(
   validateParams(requestIdParamsSchema),
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-
-    const request = await prisma.request.findUnique({
-      where: { id, deletedAt: null },
-      select: { id: true }
-    });
-    if (!request) throw new AppError(404, 'Request not found');
-
-    const existing = await prisma.requestVote.findUnique({
-      where: { requestId_userId: { requestId: id, userId: req.user.id } }
-    });
-
-    if (existing) {
-      await prisma.$transaction([
-        prisma.requestVote.delete({
-          where: { requestId_userId: { requestId: id, userId: req.user.id } }
-        }),
-        prisma.request.update({
-          where: { id },
-          data: { voteCount: { decrement: 1 } }
-        })
-      ]);
-      return res.json({ voted: false });
-    }
-
-    await prisma.$transaction([
-      prisma.requestVote.create({
-        data: { requestId: id, userId: req.user.id }
-      }),
-      prisma.request.update({
-        where: { id },
-        data: { voteCount: { increment: 1 } }
-      })
-    ]);
-    res.json({ voted: true });
+    const result = await requestLifecycle.toggleVote(id, req.user.id);
+    res.json(result);
   })
 );
 
@@ -160,26 +102,8 @@ router.get(
   validateParams(requestIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-
-    const request = await prisma.request.findUnique({
-      where: { id, deletedAt: null },
-      select: { id: true }
-    });
-    if (!request) throw new AppError(404, 'Request not found');
-
-    const [bounties, actions] = await Promise.all([
-      prisma.requestBounty.findMany({
-        where: { requestId: id },
-        include: { user: { select: { id: true, username: true } } },
-        orderBy: { createdAt: 'desc' }
-      }),
-      prisma.requestAction.findMany({
-        where: { requestId: id },
-        orderBy: { createdAt: 'desc' }
-      })
-    ]);
-
-    res.json({ bounties, actions });
+    const result = await requestLifecycle.getBountyHistory(id);
+    res.json(result);
   })
 );
 
@@ -193,7 +117,7 @@ router.post(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { amount } = parsedBody<{ amount: bigint }>(res);
-    const request = await requestModule.addBounty(req.user.id, id, amount);
+    const request = await requestLifecycle.addBounty(req.user.id, id, amount);
     res.json(request);
   })
 );
@@ -208,7 +132,7 @@ router.post(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { contributionId } = parsedBody<{ contributionId: number }>(res);
-    const request = await requestModule.fillRequest(
+    const request = await requestLifecycle.fillRequest(
       req.user.id,
       id,
       contributionId
@@ -224,40 +148,18 @@ router.put(
   requireAuth,
   validateParams(requestIdParamsSchema),
   validate(updateRequestSchema),
-  authHandler(async (req: AuthenticatedRequest, res) => {
+  authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const input = parsedBody<UpdateRequestInput>(res);
-
-    const existing = await prisma.request.findUnique({
-      where: { id, deletedAt: null },
-      select: { userId: true, status: true }
-    });
-    if (!existing) throw new AppError(404, 'Request not found');
-    if (existing.status !== 'open')
-      throw new AppError(422, 'Only open requests can be edited');
-
     const perms = await loadPermissions(req, res);
-    const isStaff = hasPermission(perms, 'requests_moderate');
-    if (existing.userId !== req.user.id && !isStaff)
-      throw new AppError(403, 'Permission denied');
-
-    const updated = await prisma.request.update({
-      where: { id },
-      data: {
-        ...(input.title !== undefined && { title: input.title }),
-        ...(input.description !== undefined && {
-          description: input.description
-        }),
-        ...(input.type !== undefined && { type: input.type }),
-        ...(input.year !== undefined && { year: input.year }),
-        ...(input.image !== undefined && { image: input.image })
-      },
-      include: {
-        user: { select: { id: true, username: true } },
-        bounties: true
-      }
+    const canModerateRequests = hasPermission(perms, 'requests_moderate');
+    const updated = await requestLifecycle.updateRequest({
+      requestId: id,
+      actorId: req.user.id,
+      canModerateRequests,
+      input
     });
-    res.json(requestModule.serializeRequest(updated));
+    res.json(updated);
   })
 );
 
@@ -268,27 +170,17 @@ router.post(
   requireAuth,
   validateParams(requestIdParamsSchema),
   validate(unfillRequestSchema),
-  authHandler(async (req: AuthenticatedRequest, res) => {
+  authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { reason } = parsedBody<{ reason?: string }>(res);
-
-    const existing = await prisma.request.findUnique({
-      where: { id, deletedAt: null },
-      select: { userId: true, fillerId: true, status: true }
-    });
-    if (!existing) throw new AppError(404, 'Request not found');
-    if (existing.status !== 'filled')
-      throw new AppError(422, 'Request is not filled');
-
     const perms = await loadPermissions(req, res);
-    const isStaff = hasPermission(perms, 'requests_moderate');
-    const isOwner = existing.userId === req.user.id;
-    const isFiller = existing.fillerId === req.user.id;
-
-    if (!isStaff && !isOwner && !isFiller)
-      throw new AppError(403, 'Permission denied');
-
-    const request = await requestModule.unfillRequest(req.user.id, id, reason);
+    const canModerateRequests = hasPermission(perms, 'requests_moderate');
+    const request = await requestLifecycle.unfillRequest({
+      requestId: id,
+      actorId: req.user.id,
+      canModerateRequests,
+      reason
+    });
     res.json(request);
   })
 );
@@ -299,22 +191,15 @@ router.delete(
   '/:id',
   requireAuth,
   validateParams(requestIdParamsSchema),
-  authHandler(async (req: AuthenticatedRequest, res) => {
+  authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-
-    const existing = await prisma.request.findUnique({
-      where: { id, deletedAt: null },
-      select: { userId: true, status: true }
-    });
-    if (!existing) throw new AppError(404, 'Request not found');
-
     const perms = await loadPermissions(req, res);
-    const isStaff = hasPermission(perms, 'requests_moderate');
-    const isOwner = existing.userId === req.user.id;
-
-    if (!isOwner && !isStaff) throw new AppError(403, 'Permission denied');
-
-    await requestModule.deleteRequest(req.user.id, id, isStaff);
+    const canModerateRequests = hasPermission(perms, 'requests_moderate');
+    await requestLifecycle.deleteRequest({
+      requestId: id,
+      actorId: req.user.id,
+      canModerateRequests
+    });
     res.status(204).end();
   })
 );


### PR DESCRIPTION
Moves the full Request lifecycle into a single module, `requestLifecycle.ts`, replacing the previous `requests.ts`.

## What changed

### New module exports
| Function | Owns |
|---|---|
| `getRequestDetail(id)` | full include graph, 404, serialization, voteCount/votes |
| `getBountyHistory(id)` | existence check, bounty + action rows |
| `toggleVote(id, userId)` | 404, vote lookup, create/delete + voteCount transaction |
| `updateRequest({ requestId, actorId, canModerateRequests, input })` | 404, 422 open-only, 403 auth, update, serialization |

### Authorization collapsed into module
- `unfillRequest` now accepts `{ requestId, actorId, canModerateRequests, reason? }` and owns the owner/filler/moderator gate and the 422 "not filled" check
- `deleteRequest` now accepts `{ requestId, actorId, canModerateRequests }` and owns the 403 ownership/mod check and the "only staff can delete filled requests" rule

### Route is now a thin adapter
`src/routes/api/requests.ts` only: validates params/body/query → derives `canModerateRequests` → calls `requestLifecycle.*` → sends response. No direct Prisma access remains.

### Tests rebalanced
- Lifecycle spec covers auth rules, state guards, transactions, and serialization
- Route spec covers delegation argument shapes and error propagation

## Test results
147 tests passing across `requests.spec.ts`, `requestLifecycle.spec.ts`, and `modules.spec.ts`. Type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)