### PR TITLE
docs(adr): ADR-0010 trunk-based single-branch workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! We appreciate your interest in contributing to Stellar API. To keep the
 
 ## Workflow (fork model)
 
-Stellar is three repos developed together — `stellar-api`, `stellar-ui`, `stellar-compose` — using a **fork model**. See [ADR-0009](docs/adr/0009-fork-workflow-and-dependency-discipline.md) for the why.
+Stellar is three repos developed together — `stellar-api`, `stellar-ui`, `stellar-compose` — using a **fork model** with a single `main` trunk. See [ADR-0009](docs/adr/0009-fork-workflow-and-dependency-discipline.md) (fork remotes + dependency discipline) and [ADR-0010](docs/adr/0010-trunk-based-single-branch-workflow.md) (trunk-based workflow) for the why.
 
 **Remotes:** `origin` = your fork (`<you>/stellar-*`), `upstream` = `orphic-inc/stellar-*` (canonical). Never push to `upstream`; PRs go fork → upstream.
 
@@ -18,15 +18,15 @@ git remote add upstream git@github.com:orphic-inc/stellar-api.git   # or: git wi
 
 **Aliases** (install via the `~/.config/git/stellar-aliases.gitconfig` include):
 
-| alias                | does                                                                  |
-| -------------------- | --------------------------------------------------------------------- |
-| `git sync`           | fetch upstream, ff `develop` to `upstream/develop`, push to your fork |
-| `git feature <name>` | `sync` then branch off a fresh `develop`                              |
-| `git publish`        | push the current branch to your fork                                  |
-| `git opr`            | open a PR from the current branch into `upstream/develop`             |
-| `git remotes`        | show which remote is fork vs upstream                                 |
+| alias                | does                                                            |
+| -------------------- | --------------------------------------------------------------- |
+| `git sync`           | fetch upstream, ff `main` to `upstream/main`, push to your fork |
+| `git feature <name>` | `sync` then branch off a fresh `main`                           |
+| `git publish`        | push the current branch to your fork                            |
+| `git opr`            | open a PR from the current branch into `upstream/main`          |
+| `git remotes`        | show which remote is fork vs upstream                           |
 
-**Branches:** `develop` = integration (PR target) · `staging` = pre-prod · `main` = released. Promotion flows **up**; `main` never runs ahead of `develop`. Linear history on `develop` — **cut feature branches from `develop`, not `main`.**
+**Branches:** `main` is the only long-lived branch and the sole PR target — there is no `develop` or `staging`. **Cut feature branches from `main`** on your fork and PR into `upstream/main`; linear history (rebase-merge). `release/*` branches may live on `upstream` when a release needs coordination — the one sanctioned exception. See [ADR-0010](docs/adr/0010-trunk-based-single-branch-workflow.md).
 
 **Dependency bumps** are isolated (own branch/PR), pinned, ADR'd, and atomic with the regen/migration they force — never entangled with feature work (ADR-0009).
 

--- a/docs/adr/0009-fork-workflow-and-dependency-discipline.md
+++ b/docs/adr/0009-fork-workflow-and-dependency-discipline.md
@@ -1,6 +1,6 @@
 # Fork-model multi-repo workflow + dependency-bump discipline
 
-**Status: Accepted.**
+**Status: Accepted — branch model superseded by [ADR-0010](0010-trunk-based-single-branch-workflow.md) (2026-06-11).** The fork-remote model and dependency-bump discipline below remain in force; the `develop`/`staging`/`main` promotion model (the "Branches — `develop` is the integration trunk" section) is retired in favour of a single `main` trunk.
 
 Stellar is three repos developed in lockstep — `stellar-api`, `stellar-ui`, `stellar-compose`. Two recurring failure modes motivated pinning the workflow: (1) **remote/clone ambiguity** — parallel clone-sets where `origin` meant the fork in one and the org in another, so `origin/develop` was ambiguous; and (2) a **dependency bump that "transcended the whole tree"** (the prisma6/openssl3 upgrade entangled schema regen, the Docker base image, and migrations with unrelated feature work).
 

--- a/docs/adr/0010-trunk-based-single-branch-workflow.md
+++ b/docs/adr/0010-trunk-based-single-branch-workflow.md
@@ -1,0 +1,38 @@
+# Trunk-based single-branch workflow
+
+**Status: Accepted (2026-06-11).** Supersedes the _branch-model_ section of [ADR-0009](0009-fork-workflow-and-dependency-discipline.md) (`develop` / `staging` / `main` promotion). The fork-remote model and dependency-bump discipline of ADR-0009 remain in force.
+
+## Context
+
+ADR-0009 pinned a three-tier branch model — `develop` (integration) → `staging` (pre-prod) → `main` (released) — with the rule that _`main` must never run ahead of `develop`_ and a back-merge whenever a hotfix landed on `main`.
+
+In practice that rule kept losing:
+
+- **`main` repeatedly diverged from `develop`.** Direct edits to `main` (releases, hotfixes, web-UI doc churn, a stray `origin=orphic` clone) left `develop` missing content `main` had — and vice-versa. On `stellar-api` the two branches diverged _both_ ways: `main` carried a stylesheet-backend / Gravatar-removal feature `develop` never saw, while `develop` carried 57 commits of music-model remodel `main` lacked.
+- **Divergence broke promotion.** Because the histories had drifted, GitHub's rebase-merge could not replay `develop → main` (duplicate commits across the divergence); the v0.5.4 promotion had to be reconciled by hand.
+- **Three tiers bought nothing at this scale.** Pre-alpha, with a small set of human + agent contributors, `staging` was perpetually stale (a pointer behind `develop`) and the extra promotion hops added ceremony, not safety. Every Mr. Robot sweep spent its largest block on `main ↔ develop` reconciliation.
+
+The cost of maintaining three long-lived branches exceeded any release-gating benefit they provided.
+
+## Decision
+
+**Collapse to a single trunk: `main`.** `develop` and `staging` are retired (deleted) across the lockstep repos — done for `stellar-api` and `stellar-ui` on 2026-06-11; `stellar-compose` to follow.
+
+- **`main` is the only long-lived branch** and the sole PR target. There is no integration or pre-prod branch.
+- **Feature branches are cut from `main`** (not `develop`) on your fork (`origin = obrien-k/stellar-*`) and PR'd **fork → `upstream/main`**, per the unchanged ADR-0009 remote model.
+- **Linear history on `main`** (rebase-merge only; no merge commits).
+- **`release/*` branches may live on `upstream`** when a release needs staging/coordination; they are short-lived and deleted after the release. This is the one sanctioned exception to "dev branches live on the fork."
+- Releases are cut and tagged directly on `main` (semver tags, manual — no release tooling yet).
+
+### Retained from ADR-0009 (still in force)
+
+- **Fork-remote model:** `origin` = personal fork, `upstream` = `orphic-inc` canonical; PRs flow fork → upstream; the ambiguous `origin=orphic` direct clones stay retired.
+- **Dependency / version-bump discipline:** major dep/runtime bumps get their own isolated, pinned, ADR-recorded PR, atomic with the regen/migration they force.
+
+## Consequences
+
+- The "`main` must never run ahead of `develop`" rule and the develop→staging→main back-merge dance are **obsolete** — there is nothing for `main` to drift against.
+- One-time cost: collapsing the existing divergence required a non-linear **merge commit on `stellar-api` `main`** (`af6a1cf`), pushed past the linear-history rule once as admin. `stellar-ui` folded cleanly as a fast-forward. From here, rebase-merge keeps the trunk linear.
+- `CONTRIBUTING.md` and the git helper aliases (`git sync`, `git feature`, `git publish`) that assume a `develop` base must be updated to target `main`. (Tracked as follow-up.)
+- Branch protection on `main` keeps: linear history + ≥1 review. The retired `develop`/`staging` protections are gone.
+- Simpler mental model for human and agent contributors: one trunk, one PR target, one place a feature can be "in."


### PR DESCRIPTION
Records the trunk-only fold (2026-06-11) and supersedes the branch-model section of ADR-0009.

## What changed
- **New: ADR-0010** — single `main` trunk; `develop`/`staging` retired on `stellar-api` + `stellar-ui` (`stellar-compose` to follow). Feature branches cut from `main` on the fork → PR to `upstream/main`; linear history; `release/*` the one sanctioned upstream-branch exception.
- **Amended: ADR-0009** — status now notes the branch model is superseded by 0010; its fork-remote model + dependency-bump discipline remain in force.

## Context
The `develop → staging → main` model kept drifting (`main` diverged from `develop` both ways; rebase-merge promotion broke on duplicate commits) and the three tiers added ceremony without payoff at pre-alpha scale. The fold itself is already applied to both repos; this PR records the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)