### PR TITLE
Extract business logic from user and auth route handlers into domain modules

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -1,4 +1,5 @@
 import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
 import gravatar from 'gravatar';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
@@ -197,6 +198,127 @@ export const registerUser = async ({
   });
 
   return { ok: true, user: toAuthUser(user) };
+};
+
+export const changePassword = async (
+  userId: number,
+  currentPassword: string,
+  newPassword: string
+): Promise<void> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, password: true }
+  });
+  if (!user) throw new AppError(401, 'Unauthorized');
+
+  const isMatch = await bcrypt.compare(currentPassword, user.password);
+  if (!isMatch) throw new AppError(400, 'Current password is incorrect');
+
+  if (await isPasswordBanned(newPassword)) {
+    throw new AppError(400, 'Password is not allowed');
+  }
+
+  const hashed = await bcrypt.hash(newPassword, await bcrypt.genSalt(10));
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: userId },
+      data: { password: hashed }
+    }),
+    prisma.userSession.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() }
+    })
+  ]);
+};
+
+export const changeEmail = async (
+  userId: number,
+  newEmail: string,
+  password: string,
+  ipAddress: string
+): Promise<void> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, password: true }
+  });
+  if (!user) throw new AppError(401, 'Unauthorized');
+
+  const isMatch = await bcrypt.compare(password, user.password);
+  if (!isMatch) throw new AppError(400, 'Password is incorrect');
+
+  const taken = await prisma.user.findUnique({
+    where: { email: newEmail.toLowerCase() }
+  });
+  if (taken) throw new AppError(400, 'Email already in use');
+
+  await prisma.$transaction([
+    prisma.userEmailHistory.create({
+      data: {
+        userId,
+        oldEmail: user.email,
+        newEmail: newEmail.toLowerCase(),
+        ipAddress
+      }
+    }),
+    prisma.user.update({
+      where: { id: userId },
+      data: { email: newEmail.toLowerCase() }
+    })
+  ]);
+};
+
+export const generateRecoveryToken = (): string =>
+  crypto.randomBytes(32).toString('hex');
+
+// Persists a recovery token for userId: expires any pending tokens first, then
+// inserts a fresh record valid for 2 hours. Call only after email delivery
+// succeeds to avoid orphaned rows when SMTP is unconfigured.
+export const persistRecoveryToken = async (
+  userId: number,
+  token: string
+): Promise<void> => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+
+  await prisma.$transaction([
+    prisma.accountRecovery.updateMany({
+      where: { userId, usedAt: null, expiresAt: { gt: now } },
+      data: { expiresAt: now }
+    }),
+    prisma.accountRecovery.create({
+      data: { userId, token, expiresAt }
+    })
+  ]);
+};
+
+export const resetPasswordWithToken = async (
+  token: string,
+  newPassword: string
+): Promise<void> => {
+  const recovery = await prisma.accountRecovery.findFirst({
+    where: { token, usedAt: null, expiresAt: { gt: new Date() } }
+  });
+  if (!recovery) throw new AppError(400, 'Invalid or expired recovery token');
+
+  if (await isPasswordBanned(newPassword)) {
+    throw new AppError(400, 'Password is not allowed');
+  }
+
+  const hashed = await bcrypt.hash(newPassword, await bcrypt.genSalt(10));
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: recovery.userId },
+      data: { password: hashed }
+    }),
+    prisma.accountRecovery.update({
+      where: { id: recovery.id },
+      data: { usedAt: new Date() }
+    }),
+    prisma.userSession.updateMany({
+      where: { userId: recovery.userId, revokedAt: null },
+      data: { revokedAt: new Date() }
+    })
+  ]);
 };
 
 export const loginUser = async (

--- a/src/modules/user.ts
+++ b/src/modules/user.ts
@@ -3,6 +3,13 @@ import { prisma } from '../lib/prisma';
 import { audit } from '../lib/audit';
 import { AppError } from '../lib/errors';
 
+export type SnatchItem = {
+  id: number;
+  release: { id: number; title: string; communityId: number | null };
+  artist: { name: string } | null;
+  downloadedAt: Date;
+};
+
 export const getUserSettings = async (userId: number) => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
@@ -130,4 +137,302 @@ export const createUser = async (
   });
 
   return user;
+};
+
+export const getSnatchList = async (
+  consumerId: number
+): Promise<SnatchItem[]> => {
+  const grants = await prisma.downloadAccessGrant.findMany({
+    where: { consumerId, status: 'COMPLETED' },
+    include: {
+      contribution: {
+        include: {
+          release: {
+            select: {
+              id: true,
+              title: true,
+              communityId: true,
+              artist: { select: { name: true } }
+            }
+          }
+        }
+      }
+    },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  const seen = new Set<number>();
+  const items: SnatchItem[] = [];
+  for (const g of grants) {
+    const rel = g.contribution.release;
+    if (!seen.has(rel.id)) {
+      seen.add(rel.id);
+      items.push({
+        id: g.id,
+        release: { id: rel.id, title: rel.title, communityId: rel.communityId },
+        artist: rel.artist ?? null,
+        downloadedAt: g.createdAt
+      });
+    }
+    if (items.length >= 100) break;
+  }
+  return items;
+};
+
+export const getInviteTree = async (pg: { skip: number; limit: number }) => {
+  const [trees, total] = await Promise.all([
+    prisma.inviteTree.findMany({
+      include: { user: { select: { id: true, username: true } } },
+      orderBy: [
+        { treeId: 'asc' },
+        { treeLevel: 'asc' },
+        { treePosition: 'asc' }
+      ],
+      skip: pg.skip,
+      take: pg.limit
+    }),
+    prisma.inviteTree.count()
+  ]);
+
+  const inviterIds = [...new Set(trees.map((t) => t.inviterId))];
+  const inviters = await prisma.user.findMany({
+    where: { id: { in: inviterIds } },
+    select: { id: true, username: true }
+  });
+  const inviterMap = new Map(inviters.map((u) => [u.id, u]));
+  const rows = trees.map((t) => ({
+    ...t,
+    inviter: inviterMap.get(t.inviterId) ?? null
+  }));
+
+  return { rows, total };
+};
+
+export const getDuplicateIps = async () => {
+  const dupes = await prisma.user.groupBy({
+    by: ['lastIp'],
+    where: { lastIp: { not: null } },
+    _count: { lastIp: true },
+    having: { lastIp: { _count: { gt: 1 } } },
+    orderBy: { _count: { lastIp: 'desc' } }
+  });
+
+  return Promise.all(
+    dupes.map(async (d) => {
+      const users = await prisma.user.findMany({
+        where: { lastIp: d.lastIp! },
+        select: {
+          id: true,
+          username: true,
+          dateRegistered: true,
+          disabled: true,
+          lastLogin: true
+        }
+      });
+      return { ip: d.lastIp!, count: d._count.lastIp, users };
+    })
+  );
+};
+
+export const warnUser = async (
+  userId: number,
+  warnedById: number,
+  reason: string,
+  expiresAt?: string
+) => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new AppError(404, 'User not found');
+
+  const [warning] = await prisma.$transaction([
+    prisma.userWarning.create({
+      data: {
+        userId,
+        warnedById,
+        reason,
+        ...(expiresAt ? { expiresAt: new Date(expiresAt) } : {})
+      }
+    }),
+    prisma.user.update({
+      where: { id: userId },
+      data: { warnedTimes: { increment: 1 }, warned: new Date() }
+    })
+  ]);
+
+  await audit(prisma, warnedById, 'user.warned', 'User', userId, { reason });
+  return warning;
+};
+
+export const deleteWarning = async (
+  userId: number,
+  warnId: number
+): Promise<void> => {
+  const warning = await prisma.userWarning.findUnique({
+    where: { id: warnId }
+  });
+  if (!warning || warning.userId !== userId) {
+    throw new AppError(404, 'Warning not found');
+  }
+  await prisma.userWarning.delete({ where: { id: warnId } });
+
+  const remaining = await prisma.userWarning.count({ where: { userId } });
+  if (remaining === 0) {
+    await prisma.user.update({ where: { id: userId }, data: { warned: null } });
+  }
+};
+
+export const setUserRank = async (
+  userId: number,
+  userRankId: number,
+  secondaryRankIds: number[],
+  actorId: number
+): Promise<void> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new AppError(404, 'User not found');
+
+  const uniqueSecondaryRankIds = [...new Set(secondaryRankIds)];
+  const ranks = await prisma.userRank.findMany({
+    where: { id: { in: [userRankId, ...uniqueSecondaryRankIds] } },
+    select: { id: true, secondary: true }
+  });
+  const rankMap = new Map(ranks.map((rank) => [rank.id, rank]));
+
+  const primaryRank = rankMap.get(userRankId);
+  if (!primaryRank) throw new AppError(404, 'Rank not found');
+  if (primaryRank.secondary) {
+    throw new AppError(422, 'Primary rank cannot be a secondary class');
+  }
+
+  for (const secondaryRankId of uniqueSecondaryRankIds) {
+    const secondaryRank = rankMap.get(secondaryRankId);
+    if (!secondaryRank) throw new AppError(404, 'Secondary rank not found');
+    if (!secondaryRank.secondary) {
+      throw new AppError(
+        422,
+        'Only secondary-class ranks can be assigned as secondary classes'
+      );
+    }
+  }
+
+  await prisma.$transaction([
+    prisma.user.update({ where: { id: userId }, data: { userRankId } }),
+    prisma.userSecondaryRank.deleteMany({ where: { userId } }),
+    ...(uniqueSecondaryRankIds.length > 0
+      ? [
+          prisma.userSecondaryRank.createMany({
+            data: uniqueSecondaryRankIds.map((secondaryRankId) => ({
+              userId,
+              userRankId: secondaryRankId,
+              assignedById: actorId
+            }))
+          })
+        ]
+      : [])
+  ]);
+
+  await audit(prisma, actorId, 'user.rank_changed', 'User', userId, {
+    userRankId,
+    secondaryRankIds: uniqueSecondaryRankIds
+  });
+};
+
+export const grantDonorStatus = async (
+  userId: number,
+  donorRankId: number,
+  expiresAt: string | null,
+  actorId: number
+): Promise<void> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new AppError(404, 'User not found');
+
+  const donorRank = await prisma.donorRank.findUnique({
+    where: { id: donorRankId }
+  });
+  if (!donorRank) throw new AppError(404, 'Donor rank not found');
+
+  // Explicit expiresAt wins; fall back to the rank's expiresAfterDays if set
+  const computedExpiresAt = expiresAt
+    ? new Date(expiresAt)
+    : donorRank.expiresAfterDays != null
+    ? new Date(Date.now() + donorRank.expiresAfterDays * 86_400_000)
+    : null;
+
+  await prisma.$transaction([
+    prisma.userDonorRank.upsert({
+      where: { userId },
+      create: {
+        userId,
+        donorRankId,
+        grantedById: actorId,
+        ...(computedExpiresAt ? { expiresAt: computedExpiresAt } : {})
+      },
+      update: {
+        donorRankId,
+        grantedAt: new Date(),
+        grantedById: actorId,
+        expiresAt: computedExpiresAt
+      }
+    }),
+    prisma.user.update({ where: { id: userId }, data: { isDonor: true } })
+  ]);
+
+  await audit(prisma, actorId, 'user.donor_granted', 'User', userId);
+};
+
+export const getUserIpHistory = async (
+  userId: number
+): Promise<{ ip: string; seenAt: string }[]> => {
+  const sessions = await prisma.userSession.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      ipAddress: true,
+      userAgent: true,
+      createdAt: true,
+      lastActiveAt: true,
+      revokedAt: true
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 50
+  });
+
+  const history = new Map<string, string>();
+  for (const session of sessions) {
+    if (!session.ipAddress) continue;
+    const seenAt = (session.lastActiveAt ?? session.createdAt).toISOString();
+    if (!history.has(session.ipAddress)) {
+      history.set(session.ipAddress, seenAt);
+    }
+  }
+  return Array.from(history.entries()).map(([ip, seenAt]) => ({ ip, seenAt }));
+};
+
+export const updateStaffBio = async (
+  userId: number,
+  staffBio: string | null,
+  actorId: number,
+  actorRankId: number,
+  isAdmin: boolean
+): Promise<void> => {
+  if (!isAdmin) {
+    const ownRank = await prisma.userRank.findUnique({
+      where: { id: actorRankId },
+      select: { displayStaff: true }
+    });
+    if (!ownRank?.displayStaff) throw new AppError(403, 'Permission denied');
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true }
+  });
+  if (!user) throw new AppError(404, 'User not found');
+
+  const normalized = staffBio?.trim() || null;
+  await prisma.user.update({
+    where: { id: userId },
+    data: { staffBio: normalized }
+  });
+  await audit(prisma, actorId, 'user.staffBio_updated', 'User', userId, {
+    staffBio: normalized
+  });
 };

--- a/src/modules/userModules.spec.ts
+++ b/src/modules/userModules.spec.ts
@@ -1,0 +1,838 @@
+/**
+ * Unit tests for the newly extracted user and auth module functions.
+ */
+
+import bcrypt from 'bcryptjs';
+import { prismaMock, resetApiTestState } from '../test/apiTestHarness';
+import type * as UserModule from './user';
+import type * as AuthModule from './auth';
+
+const {
+  getSnatchList,
+  getInviteTree,
+  getDuplicateIps,
+  warnUser,
+  deleteWarning,
+  setUserRank,
+  grantDonorStatus,
+  getUserIpHistory,
+  updateStaffBio
+} = jest.requireActual<typeof UserModule>('./user');
+
+const {
+  changePassword,
+  changeEmail,
+  persistRecoveryToken,
+  resetPasswordWithToken,
+  generateRecoveryToken
+} = jest.requireActual<typeof AuthModule>('./auth');
+
+beforeEach(() => resetApiTestState());
+
+// ─── auth.changePassword ──────────────────────────────────────────────────────
+
+describe('auth.changePassword', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.userSession.updateMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.badPassword.findFirst.mockResolvedValue(null);
+  });
+
+  it('throws 401 when user not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(changePassword(1, 'old', 'new')).rejects.toMatchObject({
+      statusCode: 401
+    });
+  });
+
+  it('throws 400 when current password is wrong', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 1,
+      password: '$2a$10$invalid'
+    } as never);
+    await expect(
+      changePassword(1, 'wrongpass', 'newpass')
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Current password is incorrect'
+    });
+  });
+
+  it('throws 400 when new password is banned', async () => {
+    // Use a real bcrypt hash so compare succeeds
+    const hash = await bcrypt.hash('currentpass', 1);
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 1,
+      password: hash
+    } as never);
+    prismaMock.badPassword.findFirst.mockResolvedValue({
+      password: 'newpass'
+    } as never);
+    await expect(
+      changePassword(1, 'currentpass', 'newpass')
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+// ─── auth.changeEmail ─────────────────────────────────────────────────────────
+
+describe('auth.changeEmail', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.userEmailHistory.create.mockResolvedValue({} as never);
+    prismaMock.user.update.mockResolvedValue({} as never);
+  });
+
+  it('throws 401 when user not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(
+      changeEmail(1, 'new@example.com', 'pass', '1.2.3.4')
+    ).rejects.toMatchObject({
+      statusCode: 401
+    });
+  });
+
+  it('throws 400 when password is wrong', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 1,
+      email: 'old@example.com',
+      password: '$2a$10$invalid'
+    } as never);
+    await expect(
+      changeEmail(1, 'new@example.com', 'wrong', '1.2.3.4')
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Password is incorrect'
+    });
+  });
+
+  it('throws 400 when new email is already taken', async () => {
+    const hash = await bcrypt.hash('pass', 1);
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({
+        id: 1,
+        email: 'old@example.com',
+        password: hash
+      } as never)
+      .mockResolvedValueOnce({ id: 2, email: 'taken@example.com' } as never);
+    await expect(
+      changeEmail(1, 'taken@example.com', 'pass', '1.2.3.4')
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+// ─── auth.persistRecoveryToken ────────────────────────────────────────────────
+
+describe('auth.persistRecoveryToken', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.accountRecovery.updateMany.mockResolvedValue({
+      count: 1
+    } as never);
+    prismaMock.accountRecovery.create.mockResolvedValue({ id: 1 } as never);
+  });
+
+  it('expires existing pending tokens before creating a new one', async () => {
+    await persistRecoveryToken(7, 'abc123');
+
+    expect(prismaMock.accountRecovery.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: 7, usedAt: null }),
+        data: expect.objectContaining({ expiresAt: expect.any(Date) })
+      })
+    );
+    expect(prismaMock.accountRecovery.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: 7, token: 'abc123' })
+      })
+    );
+  });
+
+  it('sets a 2-hour expiry on the new token', async () => {
+    const before = Date.now();
+    await persistRecoveryToken(7, 'abc123');
+    const after = Date.now();
+
+    const createCall = prismaMock.accountRecovery.create.mock.calls[0][0];
+    const expiresAt = createCall.data.expiresAt as Date;
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(
+      before + 2 * 60 * 60 * 1000 - 100
+    );
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(
+      after + 2 * 60 * 60 * 1000 + 100
+    );
+  });
+});
+
+// ─── auth.generateRecoveryToken ──────────────────────────────────────────────
+
+describe('auth.generateRecoveryToken', () => {
+  it('returns a 64-character hex string', () => {
+    const token = generateRecoveryToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns a different token each call', () => {
+    const t1 = generateRecoveryToken();
+    const t2 = generateRecoveryToken();
+    expect(t1).not.toBe(t2);
+  });
+});
+
+// ─── auth.resetPasswordWithToken ─────────────────────────────────────────────
+
+describe('auth.resetPasswordWithToken', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.accountRecovery.update.mockResolvedValue({} as never);
+    prismaMock.userSession.updateMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.badPassword.findFirst.mockResolvedValue(null);
+  });
+
+  it('throws 400 when token is invalid or expired', async () => {
+    prismaMock.accountRecovery.findFirst.mockResolvedValue(null);
+    await expect(
+      resetPasswordWithToken('badtoken', 'newpass')
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Invalid or expired recovery token'
+    });
+  });
+
+  it('throws 400 when new password is banned', async () => {
+    prismaMock.accountRecovery.findFirst.mockResolvedValue({
+      id: 1,
+      userId: 7,
+      token: 'validtoken'
+    } as never);
+    prismaMock.badPassword.findFirst.mockResolvedValue({
+      password: 'banned'
+    } as never);
+    await expect(
+      resetPasswordWithToken('validtoken', 'banned')
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Password is not allowed'
+    });
+  });
+
+  it('updates password and marks token used and revokes sessions', async () => {
+    prismaMock.accountRecovery.findFirst.mockResolvedValue({
+      id: 1,
+      userId: 7,
+      token: 'validtoken'
+    } as never);
+    await resetPasswordWithToken('validtoken', 'newpassword');
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 7 },
+        data: expect.objectContaining({ password: expect.any(String) })
+      })
+    );
+    expect(prismaMock.accountRecovery.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+        data: { usedAt: expect.any(Date) }
+      })
+    );
+    expect(prismaMock.userSession.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 7, revokedAt: null },
+        data: { revokedAt: expect.any(Date) }
+      })
+    );
+  });
+});
+
+// ─── user.getSnatchList ───────────────────────────────────────────────────────
+
+describe('user.getSnatchList', () => {
+  const makeGrant = (releaseId: number, grantId: number) => ({
+    id: grantId,
+    consumerId: 7,
+    status: 'COMPLETED',
+    createdAt: new Date(),
+    contribution: {
+      release: {
+        id: releaseId,
+        title: `Release ${releaseId}`,
+        communityId: 1,
+        artist: { name: 'Artist' }
+      }
+    }
+  });
+
+  it('returns empty array when no grants exist', async () => {
+    prismaMock.downloadAccessGrant.findMany.mockResolvedValue([]);
+    const result = await getSnatchList(7);
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates grants by release id, keeping the first seen', async () => {
+    prismaMock.downloadAccessGrant.findMany.mockResolvedValue([
+      makeGrant(1, 10),
+      makeGrant(1, 11),
+      makeGrant(2, 12)
+    ] as never);
+    const result = await getSnatchList(7);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(10);
+    expect(result[1].id).toBe(12);
+  });
+
+  it('caps the result at 100 items', async () => {
+    const grants = Array.from({ length: 150 }, (_, i) =>
+      makeGrant(i + 1, i + 100)
+    );
+    prismaMock.downloadAccessGrant.findMany.mockResolvedValue(grants as never);
+    const result = await getSnatchList(7);
+    expect(result).toHaveLength(100);
+  });
+});
+
+// ─── user.warnUser ────────────────────────────────────────────────────────────
+
+describe('user.warnUser', () => {
+  const baseWarning = {
+    id: 1,
+    userId: 5,
+    warnedById: 7,
+    reason: 'Spam',
+    expiresAt: null,
+    createdAt: new Date()
+  };
+
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.userWarning.create.mockResolvedValue(baseWarning as never);
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+  });
+
+  it('throws 404 when user not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(warnUser(5, 7, 'reason')).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('creates a warning and updates user warned counters', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+
+    const result = await warnUser(5, 7, 'Spam');
+
+    expect(prismaMock.userWarning.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 5,
+          warnedById: 7,
+          reason: 'Spam'
+        })
+      })
+    );
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 5 },
+        data: expect.objectContaining({
+          warnedTimes: { increment: 1 },
+          warned: expect.any(Date)
+        })
+      })
+    );
+    expect(result.id).toBe(1);
+  });
+
+  it('includes expiresAt in warning when provided', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    const expiry = '2026-12-31T00:00:00.000Z';
+
+    await warnUser(5, 7, 'Spam', expiry);
+
+    expect(prismaMock.userWarning.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ expiresAt: new Date(expiry) })
+      })
+    );
+  });
+});
+
+// ─── user.deleteWarning ───────────────────────────────────────────────────────
+
+describe('user.deleteWarning', () => {
+  beforeEach(() => {
+    prismaMock.userWarning.delete.mockResolvedValue({} as never);
+  });
+
+  it('throws 404 when warning not found', async () => {
+    prismaMock.userWarning.findUnique.mockResolvedValue(null);
+    await expect(deleteWarning(5, 99)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('throws 404 when warning belongs to a different user', async () => {
+    prismaMock.userWarning.findUnique.mockResolvedValue({
+      id: 99,
+      userId: 999
+    } as never);
+    await expect(deleteWarning(5, 99)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('clears the warned flag when no warnings remain', async () => {
+    prismaMock.userWarning.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 5
+    } as never);
+    prismaMock.userWarning.count.mockResolvedValue(0);
+    prismaMock.user.update.mockResolvedValue({} as never);
+
+    await deleteWarning(5, 1);
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 5 }, data: { warned: null } })
+    );
+  });
+
+  it('does not clear the warned flag when warnings remain', async () => {
+    prismaMock.userWarning.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 5
+    } as never);
+    prismaMock.userWarning.count.mockResolvedValue(2);
+
+    await deleteWarning(5, 1);
+
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+});
+
+// ─── user.setUserRank ─────────────────────────────────────────────────────────
+
+describe('user.setUserRank', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.userSecondaryRank.deleteMany.mockResolvedValue({
+      count: 0
+    } as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+  });
+
+  it('throws 404 when user not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(setUserRank(5, 1, [], 7)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('throws 404 when primary rank not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.userRank.findMany.mockResolvedValue([]);
+    await expect(setUserRank(5, 99, [], 7)).rejects.toMatchObject({
+      statusCode: 404,
+      message: 'Rank not found'
+    });
+  });
+
+  it('throws 422 when assigning a secondary rank as primary', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.userRank.findMany.mockResolvedValue([
+      { id: 1, secondary: true }
+    ] as never);
+    await expect(setUserRank(5, 1, [], 7)).rejects.toMatchObject({
+      statusCode: 422,
+      message: 'Primary rank cannot be a secondary class'
+    });
+  });
+
+  it('throws 422 when assigning a non-secondary rank as secondary', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.userRank.findMany.mockResolvedValue([
+      { id: 1, secondary: false },
+      { id: 2, secondary: false }
+    ] as never);
+    await expect(setUserRank(5, 1, [2], 7)).rejects.toMatchObject({
+      statusCode: 422,
+      message: 'Only secondary-class ranks can be assigned as secondary classes'
+    });
+  });
+
+  it('applies rank update with no secondary ranks', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.userRank.findMany.mockResolvedValue([
+      { id: 1, secondary: false }
+    ] as never);
+
+    await setUserRank(5, 1, [], 7);
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 5 }, data: { userRankId: 1 } })
+    );
+    expect(prismaMock.userSecondaryRank.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 5 }
+    });
+  });
+
+  it('deduplicates secondary rank ids', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.userRank.findMany.mockResolvedValue([
+      { id: 1, secondary: false },
+      { id: 2, secondary: true }
+    ] as never);
+    prismaMock.userSecondaryRank.createMany.mockResolvedValue({
+      count: 1
+    } as never);
+
+    await setUserRank(5, 1, [2, 2, 2], 7);
+
+    expect(prismaMock.userSecondaryRank.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [{ userId: 5, userRankId: 2, assignedById: 7 }]
+      })
+    );
+  });
+});
+
+// ─── user.grantDonorStatus ────────────────────────────────────────────────────
+
+describe('user.grantDonorStatus', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(prismaMock);
+      return Promise.all(arg as Promise<unknown>[]);
+    });
+    prismaMock.userDonorRank.upsert.mockResolvedValue({} as never);
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+  });
+
+  it('throws 404 when user not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(grantDonorStatus(5, 1, null, 7)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('throws 404 when donor rank not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.donorRank.findUnique.mockResolvedValue(null);
+    await expect(grantDonorStatus(5, 99, null, 7)).rejects.toMatchObject({
+      statusCode: 404,
+      message: 'Donor rank not found'
+    });
+  });
+
+  it('uses explicit expiresAt when provided', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.donorRank.findUnique.mockResolvedValue({
+      id: 1,
+      expiresAfterDays: 30
+    } as never);
+
+    await grantDonorStatus(5, 1, '2027-01-01T00:00:00.000Z', 7);
+
+    expect(prismaMock.userDonorRank.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          expiresAt: new Date('2027-01-01T00:00:00.000Z')
+        })
+      })
+    );
+  });
+
+  it('falls back to expiresAfterDays when no explicit expiresAt', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.donorRank.findUnique.mockResolvedValue({
+      id: 1,
+      expiresAfterDays: 7
+    } as never);
+
+    const before = Date.now();
+    await grantDonorStatus(5, 1, null, 7);
+    const after = Date.now();
+
+    const upsertCall = prismaMock.userDonorRank.upsert.mock.calls[0][0];
+    const expiresAt = upsertCall.create.expiresAt as Date;
+    const expected = 7 * 86_400_000;
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + expected - 100);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(after + expected + 100);
+  });
+
+  it('sets null expiresAt when rank has no expiry and no explicit date', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+    prismaMock.donorRank.findUnique.mockResolvedValue({
+      id: 1,
+      expiresAfterDays: null
+    } as never);
+
+    await grantDonorStatus(5, 1, null, 7);
+
+    expect(prismaMock.userDonorRank.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ expiresAt: null })
+      })
+    );
+  });
+});
+
+// ─── user.getUserIpHistory ────────────────────────────────────────────────────
+
+describe('user.getUserIpHistory', () => {
+  const now = new Date('2026-05-01T12:00:00Z');
+  const earlier = new Date('2026-04-01T10:00:00Z');
+
+  it('returns empty array when no sessions exist', async () => {
+    prismaMock.userSession.findMany.mockResolvedValue([]);
+    const result = await getUserIpHistory(7);
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates IPs, keeping only the first occurrence (most recent by query order)', async () => {
+    prismaMock.userSession.findMany.mockResolvedValue([
+      {
+        ipAddress: '1.2.3.4',
+        createdAt: now,
+        lastActiveAt: null,
+        id: 'a',
+        userAgent: '',
+        revokedAt: null
+      },
+      {
+        ipAddress: '1.2.3.4',
+        createdAt: earlier,
+        lastActiveAt: null,
+        id: 'b',
+        userAgent: '',
+        revokedAt: null
+      },
+      {
+        ipAddress: '5.6.7.8',
+        createdAt: now,
+        lastActiveAt: null,
+        id: 'c',
+        userAgent: '',
+        revokedAt: null
+      }
+    ] as never);
+
+    const result = await getUserIpHistory(7);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.ip)).toEqual(['1.2.3.4', '5.6.7.8']);
+  });
+
+  it('prefers lastActiveAt over createdAt for seenAt', async () => {
+    const lastActive = new Date('2026-05-10T09:00:00Z');
+    prismaMock.userSession.findMany.mockResolvedValue([
+      {
+        ipAddress: '1.2.3.4',
+        createdAt: now,
+        lastActiveAt: lastActive,
+        id: 'a',
+        userAgent: '',
+        revokedAt: null
+      }
+    ] as never);
+
+    const result = await getUserIpHistory(7);
+
+    expect(result[0].seenAt).toBe(lastActive.toISOString());
+  });
+
+  it('skips sessions with null ipAddress', async () => {
+    prismaMock.userSession.findMany.mockResolvedValue([
+      {
+        ipAddress: null,
+        createdAt: now,
+        lastActiveAt: null,
+        id: 'a',
+        userAgent: '',
+        revokedAt: null
+      },
+      {
+        ipAddress: '1.2.3.4',
+        createdAt: now,
+        lastActiveAt: null,
+        id: 'b',
+        userAgent: '',
+        revokedAt: null
+      }
+    ] as never);
+
+    const result = await getUserIpHistory(7);
+    expect(result).toHaveLength(1);
+    expect(result[0].ip).toBe('1.2.3.4');
+  });
+});
+
+// ─── user.updateStaffBio ─────────────────────────────────────────────────────
+
+describe('user.updateStaffBio', () => {
+  beforeEach(() => {
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+  });
+
+  it('throws 403 when non-admin actor rank lacks displayStaff', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue({
+      displayStaff: false
+    } as never);
+    await expect(updateStaffBio(5, 'bio', 7, 2, false)).rejects.toMatchObject({
+      statusCode: 403
+    });
+  });
+
+  it('throws 404 when target user not found', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue({
+      displayStaff: true
+    } as never);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(updateStaffBio(5, 'bio', 7, 2, false)).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('skips displayStaff check for admins', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+
+    await updateStaffBio(5, 'bio', 7, 2, true);
+
+    expect(prismaMock.userRank.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('normalizes empty string bio to null', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+
+    await updateStaffBio(5, '   ', 7, 2, true);
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { staffBio: null } })
+    );
+  });
+
+  it('trims whitespace from bio', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 5 } as never);
+
+    await updateStaffBio(5, '  hello world  ', 7, 2, true);
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { staffBio: 'hello world' } })
+    );
+  });
+});
+
+// ─── user.getInviteTree ───────────────────────────────────────────────────────
+
+describe('user.getInviteTree', () => {
+  it('returns total count separately from rows', async () => {
+    prismaMock.inviteTree.findMany.mockResolvedValue([]);
+    prismaMock.inviteTree.count.mockResolvedValue(5);
+    prismaMock.user.findMany.mockResolvedValue([]);
+
+    const result = await getInviteTree({ skip: 0, limit: 20 });
+    expect(result.total).toBe(5);
+    expect(result.rows).toEqual([]);
+  });
+
+  it('joins inviter data onto each tree row', async () => {
+    prismaMock.inviteTree.findMany.mockResolvedValue([
+      {
+        id: 1,
+        userId: 10,
+        inviterId: 7,
+        treeId: 1,
+        treeLevel: 0,
+        treePosition: 0,
+        user: { id: 10, username: 'child' }
+      }
+    ] as never);
+    prismaMock.inviteTree.count.mockResolvedValue(1);
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: 7, username: 'parent' }
+    ] as never);
+
+    const result = await getInviteTree({ skip: 0, limit: 20 });
+    expect(result.rows[0].inviter).toEqual({ id: 7, username: 'parent' });
+  });
+
+  it('sets inviter to null when inviter id is not in the user lookup', async () => {
+    prismaMock.inviteTree.findMany.mockResolvedValue([
+      {
+        id: 1,
+        userId: 10,
+        inviterId: 999,
+        treeId: 1,
+        treeLevel: 0,
+        treePosition: 0,
+        user: { id: 10, username: 'orphan' }
+      }
+    ] as never);
+    prismaMock.inviteTree.count.mockResolvedValue(1);
+    prismaMock.user.findMany.mockResolvedValue([]);
+
+    const result = await getInviteTree({ skip: 0, limit: 20 });
+    expect(result.rows[0].inviter).toBeNull();
+  });
+});
+
+// ─── user.getDuplicateIps ─────────────────────────────────────────────────────
+
+describe('user.getDuplicateIps', () => {
+  it('returns empty array when no duplicate IPs exist', async () => {
+    (prismaMock.user.groupBy as jest.Mock).mockResolvedValue([]);
+    const result = await getDuplicateIps();
+    expect(result).toEqual([]);
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('fetches users for each duplicate IP', async () => {
+    (prismaMock.user.groupBy as jest.Mock).mockResolvedValue([
+      { lastIp: '1.2.3.4', _count: { lastIp: 2 } }
+    ]);
+    prismaMock.user.findMany.mockResolvedValue([
+      {
+        id: 1,
+        username: 'alice',
+        dateRegistered: new Date(),
+        disabled: false,
+        lastLogin: null
+      },
+      {
+        id: 2,
+        username: 'bob',
+        dateRegistered: new Date(),
+        disabled: false,
+        lastLogin: null
+      }
+    ] as never);
+
+    const result = await getDuplicateIps();
+    expect(result).toHaveLength(1);
+    expect(result[0].ip).toBe('1.2.3.4');
+    expect(result[0].count).toBe(2);
+    expect(result[0].users).toHaveLength(2);
+  });
+});

--- a/src/routes/api/auth.ts
+++ b/src/routes/api/auth.ts
@@ -1,7 +1,5 @@
-import crypto from 'crypto';
 import express, { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
-import bcrypt from 'bcryptjs';
 import { prisma } from '../../lib/prisma';
 import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { auth as authConfig, email as emailConfig } from '../../modules/config';
@@ -31,8 +29,12 @@ import {
   authUserSelect,
   registerUser,
   loginUser,
-  isPasswordBanned,
-  toAuthUser
+  toAuthUser,
+  changePassword,
+  changeEmail,
+  generateRecoveryToken,
+  persistRecoveryToken,
+  resetPasswordWithToken
 } from '../../modules/auth';
 import { getSettings } from '../../modules/settings';
 import { sendRecoveryEmail } from '../../lib/mailer';
@@ -167,33 +169,7 @@ router.post(
   authHandler(async (req, res) => {
     const { currentPassword, newPassword } =
       parsedBody<ChangePasswordInput>(res);
-
-    const user = await prisma.user.findUnique({
-      where: { id: req.user.id },
-      select: { id: true, password: true }
-    });
-    if (!user) return res.status(401).json({ msg: 'Unauthorized' });
-
-    const isMatch = await bcrypt.compare(currentPassword, user.password);
-    if (!isMatch)
-      return res.status(400).json({ msg: 'Current password is incorrect' });
-
-    if (await isPasswordBanned(newPassword)) {
-      return res.status(400).json({ msg: 'Password is not allowed' });
-    }
-
-    const hashed = await bcrypt.hash(newPassword, await bcrypt.genSalt(10));
-    await prisma.$transaction([
-      prisma.user.update({
-        where: { id: req.user.id },
-        data: { password: hashed }
-      }),
-      prisma.userSession.updateMany({
-        where: { userId: req.user.id, revokedAt: null },
-        data: { revokedAt: new Date() }
-      })
-    ]);
-
+    await changePassword(req.user.id, currentPassword, newPassword);
     res.status(204).send();
   })
 );
@@ -205,43 +181,13 @@ router.put(
   validate(changeEmailSchema),
   authHandler(async (req, res) => {
     const { newEmail, password } = parsedBody<ChangeEmailInput>(res);
-
-    const user = await prisma.user.findUnique({
-      where: { id: req.user.id },
-      select: { id: true, email: true, password: true }
-    });
-    if (!user) return res.status(401).json({ msg: 'Unauthorized' });
-
-    const isMatch = await bcrypt.compare(password, user.password);
-    if (!isMatch) return res.status(400).json({ msg: 'Password is incorrect' });
-
-    const taken = await prisma.user.findUnique({
-      where: { email: newEmail.toLowerCase() }
-    });
-    if (taken) return res.status(400).json({ msg: 'Email already in use' });
-
     const ip =
       (req.headers['x-forwarded-for'] as string | undefined)
         ?.split(',')[0]
         ?.trim() ??
       req.ip ??
       '';
-
-    await prisma.$transaction([
-      prisma.userEmailHistory.create({
-        data: {
-          userId: req.user.id,
-          oldEmail: user.email,
-          newEmail: newEmail.toLowerCase(),
-          ipAddress: ip
-        }
-      }),
-      prisma.user.update({
-        where: { id: req.user.id },
-        data: { email: newEmail.toLowerCase() }
-      })
-    ]);
-
+    await changeEmail(req.user.id, newEmail, password, ip);
     res.json({ msg: 'Email updated' });
   })
 );
@@ -261,25 +207,12 @@ router.post(
     });
 
     if (user) {
-      const token = crypto.randomBytes(32).toString('hex');
+      const token = generateRecoveryToken();
       const resetUrl = `${emailConfig.siteUrl}/recovery?token=${token}`;
-
       // Only write to DB if email delivery succeeds — avoids dead rows when SMTP is off
       const sent = await sendRecoveryEmail(user.email, resetUrl);
       if (sent) {
-        const now = new Date();
-        const expiresAt = new Date(now.getTime() + 2 * 60 * 60 * 1000);
-
-        // Enforce single-active-token: expire any pending tokens before creating a new one
-        await prisma.$transaction([
-          prisma.accountRecovery.updateMany({
-            where: { userId: user.id, usedAt: null, expiresAt: { gt: now } },
-            data: { expiresAt: now }
-          }),
-          prisma.accountRecovery.create({
-            data: { userId: user.id, token, expiresAt }
-          })
-        ]);
+        await persistRecoveryToken(user.id, token);
       }
     }
 
@@ -294,34 +227,7 @@ router.post(
   validate(recoveryResetSchema),
   asyncHandler(async (req: Request, res: Response) => {
     const { token, newPassword } = parsedBody<RecoveryResetInput>(res);
-
-    const recovery = await prisma.accountRecovery.findFirst({
-      where: { token, usedAt: null, expiresAt: { gt: new Date() } }
-    });
-    if (!recovery) {
-      return res.status(400).json({ msg: 'Invalid or expired recovery token' });
-    }
-
-    if (await isPasswordBanned(newPassword)) {
-      return res.status(400).json({ msg: 'Password is not allowed' });
-    }
-
-    const hashed = await bcrypt.hash(newPassword, await bcrypt.genSalt(10));
-    await prisma.$transaction([
-      prisma.user.update({
-        where: { id: recovery.userId },
-        data: { password: hashed }
-      }),
-      prisma.accountRecovery.update({
-        where: { id: recovery.id },
-        data: { usedAt: new Date() }
-      }),
-      prisma.userSession.updateMany({
-        where: { userId: recovery.userId, revokedAt: null },
-        data: { revokedAt: new Date() }
-      })
-    ]);
-
+    await resetPasswordWithToken(token, newPassword);
     res.json({ msg: 'Password reset successfully' });
   })
 );

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -5,8 +5,21 @@ import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import {
   getUserSettings,
   updateUserSettings,
-  createUser
+  createUser,
+  getSnatchList,
+  getInviteTree,
+  getDuplicateIps,
+  warnUser,
+  deleteWarning,
+  setUserRank,
+  grantDonorStatus,
+  getUserIpHistory,
+  updateStaffBio
 } from '../../modules/user';
+import {
+  generateRecoveryToken,
+  persistRecoveryToken
+} from '../../modules/auth';
 import { requireAuth } from '../../middleware/auth';
 import {
   requirePermission,
@@ -51,7 +64,6 @@ import {
   type StatsPeriodQuery
 } from '../../schemas/statsHistory';
 import { getUserStatHistory } from '../../modules/statsHistory';
-import crypto from 'crypto';
 
 const router = express.Router();
 const userIdParamsSchema = z.object({
@@ -173,43 +185,7 @@ router.get(
   '/me/snatch-list',
   requireAuth,
   authHandler(async (req, res) => {
-    const grants = await prisma.downloadAccessGrant.findMany({
-      where: { consumerId: req.user.id, status: 'COMPLETED' },
-      include: {
-        contribution: {
-          include: {
-            release: {
-              select: {
-                id: true,
-                title: true,
-                communityId: true,
-                artist: { select: { name: true } }
-              }
-            }
-          }
-        }
-      },
-      orderBy: { createdAt: 'desc' }
-    });
-    const seen = new Set<number>();
-    const items = [];
-    for (const g of grants) {
-      const rel = g.contribution.release;
-      if (!seen.has(rel.id)) {
-        seen.add(rel.id);
-        items.push({
-          id: g.id,
-          release: {
-            id: rel.id,
-            title: rel.title,
-            communityId: rel.communityId
-          },
-          artist: rel.artist ?? null,
-          downloadedAt: g.createdAt
-        });
-      }
-      if (items.length >= 100) break;
-    }
+    const items = await getSnatchList(req.user.id);
     res.json(items);
   })
 );
@@ -378,29 +354,7 @@ router.get(
   validateQuery(inviteTreeQuerySchema),
   asyncHandler(async (req: Request, res: Response) => {
     const pg = parsedPage(res);
-    const [trees, total] = await Promise.all([
-      prisma.inviteTree.findMany({
-        include: { user: { select: { id: true, username: true } } },
-        orderBy: [
-          { treeId: 'asc' },
-          { treeLevel: 'asc' },
-          { treePosition: 'asc' }
-        ],
-        skip: pg.skip,
-        take: pg.limit
-      }),
-      prisma.inviteTree.count()
-    ]);
-    const inviterIds = [...new Set(trees.map((t) => t.inviterId))];
-    const inviters = await prisma.user.findMany({
-      where: { id: { in: inviterIds } },
-      select: { id: true, username: true }
-    });
-    const inviterMap = new Map(inviters.map((u) => [u.id, u]));
-    const rows = trees.map((t) => ({
-      ...t,
-      inviter: inviterMap.get(t.inviterId) ?? null
-    }));
+    const { rows, total } = await getInviteTree(pg);
     paginatedResponse(res, rows, total, pg);
   })
 );
@@ -462,28 +416,7 @@ router.get(
   '/duplicate-ips',
   ...requirePermission('duplicate_ips_view'),
   authHandler(async (_req, res) => {
-    const dupes = await prisma.user.groupBy({
-      by: ['lastIp'],
-      where: { lastIp: { not: null } },
-      _count: { lastIp: true },
-      having: { lastIp: { _count: { gt: 1 } } },
-      orderBy: { _count: { lastIp: 'desc' } }
-    });
-    const result = await Promise.all(
-      dupes.map(async (d) => {
-        const users = await prisma.user.findMany({
-          where: { lastIp: d.lastIp! },
-          select: {
-            id: true,
-            username: true,
-            dateRegistered: true,
-            disabled: true,
-            lastLogin: true
-          }
-        });
-        return { ip: d.lastIp!, count: d._count.lastIp, users };
-      })
-    );
+    const result = await getDuplicateIps();
     res.json(result);
   })
 );
@@ -617,28 +550,13 @@ router.put(
       return res.status(403).json({ msg: 'Permission denied' });
     }
 
-    if (isSelf && !isAdmin) {
-      const ownRank = await prisma.userRank.findUnique({
-        where: { id: req.user.userRankId },
-        select: { displayStaff: true }
-      });
-      if (!ownRank?.displayStaff) {
-        return res.status(403).json({ msg: 'Permission denied' });
-      }
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { id },
-      select: { id: true }
-    });
-    if (!user) return res.status(404).json({ msg: 'User not found' });
-
-    // Normalize empty string to null
-    const normalized = staffBio?.trim() || null;
-    await prisma.user.update({ where: { id }, data: { staffBio: normalized } });
-    await audit(prisma, req.user.id, 'user.staffBio_updated', 'User', id, {
-      staffBio: normalized
-    });
+    await updateStaffBio(
+      id,
+      staffBio,
+      req.user.id,
+      req.user.userRankId,
+      isAdmin
+    );
     res.json({ msg: 'Staff bio updated' });
   })
 );
@@ -658,7 +576,7 @@ router.post(
     if (!user || user.disabled)
       return res.status(404).json({ msg: 'User not found' });
 
-    const token = crypto.randomBytes(32).toString('hex');
+    const token = generateRecoveryToken();
     const resetUrl = `${emailConfig.siteUrl}/recovery?token=${token}`;
 
     // Send email first — only touch DB if delivery succeeds
@@ -667,18 +585,7 @@ router.post(
       return res.status(502).json({ msg: 'Email delivery is not configured' });
     }
 
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + 2 * 60 * 60 * 1000);
-    await prisma.$transaction([
-      prisma.accountRecovery.updateMany({
-        where: { userId: id, usedAt: null, expiresAt: { gt: now } },
-        data: { expiresAt: now }
-      }),
-      prisma.accountRecovery.create({
-        data: { userId: id, token, expiresAt }
-      })
-    ]);
-
+    await persistRecoveryToken(id, token);
     await audit(prisma, req.user.id, 'recovery.admin_triggered', 'User', id);
     res.json({ msg: 'Recovery email sent' });
   })
@@ -709,29 +616,7 @@ router.post(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { reason, expiresAt } = parsedBody<WarnUserInput>(res);
-
-    const user = await prisma.user.findUnique({ where: { id } });
-    if (!user) return res.status(404).json({ msg: 'User not found' });
-
-    const [warning] = await prisma.$transaction([
-      prisma.userWarning.create({
-        data: {
-          userId: id,
-          warnedById: req.user.id,
-          reason,
-          ...(expiresAt ? { expiresAt: new Date(expiresAt) } : {})
-        }
-      }),
-      prisma.user.update({
-        where: { id },
-        data: {
-          warnedTimes: { increment: 1 },
-          warned: new Date()
-        }
-      })
-    ]);
-
-    await audit(prisma, req.user.id, 'user.warned', 'User', id, { reason });
+    const warning = await warnUser(id, req.user.id, reason, expiresAt);
     res.status(201).json({ warning });
   })
 );
@@ -743,17 +628,7 @@ router.delete(
   validateParams(warningParamsSchema),
   authHandler(async (_req, res) => {
     const { id, warnId } = parsedParams<{ id: number; warnId: number }>(res);
-    const warning = await prisma.userWarning.findUnique({
-      where: { id: warnId }
-    });
-    if (!warning || warning.userId !== id) {
-      return res.status(404).json({ msg: 'Warning not found' });
-    }
-    await prisma.userWarning.delete({ where: { id: warnId } });
-    const remaining = await prisma.userWarning.count({ where: { userId: id } });
-    if (remaining === 0) {
-      await prisma.user.update({ where: { id }, data: { warned: null } });
-    }
+    await deleteWarning(id, warnId);
     res.status(204).send();
   })
 );
@@ -874,57 +749,7 @@ router.put(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { userRankId, secondaryRankIds } = parsedBody<SetRankInput>(res);
-
-    const user = await prisma.user.findUnique({ where: { id } });
-    if (!user) return res.status(404).json({ msg: 'User not found' });
-
-    const uniqueSecondaryRankIds = [...new Set(secondaryRankIds)];
-    const ranks = await prisma.userRank.findMany({
-      where: { id: { in: [userRankId, ...uniqueSecondaryRankIds] } },
-      select: { id: true, secondary: true }
-    });
-    const rankMap = new Map(ranks.map((rank) => [rank.id, rank]));
-    const primaryRank = rankMap.get(userRankId);
-    if (!primaryRank) return res.status(404).json({ msg: 'Rank not found' });
-    if (primaryRank.secondary) {
-      return res
-        .status(422)
-        .json({ msg: 'Primary rank cannot be a secondary class' });
-    }
-    for (const secondaryRankId of uniqueSecondaryRankIds) {
-      const secondaryRank = rankMap.get(secondaryRankId);
-      if (!secondaryRank) {
-        return res.status(404).json({ msg: 'Secondary rank not found' });
-      }
-      if (!secondaryRank.secondary) {
-        return res.status(422).json({
-          msg: 'Only secondary-class ranks can be assigned as secondary classes'
-        });
-      }
-    }
-
-    await prisma.$transaction([
-      prisma.user.update({
-        where: { id },
-        data: { userRankId }
-      }),
-      prisma.userSecondaryRank.deleteMany({ where: { userId: id } }),
-      ...(uniqueSecondaryRankIds.length > 0
-        ? [
-            prisma.userSecondaryRank.createMany({
-              data: uniqueSecondaryRankIds.map((secondaryRankId) => ({
-                userId: id,
-                userRankId: secondaryRankId,
-                assignedById: req.user.id
-              }))
-            })
-          ]
-        : [])
-    ]);
-    await audit(prisma, req.user.id, 'user.rank_changed', 'User', id, {
-      userRankId,
-      secondaryRankIds: uniqueSecondaryRankIds
-    });
+    await setUserRank(id, userRankId, secondaryRankIds, req.user.id);
     res.json({ msg: 'Rank updated' });
   })
 );
@@ -938,43 +763,7 @@ router.post(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const { donorRankId, expiresAt } = parsedBody<GrantDonorInput>(res);
-
-    const user = await prisma.user.findUnique({ where: { id } });
-    if (!user) return res.status(404).json({ msg: 'User not found' });
-
-    const donorRank = await prisma.donorRank.findUnique({
-      where: { id: donorRankId }
-    });
-    if (!donorRank)
-      return res.status(404).json({ msg: 'Donor rank not found' });
-
-    // Explicit expiresAt wins; fall back to the rank's expiresAfterDays if set
-    const computedExpiresAt = expiresAt
-      ? new Date(expiresAt)
-      : donorRank.expiresAfterDays != null
-      ? new Date(Date.now() + donorRank.expiresAfterDays * 86_400_000)
-      : null;
-
-    await prisma.$transaction([
-      prisma.userDonorRank.upsert({
-        where: { userId: id },
-        create: {
-          userId: id,
-          donorRankId,
-          grantedById: req.user.id,
-          ...(computedExpiresAt ? { expiresAt: computedExpiresAt } : {})
-        },
-        update: {
-          donorRankId,
-          grantedAt: new Date(),
-          grantedById: req.user.id,
-          expiresAt: computedExpiresAt
-        }
-      }),
-      prisma.user.update({ where: { id }, data: { isDonor: true } })
-    ]);
-
-    await audit(prisma, req.user.id, 'user.donor_granted', 'User', id);
+    await grantDonorStatus(id, donorRankId, expiresAt ?? null, req.user.id);
     res.status(201).json({ msg: 'Donor status granted' });
   })
 );
@@ -1004,33 +793,8 @@ router.get(
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const sessions = await prisma.userSession.findMany({
-      where: { userId: id },
-      select: {
-        id: true,
-        ipAddress: true,
-        userAgent: true,
-        createdAt: true,
-        lastActiveAt: true,
-        revokedAt: true
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 50
-    });
-    const history = new Map<string, string>();
-    for (const session of sessions) {
-      if (!session.ipAddress) continue;
-      const seenAt = (session.lastActiveAt ?? session.createdAt).toISOString();
-      if (!history.has(session.ipAddress)) {
-        history.set(session.ipAddress, seenAt);
-      }
-    }
-    res.json(
-      Array.from(history.entries()).map(([ip, seenAt]) => ({
-        ip,
-        seenAt
-      }))
-    );
+    const history = await getUserIpHistory(id);
+    res.json(history);
   })
 );
 
@@ -1065,43 +829,7 @@ router.get(
   validateParams(userIdParamsSchema),
   authHandler(async (_req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
-    const grants = await prisma.downloadAccessGrant.findMany({
-      where: { consumerId: id, status: 'COMPLETED' },
-      include: {
-        contribution: {
-          include: {
-            release: {
-              select: {
-                id: true,
-                title: true,
-                communityId: true,
-                artist: { select: { name: true } }
-              }
-            }
-          }
-        }
-      },
-      orderBy: { createdAt: 'desc' }
-    });
-    const seen = new Set<number>();
-    const items = [];
-    for (const g of grants) {
-      const rel = g.contribution.release;
-      if (!seen.has(rel.id)) {
-        seen.add(rel.id);
-        items.push({
-          id: g.id,
-          release: {
-            id: rel.id,
-            title: rel.title,
-            communityId: rel.communityId
-          },
-          artist: rel.artist ?? null,
-          downloadedAt: g.createdAt
-        });
-      }
-      if (items.length >= 100) break;
-    }
+    const items = await getSnatchList(id);
     res.json(items);
   })
 );

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -67,6 +67,7 @@ jest.mock('../modules/artist', () => ({
 }));
 
 jest.mock('../modules/user', () => ({
+  ...jest.requireActual('../modules/user'),
   getUserSettings: jest.fn(),
   updateUserSettings: jest.fn(),
   createUser: jest.fn()


### PR DESCRIPTION
Move non-trivial Prisma operations from routes/api/user.ts and routes/api/auth.ts into their corresponding modules, leaving trivial one-liner lookups inline.

modules/auth.ts additions:
- changePassword: credential verify + banned-password check + hash + session revocation
- changeEmail: credential verify + uniqueness check + email history + update
- generateRecoveryToken / persistRecoveryToken: single-active-token enforcement (expire pending tokens, create new 2h-TTL record) — shared across admin and self-service recovery flows
- resetPasswordWithToken: token validation + banned-password check + hash + session revocation

modules/user.ts additions:
- getSnatchList: deduped completed-grant list capped at 100 items (was duplicated across /me/snatch-list and /:id/snatch-list routes)
- getInviteTree: invite-tree fetch + separate inviter lookup + map join
- getDuplicateIps: groupBy + per-group user lookup
- warnUser: warning create + user warned-counter update (transaction) + audit
- deleteWarning: delete + clear warned flag when no warnings remain
- setUserRank: primary/secondary rank validation + atomic rank swap (transaction) + audit
- grantDonorStatus: expiry computation (explicit > rank default > null) + upsert + audit
- getUserIpHistory: session fetch + IP deduplication preferring lastActiveAt
- updateStaffBio: displayStaff permission check + normalize + update + audit

Adds 48 unit tests in src/modules/userModules.spec.ts covering all extracted functions.