### PR TITLE
fix(test): isolatedModules — kill the parallel ts-jest flakiness

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,6 +9,13 @@ module.exports = {
     '^.+\\.ts$': [
       'ts-jest',
       {
+        // Transpile-only — do NOT remove. Without this, ts-jest full-type-checks
+        // each suite's entire import graph in every parallel worker; on a busy
+        // CPU the heavy suites (docs/search/rules/communities) get time-sliced
+        // past the default 5s testTimeout and flake. isolatedModules drops the
+        // full run from minutes (with timeouts) to ~50s, clean. Type safety is
+        // still enforced by `npx tsc --noEmit` in the commit gate / CI.
+        isolatedModules: true,
         tsconfig: {
           module: 'commonjs',
           moduleResolution: 'node',


### PR DESCRIPTION
The recurring CI flake (`search`/`docs`/`rules`/`communities` time out under load, pass in isolation) — diagnosed with `/debug`, fixed at the source.

### Root cause
**Not** a leaked handle. `--detectOpenHandles` is clean, and the 4 suites run **serially in 51s**. ts-jest was **full-type-checking each suite's entire import graph in every parallel worker**; on a saturated CPU the heavy suites got time-sliced past jest's **default 5s `testTimeout`** and failed. (The "worker failed to exit gracefully / active timers" warning is a red herring — a separate harmless non-unref'd timer.)

### Fix
`isolatedModules: true` (transpile-only). One line. Type-safety is **not** lost — `npx tsc --noEmit` in the commit gate / CI still does the real check.

| | Tests | Time |
|---|---|---|
| before | 2–4 suites time out | minutes |
| after | **1429/1429** | **~53s** |

This is the fix that the earlier day-long debugging (which ended in a nonsensical implementation rewrite) was looking for — the cause was test-runner config, not application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)