### PR TITLE
Fix report source URLs; add FeaturedAlbum image field; update commit workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,15 @@ npm run db:studio        # prisma studio
 
 ## Commit workflow
 
-1. `npx tsc --noEmit` — must be clean
-2. `npm run format` — formats all of src/ including openapi.ts and spec files
-3. `npm run lint` — verify no new ESLint errors in changed files
-4. `npm run test --no-coverage` — must pass
+Run every step before committing. All must pass clean on new/changed files.
+
+1. `npm run format` — format **all** of `src/` (not just changed files — confirms nothing else drifted)
+2. `npm run lint` — must be clean on new/changed files; pre-existing errors in untouched files are acceptable
+3. `npx tsc --noEmit` — must be clean
+4. `npm run test --no-coverage` — full suite must pass
 5. Commit with descriptive message following existing log style
 
-> Note: `npm run lint` has pre-existing errors in unchanged files; only new/changed files must be clean.
+> Order matters: format before lint (Prettier violations surface as ESLint errors), and lint before type-check.
 
 ## Environment
 

--- a/prisma/migrations/20260529161547_add_featured_album_image/migration.sql
+++ b/prisma/migrations/20260529161547_add_featured_album_image/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "featured_albums" ADD COLUMN     "image" TEXT NOT NULL DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "user_settings" ALTER COLUMN "notificationMethod" SET DEFAULT 'Traditional';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1395,6 +1395,7 @@ model FeaturedAlbum {
   groupId  Int
   threadId Int
   title    String   @default("")
+  image    String   @default("")
   started  DateTime
   ended    DateTime
 

--- a/src/modules/reports.ts
+++ b/src/modules/reports.ts
@@ -159,6 +159,66 @@ async function resolveSourceUrls(
         }
         break;
       }
+      case 'Artist': {
+        for (const { reportId, targetId } of entries) {
+          urlMap.set(reportId, `/private/artists/${targetId}`);
+        }
+        break;
+      }
+      case 'Comment': {
+        const comments = await prisma.comment.findMany({
+          where: { id: { in: targetIds } },
+          select: {
+            id: true,
+            page: true,
+            artistId: true,
+            releaseId: true,
+            release: { select: { communityId: true } },
+            collageId: true,
+            requestId: true,
+            communityId: true,
+            contributionId: true,
+            contribution: {
+              select: {
+                releaseId: true,
+                release: { select: { communityId: true } }
+              }
+            }
+          }
+        });
+        const byId = new Map(comments.map((c) => [c.id, c]));
+        for (const { reportId, targetId } of entries) {
+          const c = byId.get(targetId);
+          if (!c) {
+            urlMap.set(reportId, null);
+            break;
+          }
+          let url: string | null = null;
+          if (c.page === 'artist' && c.artistId) {
+            url = `/private/artists/${c.artistId}`;
+          } else if (
+            c.page === 'release' &&
+            c.releaseId &&
+            c.release?.communityId
+          ) {
+            url = `/private/communities/${c.release.communityId}/releases/${c.releaseId}`;
+          } else if (c.page === 'collages' && c.collageId) {
+            url = `/private/collages/${c.collageId}`;
+          } else if (c.page === 'requests' && c.requestId) {
+            url = `/private/requests/${c.requestId}`;
+          } else if (
+            c.page === 'contributions' &&
+            c.contributionId &&
+            c.contribution?.release?.communityId
+          ) {
+            url = `/private/communities/${c.contribution.release.communityId}/releases/${c.contribution.releaseId}`;
+          } else if (c.page === 'communities' && c.communityId) {
+            url = `/private/communities/${c.communityId}`;
+          }
+          urlMap.set(reportId, url);
+        }
+        break;
+      }
       default: {
         for (const { reportId } of entries) {
           urlMap.set(reportId, null);

--- a/src/routes/api/announcements.ts
+++ b/src/routes/api/announcements.ts
@@ -88,13 +88,14 @@ router.post(
   ...requirePermission('news_manage'),
   validate(featuredAlbumSchema),
   asyncHandler(async (_req: Request, res: Response) => {
-    const { groupId, threadId, title, started, ended } =
+    const { groupId, threadId, title, image, started, ended } =
       parsedBody<FeaturedAlbumInput>(res);
     const album = await prisma.featuredAlbum.create({
       data: {
         groupId,
         threadId,
         title,
+        image: image ?? '',
         started: new Date(started),
         ended: new Date(ended)
       }

--- a/src/routes/api/home.ts
+++ b/src/routes/api/home.ts
@@ -52,7 +52,10 @@ router.get(
                   started: featuredAlbum.started,
                   ended: featuredAlbum.ended,
                   threadId: featuredAlbum.threadId,
-                  release
+                  release: {
+                    ...release,
+                    image: featuredAlbum.image || release.image
+                  }
                 }
               : null
           )

--- a/src/schemas/featuredAlbum.ts
+++ b/src/schemas/featuredAlbum.ts
@@ -4,6 +4,7 @@ export const featuredAlbumSchema = z.object({
   groupId: z.coerce.number().int().positive(),
   threadId: z.coerce.number().int().positive(),
   title: z.string().min(1).max(200),
+  image: z.string().url().max(1000).optional().or(z.literal('')),
   started: z.string().datetime({ offset: true }),
   ended: z.string().datetime({ offset: true })
 });


### PR DESCRIPTION
## Summary

Three focused API-side fixes from the user journey walkthrough.

- **Report source URLs**: \`resolveSourceUrls\` now handles \`Artist\` and \`Comment\` report types. Artist reports link to \`/private/artists/:id\`; Comment reports resolve their page context (release, collage, request, community, artist) to the appropriate URL. Previously both types fell through to the \`default: null\` case, leaving the source column unlinked in the reports queue and report detail view.

- **FeaturedAlbum image field**: adds \`image String @default("")\` to the \`FeaturedAlbum\` model (matching the existing pattern on \`FeaturedMerch\`). The home endpoint now uses \`featuredAlbum.image\` when set, falling back to \`release.image\`. The AOTM create endpoint accepts \`image\` as an optional field.

- **Commit workflow**: \`CLAUDE.md\` updated with an explicit ordered checklist — format all of \`src/\`, lint changed files, type-check, full test suite — with a note that format must precede lint.

## Migration note

The migration \`20260529161547_add_featured_album_image\` contains two \`ALTER TABLE\` statements:

1. **\`featured_albums.image\`** — the column we added.
2. **\`user_settings.notificationMethod SET DEFAULT 'Traditional'\`** — pre-existing schema drift, not introduced by this PR. Commit \`34b6722\` changed the Prisma schema default from \`Popup\` to \`Traditional\` but never generated a migration. Prisma detected the drift when this migration was generated and included the fix. The change is correct and aligns the DB with the schema that has been in place since that commit.

## Test plan

- [ ] All 1313 unit/spec tests pass (\`npm run test --no-coverage\`)
- [ ] TypeScript clean (\`npx tsc --noEmit\`)
- [ ] \`Artist\` report type shows a clickable link to \`/private/artists/:id\` in the reports queue
- [ ] \`Comment\` report type shows a clickable link to the appropriate content page
- [ ] Creating an Album of the Month entry with an image URL causes that image to appear on the homepage panel
- [ ] Album of the Month entries without an image fall back to the release's own image
- [ ] New \`user_settings\` rows default \`notificationMethod\` to \`Traditional\` (previously defaulted to \`Popup\` at the DB level despite the schema declaring \`Traditional\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)