### PR TITLE
chore: bump version manifest to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Bumps `package.json` `version` to `0.5.3` so the committed manifest matches the latest release tag (`v0.5.3`). It had drifted behind at `0.5.0`.

Surfaced by an end-of-sprint Mr. Robot housekeeping sweep. Manifest-only change.