### PR TITLE
docs: PRD-01 (stylesheet themes + adoption scoring) + ADR-0002 stub

### DIFF
--- a/docs/adr/0002-stylesheet-injection-isolation.md
+++ b/docs/adr/0002-stylesheet-injection-isolation.md
@@ -1,0 +1,14 @@
+# Stylesheet injection isolation & sanitization
+
+**Status: Proposed — decision pending.** Stub recording the decision to be made; see [PRD-01](../prd/01-stylesheet-themes-and-scoring.md).
+
+User-supplied stylesheets (`profile.externalStylesheet`, a URL) are injected site-wide by the stellar-ui `StylesheetInjector`. This is a trust boundary: an unsanitized user stylesheet can break the app chrome (leak past its intended scope) or carry an injection/exfiltration vector. The URL is already format-validated (`z.string().url()`), but format validation is not safety.
+
+Decision to record here (not yet made):
+
+- **Isolation:** how user CSS is scoped so it cannot override app chrome — a global-CSS-reset boundary (e.g. `all: revert` on a container, per MDN) around the injected sheet vs. an iframe/shadow-DOM sandbox.
+- **Sanitization / fetch policy:** whether stylesheets are proxied/fetched + scanned server-side, restricted to an allowlist of hosts, or constrained by CSP (`style-src`), and how `url()`/`@import` inside user CSS are handled.
+
+The adoption-**scoring** anti-abuse model (the +10/+100 self-dealing risk) is a separate decision tracked as an open question in PRD-01 and may get its own ADR.
+
+_Fill in the chosen approach and consequences once decided._

--- a/docs/prd/01-stylesheet-themes-and-scoring.md
+++ b/docs/prd/01-stylesheet-themes-and-scoring.md
@@ -1,0 +1,48 @@
+# PRD-01 — Stylesheet Themes & Adoption Scoring
+
+**Status:** Draft · **Owner:** @obrien-k · **Related:** [ADR-0002](../adr/0002-stylesheet-injection-isolation.md), stellar-ui StylesheetInjector, [stellar-ui#65](https://github.com/orphic-inc/stellar-ui/issues/65)
+
+> Lean PRD. Captures the decided shape and the open questions — not an exhaustive spec. Resolve the open questions before building the scoring path.
+
+## Problem
+
+Users want to theme their own profile and the site they browse (the `/private` universal theme). Today that's a static set of built-in stylesheets with no way for users to contribute their own look or get credit for one others adopt.
+
+## Goals
+
+- Let users select a site/profile theme from built-in **and** user-supplied stylesheets.
+- Let a user publish their own stylesheet (via profile `externalStylesheet`) and earn recognition when others adopt it.
+- Make good themes socially visible (contests / leaderboards) without compromising site safety.
+
+## Non-goals
+
+- A full CSS editor in-app (users supply a URL for now).
+- Per-page / per-route theming (theme is account-level).
+
+## Feature shape (decided)
+
+1. **Built-in themes:** `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`.
+   - **Sublime is the base/default theme**, _and_ a seeded selectable option, _and_ the reference design the contest feature is modeled on. It is the **reset target** for the injector's global-CSS-reset. (Authoring tracked separately — net-new, never written.)
+2. **User profile stylesheet:** `profile.externalStylesheet` — a URL, validated (`z.string().url()`, restored in stellar-api). Applied site-wide via the stellar-ui **StylesheetInjector**, which wraps user CSS in a **global reset boundary** so a user stylesheet cannot leak into / break the app chrome.
+3. **Adoption scoring:** when user A _sets_ user B's published stylesheet as their active theme, community-score accrues — **adopter (A) +10, author/supplier (B) +100**. The heavy author bonus is the incentive to design good themes.
+4. **Contests:** periodic stylesheet contests layer on top of the adoption signal (bonus incentive).
+
+## Open questions (resolve before building scoring)
+
+- **🔴 Anti-abuse on the +100 author bonus.** As specified it's a self-dealing magnet (sockpuppet adopts author's sheet → farm +100/puppet). Candidate controls — _unanswered, needs a decision:_
+  - unique-adopter-only (one accrual per distinct adopter)
+  - per-author cap / diminishing returns
+  - staff-curated contest rounds gate the bonus
+  - accrual only above an adoption threshold / for accounts past some trust bar
+  - This likely warrants its own ADR once chosen.
+- **Score computation model.** Computed-on-read (per the LinkHealth/community-health-pulse approach) vs. materialized? Affects where adoption events are counted.
+- **Injection safety.** Sanitization/sandboxing of user-controlled CSS + the reset boundary — see ADR-0002.
+
+## Cross-repo surfaces
+
+- **stellar-ui:** `StylesheetInjector.tsx` (+ spec, global reset), theme selector, `src/stylesheets/<theme>/`.
+- **stellar-api:** `profile.externalStylesheet` validation, community-score adoption accrual, contest endpoints.
+
+## Out-of-band but related
+
+- [stellar-ui#65](https://github.com/orphic-inc/stellar-ui/issues/65) — human-friendly contribution file-size input (contribution flow, not theming; cross-linked only because it surfaced in the same pass).


### PR DESCRIPTION
Gives **PRD-01 a home** at `docs/prd/01-stylesheet-themes-and-scoring.md` — it was referenced everywhere (Sublime authoring, StylesheetInjector global-reset, the +10/+100 community-score adoption mechanic, ADR-0002, the size-input flow) but never existed.

Lean by design — records the *decided* shape and flags the unresolved bits rather than over-specifying:

**Decided & captured:** built-in themes incl. Sublime as base/default + selectable + contest reference; user `externalStylesheet` injected via StylesheetInjector behind a global-CSS-reset boundary; adoption scoring (adopter +10, author +100); contests.

**🔴 Flagged as open (no decision invented):** anti-abuse on the +100 author bonus (sockpuppet self-dealing) — candidate controls listed; needs a call before the scoring path is built. Also: score computation model (computed-on-read?) and injection safety.

**ADR-0002** stubbed for the injection isolation/sanitization decision (status: proposed — pending). Note: confirm whether ADR-0002's intended scope is injection-safety (as stubbed) or the scoring model — easy to retitle.

Docs only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)