### PR TITLE
docs: fix redundant greeting in home.md intro

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Greetings and salutations! This in-progress document contains guidance for developing and maintaining Stellar.
+Salutations! This in-progress document contains guidance for developing and maintaining Stellar.
 
 ## Connecting to the Database
 


### PR DESCRIPTION
Narrow prose fix on `docs/home.md`.

## What
"Greetings and salutations!" → "Salutations!" — the two words are redundant (salutations *are* greetings). Aligns main's intro with the phrasing already on `develop`.

## Context
Surfaced while reconciling main↔develop drift. main's `home.md` is intentionally the stripped (non-agent) variant — no Documentation Map, since the agent docs (`AGENTS.md`, `docs/agents/*`) live only on `develop`. The only genuine defect in main's copy was this clumsy greeting. Structure left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)