### PR TITLE
docs: PRD-05 (Rules & Governance) + ADR-0004

### DIFF
--- a/docs/adr/0004-standing-warnings-bans.md
+++ b/docs/adr/0004-standing-warnings-bans.md
@@ -1,0 +1,15 @@
+# Standing → CRS, and the Warning/Ban model
+
+**Status: Proposed — decision pending.** Serves [PRD-05 Rules & Governance](../prd/05-rules-and-governance.md); the CRS backbone in [PRD-01](../prd/01-Community-Score.md).
+
+Rule compliance must move a user's Community Reputation Score: pristine standing rewards ×10, and long-term poor standing (frequent warnings, ban evasion) draws a large compounding penalty — "the mighty hammer." Today the only datum is `User.warnedTimes`; there is no Warning/Ban entity, no escalation ladder, and no ban-evasion linkage.
+
+Decision to record here (not yet finalized):
+
+- **Warning/Ban model** — entities for warnings, suspensions, bans; escalation ladder; association to the GoldenRule/CommunityRule violated; ban-evasion linkage (invite-tree + account signals).
+- **Standing → CRS computation** — how rule micro-impacts + warning history compose into the standing multiplier (the ×10 pristine reward and the repeat-offender hammer curve), and whether it is computed-on-read (mirroring the ADR-0002 pulse) or event-logged.
+- **Magnitudes** — the ×10, the hammer curve, and per-rule/SubRule micro-impact weights are TBD.
+
+Enforcement remains [ADR-0001](0001-granular-permission-checks.md) (granular permissions); standing trend input comes from [ADR-0002](0002-community-health-pulse.md) (the pulse).
+
+_Fill in the chosen model + computation + consequences once decided._

--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -1,0 +1,79 @@
+# PRD-05 — Rules & Governance
+
+**Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
+**Decisions:** [ADR-0001 granular permissions](../adr/0001-granular-permission-checks.md) (enforcement), [ADR-0002 community-health-pulse](../adr/0002-community-health-pulse.md) (standing trend), [ADR-0004 standing → CRS + warnings/bans](../adr/0004-standing-warnings-bans.md)
+**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance**
+
+> The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose (that lives in `RulesPage`).
+
+## The Golden Rules (7 — canonical, site-wide)
+
+Seven canonical rules govern the whole site. They are deliberately kept whole — not consolidated — and are the backbone of CRS standing:
+
+1. **Accounts** — one account per person per lifetime; no sharing/trading/selling; keep it active.
+2. **Invites** — you are responsible for your invitees; no public trading/offering; do not request.
+3. **Contribution Integrity & Accounting** — no manipulating the contribute/consume ledger; Contributions must be honest, with **live links + accurate metadata**; protect your credentials (AnnounceKey / API). _(Content-tracker cast: a self-hosted host counts as a seedbox-class source; RSS/IRC announcements + idle/activity tracking stand in for a torrent announce.)_
+4. **Conduct** — no blackmail/scams/impersonation; civil discourse; no backseat-moderation.
+5. **Access & Automation** — no free VPN/Tor; automated access via the **API only** (rate-limited); no automated abuse of download credits.
+6. **Bugs & Exploits** — don't seek or exploit live bugs (responsible disclosure); don't publish exploits.
+7. **Respect Staff** — staff are volunteers; their interpretation of the rules is final; raise disputes privately.
+
+## Composable rule model (the architecture)
+
+Rules form a hierarchy, each node carrying a **CRS micro-impact**:
+
+```
+GoldenRule (site-wide, 1..7)
+  └─ CommunityRules (per Community)
+        ├─ may adopt 0, some, or all GoldenRules
+        └─ may add its own rules, each with SubRules
+              └─ each rule / SubRule has its own micro-impact on CRS
+```
+
+- A Community may have **no** rules, **adopt** GoldenRules, or define e.g. **5 rules with 2 SubRules each** — every node can carry its own compliance/violation CRS weight.
+- This makes governance data-driven (a rule tree with weights), not hardcoded — superseding the legacy switch-style rule rendering. `RulesPage` / `ForumSpecificRule` are the current content homes.
+
+## CRS standing (the backbone)
+
+- **Pristine record → ×10** CRS (long-term clean standing is the strongest positive).
+- **Poor standing → lower** CRS.
+- **Long-term poor** (frequent warnings, ban evasion) → **the mighty hammer**: large, compounding negative (the downside mirror of tiering).
+- Standing reads a **Warning/Ban governance model** — net-new (today only `User.warnedTimes`). Computation + model decided in **[ADR-0004](../adr/0004-standing-warnings-bans.md)**. Magnitudes (the ×10, the hammer curve, per-rule micro-impacts) are **TBD**.
+
+## Sub-rulesets
+
+| Ruleset            | Status                                                                                                                |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| **GoldenRules**    | the 7 above (canonical)                                                                                               |
+| **CommunityRules** | composable per-Community tree (above) — leans on `Community`, `UserRank`, `RulesPage`                                 |
+| **StaffRules**     | staff conduct + the +50 CRS/week-served signal (cross-ref PRD-01) — `staff.ts`, `StaffGroup`                          |
+| **InterviewRules** | recruitment/interview conduct — net-new                                                                               |
+| **ForumRules**     | governance for the **already-built** forum (`forum.ts`, `ForumSpecificRule`, `RulesPage`) — documenting, not building |
+| **IRCRules**       | conduct on the IRC network — **rules here; the IRC feature itself is PRD-02**                                         |
+
+## Bridges to existing decisions
+
+- **ADR-0001** (granular permissions) is the **enforcement substrate** — rule gates name explicit permissions, no role bleed.
+- **ADR-0002** (community-health pulse) feeds **standing trends** into CRS.
+- **ADR-0004** (new) records the standing→CRS computation + the Warning/Ban model.
+
+## Concept → code (descent map)
+
+| Concept                                                    | Lives in                                                                    |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Forum + forum rules                                        | `forum.ts`, `ForumSpecificRule`, `RulesPage`, `Thread` (built)              |
+| Staff / ranks / reports                                    | `staff.ts`, `staffInbox.ts`, `reports.ts`, `StaffGroup`, `UserRank` (built) |
+| Permissions enforcement                                    | ADR-0001 — `requirePermission` / `hasPermission`                            |
+| Warnings/Bans, IRC rules, Community rule-tree, CRS weights | **net-new**                                                                 |
+
+## Red-green descent targets
+
+1. **Rule model** — a `Rule`/`SubRule` tree with a CRS-weight field + a pure `ruleImpact(...)` function (table-driven, mirroring the PRD-03 stylesheet slice).
+2. **Warning/Ban model** + standing computation (ADR-0004).
+3. **Document ForumRules/StaffRules** against the built code; spec IRCRules + InterviewRules as net-new.
+
+## Open questions
+
+- CRS magnitudes: the ×10 pristine reward, the repeat-offender hammer curve, and per-rule/SubRule micro-impact values — TBD.
+- Warning/Ban model shape (entities, escalation, ban-evasion detection) — ADR-0004.
+- Do CommunityRules inherit GoldenRules by default, or opt-in per Community?


### PR DESCRIPTION
The governance opus. Captures:
- **7 canonical Golden Rules** (kept whole — lean on the canon; rules 3 and 5 re-cast for a content tracker, not BitTorrent).
- A **composable, CRS-weighted rule model**: GoldenRule → CommunityRules (adopt 0/some/all) → SubRules, each node carrying a micro-impact on CRS. Data-driven, superseding hardcoded rule rendering (`RulesPage` / `ForumSpecificRule` are the content homes).
- **CRS standing backbone**: ×10 pristine, the mighty-hammer for repeat offenders (warnings, ban evasion).
- **Sub-rulesets**: Community / Staff / Interview / Forum / IRC — IRCRules live here; the IRC *feature* is PRD-02.
- **ADR-0004** stubs the standing→CRS computation + the net-new Warning/Ban model (today only `User.warnedTimes`).

Bridges ADR-0001 (enforcement) + ADR-0002 (standing trend). Magnitudes (×10, hammer curve, per-rule micro-impacts) flagged TBD. Docs only.