### PR TITLE
docs: ADR-0009 fork workflow + dependency discipline + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,28 @@ git remote add upstream git@github.com:orphic-inc/stellar-api.git   # or: git wi
 
 **Dependency bumps** are isolated (own branch/PR), pinned, ADR'd, and atomic with the regen/migration they force — never entangled with feature work (ADR-0009).
 
+## Local pre-commit gate
+
+Each repo runs a **husky** pre-commit hook that invokes **lint-staged** over your staged files, so formatting/lint never lands in a commit:
+
+- staged `*.ts`/`*.tsx` → `eslint --fix` then `prettier --write`
+- staged `*.{json,md,scss,css}` → `prettier --write` (ui also runs `stylelint` on `*.scss`)
+
+The hook installs automatically — `npm install` runs the `prepare` script (`husky install || true`; the `|| true` keeps dependency-free production/Docker builds from failing). Nothing to wire up by hand.
+
+> **One config, no shadow.** lint-staged config lives **only** in `package.json`. Do not add a `.lintstagedrc` — lint-staged prefers the rc file and silently ignores the `package.json` block, which disables the real rules.
+
+lint-staged is the fast staged-file pass, not the full check. **Before pushing**, run the complete gate (it must be clean on new/changed files):
+
+```bash
+npm run format   # prettier --write (whole tree — confirms nothing else drifted)
+npm run lint     # eslint, clean on changed files
+npx tsc --noEmit # type-check
+npm run test     # full suite
+```
+
+Order matters: format before lint (Prettier violations surface as ESLint errors), lint before type-check.
+
 ## Code Standards
 
 ### Error Handling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,45 +2,83 @@
 
 Welcome! We appreciate your interest in contributing to Stellar API. To keep the codebase healthy, modular, and maintainable, please adhere to the following architectural guidelines.
 
+## Workflow (fork model)
+
+Stellar is three repos developed together — `stellar-api`, `stellar-ui`, `stellar-compose` — using a **fork model**. See [ADR-0009](docs/adr/0009-fork-workflow-and-dependency-discipline.md) for the why.
+
+**Remotes:** `origin` = your fork (`<you>/stellar-*`), `upstream` = `orphic-inc/stellar-*` (canonical). Never push to `upstream`; PRs go fork → upstream.
+
+**Getting started:**
+
+```bash
+# Per repo (api/ui/compose): clone your fork, wire upstream
+git clone git@github.com:<you>/stellar-api.git && cd stellar-api
+git remote add upstream git@github.com:orphic-inc/stellar-api.git   # or: git wire-upstream
+```
+
+**Aliases** (install via the `~/.config/git/stellar-aliases.gitconfig` include):
+
+| alias                | does                                                                  |
+| -------------------- | --------------------------------------------------------------------- |
+| `git sync`           | fetch upstream, ff `develop` to `upstream/develop`, push to your fork |
+| `git feature <name>` | `sync` then branch off a fresh `develop`                              |
+| `git publish`        | push the current branch to your fork                                  |
+| `git opr`            | open a PR from the current branch into `upstream/develop`             |
+| `git remotes`        | show which remote is fork vs upstream                                 |
+
+**Branches:** `develop` = integration (PR target) · `staging` = pre-prod · `main` = released. Promotion flows **up**; `main` never runs ahead of `develop`. Linear history on `develop` — **cut feature branches from `develop`, not `main`.**
+
+**Dependency bumps** are isolated (own branch/PR), pinned, ADR'd, and atomic with the regen/migration they force — never entangled with feature work (ADR-0009).
+
 ## Code Standards
 
 ### Error Handling
+
 Always use the custom `AppError` class when intentionally throwing errors that should be surfaced to the client. This ensures the global error handler (`src/app.ts`) responds with the correct HTTP status code instead of a generic 500 error.
 
 **Do:**
+
 ```typescript
 import { AppError } from '../lib/errors';
 throw new AppError(404, 'User not found');
 ```
 
 **Don't:**
+
 ```typescript
 throw new Error('User not found'); // Results in a 500 status code
 ```
 
 ### Input Validation & Type Safety
+
 We use **Zod** for schema validation. Do not manually cast variables using `as T`. Instead, use the built-in `parsedBody`, `parsedParams`, and `parsedQuery` helpers which infer types securely based on your schema.
 
 **Do:**
+
 ```typescript
 import { parsedBody } from '../../middleware/validate';
 const { email, password } = parsedBody<LoginInput>(res);
 ```
 
 ### Separation of Concerns
+
 - **Routes (`src/routes`)**: Controllers should only handle HTTP mappings, response formatting, and status codes.
 - **Modules/Services (`src/modules`)**: All database operations and business logic must be housed here, decoupled from Express.
 
 ### Database Operations (Prisma)
+
 - Avoid manual string manipulation or raw SQL unless absolutely necessary.
 - **Soft Deletes**: Always rely on Prisma soft-delete patterns or extensions rather than manually filtering `deletedAt: null` across all queries.
 
 ## Testing
+
 We utilize Jest and Supertest.
+
 - New endpoints must be accompanied by integration tests in `src/integration`.
 - Utilize the `apiTestHarness` and `dbHelpers` to cleanly stub out the database or test user context during integration tests.
 
 ## Submitting Pull Requests
+
 1. Ensure `npm run build` and `npm run test` pass.
 2. If you altered API endpoints, ensure you run `npm run openapi:export` and commit the updated `openapi.json`.
 3. Provide a clear description of the changes in your PR and link to any relevant issues.

--- a/docs/adr/0009-fork-workflow-and-dependency-discipline.md
+++ b/docs/adr/0009-fork-workflow-and-dependency-discipline.md
@@ -1,0 +1,34 @@
+# Fork-model multi-repo workflow + dependency-bump discipline
+
+**Status: Accepted.**
+
+Stellar is three repos developed in lockstep — `stellar-api`, `stellar-ui`, `stellar-compose`. Two recurring failure modes motivated pinning the workflow: (1) **remote/clone ambiguity** — parallel clone-sets where `origin` meant the fork in one and the org in another, so `origin/develop` was ambiguous; and (2) a **dependency bump that "transcended the whole tree"** (the prisma6/openssl3 upgrade entangled schema regen, the Docker base image, and migrations with unrelated feature work).
+
+## Decision
+
+### Remotes — fork model, everywhere
+
+- `origin` = your personal fork (`obrien-k/stellar-*`); `upstream` = `orphic-inc/stellar-*` (canonical).
+- Never push to `upstream`; PRs go **fork → upstream**. One clone-set per repo (the fork clones); direct `origin=orphic` clones are retired to kill the ambiguity.
+- Helper aliases (see `CONTRIBUTING.md`): `git sync`, `git feature <name>`, `git publish`, `git opr`, `git remotes`, `git wire-upstream`.
+
+### Branches — `develop` is the integration trunk
+
+- `develop` = integration (the PR target). `staging` = pre-prod promotion. `main` = released.
+- Promotion flows **up** (develop → staging → main).
+- **`main` must never run ahead of `develop`.** If a hotfix lands on `main`, back-merge to `develop` immediately. (Backwards drift here has bitten repeatedly — see the develop↔main reconciliations.)
+- Linear history on `develop` (rebase-only). **Cut feature branches from `develop`, not `main`** — branches cut from `main` carry release/squash-promote baggage and re-detonate merge conflicts on rebase.
+
+### Dependency / version bumps — isolate, pin, ADR
+
+The prisma6 bump spread because it rode along with feature work. Going forward a major dependency or runtime bump is:
+
+- its **own** branch/PR, isolated from feature work;
+- **pinned** (exact version + base image), with the decision recorded as an ADR (e.g. the prisma6/OpenSSL pin ADR in `stellar-compose`);
+- atomic with the regen/migration it forces (the bump and its `prisma generate`/migration land together — never split, never entangled with unrelated features).
+
+## Consequences
+
+- `git sync` before every feature keeps forks current; drift is caught early instead of accumulating into a multi-branch sprawl.
+- Cross-repo changes (API contract → UI types → compose) coordinate through the shared `CONTRIBUTING.md` getting-started.
+- The current branch sprawl is a one-time reconciliation sweep (Mr. Robot); this discipline is what stops it recurring.


### PR DESCRIPTION
The "ADR for all of this" — pins the multi-repo dev workflow so the remote/branch drift and the tree-wide dependency bump don't recur.

- **ADR-0009** — fork model (`origin`=fork, `upstream`=orphic); `develop`/`staging`/`main` roles with **main never ahead of develop**; cut feature branches from `develop` not `main`; **dependency bumps isolated + pinned + ADR'd + atomic with their migration** (the prisma6 lesson).
- **CONTRIBUTING** — new Workflow section: getting-started, the `git sync`/`feature`/`publish`/`opr` aliases, branch model. To be mirrored into `stellar-ui` and `stellar-compose` (CONTRIBUTING currently exists only here).

Docs only. Pairs with the branch-reconciliation sweep this enables.