### PR TITLE
docs: PRD-03 (stylesheet themes + scoring) + bring PRD-01 forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,33 @@
 
 This is the Node.js API backend for **Stellar**, a modern, next-generation community content tracker and forum software.
 
+Stellar is an invite-only (`/private/`) platform built around **Communities** with granular permissions, member contributions, and a **Community Reputation Score (CRS)** that rewards long-term, healthy participation.
+
+## What's here
+
+- **Communities, membership & staff** — invite tree, roles, granular per-permission checks ([ADR-0001](docs/adr/0001-granular-permission-checks.md)).
+- **Contributions & releases** — track releases, ratio accounting (contributed/consumed), download cost ledger.
+- **Community Reputation Score (CRS)** — composite reputation across social, contribution, donation, and longevity signals ([PRD-01](docs/prd/01-Community-Score.md)); fed by a community-health pulse ([ADR-0002](docs/adr/0002-community-health-pulse.md)).
+- **Stylesheets & theming** — built-in + user-authored themes with adoption scoring ([PRD-03](docs/prd/03-stylesheet-themes-and-scoring.md), [ADR-0003](docs/adr/0003-stylesheet-injection-isolation.md)).
+- **Link health** — periodic checks on contribution links, flapping detection, staff escalation, stale-link sweep.
+
+## Documentation
+
+The README is the lamp-post; specs and decisions live in [`docs/`](docs/):
+
+| Doc                                                                                          | Covers                                       |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| [PRD-01 — Community-Score / CRS](docs/prd/01-Community-Score.md)                             | reputation model, dimensions, roadmap        |
+| [PRD-03 — Stylesheet themes & scoring](docs/prd/03-stylesheet-themes-and-scoring.md)         | themes, author stylesheets, CRS weights      |
+| [ADR-0001 — Granular permission checks](docs/adr/0001-granular-permission-checks.md)         | why no role convenience functions            |
+| [ADR-0002 — Community-health pulse → CRS](docs/adr/0002-community-health-pulse.md)           | pulse persistence + CRS folding _(proposed)_ |
+| [ADR-0003 — Stylesheet injection isolation](docs/adr/0003-stylesheet-injection-isolation.md) | user-CSS sandbox/reset _(proposed)_          |
+| [`docs/agents/`](docs/agents/) · [CONTEXT.md](CONTEXT.md) · [AGENTS.md](AGENTS.md)           | domain language, agent/dev guides            |
+
+> PRD numbering: **PRD-01** Community-Score · **PRD-02** Donations/IRC/Announce · **PRD-03** Stylesheets · **PRD-04** Contribution/Release/Music.
+
 ## Tech Stack
+
 - **Runtime**: Node.js (LTS)
 - **Framework**: Express.js
 - **Database**: PostgreSQL with Prisma ORM
@@ -20,10 +46,12 @@ See the [stellar-compose](https://github.com/orphic-inc/stellar-compose) reposit
 If you prefer to run the API directly on your local machine for development:
 
 ### 1. Prerequisites
+
 - Node.js (LTS version)
 - A running PostgreSQL instance
 
 ### 2. Installation
+
 ```bash
 git clone https://github.com/orphic-inc/stellar-api.git
 cd stellar-api
@@ -31,25 +59,30 @@ npm install
 ```
 
 ### 3. Environment Variables
+
 Copy `.env.example` to `.env` (or create one) and configure the following variables:
 
 | Variable                   | Description                                    | Default                 |
-|----------------------------|------------------------------------------------|-------------------------|
+| -------------------------- | ---------------------------------------------- | ----------------------- |
 | `DATABASE_URL`             | Prisma connection string to your Postgres DB   | `postgresql://...`      |
-| `STELLAR_AUTH_JWT_SECRET`  | Secret for signing JWTs (must be securely set) | *undefined*             |
+| `STELLAR_AUTH_JWT_SECRET`  | Secret for signing JWTs (must be securely set) | _undefined_             |
 | `STELLAR_LOG_LEVEL`        | Winston log level (e.g., debug, info, error)   | `info`                  |
 | `STELLAR_HTTP_PORT`        | API listening port                             | `8080`                  |
 | `STELLAR_HTTP_CORS_ORIGIN` | Allowed CORS origin (usually the UI url)       | `http://localhost:3000` |
 
 ### 4. Database Setup
+
 Before running the app, ensure your database schema is initialized and the Prisma Client is generated:
+
 ```bash
 npx prisma migrate dev
 npx prisma generate
 ```
 
 ### 5. Running the API
+
 Start the server in development mode (with hot-reloading):
+
 ```bash
 npm run dev
 ```
@@ -58,19 +91,23 @@ npm run dev
 
 Stellar relies on an OpenAPI specification to maintain type-safety between the API and the UI.
 When you make changes to Zod schemas or API routes, you must export the new OpenAPI spec:
+
 ```bash
 npm run openapi:export
 ```
+
 This generates an `openapi.json` file in the project root. The `stellar-ui` repository will read this file to generate its frontend TypeScript types.
 
 ## Testing
 
 Run the test suite:
+
 ```bash
 npm run test
 ```
 
 Run integration tests (requires a `stellar_test` database and `.env.test` file):
+
 ```bash
 npm run test:integration
 ```

--- a/docs/adr/0002-community-health-pulse.md
+++ b/docs/adr/0002-community-health-pulse.md
@@ -1,0 +1,14 @@
+# Community-health pulse → CommunityScore
+
+**Status: Proposed — future direction.** Serves [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md); tracked by [#75](https://github.com/orphic-inc/stellar-api/issues/75).
+
+Stellar computes a community-health signal on read (`getCommunityHealthPulse`). The decision recorded here is how that pulse becomes a durable input to the CommunityReputationScore (CRS).
+
+Decision to record (not yet finalized):
+
+- **Persistence:** snapshot the pulse over time (mirror `statsHistory`) for trend analysis vs. recompute-on-read only.
+- **Folding into CRS:** how the pulse feeds the `CommunityScore` dimension of `CommunityReputationScore`, and ultimately a `CommunityValueIndex`.
+
+This is the ADR the stylesheet-scoring work ([PRD-03](../prd/03-stylesheet-themes-and-scoring.md)) and other CRS dimensions reference for "computed-on-read vs. event-logged" accrual.
+
+_Fill in the chosen approach and consequences once decided._

--- a/docs/adr/0003-stylesheet-injection-isolation.md
+++ b/docs/adr/0003-stylesheet-injection-isolation.md
@@ -1,0 +1,12 @@
+# Stylesheet injection isolation & sanitization
+
+**Status: Proposed — decision pending.** Records the decision to be made; see [PRD-03](../prd/03-stylesheet-themes-and-scoring.md). (ADR-0002 is reserved for community-health-pulse, [#75](https://github.com/orphic-inc/stellar-api/issues/75).)
+
+User-supplied stylesheets (`profile.externalStylesheet` / AuthorStylesheetUrl) are injected site-wide by the stellar-ui `StylesheetInjector`. This is a trust boundary: an unscoped user stylesheet can break the app chrome or carry an injection/exfiltration vector. The URL is format-validated (`z.string().url()`), but format validation is not safety. Mitigated in part by the `/private/` invite-only model, but the injection mechanics still need a decided isolation strategy.
+
+Decision to record here (not yet made):
+
+- **Isolation:** how user CSS is scoped so it cannot override app chrome — a global-CSS-reset boundary (e.g. `all: revert` on a container, per MDN) around the injected sheet vs. iframe/shadow-DOM sandbox. This is the "Global SCSS/CSS reset flag" in PRD-03.
+- **Sanitization / fetch policy:** proxy + scan server-side, host allowlist, CSP `style-src`, and handling of `url()` / `@import` inside user CSS.
+
+_Fill in the chosen approach and consequences once decided._

--- a/docs/prd/01-Community-Score.md
+++ b/docs/prd/01-Community-Score.md
@@ -4,9 +4,18 @@ Version 0.0.1 → 0.0.4
 
 Related Issues
 
-* #60 Friends
-* #61 InviteTree
-* #62 Donations
+- #60 Friends
+- #61 InviteTree
+- #62 Donations
+
+Related Decisions (ADR)
+
+- [ADR-0001](../adr/0001-granular-permission-checks.md) — granular permission checks (CRS gates on per-permission checks)
+- [ADR-0002](../adr/0002-community-health-pulse.md) — community-health-pulse → CommunityScore dimension (#75)
+
+Related PRDs
+
+- [PRD-03](03-stylesheet-themes-and-scoring.md) — stylesheet scoring is a dimension of this CRS
 
 ⸻
 
@@ -30,18 +39,18 @@ Version 0.0.1 through 0.0.4 establishes foundational social signals that will co
 
 The system introduces:
 
-* Friend relationships
-* Invitation genealogy
-* Donation history
-* Community contribution signals
+- Friend relationships
+- Invitation genealogy
+- Donation history
+- Community contribution signals
 
 These systems will eventually integrate with:
 
-* IRC participation
-* RSS consumption and publishing
-* Community activity
-* Moderation actions
-* Longevity and account history
+- IRC participation
+- RSS consumption and publishing
+- Community activity
+- Moderation actions
+- Longevity and account history
 
 ⸻
 
@@ -51,11 +60,11 @@ Current user statistics provide visibility into account activity, but do not ade
 
 They do not adequately measure:
 
-* Community engagement
-* Trustworthiness
-* Cultural contribution
-* Stewardship
-* Long-term investment
+- Community engagement
+- Trustworthiness
+- Cultural contribution
+- Stewardship
+- Long-term investment
 
 As a result, highly valuable members and minimally engaged members may appear equivalent despite vastly different levels of contribution.
 
@@ -69,21 +78,21 @@ A user’s reputation should reflect their overall contribution to the preservat
 
 The system should reward:
 
-* Longevity
-* Reliability
-* Participation
-* Referrals
-* Communication
-* Community stewardship
-* Financial support
+- Longevity
+- Reliability
+- Participation
+- Referrals
+- Communication
+- Community stewardship
+- Financial support
 
 The system should discourage:
 
-* Disposable accounts
-* Short-term participation
-* Invitation abuse
-* Community extraction without contribution
-* Reputation manipulation
+- Disposable accounts
+- Short-term participation
+- Invitation abuse
+- Community extraction without contribution
+- Reputation manipulation
 
 ⸻
 
@@ -140,10 +149,10 @@ Formula
 Initial implementation:
 
 CommunityReputationScore =
-  FriendsScore +
-  InviteScore +
-  DonationScore +
-  LongevityScore
+FriendsScore +
+InviteScore +
+DonationScore +
+LongevityScore
 
 Future versions may introduce:
 
@@ -169,22 +178,22 @@ Requirements
 
 Users may:
 
-* Send friend requests
-* Accept requests
-* Remove friends
+- Send friend requests
+- Accept requests
+- Remove friends
 
 ⸻
 
 Model
 
 FriendRelationship {
-  requesterId
-  recipientId
-  status:
-    | pending
-    | accepted
-    | rejected
-  createdAt
+requesterId
+recipientId
+status:
+| pending
+| accepted
+| rejected
+createdAt
 }
 
 ⸻
@@ -199,9 +208,9 @@ The system should prioritize relationship quality, account reputation, and netwo
 
 Future versions may consider:
 
-* Friend account age
-* Mutual communities
-* Interaction frequency
+- Friend account age
+- Mutual communities
+- Interaction frequency
 
 ⸻
 
@@ -221,21 +230,21 @@ Requirements
 
 Track:
 
-* Inviter
-* Invitee
-* Tree depth
-* Branch relationships
+- Inviter
+- Invitee
+- Tree depth
+- Branch relationships
 
 ⸻
 
 Model
 
 InviteTree {
-  parentUserId
-  childUserId
-  level
-  branch
-  createdAt
+parentUserId
+childUserId
+level
+branch
+createdAt
 }
 
 ⸻
@@ -246,17 +255,17 @@ Users inherit reputation from successful invitations.
 
 Positive signals:
 
-* Active invitees
-* Long-lived invitees
-* Contributing invitees
-* High reputation invitees
+- Active invitees
+- Long-lived invitees
+- Contributing invitees
+- High reputation invitees
 
 Negative signals:
 
-* Banned invitees
-* Dormant invitees
-* Abandoned accounts
-* Warned invitees
+- Banned invitees
+- Dormant invitees
+- Abandoned accounts
+- Warned invitees
 
 ⸻
 
@@ -273,11 +282,11 @@ Financial support may contribute to reputation, but donations must never outweig
 Model
 
 Donation {
-  userId
-  amount
-  currency
-  campaign
-  createdAt
+userId
+amount
+currency
+campaign
+createdAt
 }
 
 ⸻
@@ -286,10 +295,10 @@ Requirements
 
 Support:
 
-* One-time donations
-* Recurring donations
-* Anonymous donations
-* Campaign attribution
+- One-time donations
+- Recurring donations
+- Anonymous donations
+- Campaign attribution
 
 ⸻
 
@@ -300,8 +309,8 @@ Donation value should not dominate reputation.
 Instead:
 
 DonationScore =
-  supportConsistency +
-  supportLongevity
+supportConsistency +
+supportLongevity
 
 The goal is recognition, not pay-to-win.
 
@@ -333,17 +342,17 @@ Planned for v0.1.x
 
 Measures:
 
-* Presence
-* Conversation participation
-* Community engagement
-* Event coordination
+- Presence
+- Conversation participation
+- Community engagement
+- Event coordination
 
 Potential weighting:
 
 IRCScore =
-  activity *
-  consistency *
-  channelQuality
+activity _
+consistency _
+channelQuality
 
 ⸻
 
@@ -351,16 +360,16 @@ RSS / Feed Activity
 
 Measures:
 
-* Feed publishing
-* Feed subscriptions
-* Announcement participation
+- Feed publishing
+- Feed subscriptions
+- Announcement participation
 
-Potential weighting: 
+Potential weighting:
 
 FeedScore =
-  publications +
-  subscriptions +
-  engagement
+publications +
+subscriptions +
+engagement
 
 ⸻
 
@@ -370,10 +379,10 @@ Measures:
 
 Recent participation should generally carry greater weight than historical participation, while still recognizing long-term contribution and account longevity.
 
-* Comments
-* Contributions
-* Group creation
-* Community moderation
+- Comments
+- Contributions
+- Group creation
+- Community moderation
 
 ⸻
 
@@ -382,11 +391,12 @@ Community Value Index
 Long-term objective:
 
 CommunityValueIndex =
-  RatioScore
-+ CommunityReputationScore
-+ CommunityParticipationScore
-+ IRCScore
-+ FeedScore
+RatioScore
+
+- CommunityReputationScore
+- CommunityParticipationScore
+- IRCScore
+- FeedScore
 
 This score represents the overall value a member contributes to Stellar.
 
@@ -394,17 +404,17 @@ CommunityReputationScore is intended to measure contribution, reliability, and c
 
 In Scope
 
-* Friend relationships
-* InviteTree implementation
-* Donation tracking
-* CommunityReputationScore foundation
-* Profile statistics integration
+- Friend relationships
+- InviteTree implementation
+- Donation tracking
+- CommunityReputationScore foundation
+- Profile statistics integration
 
 Out of Scope
 
-* IRC scoring
-* RSS scoring
-* Community participation scoring
-* Moderation scoring
-* Automated weighting algorithms
-* CommunityValueIndex calculation
+- IRC scoring
+- RSS scoring
+- Community participation scoring
+- Moderation scoring
+- Automated weighting algorithms
+- CommunityValueIndex calculation

--- a/docs/prd/01-Community-Score.md
+++ b/docs/prd/01-Community-Score.md
@@ -1,0 +1,410 @@
+PRD: Community Reputation
+
+Version 0.0.1 → 0.0.4
+
+Related Issues
+
+* #60 Friends
+* #61 InviteTree
+* #62 Donations
+
+⸻
+
+Executive Summary
+
+This initiative introduces the first generation of Stellar’s Community Reputation System.
+
+Communities thrive when members contribute consistently over time.
+
+Traditional reputation systems often focus on a narrow set of measurable actions. While effective for tracking specific forms of participation, they frequently fail to capture the broader behaviors that sustain healthy communities, such as mentorship, stewardship, relationship building, communication, referrals, and long-term engagement.
+
+Stellar introduces the CommunityReputationScore (CRS), a composite reputation model designed to evaluate a member’s overall contribution to the ecosystem.
+
+The CommunityReputationScore rewards behaviors that strengthen community continuity, encourage participation, and increase the long-term resilience of the platform.
+
+Rather than measuring a single activity, the score aggregates signals across multiple dimensions of participation, including social relationships, referrals, communication, financial support, community involvement, and account longevity.
+
+The objective is not to rank popularity, but to recognize members who actively contribute to the growth, stability, and preservation of the community.
+
+Version 0.0.1 through 0.0.4 establishes foundational social signals that will contribute toward a user’s overall community reputation.
+
+The system introduces:
+
+* Friend relationships
+* Invitation genealogy
+* Donation history
+* Community contribution signals
+
+These systems will eventually integrate with:
+
+* IRC participation
+* RSS consumption and publishing
+* Community activity
+* Moderation actions
+* Longevity and account history
+
+⸻
+
+Problem Statement
+
+Current user statistics provide visibility into account activity, but do not adequately represent a member's overall contribution to the community.
+
+They do not adequately measure:
+
+* Community engagement
+* Trustworthiness
+* Cultural contribution
+* Stewardship
+* Long-term investment
+
+As a result, highly valuable members and minimally engaged members may appear equivalent despite vastly different levels of contribution.
+
+⸻
+
+Vision
+
+The system favors behaviors that increase the likelihood that the community remains active, healthy, and self-sustaining over time.
+
+A user’s reputation should reflect their overall contribution to the preservation and growth of the community.
+
+The system should reward:
+
+* Longevity
+* Reliability
+* Participation
+* Referrals
+* Communication
+* Community stewardship
+* Financial support
+
+The system should discourage:
+
+* Disposable accounts
+* Short-term participation
+* Invitation abuse
+* Community extraction without contribution
+* Reputation manipulation
+
+⸻
+
+Guiding Principles
+
+Continuity Matters
+
+Long-term members contribute institutional knowledge.
+
+Account age should positively influence reputation.
+
+⸻
+
+Reliability Matters
+
+Users who consistently contribute over time should be rewarded.
+
+⸻
+
+Relationships Matter
+
+The quality of a user’s social graph is meaningful.
+
+Trusted users often invite other trusted users.
+
+⸻
+
+Preservation Matters
+
+Actions that preserve knowledge and activity are more valuable than passive consumption.
+
+⸻
+
+Contribution Matters
+
+Users who invest resources into the platform should receive recognition.
+
+⸻
+
+Community Reputation Score
+
+Overview
+
+Every user receives a computed Community Reputation Score.
+
+The score is not a replacement for ratio.
+
+Instead, it serves as an additional measure of community value.
+
+⸻
+
+Formula
+
+Initial implementation:
+
+CommunityReputationScore =
+  FriendsScore +
+  InviteScore +
+  DonationScore +
+  LongevityScore
+
+Future versions may introduce:
+
+IRCScore
+FeedScore
+CommunityScore
+ModerationScore
+ContributionScore
+
+⸻
+
+Friends System
+
+Purpose
+
+Represent trust relationships between users.
+
+Friends provide a lightweight social graph.
+
+⸻
+
+Requirements
+
+Users may:
+
+* Send friend requests
+* Accept requests
+* Remove friends
+
+⸻
+
+Model
+
+FriendRelationship {
+  requesterId
+  recipientId
+  status:
+    | pending
+    | accepted
+    | rejected
+  createdAt
+}
+
+⸻
+
+Scoring
+
+Friend count alone should not determine score.
+
+Friend relationships are treated as trust signals rather than popularity indicators.
+
+The system should prioritize relationship quality, account reputation, and network diversity over raw friend counts.
+
+Future versions may consider:
+
+* Friend account age
+* Mutual communities
+* Interaction frequency
+
+⸻
+
+InviteTree
+
+Purpose
+
+Represent referral genealogy.
+
+Invite trees establish accountability and trust inheritance.
+
+Invite relationships are directional and permanent.
+
+⸻
+
+Requirements
+
+Track:
+
+* Inviter
+* Invitee
+* Tree depth
+* Branch relationships
+
+⸻
+
+Model
+
+InviteTree {
+  parentUserId
+  childUserId
+  level
+  branch
+  createdAt
+}
+
+⸻
+
+Scoring
+
+Users inherit reputation from successful invitations.
+
+Positive signals:
+
+* Active invitees
+* Long-lived invitees
+* Contributing invitees
+* High reputation invitees
+
+Negative signals:
+
+* Banned invitees
+* Dormant invitees
+* Abandoned accounts
+* Warned invitees
+
+⸻
+
+Donations
+
+Purpose
+
+Recognize financial support.
+
+Financial support may contribute to reputation, but donations must never outweigh meaningful participation, trust, or community contribution.
+
+⸻
+
+Model
+
+Donation {
+  userId
+  amount
+  currency
+  campaign
+  createdAt
+}
+
+⸻
+
+Requirements
+
+Support:
+
+* One-time donations
+* Recurring donations
+* Anonymous donations
+* Campaign attribution
+
+⸻
+
+Scoring
+
+Donation value should not dominate reputation.
+
+Instead:
+
+DonationScore =
+  supportConsistency +
+  supportLongevity
+
+The goal is recognition, not pay-to-win.
+
+⸻
+
+Profile Integration
+
+Stats Section
+
+Current profile statistics will be expanded.
+
+Example:
+
+Member Since
+Friends
+Invited Users
+Invite Tree Depth
+Donation History
+Community Reputation
+Community Participation
+
+⸻
+
+Future Social Signals
+
+IRC Activity
+
+Planned for v0.1.x
+
+Measures:
+
+* Presence
+* Conversation participation
+* Community engagement
+* Event coordination
+
+Potential weighting:
+
+IRCScore =
+  activity *
+  consistency *
+  channelQuality
+
+⸻
+
+RSS / Feed Activity
+
+Measures:
+
+* Feed publishing
+* Feed subscriptions
+* Announcement participation
+
+Potential weighting: 
+
+FeedScore =
+  publications +
+  subscriptions +
+  engagement
+
+⸻
+
+Community Participation
+
+Measures:
+
+Recent participation should generally carry greater weight than historical participation, while still recognizing long-term contribution and account longevity.
+
+* Comments
+* Contributions
+* Group creation
+* Community moderation
+
+⸻
+
+Community Value Index
+
+Long-term objective:
+
+CommunityValueIndex =
+  RatioScore
++ CommunityReputationScore
++ CommunityParticipationScore
++ IRCScore
++ FeedScore
+
+This score represents the overall value a member contributes to Stellar.
+
+CommunityReputationScore is intended to measure contribution, reliability, and continuity. The system favors behaviors that increase the likelihood that the community remains active, healthy, and self-sustaining over time.
+
+In Scope
+
+* Friend relationships
+* InviteTree implementation
+* Donation tracking
+* CommunityReputationScore foundation
+* Profile statistics integration
+
+Out of Scope
+
+* IRC scoring
+* RSS scoring
+* Community participation scoring
+* Moderation scoring
+* Automated weighting algorithms
+* CommunityValueIndex calculation

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -1,0 +1,82 @@
+# PRD-03 — Stylesheet Themes & Scoring
+
+**Status:** Draft · **Owner:** @obrien-k
+**Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) · **Decision:** [ADR-0003 stylesheet injection isolation](../adr/0003-stylesheet-injection-isolation.md)
+**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
+
+> Lean PRD. Captures the decided shape + the Community-Score weights, flags TBDs, and maps each concept to existing code so this becomes a red-green descent, not greenfield. Stylesheet scoring is a **dimension of PRD-01's CRS**, not a separate score.
+
+## Problem
+
+Stellar is an invite-only `/private/` community site. Users want to theme their own profile and the site (the universal theme), publish their own stylesheet for others, and be rewarded for organic customization/sharing — without opening an injection vector.
+
+## Stylesheet types
+
+| Type                                       | Meaning                                                                                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Built-in / site stylesheets**            | Seeded themes: `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`. **Sublime = default/base + selectable + contest reference** (net-new authoring; reset target).                  |
+| **ExternalStylesheet**                     | A URL on the user's profile (`profile.externalStylesheet`).                                                                                                                          |
+| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` (one per author) saved for others to adopt. **Shape TBD** — depends on ExternalStylesheet + global-reset findings against the current Tailwind theme. |
+| **CommunityStylesheet**                    | Community-scoped theme (TBD — tied to Contests).                                                                                                                                     |
+| **Global SCSS/CSS reset flag**             | Per-injection boundary so a user sheet can't leak into app chrome (see ADR-0003).                                                                                                    |
+
+## Community-Score weights (proposed by PRD owner)
+
+Stylesheet activity accrues into the **CRS** along three recipients:
+
+**Site** (overall KPI score; or a specific admin if later specified):
+
+- Default stylesheet (`Sublime`): **0.1415926535** per user on the default theme.
+- **×3** if changed to another SysOp/staff stylesheet → that score goes to the **SysOp/designer** staff user.
+- **×5** for any non-site-based **Author**.
+
+**User** (rewards organic customization; deliberately not designer-gated):
+
+- Base for setting an AuthorStylesheet to a site default/alternative: **0.1**
+- **×2** when non-default
+- **×3** when a custom ExternalStylesheet / non-self AuthorStylesheet(Url)
+- **×5** when it's the user's **own** authored stylesheet
+- A user on a modified stylesheet: **+1** CRS → to Site (or admin), and to the **Author** if a custom InjectedStylesheet.
+
+**Author** (incentive to design good themes): accrues when others adopt their AuthorStylesheet (exact split TBD with Contests / CommunityStylesheets).
+
+**Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
+
+## Anti-abuse
+
+The `/private/`, invite-only model is the primary control: a sock-puppeteer must beat the **Invitation/InviteTree + Communities + Reporting** tooling, not merely a CSS sandbox. The reset/sandbox boundary (ADR-0003) handles the injection-vector half. Adoption legitimacy therefore leans on existing invite-genealogy + report-upheld signals rather than a bespoke cap. _(Confirm: any per-author cap on top of this, or is invite+report sufficient?)_
+
+## Donor add-ons
+
+**$tylesheets — donor-added slots**: donors unlock additional stylesheet slots (ties to PRD-02 Donations / `donor.ts`).
+
+## Concept → existing code (the descent map)
+
+| Concept                                             | Lives in                                                                                                                                            |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`           |
+| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector` |
+| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                           |
+| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-signal`                                               |
+| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                         |
+| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                               |
+| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                              |
+
+## Out of scope (other PRDs)
+
+- LinkHealth lifecycle (cron/flapping/72h/sweep), MusicModel, Donations/IRC scoring → covered by PRD-01 (CRS dimensions), PRD-02, PRD-04. Referenced here only where they feed stylesheet scoring.
+
+## Red-green descent targets
+
+First testable slices (much of the substrate already exists):
+
+1. **Stylesheet selection → CRS accrual** — pure scoring function over the weights above (unit-testable, no DB): table-driven red-green on each multiplier (default/non-default/external/self/author).
+2. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual.
+3. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
+
+## Open questions
+
+- AuthorStylesheetUrl storage shape (URL vs stored file) — pending ExternalStylesheet + global-reset findings.
+- Whether stylesheet-score accrual is computed-on-read (mirror the pulse) or event-logged.
+- Per-author adoption cap on top of invite+report, or not.
+- IRC scoring belongs to PRD-02 — confirm it's not duplicated here.

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -1,7 +1,7 @@
 # PRD-03 — Stylesheet Themes & Scoring
 
 **Status:** Draft · **Owner:** @obrien-k
-**Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) · **Decision:** [ADR-0003 stylesheet injection isolation](../adr/0003-stylesheet-injection-isolation.md)
+**Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) · **Decisions:** [ADR-0002 community-health-pulse → CRS](../adr/0002-community-health-pulse.md) (accrual model), [ADR-0003 stylesheet injection isolation](../adr/0003-stylesheet-injection-isolation.md)
 **Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
 
 > Lean PRD. Captures the decided shape + the Community-Score weights, flags TBDs, and maps each concept to existing code so this becomes a red-green descent, not greenfield. Stylesheet scoring is a **dimension of PRD-01's CRS**, not a separate score.

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -36,11 +36,26 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 - **×2** when non-default
 - **×3** when a custom ExternalStylesheet / non-self AuthorStylesheet(Url)
 - **×5** when it's the user's **own** authored stylesheet
-- A user on a modified stylesheet: **+1** CRS → to Site (or admin), and to the **Author** if a custom InjectedStylesheet.
+- A user on a modified stylesheet: a **+1** engagement bonus → to Site (or admin), and to the **Author** if a custom InjectedStylesheet.
 
-**Author** (incentive to design good themes): accrues when others adopt their AuthorStylesheet (exact split TBD with Contests / CommunityStylesheets).
+**Tiering (decided).** The +1 is **both** additive **and** folds into the multipliers as a user **tiers up** — engagement escalates like the [`/verbiagating`](../../../skills) tier ladder: each step of customization/sharing compounds the base rather than paying a flat one-off. The flat multipliers above are **tier 0**; the escalation schedule (the curve as a user climbs tiers) is the **next scoring slice** — curve TBD.
+
+**External disposition (decided, #84).** A `profile.externalStylesheet` that resolves to an author is scored as an **AuthorStylesheet** (credit the author). An **authorless** external `.css/.scss` earns the _user_ the customization reward but **nothing to the site** — it's a **prune/investigate** candidate, or, if multiple users share it, a hidden **Community stylesheet**, both handled at the **permission / link-health layer**, not scored here.
+
+**Author** (incentive to design good themes): accrues when others adopt their AuthorStylesheet (exact split TBD with Contests / CommunityStylesheets). **Self-use is not an adoption** — using your own sheet pays the user reward (×5) only, no author bonus (anti-farm, #84).
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
+
+## Negative scoring (decided — the model needs downside)
+
+Rewards alone let bad actors coast; CRS must be able to go **down**.
+
+- **Dead externalUrl** — an `externalStylesheet` whose link is dead/unreachable is **suspicious → negative CRS** for the user hosting it (link-health driven). This is the stylesheet sibling of contribution link-health: a dead link isn't neutral, it's a penalty.
+- **Broader negative CRS lives in PRD-01 (lifetime CRS) + the LinkHealth lifecycle**, referenced here so the stylesheet penalty stays consistent with them:
+  - flapping / unresolved-in-72h links → penalty then sweep
+  - **upheld** reports on contributions → penalty (a heavily-reported user is always suspect)
+  - **repeat offenders** → large-scale lifetime CRS penalties (compounding, the downside mirror of tiering)
+- PRD-03 scope: the dead-external penalty (magnitude TBD — flagged). The lifetime/repeat-offender curves belong to PRD-01 / PRD-04 LinkHealth lifecycle.
 
 ## Anti-abuse
 
@@ -70,13 +85,17 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 
 First testable slices (much of the substrate already exists):
 
-1. **Stylesheet selection → CRS accrual** — pure scoring function over the weights above (unit-testable, no DB): table-driven red-green on each multiplier (default/non-default/external/self/author).
-2. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual.
-3. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
+1. ✅ **Stylesheet selection → CRS accrual** — pure `scoreStylesheetSelection` (no DB), table-driven over each multiplier. **Shipped: [#84](https://github.com/orphic-inc/stellar-api/pull/84)** (tier-0 multipliers; external/self decisions applied).
+2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
+3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
+4. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual.
+5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions
 
 - AuthorStylesheetUrl storage shape (URL vs stored file) — pending ExternalStylesheet + global-reset findings.
 - Whether stylesheet-score accrual is computed-on-read (mirror the pulse) or event-logged.
-- Per-author adoption cap on top of invite+report, or not.
+- **Tiering curve** + **dead-external penalty magnitude** — values TBD.
 - IRC scoring belongs to PRD-02 — confirm it's not duplicated here.
+
+**Resolved:** external disposition (authorless → permission/link-health, not site) · self-use pays no author bonus · per-author cap not needed (the `/private` invite+report model covers it).


### PR DESCRIPTION
Supersedes the closed #82 (which was mis-numbered as PRD-01 and collided with the reserved ADR-0002).

**Numbering established:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music.

**Two commits:**
1. **Bring PRD-01 forward** — `docs/prd/01-Community-Score.md` was stranded on `main` (the Create/Delete/Create churn in #80's divergence); develop lacked it. Now docs + feature code share a base.
2. **PRD-03 + ADR-0003** — stylesheet scoring model (site/user/author CRS weights incl. the `0.1415…`/×3/×5 surface), stylesheet types (Injected/External/Author/AuthorStylesheetUrl/Community + global-reset flag), `/private` invite+report anti-abuse stance, and a **concept → existing-code descent map** (#34, #75, #76, `linkHealth.ts`, `feat/*` branches) so this drives red-green work against real modules. ADR-0003 stubs injection isolation (ADR-0002 reserved for community-health-pulse #75).

Stylesheet scoring is framed as a **dimension of PRD-01's CRS**, not a separate score. Open questions (AuthorStylesheetUrl shape, computed-on-read vs event-log, per-author cap, IRC→PRD-02) flagged inline.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)