### PR TITLE
feat(sentry): user/release/env context + drop operational 4xx noise

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,10 +12,16 @@ import { getLogger } from './modules/logging';
 import { http, sentry } from './modules/config';
 import { prisma } from './lib/prisma';
 import { appVersion } from './lib/version';
+import { sentryBeforeSend } from './lib/sentry';
 import { asyncHandler } from './modules/asyncHandler';
 
 if (sentry.dsn) {
-  Sentry.init({ dsn: sentry.dsn });
+  Sentry.init({
+    dsn: sentry.dsn,
+    release: appVersion,
+    environment: process.env.NODE_ENV ?? 'development',
+    beforeSend: sentryBeforeSend
+  });
 }
 import { isInstalled } from './modules/installState';
 import { writeLimiter } from './middleware/rateLimiter';

--- a/src/lib/sentry.spec.ts
+++ b/src/lib/sentry.spec.ts
@@ -1,0 +1,37 @@
+import type { ErrorEvent, EventHint } from '@sentry/node';
+import { sentryBeforeSend, userContextFromRequest } from './sentry';
+import { AppError } from './errors';
+
+const event = { event_id: 'evt' } as ErrorEvent;
+
+describe('sentryBeforeSend', () => {
+  it('drops operational AppErrors (statusCode < 500)', () => {
+    const hint = { originalException: new AppError(404, 'Not found') };
+    expect(sentryBeforeSend(event, hint as EventHint)).toBeNull();
+  });
+
+  it('keeps server-error AppErrors (statusCode >= 500)', () => {
+    const hint = { originalException: new AppError(500, 'Boom') };
+    expect(sentryBeforeSend(event, hint as EventHint)).toBe(event);
+  });
+
+  it('keeps unexpected (non-AppError) exceptions', () => {
+    const hint = { originalException: new TypeError('undefined is not a fn') };
+    expect(sentryBeforeSend(event, hint as EventHint)).toBe(event);
+  });
+});
+
+describe('userContextFromRequest', () => {
+  it('maps an authenticated request to a Sentry user payload', () => {
+    const req = { user: { id: 7, userRankId: 2, userRankLevel: 100 } };
+    expect(userContextFromRequest(req)).toEqual({
+      id: '7',
+      userRankId: 2,
+      userRankLevel: 100
+    });
+  });
+
+  it('returns null when there is no authenticated user', () => {
+    expect(userContextFromRequest({})).toBeNull();
+  });
+});

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,34 @@
+import type { ErrorEvent, EventHint, User } from '@sentry/node';
+import { AppError } from './errors';
+
+type AuthedRequest = {
+  user?: { id: number; userRankId: number; userRankLevel: number };
+};
+
+/**
+ * Build the Sentry user context for a request — answers "who hit this error".
+ * Returns null for unauthenticated requests (Sentry treats null as "clear").
+ */
+export const userContextFromRequest = (req: AuthedRequest): User | null => {
+  if (!req.user) return null;
+  return {
+    id: String(req.user.id),
+    userRankId: req.user.userRankId,
+    userRankLevel: req.user.userRankLevel
+  };
+};
+
+/**
+ * Sentry beforeSend hook: drops operational errors so the dashboard reflects
+ * real faults, not expected 4xx control flow. Operational = AppError with a
+ * client-error status (< 500); everything else (5xx AppErrors, unexpected
+ * exceptions) passes through.
+ */
+export const sentryBeforeSend = (
+  event: ErrorEvent,
+  hint: EventHint
+): ErrorEvent | null => {
+  const err = hint.originalException;
+  if (err instanceof AppError && err.statusCode < 500) return null;
+  return event;
+};

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,8 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
+import * as Sentry from '@sentry/node';
 import jwt from 'jsonwebtoken';
 import { auth as authConfig } from '../modules/config';
 import { prisma } from '../lib/prisma';
 import { computeUserRankAccess } from '../lib/userRankAccess';
+import { userContextFromRequest } from '../lib/sentry';
 
 interface JwtPayload {
   user: { id: number; sessionId?: string };
@@ -91,6 +93,8 @@ export const requireAuth = async (
       permittedForumIds: rankAccess.permittedForumIds,
       permissions: rankAccess.permissions as Record<string, boolean>
     };
+    // Attach who-hit-this to the request's Sentry scope for error context.
+    Sentry.setUser(userContextFromRequest(req));
     next();
   } catch {
     res.status(401).json({ msg: 'Token is not valid' });


### PR DESCRIPTION
Makes Sentry actionable (built test-first, /tdd). Two pure, unit-tested seams wired into init:

- **`sentryBeforeSend`** — drops operational `AppError`s (statusCode < 500) so the dashboard reflects real faults, not expected 4xx control flow. 5xx + unexpected exceptions pass through.
- **`userContextFromRequest`** — maps `req.user` → a Sentry user payload (id + rank), attached to the request scope in the auth middleware so errors carry who-hit-them.
- **`Sentry.init`** now stamps `release` (`appVersion`) and `environment` (`NODE_ENV`).

5 unit tests (`lib/sentry.spec.ts`), tsc + lint clean. (Full suite green; the `search`/`docs` timeouts under parallel load pass in isolation — pre-existing flakiness, unrelated.)

Pairs with stellar-ui's sentry PR (browser-noise filter + user context + release/env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)