### PR TITLE
docs: recover ADR-0005 (music model from upload form)

### DIFF
--- a/docs/adr/0005-contribution-model-from-upload-form.md
+++ b/docs/adr/0005-contribution-model-from-upload-form.md
@@ -1,0 +1,34 @@
+# Model music releases in three tiers driven by the upload form; edition data is edition-scoped
+
+The music contribution model has drifted from the thing that defines a release —
+the upload form. The form captures **Artist(s) with a role** (Main, Guest, …), a
+**release** (title, year, type, label, catalogue №), an **edition** (remaster /
+reissue / country / media), and the **encoding** (format, bitrate, scene, log,
+cue). The schema collapses that: `Release` carries a single `artistId`, an
+untyped `edition Json?` (passed around as `as never`), and free-string
+`Contribution.bitrate` / `media`. Untyped/uni-artist shapes let inconsistent
+data into the corpus and can't express a feature, a compilation, or two editions
+of one release.
+
+We model the form's tiers explicitly: **Artist —(role)→ Release —→ Edition —→
+Contribution.**
+
+- A `ReleaseArtist` join with an `ArtistRole` enum replaces the single
+  `Release.artistId` — a release can credit several artists by role.
+- An `Edition` tier sits between `Release` and `Contribution`. Edition-scoped
+  metadata — remaster/reissue title, year, record label, catalogue № — moves
+  off `Release` onto `Edition`. The form's own rule is the invariant: edition
+  info belongs to the edition, **never** the release title.
+- `Contribution` keeps the encoding (format, scene, log, cue) with typed
+  `Bitrate` / `ReleaseMedia` enums replacing the free strings.
+
+Migration is **expand → backfill → contract**: add the new tables/columns,
+backfill each release to one Main credit + a default edition (lifting today's
+`edition Json` and label/catalogue down), then drop the old columns once the
+~16 consuming modules cut over. This keeps `tsc` green throughout.
+
+This is sequenced **after** the community-health pulse ([0002](0002-community-health-pulse.md)),
+which the current shape already feeds — the remodel refines, it does not gate.
+Execution is tracked in #72 (schema), #73 (regenerate corpus), #74 (module
+migration); the existing generated corpus stays valid for non-Music communities
+until then.


### PR DESCRIPTION
## Why

The music remodel (#72/#98 — the Edition tier + ReleaseArtist credits) is the single biggest recent architectural change, yet it has **no ADR on develop**. The record was authored but stranded on the stale `feat/community-health-pulse` branch, leaving a `0005` gap in the ADR sequence (develop had 0001–0004, 0006, 0007).

## What

Recovers `docs/adr/0005-contribution-model-from-upload-form.md` **verbatim** — it already describes the as-shipped design (Artist→Release→Edition→Contribution tiers, `ReleaseArtist`+`ArtistRole`, typed `Bitrate`/`ReleaseMedia`, expand→backfill→contract migration), so no edits were needed. Fills the `0005` slot → continuous `0001–0007`.

Part of the v0.5.4 doc-completeness pass (alongside #101 ADR-0009 and #105 ADR-0008) before promoting develop→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)