### PR TITLE
fix(contributions): store sizeInBytes as BIGINT to stop INT4 overflow

### DIFF
--- a/prisma/migrations/20260607000000_contribution_sizeinbytes_bigint/migration.sql
+++ b/prisma/migrations/20260607000000_contribution_sizeinbytes_bigint/migration.sql
@@ -1,0 +1,3 @@
+-- File sizes in bytes overflow INT4 (max 2,147,483,647 ≈ 2.0 GiB).
+-- Widen contributions.sizeInBytes to BIGINT to match approvedAccountingBytes.
+ALTER TABLE "contributions" ALTER COLUMN "sizeInBytes" SET DATA TYPE BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -933,7 +933,7 @@ model Contribution {
   collaborators            Artist[]      @relation("ContributionCollaborators")
   comments                 Comment[]
   downloadUrl              String
-  sizeInBytes              Int?
+  sizeInBytes              BigInt?
   approvedAccountingBytes  BigInt?
   linkStatus               LinkHealthStatus @default(UNKNOWN)
   linkCheckedAt            DateTime?

--- a/src/integration/contributions.integration.ts
+++ b/src/integration/contributions.integration.ts
@@ -108,6 +108,30 @@ describe('createContributionSubmission', () => {
     expect(contributor).not.toBeNull();
   });
 
+  it('stores file sizes larger than INT4 max (>2 GiB) without overflow', async () => {
+    const user = await createUser('big');
+    const community = await createCommunity();
+
+    // 1_040_503_013_376 = 992301 MB * 1048576 — well past INT4 max (2_147_483_647).
+    // Lossless discographies routinely exceed 2 GiB, so sizeInBytes must be 64-bit.
+    const bigSize = 1_040_503_013_376;
+
+    const result = await createContributionSubmission({
+      userId: user.id,
+      input: { ...baseInput(community.id), sizeInBytes: bigSize }
+    });
+
+    expect(result).not.toBeNull();
+    // Contract: sizeInBytes is returned as a JS number (safe < 2^53), not a string.
+    expect(result!.sizeInBytes).toBe(bigSize);
+
+    const persisted = await testPrisma.contribution.findUnique({
+      where: { id: result!.id },
+      select: { sizeInBytes: true }
+    });
+    expect(persisted!.sizeInBytes).toBe(BigInt(bigSize));
+  });
+
   it('reuses an existing artist rather than creating a duplicate', async () => {
     const user = await createUser('b');
     const community = await createCommunity();

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -1,0 +1,9 @@
+/**
+ * Contribution.sizeInBytes is BIGINT in Postgres — file sizes routinely exceed
+ * INT4 (2 GiB). The API contract still exposes it as a JS number (exact below
+ * 2^53 ≈ 9 PB), not the string our global BigInt.toJSON (src/app.ts) would
+ * otherwise emit. Cast at every read site that returns it to a client.
+ */
+export const sizeBytesToNumber = (
+  v: bigint | number | null | undefined
+): number | null => (v == null ? null : Number(v));

--- a/src/modules/contribution.ts
+++ b/src/modules/contribution.ts
@@ -1,5 +1,6 @@
 import { FileType, Prisma, ReleaseCategory, ReleaseType } from '@prisma/client';
 import { prisma } from '../lib/prisma';
+import { sizeBytesToNumber } from '../lib/serialize';
 import { getLogger } from './logging';
 import { checkContributionLink } from './linkHealth';
 import { resolveTagNames } from './tag';
@@ -182,7 +183,10 @@ export const createContributionSubmission = async ({
     })
   );
 
-  return contribution;
+  return {
+    ...contribution,
+    sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes)
+  };
 };
 
 export const addContributionToRelease = async ({
@@ -257,6 +261,9 @@ export const addContributionToRelease = async ({
           err
         })
       );
-      return contribution;
+      return {
+        ...contribution,
+        sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes)
+      };
     });
 };

--- a/src/modules/devTools/generators/contributions.ts
+++ b/src/modules/devTools/generators/contributions.ts
@@ -130,11 +130,8 @@ export async function generateContributions(
       const fileType = pick(CONTRIBUTION_FILE_TYPES, rng);
       const bitrate = pick(BITRATES, rng);
       const media = pick(MEDIA, rng);
-      // sizeInBytes is Int? in schema — convert bigint to number (capped at 2 GB)
-      const sizeInBytes = Math.min(
-        Number(makeFileSizeBytes(rng)),
-        2_000_000_000
-      );
+      // sizeInBytes is BIGINT — no need to cap at INT4 / 2 GB anymore.
+      const sizeInBytes = makeFileSizeBytes(rng);
 
       const contribution = await prisma.contribution.create({
         data: {
@@ -147,7 +144,7 @@ export async function generateContributions(
           ),
           downloadUrl: makeSeedDownloadUrl(releaseId, c),
           sizeInBytes,
-          approvedAccountingBytes: BigInt(sizeInBytes),
+          approvedAccountingBytes: sizeInBytes,
           linkStatus: 'UNKNOWN' as LinkHealthStatus,
           type: fileType,
           bitrate,

--- a/src/modules/releaseBrowse.spec.ts
+++ b/src/modules/releaseBrowse.spec.ts
@@ -25,7 +25,18 @@ describe('releaseBrowse', () => {
       {
         id: 3,
         title: 'Kind of Blue',
-        releaseTags: [{ tag: { id: 7, name: 'jazz', occurrences: 9 } }]
+        releaseTags: [{ tag: { id: 7, name: 'jazz', occurrences: 9 } }],
+        contributions: [
+          {
+            id: 1,
+            type: 'flac',
+            // BIGINT from the DB — must be returned to clients as a number
+            sizeInBytes: 5_000_000_000n,
+            linkStatus: 'UNKNOWN',
+            user: { id: 7, username: 'miles' },
+            _count: { consumers: 0 }
+          }
+        ]
       }
     ] as never);
     prismaMock.release.count.mockResolvedValue(1);
@@ -48,5 +59,7 @@ describe('releaseBrowse', () => {
     expect(result.data[0].tags).toEqual([
       { id: 7, name: 'jazz', occurrences: 9 }
     ]);
+    // sizeInBytes is exposed as a JS number, not a bigint/string
+    expect(result.data[0].contributions[0].sizeInBytes).toBe(5_000_000_000);
   });
 });

--- a/src/modules/releaseBrowse.ts
+++ b/src/modules/releaseBrowse.ts
@@ -1,5 +1,6 @@
 import { RegistrationStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
+import { sizeBytesToNumber } from '../lib/serialize';
 import { AppError } from '../lib/errors';
 import { isCommunityMember } from '../routes/api/communities/communities';
 
@@ -65,6 +66,10 @@ export const listCommunityReleases = async (input: {
   return {
     data: releases.map((release) => ({
       ...release,
+      contributions: release.contributions.map((c) => ({
+        ...c,
+        sizeInBytes: sizeBytesToNumber(c.sizeInBytes)
+      })),
       tags: buildPlainTags(release.releaseTags)
     })),
     total

--- a/src/modules/releaseWorkbench/contributions.ts
+++ b/src/modules/releaseWorkbench/contributions.ts
@@ -1,5 +1,6 @@
 import { FileType, ReleaseHistoryAction } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
+import { sizeBytesToNumber } from '../../lib/serialize';
 import { AppError } from '../../lib/errors';
 import { emitNotifications } from '../../lib/notifications';
 import { addContributionToRelease } from '../contribution';
@@ -94,7 +95,7 @@ export const attachReleaseWorkbenchContribution = async (
         after: {
           contributionId: contribution.id,
           type: contribution.type,
-          sizeInBytes: contribution.sizeInBytes ?? null,
+          sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes),
           contributor: contribution.user?.username ?? null
         } as never,
         snapshot: snapshotRelease(releaseWithTags) as never

--- a/src/routes/api/communities/contributions.ts
+++ b/src/routes/api/communities/contributions.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
 import { prisma } from '../../../lib/prisma';
+import { sizeBytesToNumber } from '../../../lib/serialize';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { createContributionSubmission } from '../../../modules/contribution';
 import { fileReport } from '../../../modules/reports';
@@ -74,7 +75,15 @@ router.get(
       }),
       prisma.contribution.count({ where })
     ]);
-    paginatedResponse(res, contributions, total, pg);
+    paginatedResponse(
+      res,
+      contributions.map((c) => ({
+        ...c,
+        sizeInBytes: sizeBytesToNumber(c.sizeInBytes)
+      })),
+      total,
+      pg
+    );
   })
 );
 
@@ -117,7 +126,10 @@ router.get(
     });
     if (!contribution)
       return res.status(404).json({ msg: 'Contribution not found' });
-    res.json(contribution);
+    res.json({
+      ...contribution,
+      sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes)
+    });
   })
 );
 

--- a/src/schemas/contribution.ts
+++ b/src/schemas/contribution.ts
@@ -15,7 +15,12 @@ export const createContributionSchema = z.object({
   year: z.number().int().min(1900).max(2100),
   fileType: fileTypeEnum,
   downloadUrl: z.string().url('A valid download URL is required'),
-  sizeInBytes: z.number().int().positive().optional(),
+  sizeInBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(Number.MAX_SAFE_INTEGER)
+    .optional(),
   tags: z
     .string()
     .optional()
@@ -62,7 +67,12 @@ export type CreateContributionInput = z.infer<typeof createContributionSchema>;
 export const addContributionToReleaseSchema = z.object({
   fileType: fileTypeEnum,
   downloadUrl: z.string().url('A valid download URL is required'),
-  sizeInBytes: z.number().int().positive().optional(),
+  sizeInBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(Number.MAX_SAFE_INTEGER)
+    .optional(),
   releaseDescription: z
     .string()
     .optional()


### PR DESCRIPTION
## Bug
Creating a contribution with a file size over ~2 GiB fails:
`ConversionError: Unable to fit integer value '1040503013376' into an INT4 (32-bit signed integer)` at `contribution.ts` → `tx.contribution.create`.

`992301 MB × 1048576 = 1,040,503,013,376` bytes, but `contributions.sizeInBytes` was `Int` (INT4, max 2,147,483,647 ≈ 2.0 GiB). Lossless discographies routinely exceed that. **Present on `main` → affects production.**

## Root cause
`sizeInBytes Int?` while its sibling `approvedAccountingBytes` is already `BigInt?`. Zod had no upper bound, so the oversized value passed validation and died at the DB. The recent commit `83906f4` fixed the *neighbouring* `approvedAccountingBytes` column and left `sizeInBytes` untouched — `sizeInBytes` was never BigInt on any branch.

## Fix
- `schema.prisma`: `sizeInBytes Int? → BigInt?` + migration `ALTER COLUMN ... SET DATA TYPE BIGINT`
- New `lib/serialize.ts#sizeBytesToNumber` — cast bigint→number at **every client-facing read** (create, addToRelease, releaseBrowse, releaseWorkbench snapshot, GET list + GET /:id) so the API contract stays a **number** (exact < 2^53), not the string our global `BigInt.toJSON` would emit
- Zod `.max(Number.MAX_SAFE_INTEGER)` precision guard
- Dropped the now-stale 2 GB cap in the seed generator

## Tests
- New integration test: create a contribution with `sizeInBytes = 1_040_503_013_376` → persists + round-trips as a number (RED before, GREEN after)
- contributions 7/7, downloads 5/5, downloads + releaseBrowse unit 12/12; tsc + eslint clean
- (Unrelated pre-existing parallel-run flakiness in install/posts/docs specs — pass in isolation)

## ⚠️ Promotion
Production bug lives on `main`; `develop` is mid-reconciliation (#80). Decide whether to also fast-track this to `main` rather than wait for the develop↔main dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)