### PR TITLE
chore: collages permission inline + CHANGELOG v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,268 @@
+# Changelog
+
+All notable changes to stellar-api are documented here.
+
+---
+
+## [Unreleased]
+
+- Stub tracking issues filed for friends (#60), invite tree (#61), and donations (#62)
+
+---
+
+## [0.5.3] — 2026-06-01
+
+### Added
+- CI: staging and develop branch workflows
+
+### Changed
+- `collages.ts`: inline permission checks at all call sites, removing `isStaffOrModerator` named role helper (ADR-0001 compliance) — eliminates double DB lookup on GET `/:id`
+
+### Fixed
+- devTools generators: expanded offset space to eliminate cross-run unique constraint collisions on seeded usernames
+
+---
+
+## [0.5.2] — 2026-05-30
+
+### Added
+- Sentry error reporting integration
+- Structured security event logging (failed logins, 403s, 429s)
+- Health check endpoint with graceful shutdown and request logging
+- BBCode parser for profile rendering
+- `FeaturedAlbum.image` field wired through home endpoint and AOTM create
+- CI checks: lint, format, OpenAPI freshness
+
+### Changed
+- Business logic extracted from user and auth route handlers into domain modules
+- Seed generator byte accounting fixed; devTools generator offset space expanded
+- Rate limiting expanded to all write endpoints and download grants
+- Integration test coverage: contributions, downloads, PM, permission loading
+
+### Fixed
+- Forum trash handling, BBCode Prettier conflicts, integration timeouts
+- Report source URLs for Artist and Comment target types
+- Sentry type lint error
+- Test suite flakiness: persistent supertest server, worker force-exit, empty setup stub removed
+
+---
+
+## [0.5.1] — 2026-05-28
+
+### Changed
+- Release backend refactored into workbench modules
+- Forum topic model deepened: `topicSession` module and session endpoint
+- Request lifecycle deepened: detail, vote, history, and auth moved into module
+- Pagination deepened: `paginationBase`, `parsedPage`, `validateQuery` on all list routes
+- `registerUser` deepened: invite gate and consumption moved into module
+- `isModerator` replaced with granular permission checks at all call sites (ADR-0001)
+
+### Added
+- `GET /tools/user-ranks/permissions` endpoint; static `permissionCatalog` duplicate removed
+- Missing OpenAPI specs; forum topic trash endpoint
+
+### Fixed
+- Integration test calls to `registerUser` after options-object refactor
+- Release workbench lint issues
+- DownloadAccessGrant FK fields and cleanup ordering
+
+---
+
+## [0.5.0] — 2026-05-19
+
+### Added
+- Comprehensive unit test coverage across all API routes and modules
+- Permissions middleware spec; comment schema cross-page validation tests
+- Coverage for: auth, PM, forum, top10, communities, reports, requests, collages, wiki, search, downloads, notifications, bookmarks, posts, profile, announcements, settings, tools, subscriptions, stats, home, stylesheet, random, user, artist, DNU, poll
+
+### Fixed
+- Comment targets for contributions and requests
+- Reports module mock completeness
+- Test suite Prettier formatting
+
+---
+
+## [0.4.99] — 2026-05-27 _(alias: v0.4.9)_
+
+### Added
+- Staff toolbox: generate test data API (Phases A–C) — user, community, release, forum, wiki, moderation generators seeded from real music library data and publicly available packaging data rates
+
+---
+
+## [0.4.9] — 2026-05-17
+
+### Added
+- Top 10 leaderboards with TTL caching and snapshot persistence
+- Release voting and tag management
+
+### Changed
+- `upload`/`download` renamed to `contribute`/`consume` throughout (domain language alignment)
+- Staff PMs bifurcated from user private conversations into dedicated staff inbox
+
+---
+
+## [0.3.9] — 2026-05-17
+
+### Added
+- **Economy**: download grants, ratio calculation, ratio watch state machine, link health checks and approval workflow, requests/bounty system
+- **Communities**: download URLs, domain gate via SiteSettings, per-community `allowDuplicateFormats`
+- **Collages**: full CRUD with personal collage limits per user rank
+- **PM + Staff Inbox**: private messaging system; support tickets unified with PM conversations
+- **Reports**: content moderation and reporting system
+- **Wiki**: API with revision history, aliases, and page comparison
+- **Search**: cross-domain search and random release endpoints
+- **Profile**: aggregate visibility controls, donor presentation, staff surfaces; accepts username or numeric ID
+- **Bookmarks**: artist, release, community, request bookmark CRUD
+- **Site history**, DNU list management, moderation tooling, donor ranks
+- **Auth payload**: contribute/consume/ratio stats included on login
+- **Notifications**: subscription events, request fills, read-tracking
+- **Ratio policy**: staff override routes with OpenAPI contracts
+- Dev QoL: lint-staged, seed script, Dockerfile improvements
+
+### Fixed
+- Boolean query-param parsing in report and ticket queues
+- Five UX bugs in ticket workflow
+- Install flow: survive DB resets; launch checklist handling
+- Feature drift: auth, communities, reports, and email bug fixes
+
+---
+
+## [0.3.4] — 2026-04-24 _(Phase 4)_
+
+### Fixed
+- `parsedParams` ESLint import conflict reverted and reworked
+- DOMPurify mock converted to TypeScript
+- Integration script and Codacy parsing errors
+
+---
+
+## [0.3.3] — 2026-04-23 _(Phase 3)_
+
+### Added
+- DB-backed integration test harness
+- Codacy artifact exclusions
+
+---
+
+## [0.3.2] — 2026-04-23 _(Phase 2)_
+
+### Changed
+- Business logic extracted from route files into service modules (auth, stats, comment, artist)
+- `AuthenticatedRequest` introduced; `req.user!` assertions eliminated
+- Error envelope fully standardized: `{ msg }` replaces legacy `{ errors: [] }` shape
+- Mutation response contracts normalized across posts, forum, announcements
+- Parsed body and parsed params rolled out across all handlers
+- Forum logic fully extracted to modules; OpenAPI schema gaps filled
+
+### Fixed
+- `Post.comments` and `ForumPost.edits` normalized from JSON to relational tables
+- 30-day audit fixes: batch collaborator upsert, `express-validator` removed
+
+---
+
+## [0.3.1] — 2026-04-23 _(Phase 1)_ _(alias: v0.4.1)_
+
+### Changed
+- Full audit remediation: C1–C7, H1–H6, M1–M7, L1–L4
+- Routes reorganized from `sections/` into domain-based directory structure
+- `install.ts` schemas split into domain schema files
+- Error envelope standardized; auth middleware hardened
+- Zod validation added to 8 previously unvalidated mutating handlers
+- `installLimiter` wired; missing CRUD operations completed
+- Audit log model and trail wired to admin/mod actions
+- Transaction boundaries added; moderator overrides on forum mutations
+- HTML sanitization on all free-text input fields
+- Pagination added to all unbounded list endpoints
+- Codacy ESLint warnings resolved; `package-lock.json` tracked
+
+---
+
+## [0.3.0] — 2026-04-23
+
+### Added
+- Jest API contract coverage (domain-split)
+- Workflow actions pinned; CI test setup hardened
+
+---
+
+## [0.2.5] — 2026-04-23
+
+### Added
+- `validateParams` and `validateQuery` helpers — reusable param/query validation
+- Param validation rolled out: forum topics, forum posts, communities routes
+- Homepage featured content and hardened poll reads
+- Profile contracts and invite tree documented in OpenAPI
+- Artist, forum, stats, announcements, notifications OpenAPI expansion
+
+### Fixed
+- Forum auth guards and install OpenAPI sync
+
+---
+
+## [0.2.0] — 2026-04-23
+
+### Added
+- Prisma-backed installation flow and API routes
+- `GET /api/stats` endpoint
+- Audit hardening: core infra, permissions, auth, Zod validation, rate limiting
+- `AuditLog` model wired to admin and mod actions
+- Transaction boundaries on forum topic/post mutations
+- HTML sanitization on all free-text inputs
+- Pagination on list endpoints
+- Artist DELETE and full announcements CRUD
+
+### Changed
+- Routes reorganized into domain-based directories
+- Schemas split by domain
+- Error envelope standardized (P5/P6)
+- `express-validator` replaced with Zod
+
+### Fixed
+- Poll field sanitization; 201 status codes corrected
+- Codacy ESLint warnings resolved
+
+_Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a04` `77665dc`)_
+
+---
+
+## [0.1.0] — 2026-04-22
+
+### Added
+- Full Prisma schema with stub models: User, Community, Artist, Release, Tag, enums
+- Relational fields: consumer/contributor/invite stubs
+- User route scaffolding and Prisma connection
+- Docker image publish workflow; `.dockerignore`
+- Dev environment setup guide and skeleton README
+- Web server and Dockerfile
+
+### Changed
+- Converted codebase to TypeScript
+- Environment variable names unified across UI and API
+- Config keys and logging type errors resolved
+
+---
+
+## [0.0.1] — 2024-02-14
+
+### Added
+- Initial import: project scaffolding, config, formatting baseline
+
+---
+
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/orphic-inc/stellar-api/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/orphic-inc/stellar-api/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/orphic-inc/stellar-api/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/orphic-inc/stellar-api/compare/v0.4.99...v0.5.0
+[0.4.99]: https://github.com/orphic-inc/stellar-api/compare/v0.4.9...v0.4.99
+[0.4.9]: https://github.com/orphic-inc/stellar-api/compare/v0.3.9...v0.4.9
+[0.3.9]: https://github.com/orphic-inc/stellar-api/compare/v0.3.4...v0.3.9
+[0.3.4]: https://github.com/orphic-inc/stellar-api/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/orphic-inc/stellar-api/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/orphic-inc/stellar-api/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/orphic-inc/stellar-api/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/orphic-inc/stellar-api/compare/v0.2.5...v0.3.0
+[0.2.5]: https://github.com/orphic-inc/stellar-api/compare/v0.2.0...v0.2.5
+[0.2.0]: https://github.com/orphic-inc/stellar-api/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/orphic-inc/stellar-api/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/orphic-inc/stellar-api/releases/tag/v0.0.1

--- a/src/routes/api/collages.ts
+++ b/src/routes/api/collages.ts
@@ -45,16 +45,6 @@ const entryParamsSchema = z.object({
   releaseId: z.coerce.number().int().positive()
 });
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-const isStaffOrModerator = async (
-  req: AuthenticatedRequest,
-  res: Response
-): Promise<boolean> => {
-  const perms = await loadPermissions(req, res);
-  return !!(perms['collages_moderate'] || perms['staff'] || perms['admin']);
-};
-
 const collageInclude = {
   user: { select: { id: true, username: true, avatar: true } },
   _count: { select: { entries: true, subscriptions: true, bookmarks: true } }
@@ -177,16 +167,20 @@ router.get(
 
     if (!collage) return res.status(404).json({ msg: 'Collage not found' });
 
-    if (collage.isDeleted && !(await isStaffOrModerator(authReq, res))) {
+    const perms = await loadPermissions(authReq, res);
+    const staff = !!(
+      perms['collages_moderate'] ||
+      perms['staff'] ||
+      perms['admin']
+    );
+
+    if (collage.isDeleted && !staff) {
       return res.status(404).json({ msg: 'Collage not found' });
     }
 
     // For personal collages, only owner or staff can view
     if (isPersonal(collage.categoryId)) {
-      if (
-        collage.userId !== authReq.user.id &&
-        !(await isStaffOrModerator(authReq, res))
-      ) {
+      if (collage.userId !== authReq.user.id && !staff) {
         return res.status(403).json({ msg: 'Permission denied' });
       }
     }
@@ -289,7 +283,12 @@ router.put(
     const { id } = parsedParams<{ id: number }>(res);
     const updates = parsedBody<UpdateCollageInput>(res);
     const userId = req.user.id;
-    const staff = await isStaffOrModerator(req, res);
+    const perms = await loadPermissions(req, res);
+    const staff = !!(
+      perms['collages_moderate'] ||
+      perms['staff'] ||
+      perms['admin']
+    );
 
     const collage = await prisma.collage.findUnique({ where: { id } });
     if (!collage || collage.isDeleted)
@@ -374,7 +373,12 @@ router.delete(
   authHandler(async (req, res) => {
     const { id } = parsedParams<{ id: number }>(res);
     const userId = req.user.id;
-    const staff = await isStaffOrModerator(req, res);
+    const perms = await loadPermissions(req, res);
+    const staff = !!(
+      perms['collages_moderate'] ||
+      perms['staff'] ||
+      perms['admin']
+    );
 
     const collage = await prisma.collage.findUnique({ where: { id } });
     if (!collage || collage.isDeleted)
@@ -442,7 +446,12 @@ router.post(
     const { id } = parsedParams<{ id: number }>(res);
     const { releaseId } = parsedBody<AddEntryInput>(res);
     const userId = req.user.id;
-    const staff = await isStaffOrModerator(req, res);
+    const perms = await loadPermissions(req, res);
+    const staff = !!(
+      perms['collages_moderate'] ||
+      perms['staff'] ||
+      perms['admin']
+    );
 
     const collage = await prisma.collage.findUnique({ where: { id } });
     if (!collage || collage.isDeleted)
@@ -553,7 +562,12 @@ router.delete(
       res
     );
     const userId = req.user.id;
-    const staff = await isStaffOrModerator(req, res);
+    const perms = await loadPermissions(req, res);
+    const staff = !!(
+      perms['collages_moderate'] ||
+      perms['staff'] ||
+      perms['admin']
+    );
 
     const collage = await prisma.collage.findUnique({ where: { id } });
     if (!collage || collage.isDeleted)
@@ -597,7 +611,12 @@ router.put(
     const { id } = parsedParams<{ id: number }>(res);
     const { entries } = parsedBody<ReorderEntriesInput>(res);
     const userId = req.user.id;
-    const staff = await isStaffOrModerator(req, res);
+    const perms = await loadPermissions(req, res);
+    const staff = !!(
+      perms['collages_moderate'] ||
+      perms['staff'] ||
+      perms['admin']
+    );
 
     const collage = await prisma.collage.findUnique({ where: { id } });
     if (!collage || collage.isDeleted)


### PR DESCRIPTION
Inline `loadPermissions` at all `collages.ts` call sites (removes `isStaffOrModerator` helper per ADR-0001). Adds CHANGELOG.md.