### PR TITLE
fix(test): repair integration suite after #98 music-model remodel

### DIFF
--- a/src/integration/collages.integration.ts
+++ b/src/integration/collages.integration.ts
@@ -30,12 +30,12 @@ const createUser = async (tag: string) => {
 const createRelease = async (artistId: number) =>
   testPrisma.release.create({
     data: {
-      artistId,
       title: `Release-${Date.now()}-${Math.random()}`,
       description: 'desc',
       type: ReleaseType.Music,
       releaseType: ReleaseCategory.Album,
-      year: 2020
+      year: 2020,
+      credits: { create: { artistId } }
     }
   });
 

--- a/src/integration/downloads.integration.ts
+++ b/src/integration/downloads.integration.ts
@@ -58,13 +58,16 @@ const createContribution = async (userId: number, sizeBytes = 1_000_000) => {
   });
   const release = await testPrisma.release.create({
     data: {
-      artistId: artist.id,
       title: `DL-Release-${Date.now()}`,
       description: 'desc',
       type: ReleaseType.Music,
       releaseType: 'Album',
-      year: 2020
+      year: 2020,
+      credits: { create: { artistId: artist.id } }
     }
+  });
+  const edition = await testPrisma.edition.create({
+    data: { releaseId: release.id }
   });
   const contributor = await testPrisma.contributor.upsert({
     where: { userId },
@@ -76,6 +79,7 @@ const createContribution = async (userId: number, sizeBytes = 1_000_000) => {
       userId,
       releaseId: release.id,
       contributorId: contributor.id,
+      editionId: edition.id,
       type: FileType.flac,
       downloadUrl: 'https://example.com/file.torrent',
       sizeInBytes: sizeBytes,

--- a/src/integration/vanityHouse.integration.ts
+++ b/src/integration/vanityHouse.integration.ts
@@ -49,13 +49,13 @@ describe('vanity house toggle', () => {
     const vh = await testPrisma.artist.findMany({
       where: { vanityHouse: true },
       orderBy: { name: 'asc' },
-      include: { _count: { select: { releases: true } } }
+      include: { _count: { select: { credits: true } } }
     });
 
     const ids = vh.map((a) => a.id);
     expect(ids).toContain(a1.id);
     expect(ids).not.toContain(a2.id);
-    expect(vh[0]._count).toHaveProperty('releases');
+    expect(vh[0]._count).toHaveProperty('credits');
   });
 
   it('throws when updating a non-existent artist', async () => {

--- a/src/modules/devTools/cleanup.ts
+++ b/src/modules/devTools/cleanup.ts
@@ -426,6 +426,33 @@ export async function cleanupRun(
     failedItems
   );
 
+  // 8b. ReleaseArtist credits + Editions (music remodel #72).
+  //     Both have non-cascading FKs to Release; ReleaseArtist also references
+  //     Artist; Edition is referenced by Contribution (deleted in step 7).
+  //     Delete by relation (not tracked IDs) so credits/editions are caught
+  //     even if the generator never tracked them individually.
+  deletedCounts['ReleaseArtist'] = await safeDeleteMany(
+    () =>
+      prisma.releaseArtist.deleteMany({
+        where: {
+          OR: [
+            { releaseId: { in: getIds('Release') } },
+            { artistId: { in: getIds('Artist') } }
+          ]
+        }
+      }),
+    'ReleaseArtist',
+    failedItems
+  );
+  deletedCounts['Edition'] = await safeDeleteMany(
+    () =>
+      prisma.edition.deleteMany({
+        where: { releaseId: { in: getIds('Release') } }
+      }),
+    'Edition',
+    failedItems
+  );
+
   // 9. Releases
   deletedCounts['Release'] = await safeDeleteMany(
     () =>


### PR DESCRIPTION
## Why

`develop`'s integration suite is **red**. PR #98 collapsed `Release` to `ReleaseArtist` credits + an `Edition` tier, but four test/cleanup consumers were never migrated. CI builds the test DB fresh (so the destructive `contract_music_model` migration applies cleanly), then fails on these consumers — blocking every open PR.

## Fixes (all #98 fallout)

- **collages / downloads** — `Release.create` no longer accepts `artistId`; credit the artist via `credits: { create: { artistId } }`.
- **downloads** — `Contribution.editionId` is now a required FK; create an `Edition` and pass `editionId`.
- **vanityHouse** — `Artist._count` select `releases` → `credits` (the Artist→Release link is now the `ReleaseArtist` join, exposed as `credits`).
- **devTools cleanup** — sweep `ReleaseArtist` + `Edition` before `Release`; the new non-cascading FKs were blocking deletion and leaving the run `'partial'`.

## Verification

Against a real test DB (clean, fully-migrated `stellar_test`):

- Full integration suite: **14/14 suites, 92/92 tests** ✅
- Unit suite: **1415/1415** ✅
- `tsc --noEmit` + `eslint` clean ✅

Note: the integration type errors (`downloads`, `vanityHouse`) don't surface in `tsc --noEmit` because `tsconfig` excludes `**/*.integration.ts`; they only fail under ts-jest at suite runtime. Worth a follow-up to type-check integration files in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)