### PR TITLE
fix(devtools): restore 'seeded' avatar sentinel so seeded users are distinct

### DIFF
--- a/src/integration/devTools.integration.ts
+++ b/src/integration/devTools.integration.ts
@@ -118,6 +118,29 @@ describe('runGeneration — minimal isolated', () => {
     expect(communityRecords).toBe(result.summary['Community']);
   }, 120_000);
 
+  it('stamps generated users with the seeded-avatar sentinel the UI maps', async () => {
+    const result = await runGeneration(MINIMAL_ISOLATED, actorId);
+
+    const records = await testPrisma.devSeedRecord.findMany({
+      where: { runId: result.runId, entityType: 'User' },
+      select: { pk: true }
+    });
+    // pk is JSON: { id: <number> } for User records.
+    const ids = records.map((r) => (r.pk as { id: number }).id);
+    const users = await testPrisma.user.findMany({
+      where: { id: { in: ids } },
+      select: { avatar: true }
+    });
+
+    // Contract: generated users carry the 'seeded' sentinel so stellar-ui's
+    // avatarSrc() maps them to the distinct seeded.png (not the shared default).
+    // Must stay in sync with SEEDED_AVATAR_SENTINEL in stellar-ui
+    // src/utils/avatar.ts. (Regression: the generator briefly stored null,
+    // making seeded users indistinguishable from real null-avatar accounts.)
+    expect(users.length).toBeGreaterThan(0);
+    for (const u of users) expect(u.avatar).toBe('seeded');
+  }, 120_000);
+
   it('dry run returns estimates without writing any rows', async () => {
     const result = await runGeneration(
       { ...MINIMAL_ISOLATED, dryRun: true },

--- a/src/modules/devTools/generators/users.ts
+++ b/src/modules/devTools/generators/users.ts
@@ -34,12 +34,13 @@ import {
 } from '../contentFactory';
 import { trackCreate, appendWarning } from '../tracking';
 
-// Seed users store no avatar and fall back to the shared default in the UI,
-// exactly like real null-avatar accounts. (The previous `'seeded'` sentinel
-// rendered as a broken <img src="seeded"> — no UI mapper existed — and the
-// hardcoded `/static/.../seeded.jpg` path 404s where no such asset is served.
-// A distinct seeded avatar needs a real asset placed alongside default.png.)
-const SEEDED_AVATAR: string | null = null;
+// Seed users carry the 'seeded' sentinel so generated test accounts are
+// visually obvious. stellar-ui's avatarSrc() (src/utils/avatar.ts,
+// SEEDED_AVATAR_SENTINEL) maps it to the distinct bundled seeded.png. This
+// briefly stored null — back when no UI mapper/asset existed and the sentinel
+// rendered as a broken <img src="seeded"> — but #59/#68 landed the mapper +
+// seeded.png, so the value is restored. Keep it in sync with the UI sentinel.
+const SEEDED_AVATAR: string | null = 'seeded';
 
 // User archetype distribution
 const ARCHETYPES = [


### PR DESCRIPTION
**Root cause — cross-repo contract drift** (diagnosed via /debug).

`generators/users.ts` set `SEEDED_AVATAR = null` as a stopgap (321935e), pending stellar-ui shipping a seeded-avatar asset + mapper. stellar-ui delivered it (#59: `seeded.png` + `avatarSrc('seeded')→seeded.png`; #68 bundles the art) — but this side was never flipped back. Result: seeded users sent `avatar:null` → `avatarSrc(null)` → **default.png**, indistinguishable from real null-avatar users. The "visually-obvious generated accounts" feature was dead, which is what blocked stellar-ui #68.

**Fix:** restore `SEEDED_AVATAR = 'seeded'` (the UI precondition — a real asset + mapper — is now met). Regression test at the real seam (`devTools.integration.ts`): generated users carry the `'seeded'` sentinel. Verified **red (`null`) → green (`'seeded'`)**.

Pairs with a stellar-ui contract test (avatarSrc mapping) to lock both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)