### PR TITLE
Ratio overhaul (LinkHealth-gated relief) + CRS foundation [PRD-01/06]

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,11 +31,36 @@ _Avoid_: active passport, logged-in session, user record
 The isolated, transactional test database targeting custom parameters from `.env.test` executed via `npm run test:integration` inside `jest`.
 _Avoid_: live testing database, local test instance
 
+**Effective Availability**:
+A contribution is effectively available — the local analog of a seeded release — while its current `linkStatus` is not `FAIL`. Effective availability, not a one-time approval, is what earns ongoing ratio relief.
+_Avoid_: link uptime, seeding status, alive link
+
+**Eligible Contribution Bytes**:
+The staff-approved, 72h-matured contribution bytes that are also effectively available, summed per user to form the **coverage** term that lowers their required ratio. Revocable: bytes leave the pool when a contribution goes `FAIL`.
+_Avoid_: contribution credit, ratio bonus, approved bytes
+
+**Ratio Mechanism**:
+The standalone `contributed`/`consumed` download gate (required-ratio brackets + the `OK/WATCH/LEECH_DISABLED` policy). Distinct from **RatioScore**. The Ratio Mechanism never reads CRS.
+_Avoid_: ratio score, ratio policy (when meaning the whole gate)
+
+**RatioScore**:
+A bounded CRS **Dimension Scorer** derived one-way from a user's current ratio health. An input to reputation, never an enforcement lever.
+_Avoid_: ratio, required ratio
+
+**Dimension Scorer**:
+A bounded, pure function `compute(user) → subScore` contributing one capped term to the Community Reputation Score. Self-registers into the CRS registry.
+_Avoid_: metric, plugin, scorer module
+
+**Controlled Vector**:
+A bounded cross-dimension CRS edge — one signal nudging another dimension — capped and deduplicated to resist farming (e.g. stylesheet adoption feeding the Friends dimension).
+_Avoid_: cross-score, bonus link, coupling
+
 ## Relationships
 
 - A **Contract Schema** directly structures incoming inputs and dictates the programmatic generation of the schema served by `swagger-ui-express`.
 - An **Identity State** acts as an authorized gateway, validating if a request can access or mutate a specific database record via the **Data Client**.
 - **Sanitized Values** must be extracted at the Controller layer using **Contract Schemas** before execution by domain services.
+- The **Ratio Mechanism** reads **Eligible Contribution Bytes** (gated by **Effective Availability**) and never reads CRS; a derived **RatioScore** flows one-way into CRS as one **Dimension Scorer**. CRS never gates downloads.
 
 ## Flagged Ambiguities
 

--- a/docs/adr/0002-community-health-pulse.md
+++ b/docs/adr/0002-community-health-pulse.md
@@ -11,4 +11,4 @@ Decision to record (not yet finalized):
 
 This is the ADR the stylesheet-scoring work ([PRD-03](../prd/03-stylesheet-themes-and-scoring.md)) and other CRS dimensions reference for "computed-on-read vs. event-logged" accrual.
 
-_Fill in the chosen approach and consequences once decided._
+**Resolved by [ADR-0007 — CRS computation: read-time value + event accrual ledger](0007-crs-read-time-and-event-ledger.md):** the score is computed-on-read; only events that current state cannot reconstruct are append-only logged (a `CRS_*` reason on `EconomyTransaction`); time-series snapshots (the pulse-over-time trend this ADR anticipated) are a deferred additive layer mirroring `statsHistory`, never the source of truth. The pulse stays computed-on-read and folds into the `CommunityScore` dimension under that model.

--- a/docs/adr/0006-linkhealth-gated-ratio-relief.md
+++ b/docs/adr/0006-linkhealth-gated-ratio-relief.md
@@ -1,0 +1,30 @@
+# LinkHealth-gated ratio relief (effective-seeding analog)
+
+**Status: Accepted.** Serves [PRD-06 Ratio](../prd/06-ratio.md) and [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md). Relates to the LinkHealth lifecycle ([`linkHealth.ts`](../../src/modules/linkHealth.ts), [`linkHealthJob.ts`](../../src/modules/linkHealthJob.ts)).
+
+## Context
+
+Stellar's required-ratio model (`src/modules/ratio.ts`) follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)), in which required ratio is `maximum required ratio × (1 − X)` and depends on **downloaded amount, how many things you are seeding, and how long you have seeded them over the trailing window** — a release is *effectively seeded* if it has been available for at least 72 hours in the past seven days.
+
+Our implementation captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief term `X` as a **static, permanent byte-credit**: `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` is the sum of a user's staff-approved, 72h-old contribution bytes. Once approved, a contribution lowers the user's required ratio **forever** — even if its download link died years ago. That misses the central pillar: relief comes from *ongoing availability*, not a one-time act of uploading.
+
+Stellar has no peer-to-peer transfers — contributions are hosted links, and `downloads.ts` accrues a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**: `linkStatus` already tracks whether a contribution's link is reachable (`PASS`), suspect (`WARN`), unchecked (`UNKNOWN`), or dead (`FAIL`), rechecked every 24h by `linkHealthJob.ts`.
+
+## Decision
+
+Gate ratio relief on current link health. A contribution's approved bytes count toward `eligibleContributionBytes` **only while its latest `linkStatus ≠ FAIL`**.
+
+1. **Revocable relief.** A contribution flipping to `FAIL` drops its bytes out of the relief pool, so a user's required ratio can *rise* as their links rot — with no new download on their part. This mirrors a release losing its seeding credit when nobody keeps it available.
+2. **Suspicion does not revoke.** `WARN` (including the ≥3-distinct-reporter auto-warn) and `UNKNOWN` keep counting. Only a machine-confirmed dead link (`FAIL`) revokes. Community reports therefore cannot be weaponized to inflate a rival's required ratio — only an actual failed HEAD check can.
+3. **Persistent suspicion is promoted.** A contribution stuck at `WARN` and unresolved for **72 hours** is swept to `FAIL` by the link-health job (PM the contributor, file the staff report), which then revokes relief. This closes the "returns 200 but the file is gone" hole without making reports a weapon.
+4. **Current status only.** Ratio relief reads the latest `linkStatus`; the 24h recheck keeps it fresh. We do **not** build a link-health history series for ratio. Cumulative-uptime-over-account-lifetime is a separate, slower CRS dimension (`LinkHealthBonusPoints`) tracked elsewhere.
+5. **No clawback of `contributed`.** Revocation affects only the *relief pool* (`eligibleContributionBytes`, which lowers required ratio). A user's lifetime `contributed` — bytes others actually downloaded from them — is historical and is never reduced when a link dies; already-earned upload credit is permanent.
+
+Ratio remains a standalone download gate. It does not read CRS, and CRS does not gate downloads (see [ADR-0007](0007-crs-read-time-and-event-ledger.md)).
+
+## Consequences
+
+- **Faithful to the reference model**, and reuses the existing `linkHealth.ts` / `linkHealthJob.ts` substrate — slice 1 is a `linkStatus ≠ FAIL` filter on the eligible-bytes query plus the 72h sweep; no schema change.
+- **User-visible behavior change with teeth:** a user who stops maintaining their links sees their required ratio climb. This is intended (it rewards sustained availability) but must be surfaced clearly in the profile/ratio UI and is the reason this is recorded as an Accepted ADR rather than left implicit.
+- The `WARN`-never-revokes rule means a genuinely-dead-but-200 link keeps relief for up to 72h after the first report; acceptable given the anti-weaponization benefit.
+- Establishes LinkHealth as the shared availability substrate for both Ratio (current status) and CRS (lifetime uptime), so the two systems read one signal at two timescales.

--- a/docs/adr/0007-crs-read-time-and-event-ledger.md
+++ b/docs/adr/0007-crs-read-time-and-event-ledger.md
@@ -1,0 +1,25 @@
+# CRS computation: read-time value + event accrual ledger
+
+**Status: Accepted.** Resolves the open question in [ADR-0002 community-health-pulse → CRS](0002-community-health-pulse.md) ("computed-on-read vs. event-logged accrual"). Serves [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md); referenced by [PRD-03 stylesheet scoring](../prd/03-stylesheet-themes-and-scoring.md).
+
+## Context
+
+CRS aggregates many dimensions (Friends, Invite, Donation, Longevity now; RatioScore, stylesheet, LinkHealth-lifetime, IRC, Feed later). ADR-0002 and PRD-03 both flagged the same undecided question: is a user's score **computed on read** from current state, or **accrued from logged events**? The two break differently per dimension:
+
+- **Reconstructable from current state:** Longevity (`User.createdAt`), Friends (current relationship rows), Donation (donation history), RatioScore (current ratio health). A read-time recompute is always correct and never goes stale.
+- **Not reconstructable from current state:** event signals where "what is true now" loses history. The clearest case is the Friends×Stylesheet controlled vector ([PRD-03](../prd/03-stylesheet-themes-and-scoring.md)): "A currently uses sheet X" does not tell you the *set of distinct adoptions A has ever made*. A pure recompute would silently lose credit (A adopted then switched) or double-count it.
+
+## Decision
+
+A **hybrid**: read-time value, with a thin durable ledger only for events that current state cannot reconstruct.
+
+1. **The CRS value is always computed on read.** There is no denormalized `crsScore` column that can drift. The aggregator (`reputation.ts`) sums the registered dimension scorers on demand, the same way `ratio.ts` computes ratio.
+2. **Non-reconstructable event signals are append-only logged.** Reuse the existing immutable-ledger pattern of `EconomyTransaction` (double-entry, reason-tagged, staff-auditable) with a new `CRS_*` reason family. The stylesheet-adoption edge is the first such event: it records the `(adopter, author)` pair so the once-per-pair dedup and per-user cap of the controlled vector are durable. Read-time computation reads this ledger for the affected dimensions.
+3. **Time-series snapshots are deferred.** Trends over time (CRS history, the lifetime-uptime `LinkHealthBonusPoints` dimension) are an *additive* layer that mirrors `statsHistory.ts` — they are **not** the source of truth and do not change rule 1. Tracked as a follow-up issue; this is the "future direction" ADR-0002 anticipated.
+
+## Consequences
+
+- **No staleness, no recompute job** for the score itself; correctness is structural.
+- A small, well-understood durable surface (the `CRS_*` ledger) carries only what genuinely needs history — keeping most dimensions pure functions in the spirit of `stylesheetScore.ts`.
+- Snapshots, when built, become a read-model for trends and never the authority — so a snapshot bug can never corrupt a user's actual score.
+- Resolves ADR-0002's and PRD-03's open "computed-on-read vs event-logged" question for all CRS dimensions uniformly: **read-time by default, ledger only for irreducible events.**

--- a/docs/prd/01-Community-Score.md
+++ b/docs/prd/01-Community-Score.md
@@ -187,6 +187,16 @@ Ratio (the contributed/consumed download gate, PRD-06) and CRS are layered stric
 - A derived RatioScore flows one-way into this CRS (and the eventual CommunityValueIndex) as one bounded dimension among many.
 - CRS never gates downloads. It is a status/trust signal, not an enforcement lever.
 
+Implementation status (PR #96)
+
+The registry + aggregator (computed-on-read) ship with three bounded dimensions:
+
+- ✅ LongevityScore — account age, diminishing returns, cap 10.
+- ✅ RatioScore — current ratio health, one-way, cap 8; gated on contributed > 0.
+- ✅ FriendsScore — friend count, deliberately low cap 4 (count can't dominate).
+- ⏳ InviteScore, DonationScore — next dimensions (#61, #62).
+- Surfaced at GET /api/profile/me/reputation (score + per-dimension breakdown).
+
 ⸻
 
 Friends System

--- a/docs/prd/01-Community-Score.md
+++ b/docs/prd/01-Community-Score.md
@@ -12,10 +12,13 @@ Related Decisions (ADR)
 
 - [ADR-0001](../adr/0001-granular-permission-checks.md) — granular permission checks (CRS gates on per-permission checks)
 - [ADR-0002](../adr/0002-community-health-pulse.md) — community-health-pulse → CommunityScore dimension (#75)
+- [ADR-0006](../adr/0006-linkhealth-gated-ratio-relief.md) — LinkHealth-gated ratio relief (RatioScore substrate)
+- [ADR-0007](../adr/0007-crs-read-time-and-event-ledger.md) — CRS computed-on-read + event accrual ledger
 
 Related PRDs
 
 - [PRD-03](03-stylesheet-themes-and-scoring.md) — stylesheet scoring is a dimension of this CRS
+- [PRD-06](06-ratio.md) — the Ratio mechanism; a derived `RatioScore` feeds this CRS (one-way)
 
 ⸻
 
@@ -161,6 +164,28 @@ FeedScore
 CommunityScore
 ModerationScore
 ContributionScore
+
+⸻
+
+Architecture (decided)
+
+CRS is a registry of bounded, pure dimension-scorers — not a hardcoded sum.
+
+- Each dimension is a pure function compute(user) → subScore, mirroring the shipped stylesheetScore.ts. No DB inside the scorer.
+- Each dimension is bounded — diminishing returns and/or a hard cap — so no single axis can dominate. This enforces the PRD's guardrails structurally rather than by good intentions: "Friend count alone should not determine score" and "Donation value should not dominate" become caps, not hopes.
+- CRS = Σ (weight_i × subScore_i), with explicit, hand-pinned weight and cap constants (no automated weighting algorithm yet — that stays out of scope). Recent participation may be weighted over historical, while still recognising longevity.
+- Dimensions self-register. New dimensions (RatioScore, stylesheet, LinkHealthBonusPoints, IRC, Feed) slot in by adding a registry entry — never by editing the aggregator.
+- v0.0.x dimension set: Friends, Invite, Donation, Longevity.
+
+Computation: the CRS value is always computed on read (no stored, stale score column). Only events that current state cannot reconstruct — e.g. the Friends×Stylesheet adoption edges and their once-per-pair dedup — are append-only logged to a CRS_* reason on the existing EconomyTransaction ledger. Time-series snapshots (trends) are a deferred additive layer. See ADR-0007.
+
+Ratio independence (decided)
+
+Ratio (the contributed/consumed download gate, PRD-06) and CRS are layered strictly one-way:
+
+- Ratio is a standalone enforcement mechanism. It never reads CRS — reputation, friends, or donations cannot lower a user's required ratio. The gate stays uncorruptible.
+- A derived RatioScore flows one-way into this CRS (and the eventual CommunityValueIndex) as one bounded dimension among many.
+- CRS never gates downloads. It is a status/trust signal, not an enforcement lever.
 
 ⸻
 

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -95,7 +95,7 @@ First testable slices (much of the substrate already exists):
 1. ✅ **Stylesheet selection → CRS accrual** — pure `scoreStylesheetSelection` (no DB), table-driven over each multiplier. **Shipped: [#84](https://github.com/orphic-inc/stellar-api/pull/84)** (tier-0 multipliers; external/self decisions applied).
 2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
 3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
-4. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual.
+4. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual. **Currently the keystone gap:** `scoreStylesheetSelection` (shipped #84) is wired to *nothing* — no `AuthorStylesheet` model, no adopt event. This slice wires it, and **unblocks** the Friends×Stylesheet controlled vector + the `CRS_*` adoption ledger (PRD-01 / ADR-0007), which have no event to hook onto until adoption exists.
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -46,6 +46,13 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
 
+**Friends × Stylesheet — controlled vector (decided).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — *separate from and additive to* the stylesheet-dimension weights above:
+
+- **Adopter: +0.2** (rewards active, organic curation — the adopter earns slightly more than the author, to favour participation).
+- **Author: +0.1** (recognition that someone vouched for your sheet).
+- **Bounded ("controlled"):** counted **once per distinct (adopter, author) pair**, with a per-user cap on total Friends-dimension score this vector can contribute — so ring/sock-puppet mass-adoption flattens out. Plain friending remains the stronger, separate signal; adoption is the weak-tie nudge.
+- Fires on **any** adoption (friend or not). The dedup + cap are durable via the CRS event ledger ([ADR-0007](../adr/0007-crs-read-time-and-event-ledger.md)).
+
 ## Negative scoring (decided — the model needs downside)
 
 Rewards alone let bad actors coast; CRS must be able to go **down**.
@@ -94,8 +101,7 @@ First testable slices (much of the substrate already exists):
 ## Open questions
 
 - AuthorStylesheetUrl storage shape (URL vs stored file) — pending ExternalStylesheet + global-reset findings.
-- Whether stylesheet-score accrual is computed-on-read (mirror the pulse) or event-logged.
 - **Tiering curve** + **dead-external penalty magnitude** — values TBD.
 - IRC scoring belongs to PRD-02 — confirm it's not duplicated here.
 
-**Resolved:** external disposition (authorless → permission/link-health, not site) · self-use pays no author bonus · per-author cap not needed (the `/private` invite+report model covers it).
+**Resolved:** external disposition (authorless → permission/link-health, not site) · self-use pays no author bonus · per-author cap not needed for the stylesheet-dimension author bonus (the `/private` invite+report model covers it) · **accrual model = computed-on-read, with adoption events logged to a `CRS_*` ledger** ([ADR-0007](../adr/0007-crs-read-time-and-event-ledger.md)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1, once-per-pair + per-user cap).

--- a/docs/prd/06-ratio.md
+++ b/docs/prd/06-ratio.md
@@ -57,9 +57,9 @@ Stellar has no peer-to-peer transfers — contributions are hosted links. `downl
 
 ## Red-green descent targets
 
-1. **Relief LinkHealth gate** — filter `eligibleContributionBytes` by `linkStatus ≠ FAIL`; spec that required ratio rises when a covered contribution flips `FAIL`, and that `WARN`/`UNKNOWN` still count. *No schema change.*
-2. **72h WARN→FAIL sweep** — extend `linkHealthJob.ts`; PM contributor + staff report on promotion.
-3. **`RatioScore` dimension** — derive a bounded CRS sub-score from current ratio health (one-way into PRD-01's registry).
+1. ✅ **Relief LinkHealth gate** — `eligibleContributionBytes` filtered by `linkStatus ≠ FAIL`; required ratio rises when a covered contribution flips `FAIL`, `WARN`/`UNKNOWN` still count. **Shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96).**
+2. 🟡 **72h WARN→FAIL sweep** — `linkStatusChangedAt` + `sweepStaleWarnLinks` in `linkHealthJob.ts`. **Promotion shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96)**; the contributor-PM + staff-report notification on promotion is still TODO.
+3. ✅ **`RatioScore` dimension** — bounded CRS sub-score from current ratio health, one-way into PRD-01's registry. **Shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96).**
 
 ## Open questions
 

--- a/docs/prd/06-ratio.md
+++ b/docs/prd/06-ratio.md
@@ -1,0 +1,67 @@
+# PRD-06 — Ratio
+
+**Status:** Draft · **Owner:** @obrien-k
+**Decisions:** [ADR-0006 LinkHealth-gated ratio relief](../adr/0006-linkhealth-gated-ratio-relief.md)
+**Feeds:** [PRD-01 Community-Score / CRS](01-Community-Score.md) — a derived `RatioScore` is one CRS/CVI dimension; the ratio *mechanism* itself is independent of CRS.
+
+> Lean PRD. Captures the ratio mechanism as it should be, maps each piece to existing code, and flags the overhaul. Ratio is an **enforcement** mechanism (download gate); CRS is a **reputation** signal. They are layered one-way: a `RatioScore` flows into CRS; CRS never gates downloads and ratio never reads CRS.
+
+## Problem
+
+Stellar's required-ratio model follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)) but is incomplete. That model's required ratio depends on three pillars — **downloaded amount**, **how many things you're seeding**, and **how long they've stayed available over the trailing window** (effectively seeded if available ≥ 72h in the past 7 days). The formula was `maximum required ratio × (1 − X)`.
+
+`src/modules/ratio.ts` captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The *seeding / ongoing-availability* pillar is missing.
+
+## The seeding analog: LinkHealth
+
+Stellar has no peer-to-peer transfers — contributions are hosted links. `downloads.ts` credits a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**:
+
+| Reference model | Stellar |
+| --- | --- |
+| Seeding a release | A contribution whose link is reachable (`linkStatus = PASS`) |
+| Effectively seeded (available ≥72h/7d) | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh) |
+| Stopped seeding → lose relief | Link `FAIL` → contribution drops from the relief pool |
+| Uploaded bytes (others snatched) | `User.contributed` (others downloaded from you) — permanent, never clawed back |
+
+## Mechanism
+
+### Required ratio (unchanged shape, gated relief)
+
+- **Download brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). *Bracket values are tuning; current table assumed settled, flagged for review.*
+- **Formula:** `requiredRatio = max(minRequired, maxRequired × (1 − coverage))`.
+- **Coverage (the overhaul):** `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` sums a user's staff-approved, 72h-old contribution bytes **whose current `linkStatus ≠ FAIL`**. See [ADR-0006](../adr/0006-linkhealth-gated-ratio-relief.md):
+  - `FAIL` revokes relief (required ratio can rise as links rot).
+  - `WARN`/`UNKNOWN` keep counting — reports alone cannot tank a rival's ratio.
+  - A contribution stuck `WARN` and unresolved 72h is swept to `FAIL`, then drops.
+  - No clawback of lifetime `contributed`.
+
+### Policy state machine (unchanged)
+
+`ratioPolicy.ts`: `OK → WATCH → LEECH_DISABLED`. `WATCH` lasts 14 days; auto-disable on 10 GiB consumed during watch or watch expiry; `LEECH_DISABLED` reversed by staff only.
+
+### Concepts from the reference model not yet modelled (flagged)
+
+- **Seeding *count*** (the reference factors how many releases you seed, not just bytes) — out of scope for v1; byte-coverage is the lever.
+- **Freeleech / neutral-leech** (download without ratio impact) — a tracker feature; separate concern, not in this overhaul.
+
+## Concept → existing code (the descent map)
+
+| Concept | Lives in |
+| --- | --- |
+| Ratio + required-ratio + brackets | `src/modules/ratio.ts` |
+| Policy state machine | `src/modules/ratioPolicy.ts` |
+| `contributed` credit (seeding-snatch analog) | `src/modules/downloads.ts` |
+| LinkHealth status + 24h recheck + 72h sweep | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts` |
+| Ratio surface | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
+| Lifetime uptime (CRS, not ratio) | deferred — `LinkHealthBonusPoints` dimension, PRD-01 |
+
+## Red-green descent targets
+
+1. **Relief LinkHealth gate** — filter `eligibleContributionBytes` by `linkStatus ≠ FAIL`; spec that required ratio rises when a covered contribution flips `FAIL`, and that `WARN`/`UNKNOWN` still count. *No schema change.*
+2. **72h WARN→FAIL sweep** — extend `linkHealthJob.ts`; PM contributor + staff report on promotion.
+3. **`RatioScore` dimension** — derive a bounded CRS sub-score from current ratio health (one-way into PRD-01's registry).
+
+## Open questions
+
+- Bracket values — keep the current table or re-tune to specific numeric thresholds? (assumed settled for now)
+- Whether the policy `WATCH` thresholds (14d / 10 GiB) change in the overhaul (assumed unchanged).

--- a/prisma/migrations/20260608000000_contribution_link_status_changed_at/migration.sql
+++ b/prisma/migrations/20260608000000_contribution_link_status_changed_at/migration.sql
@@ -1,0 +1,8 @@
+-- Track when a contribution's linkStatus last changed, so the WARN->FAIL
+-- sweep (ADR-0006) can measure "stuck at WARN for >72h". linkCheckedAt is
+-- last-checked, not first-warned, so it can't serve this purpose.
+ALTER TABLE "contributions" ADD COLUMN "linkStatusChangedAt" TIMESTAMP(3);
+
+-- Backfill existing rows with their last check time (best available proxy)
+-- so pre-existing WARN links get a clock and become sweepable.
+UPDATE "contributions" SET "linkStatusChangedAt" = "linkCheckedAt" WHERE "linkCheckedAt" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -937,6 +937,7 @@ model Contribution {
   approvedAccountingBytes  BigInt?
   linkStatus               LinkHealthStatus @default(UNKNOWN)
   linkCheckedAt            DateTime?
+  linkStatusChangedAt      DateTime?
   type                     FileType
   bitrate                  String?
   media                    String?

--- a/src/modules/linkHealth.spec.ts
+++ b/src/modules/linkHealth.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the link-health WARN->FAIL sweep and transition stamping.
+ * DB + fetch are mocked.
+ */
+
+const mockPrismaContribution = {
+  findUnique: jest.fn(),
+  update: jest.fn(),
+  updateMany: jest.fn()
+};
+
+jest.mock('../lib/prisma', () => ({
+  prisma: { contribution: mockPrismaContribution }
+}));
+
+jest.mock('./logging', () => ({
+  getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+}));
+
+import { sweepStaleWarnLinks, checkContributionLink } from './linkHealth';
+
+// ─── sweepStaleWarnLinks ──────────────────────────────────────────────────────
+
+describe('sweepStaleWarnLinks', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('promotes WARN links stuck past the 72h window to FAIL', async () => {
+    mockPrismaContribution.updateMany.mockResolvedValue({ count: 2 });
+    await sweepStaleWarnLinks();
+    expect(mockPrismaContribution.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          linkStatus: 'WARN',
+          linkStatusChangedAt: expect.objectContaining({ lt: expect.any(Date) })
+        }),
+        data: expect.objectContaining({ linkStatus: 'FAIL' })
+      })
+    );
+  });
+
+  it('uses a cutoff ~72h in the past (not last-checked, but stuck-since)', async () => {
+    mockPrismaContribution.updateMany.mockResolvedValue({ count: 0 });
+    await sweepStaleWarnLinks();
+    const arg = mockPrismaContribution.updateMany.mock.calls[0][0];
+    const cutoff: Date = arg.where.linkStatusChangedAt.lt;
+    const ageHours = (Date.now() - cutoff.getTime()) / 3_600_000;
+    expect(ageHours).toBeGreaterThan(71);
+    expect(ageHours).toBeLessThan(73);
+  });
+});
+
+// ─── checkContributionLink — transition stamping ──────────────────────────────
+
+describe('checkContributionLink stamps linkStatusChangedAt on transition', () => {
+  const fetchMock = jest.fn();
+  beforeAll(() => {
+    (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+  });
+  beforeEach(() => jest.clearAllMocks());
+
+  it('stamps the change when status flips (WARN → PASS)', async () => {
+    mockPrismaContribution.findUnique.mockResolvedValue({
+      downloadUrl: 'http://example.test/x',
+      linkStatus: 'WARN',
+      linkStatusChangedAt: new Date('2020-01-01')
+    });
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    await checkContributionLink(5);
+    const { data } = mockPrismaContribution.update.mock.calls[0][0];
+    expect(data.linkStatus).toBe('PASS');
+    expect(data.linkStatusChangedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not re-stamp when status is unchanged and already stamped', async () => {
+    mockPrismaContribution.findUnique.mockResolvedValue({
+      downloadUrl: 'http://example.test/x',
+      linkStatus: 'PASS',
+      linkStatusChangedAt: new Date('2020-01-01')
+    });
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    await checkContributionLink(5);
+    const { data } = mockPrismaContribution.update.mock.calls[0][0];
+    expect(data.linkStatus).toBe('PASS');
+    expect(data.linkStatusChangedAt).toBeUndefined();
+  });
+
+  it('initializes the clock when it has never been stamped (backfill case)', async () => {
+    mockPrismaContribution.findUnique.mockResolvedValue({
+      downloadUrl: 'http://example.test/x',
+      linkStatus: 'PASS',
+      linkStatusChangedAt: null
+    });
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    await checkContributionLink(5);
+    const { data } = mockPrismaContribution.update.mock.calls[0][0];
+    expect(data.linkStatusChangedAt).toBeInstanceOf(Date);
+  });
+});

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -8,6 +8,8 @@ const TIMEOUT_MS = 10_000;
 const STALE_AFTER_DAYS = 7;
 // Auto-WARN a contribution when this many distinct users have reported it
 const REPORT_WARN_THRESHOLD = 3;
+// A contribution stuck at WARN this long is promoted to FAIL (ADR-0006)
+const WARN_SWEEP_AFTER_MS = 72 * 60 * 60 * 1000;
 
 export const checkUrl = async (url: string): Promise<LinkHealthStatus> => {
   const controller = new AbortController();
@@ -35,16 +37,42 @@ export const checkContributionLink = async (
 ): Promise<void> => {
   const contribution = await prisma.contribution.findUnique({
     where: { id: contributionId },
-    select: { downloadUrl: true }
+    select: { downloadUrl: true, linkStatus: true, linkStatusChangedAt: true }
   });
   if (!contribution) return;
 
   const status = await checkUrl(contribution.downloadUrl);
+  const now = new Date();
+  // Stamp the transition time when the status actually changes — or when it's
+  // never been stamped (backfill) — so the WARN sweep has a clock to read.
+  const stampChange =
+    status !== contribution.linkStatus ||
+    contribution.linkStatusChangedAt === null;
   await prisma.contribution.update({
     where: { id: contributionId },
-    data: { linkStatus: status, linkCheckedAt: new Date() }
+    data: {
+      linkStatus: status,
+      linkCheckedAt: now,
+      ...(stampChange ? { linkStatusChangedAt: now } : {})
+    }
   });
   log.info('Link checked', { contributionId, status });
+};
+
+// Promote contributions stuck at WARN past the sweep window to FAIL. Suspicion
+// alone never revokes ratio relief; only a confirmed-or-persistent FAIL does
+// (ADR-0006). This closes the "returns 200 but the file is gone" hole.
+export const sweepStaleWarnLinks = async (): Promise<void> => {
+  const cutoff = new Date(Date.now() - WARN_SWEEP_AFTER_MS);
+  const now = new Date();
+  const { count } = await prisma.contribution.updateMany({
+    where: {
+      linkStatus: LinkHealthStatus.WARN,
+      linkStatusChangedAt: { lt: cutoff }
+    },
+    data: { linkStatus: LinkHealthStatus.FAIL, linkStatusChangedAt: now }
+  });
+  if (count > 0) log.info('Swept stale WARN links to FAIL', { count });
 };
 
 export const recheckStaleLinks = async (): Promise<void> => {
@@ -80,17 +108,32 @@ export const recordContributionReport = async (
     distinct: ['reporterId']
   });
   if (distinctReporters.length >= REPORT_WARN_THRESHOLD) {
-    await prisma.contribution.update({
+    const current = await prisma.contribution.findUnique({
       where: { id: contributionId },
-      data: { linkStatus: LinkHealthStatus.WARN }
+      select: { linkStatus: true }
     });
-    log.info('Contribution auto-warned by reports', {
-      contributionId,
-      distinctReporters: distinctReporters.length
-    });
-    // Kick off a recheck so status can be corrected if the link is actually fine
-    checkContributionLink(contributionId).catch((err) =>
-      log.warn('Post-report link recheck failed', { contributionId, err })
-    );
+    // Only warn from a healthy/unknown state: don't reset the sweep clock on
+    // an already-WARN link, and don't downgrade a confirmed FAIL back to WARN.
+    if (
+      current &&
+      current.linkStatus !== LinkHealthStatus.WARN &&
+      current.linkStatus !== LinkHealthStatus.FAIL
+    ) {
+      await prisma.contribution.update({
+        where: { id: contributionId },
+        data: {
+          linkStatus: LinkHealthStatus.WARN,
+          linkStatusChangedAt: new Date()
+        }
+      });
+      log.info('Contribution auto-warned by reports', {
+        contributionId,
+        distinctReporters: distinctReporters.length
+      });
+      // Kick off a recheck so status can be corrected if the link is actually fine
+      checkContributionLink(contributionId).catch((err) =>
+        log.warn('Post-report link recheck failed', { contributionId, err })
+      );
+    }
   }
 };

--- a/src/modules/linkHealthJob.ts
+++ b/src/modules/linkHealthJob.ts
@@ -1,21 +1,26 @@
 import { getLogger } from './logging';
-import { recheckStaleLinks } from './linkHealth';
+import { recheckStaleLinks, sweepStaleWarnLinks } from './linkHealth';
 
 const log = getLogger('linkHealthJob');
 
 const INTERVAL_MS = 24 * 60 * 60 * 1000; // every 24 hours
 const STARTUP_DELAY_MS = 60_000; // wait 60s after boot before first run
 
+const runCycle = async (): Promise<void> => {
+  // Recheck stale links first (may resolve WARNs), then sweep the persistent
+  // ones to FAIL.
+  await recheckStaleLinks().catch((err) =>
+    log.error('Stale link recheck failed', { err })
+  );
+  await sweepStaleWarnLinks().catch((err) =>
+    log.error('Stale WARN sweep failed', { err })
+  );
+};
+
 export const startLinkHealthJob = (): void => {
   const outer = setTimeout(() => {
-    recheckStaleLinks().catch((err) =>
-      log.error('Stale link recheck failed', { err })
-    );
-    setInterval(() => {
-      recheckStaleLinks().catch((err) =>
-        log.error('Stale link recheck failed', { err })
-      );
-    }, INTERVAL_MS).unref();
+    void runCycle();
+    setInterval(() => void runCycle(), INTERVAL_MS).unref();
   }, STARTUP_DELAY_MS);
   outer.unref();
 

--- a/src/modules/ratio.spec.ts
+++ b/src/modules/ratio.spec.ts
@@ -129,6 +129,32 @@ describe('getEligibleContributionBytes', () => {
     const result = await getEligibleContributionBytes(1);
     expect(result).toBe(0n);
   });
+
+  it('excludes FAIL-status contributions from the relief pool (ADR-0006)', async () => {
+    // The LinkHealth gate is enforced in the query: a confirmed-dead link
+    // (FAIL) must not count toward coverage. WARN/UNKNOWN are NOT excluded —
+    // suspicion alone never revokes relief.
+    mockPrismaContribution.findMany.mockResolvedValue([]);
+    await getEligibleContributionBytes(1);
+    expect(mockPrismaContribution.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          approvedAccountingBytes: { not: null },
+          linkStatus: { not: 'FAIL' }
+        })
+      })
+    );
+  });
+
+  it('relief is revocable: losing a contribution to FAIL raises required ratio', () => {
+    // 15 GiB consumed (10–20 GiB bracket: max 0.20). With 7.5 GiB eligible,
+    // coverage 0.5 → required 0.10. If that contribution flips FAIL it leaves
+    // the pool (eligible → 0), coverage 0 → required rises to the 0.20 ceiling.
+    const consumed = 15n * GiB;
+    const withHealthyLink = BigInt(Math.round(7.5 * 1024 ** 3));
+    expect(computeRequiredRatio(consumed, withHealthyLink)).toBeCloseTo(0.1);
+    expect(computeRequiredRatio(consumed, 0n)).toBeCloseTo(0.2);
+  });
 });
 
 // ─── getRatioStats ────────────────────────────────────────────────────────────

--- a/src/modules/ratio.ts
+++ b/src/modules/ratio.ts
@@ -1,3 +1,4 @@
+import { LinkHealthStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 
 const GiB = BigInt(1024 ** 3);
@@ -63,12 +64,17 @@ export const getEligibleContributionBytes = async (
   userId: number
 ): Promise<bigint> => {
   const cutoff = new Date(Date.now() - ELIGIBILITY_WINDOW_MS);
-  // Only count contributions that staff have explicitly approved (approvedAccountingBytes set)
+  // Count a contribution toward coverage only if staff approved it
+  // (approvedAccountingBytes set) AND its link is not confirmed dead. A live
+  // link is the seeding analog — relief tracks ongoing availability, so a
+  // FAIL contribution drops out of the pool (ADR-0006). WARN/UNKNOWN still
+  // count: suspicion alone never revokes; only a confirmed FAIL does.
   const contributions = await prisma.contribution.findMany({
     where: {
       userId,
       createdAt: { lt: cutoff },
-      approvedAccountingBytes: { not: null }
+      approvedAccountingBytes: { not: null },
+      linkStatus: { not: LinkHealthStatus.FAIL }
     },
     select: { approvedAccountingBytes: true }
   });

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the Community Reputation Score (CRS) module.
+ * computeCrs is pure; getReputation uses a Prisma mock.
+ */
+
+const mockPrismaUser = { findUnique: jest.fn() };
+
+jest.mock('../lib/prisma', () => ({
+  prisma: { user: mockPrismaUser }
+}));
+
+import { computeCrs, getReputation } from './reputation';
+
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-06-08T00:00:00Z');
+const yearsAgo = (n: number): Date => new Date(NOW.getTime() - n * YEAR_MS);
+
+// ─── computeCrs / LongevityScore ──────────────────────────────────────────────
+
+describe('computeCrs — Longevity dimension', () => {
+  it('a brand-new account scores ~0 longevity', () => {
+    const { score, dimensions } = computeCrs({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW
+    });
+    const longevity = dimensions.find((d) => d.name === 'longevity')!;
+    expect(longevity.subScore).toBeCloseTo(0, 5);
+    expect(score).toBeCloseTo(0, 5);
+  });
+
+  it('rewards age with diminishing returns (~63% of cap at TAU=3y)', () => {
+    const { dimensions } = computeCrs({
+      userId: 1,
+      createdAt: yearsAgo(3),
+      now: NOW
+    });
+    const longevity = dimensions.find((d) => d.name === 'longevity')!;
+    // cap 10, asymptotic: 10 * (1 - e^-1) ≈ 6.32
+    expect(longevity.subScore).toBeCloseTo(6.32, 1);
+  });
+
+  it('each year is worth less than the last (concave)', () => {
+    const at = (y: number) =>
+      computeCrs({ userId: 1, createdAt: yearsAgo(y), now: NOW }).score;
+    const gain1 = at(1) - at(0);
+    const gain5 = at(5) - at(4);
+    expect(gain5).toBeLessThan(gain1);
+  });
+
+  it('is bounded: even an ancient account stays at or below the cap', () => {
+    const { dimensions } = computeCrs({
+      userId: 1,
+      createdAt: yearsAgo(100),
+      now: NOW
+    });
+    const longevity = dimensions.find((d) => d.name === 'longevity')!;
+    expect(longevity.subScore).toBeLessThanOrEqual(10);
+    expect(longevity.subScore).toBeGreaterThan(9.9);
+  });
+
+  it('clamps negative age (createdAt in the future) to 0', () => {
+    const { score } = computeCrs({
+      userId: 1,
+      createdAt: new Date(NOW.getTime() + YEAR_MS),
+      now: NOW
+    });
+    expect(score).toBeCloseTo(0, 5);
+  });
+
+  it('score is the sum of weighted dimensions', () => {
+    const { score, dimensions } = computeCrs({
+      userId: 1,
+      createdAt: yearsAgo(4),
+      now: NOW
+    });
+    const expected = dimensions.reduce((s, d) => s + d.weighted, 0);
+    expect(score).toBeCloseTo(expected, 10);
+  });
+});
+
+// ─── getReputation (read-time assembler) ──────────────────────────────────────
+
+describe('getReputation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('computes CRS from the user createdAt', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({ createdAt: yearsAgo(6) });
+    const result = await getReputation(1);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.dimensions.map((d) => d.name)).toContain('longevity');
+  });
+
+  it('returns an empty score for an unknown user', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue(null);
+    const result = await getReputation(999);
+    expect(result).toEqual({ score: 0, dimensions: [] });
+  });
+});

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -79,16 +79,78 @@ describe('computeCrs — Longevity dimension', () => {
   });
 });
 
+// ─── computeCrs / Ratio dimension ─────────────────────────────────────────────
+
+describe('computeCrs — Ratio dimension', () => {
+  const ratioOf = (input: Parameters<typeof computeCrs>[0]) =>
+    computeCrs(input).dimensions.find((d) => d.name === 'ratio')!.subScore;
+
+  it('earns nothing without demonstrated contribution (fresh default account)', () => {
+    // default ratio 1.0, contributed 0 → no ratio reputation
+    expect(ratioOf({ userId: 1, createdAt: NOW, now: NOW })).toBe(0);
+    expect(
+      ratioOf({
+        userId: 1,
+        createdAt: NOW,
+        now: NOW,
+        ratio: 1,
+        contributed: 0n
+      })
+    ).toBe(0);
+  });
+
+  it('rewards a net contributor, diminishing returns toward the cap', () => {
+    const contributed = 1n;
+    const low = ratioOf({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      ratio: 1,
+      contributed
+    });
+    const high = ratioOf({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      ratio: 4,
+      contributed
+    });
+    expect(high).toBeGreaterThan(low);
+    expect(high).toBeLessThanOrEqual(8); // cap
+  });
+
+  it('is bounded even for an enormous ratio', () => {
+    const sub = ratioOf({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      ratio: 1000,
+      contributed: 1n
+    });
+    expect(sub).toBeLessThanOrEqual(8);
+    expect(sub).toBeGreaterThan(7.9);
+  });
+});
+
 // ─── getReputation (read-time assembler) ──────────────────────────────────────
 
 describe('getReputation', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('computes CRS from the user createdAt', async () => {
-    mockPrismaUser.findUnique.mockResolvedValue({ createdAt: yearsAgo(6) });
+  it('computes CRS from the user createdAt + ratio', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({
+      createdAt: yearsAgo(6),
+      contributed: 30n * 1024n ** 3n,
+      consumed: 10n * 1024n ** 3n // ratio 3.0
+    });
     const result = await getReputation(1);
     expect(result.score).toBeGreaterThan(0);
-    expect(result.dimensions.map((d) => d.name)).toContain('longevity');
+    expect(result.dimensions.map((d) => d.name)).toEqual(
+      expect.arrayContaining(['longevity', 'ratio'])
+    );
+    expect(
+      result.dimensions.find((d) => d.name === 'ratio')!.subScore
+    ).toBeGreaterThan(0);
   });
 
   it('returns an empty score for an unknown user', async () => {

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -4,9 +4,10 @@
  */
 
 const mockPrismaUser = { findUnique: jest.fn() };
+const mockPrismaFriend = { count: jest.fn() };
 
 jest.mock('../lib/prisma', () => ({
-  prisma: { user: mockPrismaUser }
+  prisma: { user: mockPrismaUser, friend: mockPrismaFriend }
 }));
 
 import { computeCrs, getReputation } from './reputation';
@@ -132,17 +133,47 @@ describe('computeCrs — Ratio dimension', () => {
   });
 });
 
+// ─── computeCrs / Friends dimension ───────────────────────────────────────────
+
+describe('computeCrs — Friends dimension', () => {
+  const friendsOf = (friendCount: number) =>
+    computeCrs({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      friendCount
+    }).dimensions.find((d) => d.name === 'friends')!.subScore;
+
+  it('zero friends → zero', () => {
+    expect(friendsOf(0)).toBe(0);
+  });
+
+  it('more friends help, with diminishing returns', () => {
+    expect(friendsOf(5)).toBeGreaterThan(friendsOf(2));
+    expect(friendsOf(20) - friendsOf(15)).toBeLessThan(
+      friendsOf(5) - friendsOf(0)
+    );
+  });
+
+  it('count cannot dominate: even thousands of friends stay under the low cap', () => {
+    // FRIENDS_CAP = 4, far below longevity (10) / ratio (8) — count alone can't win
+    expect(friendsOf(10_000)).toBeLessThanOrEqual(4);
+    expect(friendsOf(10_000)).toBeGreaterThan(3.9);
+  });
+});
+
 // ─── getReputation (read-time assembler) ──────────────────────────────────────
 
 describe('getReputation', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('computes CRS from the user createdAt + ratio', async () => {
+  it('computes CRS from the user createdAt + ratio + friends', async () => {
     mockPrismaUser.findUnique.mockResolvedValue({
       createdAt: yearsAgo(6),
       contributed: 30n * 1024n ** 3n,
       consumed: 10n * 1024n ** 3n // ratio 3.0
     });
+    mockPrismaFriend.count.mockResolvedValue(5);
     const result = await getReputation(1);
     expect(result.score).toBeGreaterThan(0);
     expect(result.dimensions.map((d) => d.name)).toEqual(
@@ -151,10 +182,14 @@ describe('getReputation', () => {
     expect(
       result.dimensions.find((d) => d.name === 'ratio')!.subScore
     ).toBeGreaterThan(0);
+    expect(
+      result.dimensions.find((d) => d.name === 'friends')!.subScore
+    ).toBeGreaterThan(0);
   });
 
   it('returns an empty score for an unknown user', async () => {
     mockPrismaUser.findUnique.mockResolvedValue(null);
+    mockPrismaFriend.count.mockResolvedValue(0);
     const result = await getReputation(999);
     expect(result).toEqual({ score: 0, dimensions: [] });
   });

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -27,6 +27,8 @@ export interface DimensionInput {
   ratio?: number;
   /** Lifetime contributed bytes — gates RatioScore so a fresh default account earns nothing. */
   contributed?: bigint;
+  /** Number of friend relationships. Defaults to 0. */
+  friendCount?: number;
   /** Injectable for deterministic tests; defaults to now. */
   now?: Date;
 }
@@ -95,9 +97,33 @@ const ratioScorer: DimensionScorer = {
   }
 };
 
-// Registry — add a dimension here (Friends, Invite, Donation, …) and the
-// aggregator picks it up unchanged.
-const REGISTRY: DimensionScorer[] = [longevityScorer, ratioScorer];
+// ─── FriendsScore ─────────────────────────────────────────────────────────
+// A lightweight trust signal (PRD-01 "Relationships Matter"). The PRD is
+// explicit that "friend count alone should not determine score", so this is
+// deliberately the weakest dimension: a LOW cap and heavy diminishing returns,
+// so even a huge friend list can't dominate longevity/ratio — and ring-farming
+// (the model is a directed add, no reciprocity yet, #60) hits the cap fast.
+// Quality-weighting (mutuality, friend account age, network diversity) is
+// future work per the PRD.
+const FRIENDS_CAP = 4;
+const FRIENDS_TAU = 5; // 5 friends → ~63% of cap; diminishing hard after
+const FRIENDS_WEIGHT = 1.0;
+
+const friendsScorer: DimensionScorer = {
+  name: 'friends',
+  weight: FRIENDS_WEIGHT,
+  cap: FRIENDS_CAP,
+  compute: ({ friendCount = 0 }) =>
+    FRIENDS_CAP * (1 - Math.exp(-Math.max(0, friendCount) / FRIENDS_TAU))
+};
+
+// Registry — add a dimension here (Invite, Donation, …) and the aggregator
+// picks it up unchanged.
+const REGISTRY: DimensionScorer[] = [
+  longevityScorer,
+  ratioScorer,
+  friendsScorer
+];
 
 /** Pure aggregator: sum each capped dimension's weighted subScore. */
 export const computeCrs = (input: DimensionInput): CrsResult => {
@@ -111,15 +137,19 @@ export const computeCrs = (input: DimensionInput): CrsResult => {
 
 /** Read-time CRS for a user. Assembles the dimension input, then computes. */
 export const getReputation = async (userId: number): Promise<CrsResult> => {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { createdAt: true, contributed: true, consumed: true }
-  });
+  const [user, friendCount] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: { createdAt: true, contributed: true, consumed: true }
+    }),
+    prisma.friend.count({ where: { userId } })
+  ]);
   if (!user) return { score: 0, dimensions: [] };
   return computeCrs({
     userId,
     createdAt: user.createdAt,
     ratio: computeRatio(user.contributed, user.consumed),
-    contributed: user.contributed
+    contributed: user.contributed,
+    friendCount
   });
 };

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -1,0 +1,94 @@
+/**
+ * Community Reputation Score (CRS) — PRD-01.
+ *
+ * A registry of bounded, pure dimension-scorers (mirrors the pure-scoring
+ * style of `stylesheetScore.ts` / `ratio.ts`). The score is:
+ *
+ *     CRS = Σ (weight_i × subScore_i)
+ *
+ * Each dimension's subScore is clamped to a per-dimension cap, so no single
+ * axis can dominate — the PRD's "friend count alone should not determine
+ * score" and "donation value should not dominate" guardrails are enforced as
+ * caps, not hopes. The value is computed on read (ADR-0007); only events that
+ * current state can't reconstruct are ledger-logged elsewhere.
+ *
+ * New dimensions self-register into REGISTRY; the aggregator never changes.
+ * Weight/cap constants are tier-0 — tune alongside the PRD.
+ */
+import { prisma } from '../lib/prisma';
+
+/** What dimension scorers may read. Grows as dimensions are added; the
+ *  assembler (`getReputation`) fetches it, keeping each scorer pure. */
+export interface DimensionInput {
+  userId: number;
+  createdAt: Date;
+  /** Injectable for deterministic tests; defaults to now. */
+  now?: Date;
+}
+
+export interface DimensionScorer {
+  name: string;
+  weight: number;
+  cap: number;
+  /** Pure: no DB, no clock except `input.now`. Returns the raw (pre-clamp) subScore. */
+  compute: (input: DimensionInput) => number;
+}
+
+export interface DimensionResult {
+  name: string;
+  subScore: number;
+  weighted: number;
+}
+
+export interface CrsResult {
+  score: number;
+  dimensions: DimensionResult[];
+}
+
+const clamp = (value: number, cap: number): number =>
+  Math.max(0, Math.min(cap, value));
+
+// ─── LongevityScore ───────────────────────────────────────────────────────
+// Continuity matters (PRD-01): account age positively influences reputation,
+// with diminishing returns — asymptotic to the cap, each year worth less than
+// the last. ~63% of cap at TAU years, ~86% at 2×TAU.
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+const LONGEVITY_CAP = 10;
+const LONGEVITY_TAU_YEARS = 3;
+const LONGEVITY_WEIGHT = 1.0;
+
+const longevityScorer: DimensionScorer = {
+  name: 'longevity',
+  weight: LONGEVITY_WEIGHT,
+  cap: LONGEVITY_CAP,
+  compute: ({ createdAt, now }) => {
+    const ageYears =
+      Math.max(0, (now ?? new Date()).getTime() - createdAt.getTime()) /
+      YEAR_MS;
+    return LONGEVITY_CAP * (1 - Math.exp(-ageYears / LONGEVITY_TAU_YEARS));
+  }
+};
+
+// Registry — add a dimension here (Friends, Invite, Donation, RatioScore, …)
+// and the aggregator picks it up unchanged.
+const REGISTRY: DimensionScorer[] = [longevityScorer];
+
+/** Pure aggregator: sum each capped dimension's weighted subScore. */
+export const computeCrs = (input: DimensionInput): CrsResult => {
+  const dimensions = REGISTRY.map((d) => {
+    const subScore = clamp(d.compute(input), d.cap);
+    return { name: d.name, subScore, weighted: d.weight * subScore };
+  });
+  const score = dimensions.reduce((sum, d) => sum + d.weighted, 0);
+  return { score, dimensions };
+};
+
+/** Read-time CRS for a user. Assembles the dimension input, then computes. */
+export const getReputation = async (userId: number): Promise<CrsResult> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { createdAt: true }
+  });
+  if (!user) return { score: 0, dimensions: [] };
+  return computeCrs({ userId, createdAt: user.createdAt });
+};

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -16,12 +16,17 @@
  * Weight/cap constants are tier-0 — tune alongside the PRD.
  */
 import { prisma } from '../lib/prisma';
+import { computeRatio } from './ratio';
 
 /** What dimension scorers may read. Grows as dimensions are added; the
  *  assembler (`getReputation`) fetches it, keeping each scorer pure. */
 export interface DimensionInput {
   userId: number;
   createdAt: Date;
+  /** Current ratio (contributed/consumed). Defaults to the break-even 1.0. */
+  ratio?: number;
+  /** Lifetime contributed bytes — gates RatioScore so a fresh default account earns nothing. */
+  contributed?: bigint;
   /** Injectable for deterministic tests; defaults to now. */
   now?: Date;
 }
@@ -69,9 +74,30 @@ const longevityScorer: DimensionScorer = {
   }
 };
 
-// Registry — add a dimension here (Friends, Invite, Donation, RatioScore, …)
-// and the aggregator picks it up unchanged.
-const REGISTRY: DimensionScorer[] = [longevityScorer];
+// ─── RatioScore ───────────────────────────────────────────────────────────
+// Reputation reflection of the Ratio mechanism, strictly one-way: CRS reads
+// ratio, ratio never reads CRS (ADR-0006 / PRD-06). Rewards a net-contributor
+// ratio with diminishing returns — but only once the user has demonstrated
+// contribution (contributed > 0), so a fresh account at the default 1.0 ratio
+// earns nothing. Non-negative: ratio enforcement (WATCH/LEECH_DISABLED) is the
+// Ratio mechanism's job, not a CRS penalty.
+const RATIO_CAP = 8;
+const RATIO_TAU = 1.5; // ratio 1.5 → ~63% of cap, 3.0 → ~86%
+const RATIO_WEIGHT = 1.0;
+
+const ratioScorer: DimensionScorer = {
+  name: 'ratio',
+  weight: RATIO_WEIGHT,
+  cap: RATIO_CAP,
+  compute: ({ ratio = 1, contributed = 0n }) => {
+    if (contributed <= 0n) return 0;
+    return RATIO_CAP * (1 - Math.exp(-Math.max(0, ratio) / RATIO_TAU));
+  }
+};
+
+// Registry — add a dimension here (Friends, Invite, Donation, …) and the
+// aggregator picks it up unchanged.
+const REGISTRY: DimensionScorer[] = [longevityScorer, ratioScorer];
 
 /** Pure aggregator: sum each capped dimension's weighted subScore. */
 export const computeCrs = (input: DimensionInput): CrsResult => {
@@ -87,8 +113,13 @@ export const computeCrs = (input: DimensionInput): CrsResult => {
 export const getReputation = async (userId: number): Promise<CrsResult> => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { createdAt: true }
+    select: { createdAt: true, contributed: true, consumed: true }
   });
   if (!user) return { score: 0, dimensions: [] };
-  return computeCrs({ userId, createdAt: user.createdAt });
+  return computeCrs({
+    userId,
+    createdAt: user.createdAt,
+    ratio: computeRatio(user.contributed, user.consumed),
+    contributed: user.contributed
+  });
 };

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -8,6 +8,7 @@ import {
   createInvite
 } from '../../modules/profile';
 import { getRatioStats } from '../../modules/ratio';
+import { getReputation } from '../../modules/reputation';
 import { getPolicyState } from '../../modules/ratioPolicy';
 import { requireAuth } from '../../middleware/auth';
 import { audit } from '../../lib/audit';
@@ -81,6 +82,15 @@ router.get(
       getPolicyState(req.user.id)
     ]);
     res.json({ ...stats, policy });
+  })
+);
+
+// GET /api/profile/me/reputation — Community Reputation Score (PRD-01), computed on read
+router.get(
+  '/me/reputation',
+  requireAuth,
+  authHandler(async (req, res) => {
+    res.json(await getReputation(req.user.id));
   })
 );
 


### PR DESCRIPTION
Crystallizes the Ratio/CRS architecture-design session into docs, then implements the foundation. Ratio is enforcement (download gate); CRS is reputation; layered strictly one-way.

## Design docs
- **ADR-0006** — LinkHealth-gated ratio relief: a contribution earns relief only while its link is alive (`linkStatus ≠ FAIL`); a live link is the seeding analog, so relief tracks ongoing availability and is revocable. `WARN`/`UNKNOWN` never revoke (anti-weaponization); persistent `WARN` is swept to `FAIL`. No clawback of lifetime `contributed`.
- **ADR-0007** — CRS computed-on-read; only non-reconstructable events ledger-logged (`CRS_*` reason); snapshots deferred. Resolves ADR-0002's open question.
- **PRD-06** (Ratio), **PRD-01** (CRS registry + Ratio independence), **PRD-03** (Friends×Stylesheet vector), **CONTEXT.md** glossary.

## Implementation (tracer-bullet slices, red-green)
- **Slice 1** — ratio relief gated on `linkStatus ≠ FAIL`; required ratio rises as links rot.
- **Slice 1b** — `linkStatusChangedAt` (migration, applied) + 72h `WARN→FAIL` sweep in the link-health job.
- **Slice 2** — `reputation.ts`: registry of bounded pure dimension-scorers + `LongevityScore` + `GET /api/profile/me/reputation`.
- **Slice 3** — `RatioScore` (one-way: CRS reads ratio, never the reverse).
- **Slice 4** — `FriendsScore` (deliberately low cap so count can't dominate).

Anti-dominance is structural: caps Longevity 10 / Ratio 8 / Friends 4.

## Tests
**1404/1404 green**, `tsc` clean, lint clean.

## Follow-ups (tracked, out of scope here)
- #94 CRS time-series snapshots · #95 LinkHealthBonusPoints lifetime dimension
- Friends×Stylesheet vector + `CRS_*` ledger — blocked on the AuthorStylesheet save/adopt feature (PRD-03 slice 4), which is currently a pure function wired to nothing.
- `DonationScore` / `InviteScore` dimensions (#62/#61).
- The `WARN→FAIL` sweep's contributor-PM + staff-report notification (promotion itself is done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)