### PR TITLE
Community-health pulse (rebased, clean) — supersedes #87

### DIFF
--- a/docs/adr/0002-community-health-pulse.md
+++ b/docs/adr/0002-community-health-pulse.md
@@ -8,10 +8,14 @@ those up to the community level.
 
 We aggregate **on read** rather than storing a score. `getCommunityHealthPulse`
 (`src/modules/linkHealth.ts`) groups a community's contributions by `linkStatus`
-(via `release.communityId`) and returns a pulse = `pass / checked`, where
-`checked = pass + warn + fail` (UNKNOWN is excluded — not yet probed). The ratio
-is banded `Healthy ≥ 0.90`, `Ailing ≥ 0.60`, `Critical` otherwise, `Unknown`
-when nothing is checked. It is served at `GET /api/communities/:id/health`.
+(via `release.communityId`). Only `PASS` and `FAIL` are definitive (`checked`);
+`WARN` (transient 5xx / report-flagged) and `UNKNOWN` (unprobed) are
+indeterminate and excluded — so a transient-only community reads `Unknown`, not
+`Critical`. The pulse = `pass / checked`, banded `Healthy ≥ 0.90`,
+`Ailing ≥ 0.60`, `Critical` otherwise. It withholds a confident band and reports
+`Unknown` until coverage (`checked / total`) clears a floor (`0.5`), so one
+probed link among thousands of unprobed ones doesn't read `Healthy`. Served at
+`GET /api/communities/:id/health`.
 
 No schema change and no stored state: the pulse is cheap to compute and always
 reflects current link reality, so there is nothing to invalidate. The existing

--- a/docs/adr/0002-community-health-pulse.md
+++ b/docs/adr/0002-community-health-pulse.md
@@ -1,14 +1,24 @@
-# Community-health pulse → CommunityScore
+# Compute community health as a read-time link pulse; defer persistence and scoring
 
-**Status: Proposed — future direction.** Serves [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md); tracked by [#75](https://github.com/orphic-inc/stellar-api/issues/75).
+`01-Community-Score.md` favours communities that stay "active, healthy, and
+self-sustaining." LinkHealth already gives that health a per-contribution
+signal: submitting through the contribution form sets `Contribution.linkStatus`
+(`UNKNOWN | PASS | WARN | FAIL`), and a job re-checks stale links. Nothing rolled
+those up to the community level.
 
-Stellar computes a community-health signal on read (`getCommunityHealthPulse`). The decision recorded here is how that pulse becomes a durable input to the CommunityReputationScore (CRS).
+We aggregate **on read** rather than storing a score. `getCommunityHealthPulse`
+(`src/modules/linkHealth.ts`) groups a community's contributions by `linkStatus`
+(via `release.communityId`) and returns a pulse = `pass / checked`, where
+`checked = pass + warn + fail` (UNKNOWN is excluded — not yet probed). The ratio
+is banded `Healthy ≥ 0.90`, `Ailing ≥ 0.60`, `Critical` otherwise, `Unknown`
+when nothing is checked. It is served at `GET /api/communities/:id/health`.
 
-Decision to record (not yet finalized):
+No schema change and no stored state: the pulse is cheap to compute and always
+reflects current link reality, so there is nothing to invalidate. The existing
+`Release → Contribution` shape feeds it as-is, so this does not wait on the Music
+model remodel (#72–#74). Persisting/snapshotting the pulse and folding it into
+the PRD's `CommunityScore` is deliberately deferred (#75), as is weighting it by
+upload quality — a lossless/logged/cued release should count for more than a
+transcode (#76).
 
-- **Persistence:** snapshot the pulse over time (mirror `statsHistory`) for trend analysis vs. recompute-on-read only.
-- **Folding into CRS:** how the pulse feeds the `CommunityScore` dimension of `CommunityReputationScore`, and ultimately a `CommunityValueIndex`.
-
-This is the ADR the stylesheet-scoring work ([PRD-03](../prd/03-stylesheet-themes-and-scoring.md)) and other CRS dimensions reference for "computed-on-read vs. event-logged" accrual.
-
-**Resolved by [ADR-0007 — CRS computation: read-time value + event accrual ledger](0007-crs-read-time-and-event-ledger.md):** the score is computed-on-read; only events that current state cannot reconstruct are append-only logged (a `CRS_*` reason on `EconomyTransaction`); time-series snapshots (the pulse-over-time trend this ADR anticipated) are a deferred additive layer mirroring `statsHistory`, never the source of truth. The pulse stays computed-on-read and folds into the `CommunityScore` dimension under that model.
+**Resolved by [ADR-0007 — CRS computation: read-time value + event accrual ledger](0007-crs-read-time-and-event-ledger.md):** the computed-on-read-vs-event-logged question this ADR left open is settled — the CRS value is computed-on-read; only events current state cannot reconstruct are append-only logged (a `CRS_*` reason on `EconomyTransaction`); time-series snapshots (the pulse-over-time trend, #75 / #94) are a deferred additive layer mirroring `statsHistory`, never the source of truth.

--- a/src/communities.spec.ts
+++ b/src/communities.spec.ts
@@ -135,15 +135,16 @@ describe('GET /api/communities/:id/health', () => {
       fail: 2,
       unknown: 0,
       total: 10,
-      checked: 10,
-      pulse: 0.6,
+      checked: 8,
+      coverage: 0.8,
+      pulse: 0.75,
       status: 'Ailing'
     });
 
     const res = await request(app).get('/api/communities/1/health');
 
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ pulse: 0.6, status: 'Ailing', checked: 10 });
+    expect(res.body).toMatchObject({ pulse: 0.75, status: 'Ailing', checked: 8 });
     expect(getCommunityHealthPulseMock).toHaveBeenCalledWith(1);
   });
 

--- a/src/communities.spec.ts
+++ b/src/communities.spec.ts
@@ -1,6 +1,7 @@
 import { CommunityType, RegistrationStatus } from '@prisma/client';
 import {
   app,
+  getCommunityHealthPulseMock,
   makeUserRank,
   prismaMock,
   request,
@@ -114,6 +115,49 @@ describe('GET /api/communities/:id', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Jazz');
+  });
+});
+
+describe('GET /api/communities/:id/health', () => {
+  it('returns 404 when the community does not exist', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/communities/1/health');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the link-health pulse for a member', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    getCommunityHealthPulseMock.mockResolvedValue({
+      pass: 6,
+      warn: 2,
+      fail: 2,
+      unknown: 0,
+      total: 10,
+      checked: 10,
+      pulse: 0.6,
+      status: 'Ailing'
+    });
+
+    const res = await request(app).get('/api/communities/1/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ pulse: 0.6, status: 'Ailing', checked: 10 });
+    expect(getCommunityHealthPulseMock).toHaveBeenCalledWith(1);
+  });
+
+  it('returns 403 when the user is not a member of a restricted community', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ registrationStatus: RegistrationStatus.invite }) as never
+    );
+    prismaMock.consumer.findFirst.mockResolvedValue(null);
+    prismaMock.contributor.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/communities/1/health');
+
+    expect(res.status).toBe(403);
+    expect(getCommunityHealthPulseMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/communities.spec.ts
+++ b/src/communities.spec.ts
@@ -144,7 +144,11 @@ describe('GET /api/communities/:id/health', () => {
     const res = await request(app).get('/api/communities/1/health');
 
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ pulse: 0.75, status: 'Ailing', checked: 8 });
+    expect(res.body).toMatchObject({
+      pulse: 0.75,
+      status: 'Ailing',
+      checked: 8
+    });
     expect(getCommunityHealthPulseMock).toHaveBeenCalledWith(1);
   });
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2722,6 +2722,7 @@ const CommunityHealthPulse = z
     unknown: z.number(),
     total: z.number(),
     checked: z.number(),
+    coverage: z.number().nullable(),
     pulse: z.number().nullable(),
     status: z.enum(['Healthy', 'Ailing', 'Critical', 'Unknown'])
   })

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2505,6 +2505,8 @@ const Contribution = registry.register(
     type: z.string(),
     downloadUrl: z.string(),
     sizeInBytes: z.number().nullable().optional(),
+    linkStatus: z.enum(['UNKNOWN', 'PASS', 'WARN', 'FAIL']),
+    linkCheckedAt: z.string().nullable().optional(),
     collaborators: z.array(
       z.object({
         id: z.number(),
@@ -2704,6 +2706,40 @@ registry.registerPath({
     200: {
       description: 'Community',
       content: { 'application/json': { schema: Community } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+const CommunityHealthPulse = z
+  .object({
+    pass: z.number(),
+    warn: z.number(),
+    fail: z.number(),
+    unknown: z.number(),
+    total: z.number(),
+    checked: z.number(),
+    pulse: z.number().nullable(),
+    status: z.enum(['Healthy', 'Ailing', 'Critical', 'Unknown'])
+  })
+  .openapi('CommunityHealthPulse');
+
+registry.registerPath({
+  method: 'get',
+  path: '/communities/{id}/health',
+  tags: ['Communities'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Community link-health pulse',
+      content: { 'application/json': { schema: CommunityHealthPulse } }
+    },
+    403: {
+      description: 'Not a member of this community',
+      content: { 'application/json': { schema: MsgResponse } }
     },
     404: {
       description: 'Not found',

--- a/src/modules/linkHealth.spec.ts
+++ b/src/modules/linkHealth.spec.ts
@@ -145,15 +145,51 @@ describe('getCommunityHealthPulse', () => {
     expect(r.total).toBe(10);
   });
 
-  it('computes the pass ratio over checked links, excluding UNKNOWN', async () => {
+  it('computes the pass ratio over definitive links, excluding WARN and UNKNOWN', async () => {
     mockPrismaContribution.groupBy.mockResolvedValue(
       groupRows({ PASS: 6, WARN: 2, FAIL: 2 })
     );
 
     const r = await getCommunityHealthPulse(1);
 
-    expect(r.pulse).toBe(0.6); // 6 / (6 + 2 + 2)
+    expect(r.pulse).toBe(0.75); // 6 PASS / (6 PASS + 2 FAIL); WARN is indeterminate
     expect(r.status).toBe('Ailing'); // >= 0.6
+  });
+
+  it('reads Unknown — not Critical — for a transient-only (WARN) community', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue(groupRows({ WARN: 5 }));
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r.checked).toBe(0); // WARN is not definitive
+    expect(r.pulse).toBeNull();
+    expect(r.status).toBe('Unknown');
+  });
+
+  it('withholds a confident band until coverage clears the floor', async () => {
+    // One PASS among 99 unprobed: pulse is technically 1.0, but only 1% probed.
+    mockPrismaContribution.groupBy.mockResolvedValue(
+      groupRows({ PASS: 1, UNKNOWN: 99 })
+    );
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r.pulse).toBe(1);
+    expect(r.coverage).toBeCloseTo(0.01);
+    expect(r.status).toBe('Unknown'); // below PULSE_MIN_COVERAGE — not Healthy
+  });
+
+  it('scopes the aggregation to the community via the release relation', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue(groupRows({ PASS: 1 }));
+
+    await getCommunityHealthPulse(42);
+
+    expect(mockPrismaContribution.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        by: ['linkStatus'],
+        where: { release: { communityId: 42 } }
+      })
+    );
   });
 
   it('reads Critical when failures dominate', async () => {

--- a/src/modules/linkHealth.spec.ts
+++ b/src/modules/linkHealth.spec.ts
@@ -1,12 +1,16 @@
 /**
- * Unit tests for the link-health WARN->FAIL sweep and transition stamping.
+ * Unit tests for link-health: the WARN->FAIL sweep + transition stamping, and
+ * the community pulse (aggregate heartbeat over per-contribution linkStatus).
  * DB + fetch are mocked.
  */
+
+import { LinkHealthStatus } from '@prisma/client';
 
 const mockPrismaContribution = {
   findUnique: jest.fn(),
   update: jest.fn(),
-  updateMany: jest.fn()
+  updateMany: jest.fn(),
+  groupBy: jest.fn()
 };
 
 jest.mock('../lib/prisma', () => ({
@@ -17,7 +21,11 @@ jest.mock('./logging', () => ({
   getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
 }));
 
-import { sweepStaleWarnLinks, checkContributionLink } from './linkHealth';
+import {
+  sweepStaleWarnLinks,
+  checkContributionLink,
+  getCommunityHealthPulse
+} from './linkHealth';
 
 // ─── sweepStaleWarnLinks ──────────────────────────────────────────────────────
 
@@ -94,5 +102,81 @@ describe('checkContributionLink stamps linkStatusChangedAt on transition', () =>
     await checkContributionLink(5);
     const { data } = mockPrismaContribution.update.mock.calls[0][0];
     expect(data.linkStatusChangedAt).toBeInstanceOf(Date);
+  });
+});
+
+// ─── getCommunityHealthPulse ──────────────────────────────────────────────────
+
+// Shape rows the way prisma.contribution.groupBy(by: ['linkStatus']) returns them.
+const groupRows = (counts: Partial<Record<LinkHealthStatus, number>>) =>
+  Object.entries(counts).map(([linkStatus, n]) => ({
+    linkStatus: linkStatus as LinkHealthStatus,
+    _count: { _all: n }
+  }));
+
+describe('getCommunityHealthPulse', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reads Unknown with a null pulse when nothing has been checked yet', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue(groupRows({ UNKNOWN: 5 }));
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r).toMatchObject({
+      pass: 0,
+      unknown: 5,
+      checked: 0,
+      total: 5,
+      pulse: null,
+      status: 'Unknown'
+    });
+  });
+
+  it('reads a full heartbeat when every checked link passes', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue(
+      groupRows({ PASS: 8, UNKNOWN: 2 })
+    );
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r.pulse).toBe(1);
+    expect(r.status).toBe('Healthy');
+    expect(r.checked).toBe(8);
+    expect(r.total).toBe(10);
+  });
+
+  it('computes the pass ratio over checked links, excluding UNKNOWN', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue(
+      groupRows({ PASS: 6, WARN: 2, FAIL: 2 })
+    );
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r.pulse).toBe(0.6); // 6 / (6 + 2 + 2)
+    expect(r.status).toBe('Ailing'); // >= 0.6
+  });
+
+  it('reads Critical when failures dominate', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue(
+      groupRows({ PASS: 1, FAIL: 9 })
+    );
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r.pulse).toBeCloseTo(0.1);
+    expect(r.status).toBe('Critical');
+  });
+
+  it('returns a null pulse for a community with no contributions', async () => {
+    mockPrismaContribution.groupBy.mockResolvedValue([]);
+
+    const r = await getCommunityHealthPulse(1);
+
+    expect(r).toMatchObject({
+      total: 0,
+      checked: 0,
+      pulse: null,
+      status: 'Unknown'
+    });
   });
 });

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -11,9 +11,12 @@ const REPORT_WARN_THRESHOLD = 3;
 // A contribution stuck at WARN this long is promoted to FAIL (ADR-0006)
 const WARN_SWEEP_AFTER_MS = 72 * 60 * 60 * 1000;
 
-// Community pulse bands — the share of *checked* links that PASS. Retune here.
+// Community pulse bands — the share of *definitively probed* links that PASS.
 const PULSE_HEALTHY = 0.9;
 const PULSE_AILING = 0.6;
+// Below this share of links definitively probed, the pulse isn't trustworthy
+// enough to band — report Unknown rather than a confident Healthy/Critical.
+const PULSE_MIN_COVERAGE = 0.5;
 
 export const checkUrl = async (url: string): Promise<LinkHealthStatus> => {
   const controller = new AbortController();
@@ -151,9 +154,14 @@ export interface CommunityHealthPulse {
   unknown: number;
   /** All contributions in the community. */
   total: number;
-  /** Contributions whose link has actually been probed (PASS + WARN + FAIL). */
+  /**
+   * Definitively probed links (PASS + FAIL). WARN is transient/uncertain and
+   * UNKNOWN is unprobed — both are indeterminate and excluded from the pulse.
+   */
   checked: number;
-  /** Share of checked links that PASS, 0–1. `null` when nothing is checked yet. */
+  /** Share of all links that are definitively probed, 0–1. `null` when empty. */
+  coverage: number | null;
+  /** Share of probed links that PASS, 0–1. `null` when none are probed yet. */
   pulse: number | null;
   status: CommunityPulseStatus;
 }
@@ -191,11 +199,16 @@ export const getCommunityHealthPulse = async (
     }
   }
 
-  const checked = counts.pass + counts.warn + counts.fail;
-  const total = checked + counts.unknown;
+  // Only PASS/FAIL are definitive; WARN (transient) and UNKNOWN (unprobed) are
+  // indeterminate and excluded from the pulse.
+  const checked = counts.pass + counts.fail;
+  const total = checked + counts.warn + counts.unknown;
+  const coverage = total === 0 ? null : checked / total;
   const pulse = checked === 0 ? null : counts.pass / checked;
+  // Don't claim a confident band until enough links are actually probed —
+  // otherwise one PASS among thousands of UNKNOWN would read "Healthy".
   const status: CommunityPulseStatus =
-    pulse === null
+    pulse === null || coverage === null || coverage < PULSE_MIN_COVERAGE
       ? 'Unknown'
       : pulse >= PULSE_HEALTHY
         ? 'Healthy'
@@ -203,5 +216,5 @@ export const getCommunityHealthPulse = async (
           ? 'Ailing'
           : 'Critical';
 
-  return { ...counts, total, checked, pulse, status };
+  return { ...counts, total, checked, coverage, pulse, status };
 };

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -145,7 +145,11 @@ export const recordContributionReport = async (
   }
 };
 
-export type CommunityPulseStatus = 'Healthy' | 'Ailing' | 'Critical' | 'Unknown';
+export type CommunityPulseStatus =
+  | 'Healthy'
+  | 'Ailing'
+  | 'Critical'
+  | 'Unknown';
 
 export interface CommunityHealthPulse {
   pass: number;
@@ -211,10 +215,10 @@ export const getCommunityHealthPulse = async (
     pulse === null || coverage === null || coverage < PULSE_MIN_COVERAGE
       ? 'Unknown'
       : pulse >= PULSE_HEALTHY
-        ? 'Healthy'
-        : pulse >= PULSE_AILING
-          ? 'Ailing'
-          : 'Critical';
+      ? 'Healthy'
+      : pulse >= PULSE_AILING
+      ? 'Ailing'
+      : 'Critical';
 
   return { ...counts, total, checked, coverage, pulse, status };
 };

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -11,6 +11,10 @@ const REPORT_WARN_THRESHOLD = 3;
 // A contribution stuck at WARN this long is promoted to FAIL (ADR-0006)
 const WARN_SWEEP_AFTER_MS = 72 * 60 * 60 * 1000;
 
+// Community pulse bands — the share of *checked* links that PASS. Retune here.
+const PULSE_HEALTHY = 0.9;
+const PULSE_AILING = 0.6;
+
 export const checkUrl = async (url: string): Promise<LinkHealthStatus> => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
@@ -136,4 +140,68 @@ export const recordContributionReport = async (
       );
     }
   }
+};
+
+export type CommunityPulseStatus = 'Healthy' | 'Ailing' | 'Critical' | 'Unknown';
+
+export interface CommunityHealthPulse {
+  pass: number;
+  warn: number;
+  fail: number;
+  unknown: number;
+  /** All contributions in the community. */
+  total: number;
+  /** Contributions whose link has actually been probed (PASS + WARN + FAIL). */
+  checked: number;
+  /** Share of checked links that PASS, 0–1. `null` when nothing is checked yet. */
+  pulse: number | null;
+  status: CommunityPulseStatus;
+}
+
+/**
+ * The community's link-health "pulse": roll every contribution's linkStatus up
+ * into a single heartbeat. A living community keeps its links alive; the pulse
+ * weakens as they rot. Computed on read — no stored state.
+ */
+export const getCommunityHealthPulse = async (
+  communityId: number
+): Promise<CommunityHealthPulse> => {
+  const grouped = await prisma.contribution.groupBy({
+    by: ['linkStatus'],
+    where: { release: { communityId } },
+    _count: { _all: true }
+  });
+
+  const counts = { pass: 0, warn: 0, fail: 0, unknown: 0 };
+  for (const row of grouped) {
+    const n = row._count._all;
+    switch (row.linkStatus) {
+      case LinkHealthStatus.PASS:
+        counts.pass += n;
+        break;
+      case LinkHealthStatus.WARN:
+        counts.warn += n;
+        break;
+      case LinkHealthStatus.FAIL:
+        counts.fail += n;
+        break;
+      default:
+        counts.unknown += n; // UNKNOWN — not yet probed
+        break;
+    }
+  }
+
+  const checked = counts.pass + counts.warn + counts.fail;
+  const total = checked + counts.unknown;
+  const pulse = checked === 0 ? null : counts.pass / checked;
+  const status: CommunityPulseStatus =
+    pulse === null
+      ? 'Unknown'
+      : pulse >= PULSE_HEALTHY
+        ? 'Healthy'
+        : pulse >= PULSE_AILING
+          ? 'Ailing'
+          : 'Critical';
+
+  return { ...counts, total, checked, pulse, status };
 };

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { RegistrationStatus } from '@prisma/client';
 import { prisma } from '../../../lib/prisma';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
+import { getCommunityHealthPulse } from '../../../modules/linkHealth';
 import { requireAuth } from '../../../middleware/auth';
 import {
   requirePermission,
@@ -118,6 +119,27 @@ router.get(
       return res.status(403).json({ msg: 'Not a member of this community' });
     }
     res.json(community);
+  })
+);
+
+// GET /api/communities/:id/health — the community's link-health pulse
+router.get(
+  '/:id/health',
+  requireAuth,
+  validateParams(communityIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const community = await prisma.community.findUnique({
+      where: { id },
+      select: { registrationStatus: true }
+    });
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (
+      !(await isCommunityMember(id, req.user.id, community.registrationStatus))
+    ) {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
+    res.json(await getCommunityHealthPulse(id));
   })
 );
 

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -39,7 +39,8 @@ jest.mock('../modules/reports', () => ({
 
 jest.mock('../modules/linkHealth', () => ({
   recordContributionReport: jest.fn(),
-  recheckStaleLinks: jest.fn()
+  recheckStaleLinks: jest.fn(),
+  getCommunityHealthPulse: jest.fn()
 }));
 
 jest.mock('../modules/linkHealthJob', () => ({
@@ -281,7 +282,10 @@ import {
   reverseDownloadAccess
 } from '../modules/downloads';
 import { fileReport } from '../modules/reports';
-import { recordContributionReport } from '../modules/linkHealth';
+import {
+  recordContributionReport,
+  getCommunityHealthPulse
+} from '../modules/linkHealth';
 import * as donorModule from '../modules/donor';
 
 const sanitize = jest.requireMock('../lib/sanitize') as {
@@ -409,6 +413,10 @@ export const fileReportMock = fileReport as jest.MockedFunction<
 export const recordContributionReportMock =
   recordContributionReport as jest.MockedFunction<
     typeof recordContributionReport
+  >;
+export const getCommunityHealthPulseMock =
+  getCommunityHealthPulse as jest.MockedFunction<
+    typeof getCommunityHealthPulse
   >;
 export const pmMock = pmModule as jest.Mocked<typeof pmModule>;
 export const staffInboxMock = staffInboxModule as jest.Mocked<


### PR DESCRIPTION
Rebased + de-contaminated version of #87. Lands the community link-health pulse on current `develop`.

## What it adds
- `getCommunityHealthPulse` (`src/modules/linkHealth.ts`) — rolls a community's per-contribution `linkStatus` into a single heartbeat. Only `PASS`/`FAIL` are definitive (`checked`); `WARN` (transient) and `UNKNOWN` (unprobed) are indeterminate and excluded. Pulse = `pass / checked`, banded Healthy ≥ 0.90 / Ailing ≥ 0.60 / Critical, and withholds a band (`Unknown`) until coverage clears a 0.5 floor. Computed on read, no stored state.
- `GET /api/communities/:id/health`.
- Realizes ADR-0002; integrated with the ADR-0007 resolution (computed-on-read + deferred snapshots, #75/#94).

## Why a new PR instead of #87
#87 had drifted off pre-reconcile `develop` and accumulated:
- a `linkHealth.spec.ts` add/add collision with the slice-1b sweep work now on develop (#96),
- an `ADR-0002` conflict with develop's ADR-0007 resolution note,
- unrelated **music** contamination (a `0003-contribution-model-from-upload-form` ADR colliding with stylesheet ADR-0003, plus a music-ADR-rename commit).

This branch cherry-picks **only** the two pulse commits onto current develop, merges the spec/ADR conflicts cleanly, and drops the music cruft. Pulse and the WARN→FAIL sweep now share `linkHealth.ts` coherently.

## Tests
**1415/1415 green**, `tsc` + lint clean.

Supersedes #87 (to be closed). Feeds #75 (pulse → CommunityScore persistence/fold, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)