### PR TITLE
fix(logging): type Request.requestId, drop the cast workaround [#78]

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -82,7 +82,7 @@ export const createApp = () => {
   app.use((req: Request, res: Response, next: NextFunction) => {
     const requestId = (req.headers['x-request-id'] as string) || randomUUID();
     res.setHeader('x-request-id', requestId);
-    (req as Request & { requestId: string }).requestId = requestId;
+    req.requestId = requestId;
     const start = Date.now();
     res.on('finish', () => {
       log.info('request', {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -2,6 +2,8 @@ import 'express';
 
 declare module 'express' {
   interface Request {
+    /** Correlation id set by the request-logging middleware (also echoed as the x-request-id header). */
+    requestId?: string;
     user?: {
       id: number;
       userRankId: number;


### PR DESCRIPTION
Closes #78.

The request-logging middleware cast `req as Request & { requestId }` as a config workaround because the Express `Request` augmentation (`src/types/express.d.ts`) typed `user` but not `requestId`. Declared `requestId` on that augmentation and dropped the inline cast — no new dependency, no behaviour change.

**Note on the issue title:** morgan was never in this codebase (no history) and `@morgan/types` isn't a real package — the actual "config workaround" was the requestId cast, now removed.