### PR TITLE
feat(scoring): stylesheet-selection CRS scoring (PRD-03 red-green slice)

### DIFF
--- a/src/modules/stylesheetScore.spec.ts
+++ b/src/modules/stylesheetScore.spec.ts
@@ -1,0 +1,71 @@
+import { scoreStylesheetSelection } from './stylesheetScore';
+
+// PRD-03 stylesheet scoring (docs/prd/03-stylesheet-themes-and-scoring.md).
+// Pure: CRS deltas for {user, site, author} from a selection event.
+// USER_BASE = 0.1, SITE_BASE = 0.1415926535. Weights are PRD interpretation
+// pending confirmation (see flags in PRD-03); change constants + this spec together.
+const SITE_BASE = 0.1415926535;
+
+describe('scoreStylesheetSelection', () => {
+  it('credits the site its base CRS when a user picks the default theme', () => {
+    const a = scoreStylesheetSelection({
+      userId: 1,
+      origin: { kind: 'site', isDefault: true }
+    });
+    expect(a.user).toBeCloseTo(0.1, 10); // USER_BASE x1
+    expect(a.site).toBeCloseTo(SITE_BASE, 10); // SITE_BASE x1
+    expect(a.author).toBeNull();
+  });
+
+  it('doubles the user reward for a non-default site theme', () => {
+    const a = scoreStylesheetSelection({
+      userId: 1,
+      origin: { kind: 'site', isDefault: false }
+    });
+    expect(a.user).toBeCloseTo(0.2, 10); // USER_BASE x2
+    expect(a.site).toBeCloseTo(SITE_BASE, 10);
+    expect(a.author).toBeNull();
+  });
+
+  it('routes the x3 site bonus to the staff author when adopting a staff stylesheet', () => {
+    const a = scoreStylesheetSelection({
+      userId: 1,
+      origin: { kind: 'staff', authorId: 42 }
+    });
+    expect(a.user).toBeCloseTo(0.3, 10); // USER_BASE x3
+    expect(a.site).toBe(0); // routed away from the site
+    expect(a.author).toEqual({ userId: 42, delta: SITE_BASE * 3 });
+  });
+
+  it('credits the site x5 for a self-set external stylesheet (no author entity)', () => {
+    const a = scoreStylesheetSelection({
+      userId: 1,
+      origin: { kind: 'external' }
+    });
+    expect(a.user).toBeCloseTo(0.3, 10); // USER_BASE x3
+    expect(a.site).toBeCloseTo(SITE_BASE * 5, 10); // FLAG: external x5 -> site (no author)
+    expect(a.author).toBeNull();
+  });
+
+  it('pays the author the x5 bonus when another user adopts their stylesheet', () => {
+    const a = scoreStylesheetSelection({
+      userId: 1,
+      origin: { kind: 'author', authorId: 7 }
+    });
+    expect(a.user).toBeCloseTo(0.3, 10); // adopter: USER_BASE x3
+    expect(a.site).toBe(0);
+    expect(a.author).toEqual({ userId: 7, delta: SITE_BASE * 5 });
+  });
+
+  it('gives the x5 user reward but no author bonus when using your own stylesheet', () => {
+    // FLAG: self-selection is not an "adoption" — author bonus only fires for
+    // OTHER users adopting, so self-use pays the user reward only (anti-farm).
+    const a = scoreStylesheetSelection({
+      userId: 7,
+      origin: { kind: 'author', authorId: 7 }
+    });
+    expect(a.user).toBeCloseTo(0.5, 10); // USER_BASE x5
+    expect(a.site).toBe(0);
+    expect(a.author).toBeNull();
+  });
+});

--- a/src/modules/stylesheetScore.spec.ts
+++ b/src/modules/stylesheetScore.spec.ts
@@ -37,14 +37,14 @@ describe('scoreStylesheetSelection', () => {
     expect(a.author).toEqual({ userId: 42, delta: SITE_BASE * 3 });
   });
 
-  it('credits the site x5 for a self-set external stylesheet (no author entity)', () => {
+  it('rewards the user but credits no site/author for an authorless external (prune/community handled elsewhere)', () => {
     const a = scoreStylesheetSelection({
       userId: 1,
       origin: { kind: 'external' }
     });
-    expect(a.user).toBeCloseTo(0.3, 10); // USER_BASE x3
-    expect(a.site).toBeCloseTo(SITE_BASE * 5, 10); // FLAG: external x5 -> site (no author)
-    expect(a.author).toBeNull();
+    expect(a.user).toBeCloseTo(0.3, 10); // USER_BASE x3 — customization still counts
+    expect(a.site).toBe(0); // unowned external earns the site nothing
+    expect(a.author).toBeNull(); // prune/investigate (or Community) at the permission layer
   });
 
   it('pays the author the x5 bonus when another user adopts their stylesheet', () => {

--- a/src/modules/stylesheetScore.ts
+++ b/src/modules/stylesheetScore.ts
@@ -56,9 +56,13 @@ export const scoreStylesheetSelection = (
       };
 
     case 'external':
-      // Self-set external URL has no author entity to credit, so the x5 accrues
-      // to the site. (FLAG: PRD-03 — could credit no one instead.)
-      return { user: USER_BASE * 3, site: SITE_BASE * 5, author: null };
+      // Authorless external stylesheet: the user's customization still earns the
+      // engagement reward, but NOTHING accrues to the site. An unowned external
+      // .css/.scss is a prune/investigate candidate — or, if other users share it,
+      // a hidden Community stylesheet — resolved at the permission / link-health
+      // layer, not credited here. An external that resolves to an author is scored
+      // as `author` instead.
+      return { user: USER_BASE * 3, site: 0, author: null };
 
     case 'author': {
       const isSelf = origin.authorId === userId;

--- a/src/modules/stylesheetScore.ts
+++ b/src/modules/stylesheetScore.ts
@@ -1,0 +1,76 @@
+/**
+ * PRD-03 stylesheet scoring — docs/prd/03-stylesheet-themes-and-scoring.md.
+ *
+ * Pure function: given a stylesheet-selection event, return the Community
+ * Reputation Score (CRS) deltas for the selecting user, the site, and any
+ * author/staff recipient. No DB — mirrors the pure-scoring style of ratio.ts.
+ *
+ * Weights are pinned from PRD-03 and flagged there as interpretation pending
+ * confirmation; change the constants here + the spec together.
+ */
+
+export type StylesheetOrigin =
+  | { kind: 'site'; isDefault: boolean } // built-in site stylesheet (default = Sublime)
+  | { kind: 'staff'; authorId: number } // authored by a SysOp/staff user
+  | { kind: 'external' } // user's own external stylesheet URL
+  | { kind: 'author'; authorId: number }; // a user-authored stylesheet
+
+export interface StylesheetSelection {
+  userId: number;
+  origin: StylesheetOrigin;
+}
+
+export interface CrsAccrual {
+  /** CRS to the selecting user (reward for customizing). */
+  user: number;
+  /** CRS to the site's own KPI score. */
+  site: number;
+  /** CRS routed to a staff/author recipient, if any. */
+  author: { userId: number; delta: number } | null;
+}
+
+const USER_BASE = 0.1;
+const SITE_BASE = 0.1415926535;
+
+export const scoreStylesheetSelection = (
+  selection: StylesheetSelection
+): CrsAccrual => {
+  const { userId, origin } = selection;
+
+  switch (origin.kind) {
+    case 'site':
+      // Built-in theme: site keeps its base; user reward doubles off-default.
+      return {
+        user: USER_BASE * (origin.isDefault ? 1 : 2),
+        site: SITE_BASE,
+        author: null
+      };
+
+    case 'staff':
+      // Adopting a staff-authored theme: the x3 bonus is routed to that staff
+      // member, not the site.
+      return {
+        user: USER_BASE * 3,
+        site: 0,
+        author: { userId: origin.authorId, delta: SITE_BASE * 3 }
+      };
+
+    case 'external':
+      // Self-set external URL has no author entity to credit, so the x5 accrues
+      // to the site. (FLAG: PRD-03 — could credit no one instead.)
+      return { user: USER_BASE * 3, site: SITE_BASE * 5, author: null };
+
+    case 'author': {
+      const isSelf = origin.authorId === userId;
+      // Self-use is not an adoption — pay only the user reward, no author bonus
+      // (FLAG: PRD-03 anti-farm interpretation). Others adopting pay the author x5.
+      return {
+        user: USER_BASE * (isSelf ? 5 : 3),
+        site: 0,
+        author: isSelf
+          ? null
+          : { userId: origin.authorId, delta: SITE_BASE * 5 }
+      };
+    }
+  }
+};


### PR DESCRIPTION
First red-green slice of [PRD-03](docs/prd/03-stylesheet-themes-and-scoring.md): a **pure** `scoreStylesheetSelection` that returns CRS deltas for `{user, site, author}` from a selection event. No DB — mirrors `ratio.ts`. Table-driven tests (6/6) pin the weights as executable spec.

| Selected origin | user | site | author |
|---|---|---|---|
| site default | 0.1 | 0.1415926535 | — |
| site non-default | 0.2 | 0.1415926535 | — |
| staff-authored | 0.3 | 0 | staff ×3 |
| external URL | 0.3 | ×5 | — |
| author (other) | 0.3 | 0 | author ×5 |
| author (self) | 0.5 | 0 | — |

**🚩 Flagged interpretations to confirm** (cheap to change — constants + spec together):
1. **external URL** → ×5 routed to the **site** (no author entity to credit).
2. **self-use** pays the user reward only, **no author bonus** — author ×5 fires only when *another* user adopts (anti-farm; aligns with the `/private` invite+report stance).

**Deferred** (next tests, once confirmed): the *"+1 on a modified stylesheet → Site/admin + Author"* rule (overlaps the multipliers — needs your call on additive vs folded), and wiring this into the actual selection endpoint (integration slice).

ADR for accrual model: [ADR-0002](docs/adr/0002-community-health-pulse.md) (computed-on-read vs event-logged still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)