### PR TITLE
ci: type-check test files (tsconfig.test.json)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,8 @@ jobs:
         run: npm run lint
       - name: Type check
         run: npx tsc --noEmit
+      - name: Type check (test files)
+        run: npm run typecheck:test
       - name: Unit tests
         run: npm test
       - name: OpenAPI freshness

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/index.ts --esm",
     "watch": "tsc -w",
     "lint": "eslint src --ext .ts",
+    "typecheck:test": "tsc -p tsconfig.test.json",
     "format": "prettier --write src",
     "test": "jest --forceExit",
     "test:watch": "jest --watch --forceExit",

--- a/src/integration/collages.integration.ts
+++ b/src/integration/collages.integration.ts
@@ -30,12 +30,12 @@ const createUser = async (tag: string) => {
 const createRelease = async (artistId: number) =>
   testPrisma.release.create({
     data: {
-      artistId,
       title: `Release-${Date.now()}-${Math.random()}`,
       description: 'desc',
       type: ReleaseType.Music,
       releaseType: ReleaseCategory.Album,
-      year: 2020
+      year: 2020,
+      credits: { create: { artistId } }
     }
   });
 

--- a/src/integration/downloads.integration.ts
+++ b/src/integration/downloads.integration.ts
@@ -58,13 +58,16 @@ const createContribution = async (userId: number, sizeBytes = 1_000_000) => {
   });
   const release = await testPrisma.release.create({
     data: {
-      artistId: artist.id,
       title: `DL-Release-${Date.now()}`,
       description: 'desc',
       type: ReleaseType.Music,
       releaseType: 'Album',
-      year: 2020
+      year: 2020,
+      credits: { create: { artistId: artist.id } }
     }
+  });
+  const edition = await testPrisma.edition.create({
+    data: { releaseId: release.id }
   });
   const contributor = await testPrisma.contributor.upsert({
     where: { userId },
@@ -76,6 +79,7 @@ const createContribution = async (userId: number, sizeBytes = 1_000_000) => {
       userId,
       releaseId: release.id,
       contributorId: contributor.id,
+      editionId: edition.id,
       type: FileType.flac,
       downloadUrl: 'https://example.com/file.torrent',
       sizeInBytes: sizeBytes,

--- a/src/integration/vanityHouse.integration.ts
+++ b/src/integration/vanityHouse.integration.ts
@@ -49,13 +49,13 @@ describe('vanity house toggle', () => {
     const vh = await testPrisma.artist.findMany({
       where: { vanityHouse: true },
       orderBy: { name: 'asc' },
-      include: { _count: { select: { releases: true } } }
+      include: { _count: { select: { credits: true } } }
     });
 
     const ids = vh.map((a) => a.id);
     expect(ids).toContain(a1.id);
     expect(ids).not.toContain(a2.id);
-    expect(vh[0]._count).toHaveProperty('releases');
+    expect(vh[0]._count).toHaveProperty('credits');
   });
 
   it('throws when updating a non-existent artist', async () => {

--- a/src/modules/devTools/cleanup.ts
+++ b/src/modules/devTools/cleanup.ts
@@ -426,6 +426,33 @@ export async function cleanupRun(
     failedItems
   );
 
+  // 8b. ReleaseArtist credits + Editions (music remodel #72).
+  //     Both have non-cascading FKs to Release; ReleaseArtist also references
+  //     Artist; Edition is referenced by Contribution (deleted in step 7).
+  //     Delete by relation (not tracked IDs) so credits/editions are caught
+  //     even if the generator never tracked them individually.
+  deletedCounts['ReleaseArtist'] = await safeDeleteMany(
+    () =>
+      prisma.releaseArtist.deleteMany({
+        where: {
+          OR: [
+            { releaseId: { in: getIds('Release') } },
+            { artistId: { in: getIds('Artist') } }
+          ]
+        }
+      }),
+    'ReleaseArtist',
+    failedItems
+  );
+  deletedCounts['Edition'] = await safeDeleteMany(
+    () =>
+      prisma.edition.deleteMany({
+        where: { releaseId: { in: getIds('Release') } }
+      }),
+    'Edition',
+    failedItems
+  );
+
   // 9. Releases
   deletedCounts['Release'] = await safeDeleteMany(
     () =>

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  // Type-checks the whole tree INCLUDING test files. The base tsconfig excludes
+  // *.spec.ts / *.integration.ts / src/test, so `tsc --noEmit` never catches
+  // type errors in tests — they only surface at ts-jest runtime. CI runs this
+  // (`npm run typecheck:test`) so test-only type breakage fails fast.
+  //
+  // module/moduleResolution are overridden to match how ts-jest executes the
+  // tests (commonjs/node), not the NodeNext build config — otherwise extension-
+  // less imports in tests trip TS2835 false positives.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Why

The base `tsconfig.json` excludes `**/*.spec.ts`, `**/*.integration.ts`, and `src/test`, so CI's `tsc --noEmit` step **never type-checks test files** — type errors there only surface at ts-jest runtime (or not at all, if the suite isn't run).

This is exactly how #98's music-model remodel slipped two broken integration suites (`downloads`, `vanityHouse`) past a green type-check (fixed in #107).

## What

- **`tsconfig.test.json`** — extends the base, includes the whole tree *including* tests. `module`/`moduleResolution` are overridden to `commonjs`/`node` to mirror how ts-jest actually executes the tests; the base's `NodeNext` would otherwise raise `TS2835` false positives on the extensionless relative imports used throughout the tests.
- **`npm run typecheck:test`** — `tsc -p tsconfig.test.json`.
- **CI** — new "Type check (test files)" step right after the existing type-check.

## Notes

- **Stacked on #107.** Until #107 merges into `develop`, this branch carries those fix commits too (so its own CI is green). After #107 merges, this PR's diff reduces to just the 3 config/CI files. Merge #107 first.
- Node version is unrelated: CI already runs Node 22 (`setup-node`); this is purely about module *format* (the project is CommonJS — no `"type": "module"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)