### PR TITLE
feat(stylesheets): AuthorStylesheet — save a named stylesheet (PRD-03 #4a)

### DIFF
--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -46,7 +46,7 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
 
-**Friends × Stylesheet — controlled vector (decided).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — *separate from and additive to* the stylesheet-dimension weights above:
+**Friends × Stylesheet — controlled vector (decided).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — _separate from and additive to_ the stylesheet-dimension weights above:
 
 - **Adopter: +0.2** (rewards active, organic curation — the adopter earns slightly more than the author, to favour participation).
 - **Author: +0.1** (recognition that someone vouched for your sheet).
@@ -74,15 +74,15 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 
 ## Concept → existing code (the descent map)
 
-| Concept                                             | Lives in                                                                                                                                            |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`           |
-| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector` |
-| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                           |
-| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102))                                               |
-| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                         |
-| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                               |
-| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                              |
+| Concept                                             | Lives in                                                                                                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`                         |
+| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector`               |
+| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                                         |
+| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102)) |
+| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                                       |
+| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                                             |
+| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                                            |
 
 ## Out of scope (other PRDs)
 
@@ -95,7 +95,10 @@ First testable slices (much of the substrate already exists):
 1. ✅ **Stylesheet selection → CRS accrual** — pure `scoreStylesheetSelection` (no DB), table-driven over each multiplier. **Shipped: [#84](https://github.com/orphic-inc/stellar-api/pull/84)** (tier-0 multipliers; external/self decisions applied).
 2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
 3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
-4. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual. **Currently the keystone gap:** `scoreStylesheetSelection` (shipped #84) is wired to *nothing* — no `AuthorStylesheet` model, no adopt event. This slice wires it, and **unblocks** the Friends×Stylesheet controlled vector + the `CRS_*` adoption ledger (PRD-01 / ADR-0007), which have no event to hook onto until adoption exists.
+4. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual. **Currently the keystone gap:** `scoreStylesheetSelection` (shipped #84) is wired to _nothing_ — no `AuthorStylesheet` model, no adopt event. This slice wires it, and **unblocks** the Friends×Stylesheet controlled vector + the `CRS_*` adoption ledger (PRD-01 / ADR-0007), which have no event to hook onto until adoption exists.
+   - **4a. Save** — ~~`AuthorStylesheet` model + `POST`/`GET /stylesheet/author`; create→fetch round-trip; no CRS wiring.~~ **Shipped: [#118](https://github.com/orphic-inc/stellar-api/issues/118) ([PR #127](https://github.com/orphic-inc/stellar-api/pull/127)).** The model `scoreStylesheetSelection` had nothing to hook onto now exists.
+   - **4b. Adopt** — [#119](https://github.com/orphic-inc/stellar-api/issues/119): a user adopts another's AuthorStylesheet (the adoption event). _Blocked on 4a — now unblocked._
+   - **4c. Score-on-adopt** — [#120](https://github.com/orphic-inc/stellar-api/issues/120): wire the adopt event into `scoreStylesheetSelection` → author/site accrual + the Friends×Stylesheet vector. _Blocked on 4b._
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions

--- a/prisma/migrations/20260612000000_author_stylesheet/migration.sql
+++ b/prisma/migrations/20260612000000_author_stylesheet/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "author_stylesheets" (
+    "id" SERIAL NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "source" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "author_stylesheets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "author_stylesheets_authorId_idx" ON "author_stylesheets"("authorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "author_stylesheets_authorId_name_key" ON "author_stylesheets"("authorId", "name");
+
+-- AddForeignKey
+ALTER TABLE "author_stylesheets" ADD CONSTRAINT "author_stylesheets_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -436,6 +436,7 @@ model User {
   rulesPagesAuthored       RulesPage[]                      @relation("RulesPageAuthor")
   userStatSnapshots        UserStatSnapshot[]
   tagAliasesCreated        TagAlias[]                       @relation("TagAliasCreator")
+  authorStylesheets        AuthorStylesheet[]               @relation("AuthorStylesheets")
 
   @@index([userRankId])
   @@map("users")
@@ -519,6 +520,26 @@ model Stylesheet {
   createdAt   DateTime @default(now())
 
   @@map("stylesheets")
+}
+
+/// A user-authored, named stylesheet saved for others to adopt (PRD-03 #4a,
+/// keystone slice — docs/prd/03-stylesheet-themes-and-scoring.md). This is the
+/// model `scoreStylesheetSelection` (shipped #84) had nothing to hook onto.
+/// One author may save several sheets; (authorId, name) is unique. No CRS wiring
+/// yet — the adopt → accrual hook is descent-target #4c (#120).
+model AuthorStylesheet {
+  id          Int      @id @default(autoincrement())
+  authorId    Int
+  author      User     @relation("AuthorStylesheets", fields: [authorId], references: [id], onDelete: Cascade)
+  name        String
+  description String   @default("")
+  source      String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([authorId, name])
+  @@index([authorId])
+  @@map("author_stylesheets")
 }
 
 // ─── Forum ────────────────────────────────────────────────────────────────────

--- a/src/integration/authorStylesheet.integration.ts
+++ b/src/integration/authorStylesheet.integration.ts
@@ -1,0 +1,116 @@
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import {
+  createAuthorStylesheet,
+  getAuthorStylesheets
+} from '../modules/stylesheet';
+import { AppError } from '../lib/errors';
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const createUser = async (username: string) => {
+  const rank = await testPrisma.userRank.findFirstOrThrow();
+  const settings = await testPrisma.userSettings.create({ data: {} });
+  const profile = await testPrisma.profile.create({ data: {} });
+  return testPrisma.user.create({
+    data: {
+      username,
+      email: `${username}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id
+    }
+  });
+};
+
+describe('AuthorStylesheet (PRD-03 #4a)', () => {
+  it('create → fetch round-trips for the owning author', async () => {
+    const author = await createUser('themer');
+
+    const created = await createAuthorStylesheet(author.id, {
+      name: 'midnight',
+      description: 'Dark theme',
+      source: 'body { background: #000; }'
+    });
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.authorId).toBe(author.id);
+
+    const fetched = await getAuthorStylesheets(author.id);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].name).toBe('midnight');
+    expect(fetched[0].source).toBe('body { background: #000; }');
+    expect(fetched[0].description).toBe('Dark theme');
+  });
+
+  it('lets one author save several distinct named stylesheets', async () => {
+    const author = await createUser('themer');
+
+    await createAuthorStylesheet(author.id, {
+      name: 'midnight',
+      description: '',
+      source: 'body {}'
+    });
+    await createAuthorStylesheet(author.id, {
+      name: 'daybreak',
+      description: '',
+      source: 'body {}'
+    });
+
+    const fetched = await getAuthorStylesheets(author.id);
+    expect(fetched.map((s) => s.name)).toEqual(['midnight', 'daybreak']);
+  });
+
+  it('rejects a duplicate name for the same author (409)', async () => {
+    const author = await createUser('themer');
+
+    await createAuthorStylesheet(author.id, {
+      name: 'midnight',
+      description: '',
+      source: 'body {}'
+    });
+
+    await expect(
+      createAuthorStylesheet(author.id, {
+        name: 'midnight',
+        description: '',
+        source: 'body { color: red; }'
+      })
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(
+      createAuthorStylesheet(author.id, {
+        name: 'midnight',
+        description: '',
+        source: 'body {}'
+      })
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  it('scopes saved stylesheets to their author', async () => {
+    const alice = await createUser('alice');
+    const bob = await createUser('bob');
+
+    await createAuthorStylesheet(alice.id, {
+      name: 'shared-name',
+      description: '',
+      source: 'body {}'
+    });
+    // Same name is allowed for a different author (unique is per-author).
+    await createAuthorStylesheet(bob.id, {
+      name: 'shared-name',
+      description: '',
+      source: 'body {}'
+    });
+
+    expect(await getAuthorStylesheets(alice.id)).toHaveLength(1);
+    expect(await getAuthorStylesheets(bob.id)).toHaveLength(1);
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -39,7 +39,8 @@ import {
 } from '../schemas/artist';
 import {
   stylesheetSchema,
-  stylesheetUpdateSchema
+  stylesheetUpdateSchema,
+  authorStylesheetSchema
 } from '../schemas/stylesheet';
 import {
   subscribeSchema,
@@ -1260,6 +1261,19 @@ const StylesheetStat = registry.register(
   })
 );
 
+const AuthorStylesheet = registry.register(
+  'AuthorStylesheet',
+  z.object({
+    id: z.number(),
+    authorId: z.number(),
+    name: z.string(),
+    description: z.string(),
+    source: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
 registry.registerPath({
   method: 'get',
   path: '/announcements',
@@ -1575,6 +1589,46 @@ registry.registerPath({
     404: {
       description: 'Not found',
       content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/stylesheet/author',
+  tags: ['Stylesheets'],
+  description: "Save the authed user's own named, adoptable stylesheet",
+  request: {
+    body: {
+      content: { 'application/json': { schema: authorStylesheetSchema } }
+    }
+  },
+  responses: {
+    201: {
+      description: 'AuthorStylesheet created',
+      content: { 'application/json': { schema: AuthorStylesheet } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    409: {
+      description: 'Author already has a stylesheet with that name',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/stylesheet/author/{authorId}',
+  tags: ['Stylesheets'],
+  description: "Read an author's saved stylesheets",
+  request: { params: z.object({ authorId: z.string() }) },
+  responses: {
+    200: {
+      description: 'Author stylesheets',
+      content: { 'application/json': { schema: z.array(AuthorStylesheet) } }
     }
   }
 });

--- a/src/modules/stylesheet.ts
+++ b/src/modules/stylesheet.ts
@@ -80,3 +80,25 @@ export const deleteStylesheet = async (id: number) => {
     throw new AppError(400, 'Cannot delete the default stylesheet');
   await prisma.stylesheet.delete({ where: { id } });
 };
+
+// ─── AuthorStylesheet (PRD-03 #4a) ────────────────────────────────────────────
+// User-owned, named stylesheets saved for others to adopt. No CRS wiring yet —
+// the adopt → scoreStylesheetSelection accrual hook is descent-target #4c (#120).
+
+export const createAuthorStylesheet = async (
+  authorId: number,
+  data: { name: string; description: string; source: string }
+) => {
+  const existing = await prisma.authorStylesheet.findUnique({
+    where: { authorId_name: { authorId, name: data.name } }
+  });
+  if (existing)
+    throw new AppError(409, 'You already have a stylesheet with that name');
+  return prisma.authorStylesheet.create({ data: { authorId, ...data } });
+};
+
+export const getAuthorStylesheets = async (authorId: number) =>
+  prisma.authorStylesheet.findMany({
+    where: { authorId },
+    orderBy: { createdAt: 'asc' }
+  });

--- a/src/routes/api/stylesheet.ts
+++ b/src/routes/api/stylesheet.ts
@@ -12,20 +12,27 @@ import {
 import {
   stylesheetSchema,
   stylesheetUpdateSchema,
+  authorStylesheetSchema,
   type StylesheetInput,
-  type StylesheetUpdateInput
+  type StylesheetUpdateInput,
+  type AuthorStylesheetInput
 } from '../../schemas/stylesheet';
 import {
   createStylesheet,
   updateStylesheet,
   deleteStylesheet,
-  getStylesheetStats
+  getStylesheetStats,
+  createAuthorStylesheet,
+  getAuthorStylesheets
 } from '../../modules/stylesheet';
 import { prisma } from '../../lib/prisma';
 
 const router = express.Router();
 const stylesheetIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
+});
+const authorParamsSchema = z.object({
+  authorId: z.coerce.number().int().positive()
 });
 
 // GET /api/stylesheet/admin/stats — must be before /:id
@@ -47,6 +54,36 @@ router.get(
       orderBy: { createdAt: 'asc' }
     });
     res.json(stylesheets);
+  })
+);
+
+// ─── AuthorStylesheet (PRD-03 #4a) — must be before /:id ──────────────────────
+
+// POST /api/stylesheet/author — save the authed user's own named stylesheet
+router.post(
+  '/author',
+  requireAuth,
+  validate(authorStylesheetSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const data = parsedBody<AuthorStylesheetInput>(res);
+    const created = await createAuthorStylesheet(req.user!.id, {
+      name: data.name,
+      description: data.description ?? '',
+      source: data.source
+    });
+    res.status(201).json(created);
+  })
+);
+
+// GET /api/stylesheet/author/:authorId — read an author's saved stylesheets
+router.get(
+  '/author/:authorId',
+  requireAuth,
+  validateParams(authorParamsSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { authorId } = parsedParams<{ authorId: number }>(res);
+    const sheets = await getAuthorStylesheets(authorId);
+    res.json(sheets);
   })
 );
 

--- a/src/schemas/stylesheet.ts
+++ b/src/schemas/stylesheet.ts
@@ -22,3 +22,14 @@ export const stylesheetUpdateSchema = z
 
 export type StylesheetInput = z.infer<typeof stylesheetSchema>;
 export type StylesheetUpdateInput = z.infer<typeof stylesheetUpdateSchema>;
+
+// A user-authored, named stylesheet saved for others to adopt (PRD-03 #4a).
+// `source` is the CSS/SCSS the author wrote — not a URL like the admin
+// Stylesheet's `cssUrl`.
+export const authorStylesheetSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional().default(''),
+  source: z.string().min(1, 'Stylesheet source is required')
+});
+
+export type AuthorStylesheetInput = z.infer<typeof authorStylesheetSchema>;

--- a/src/stylesheet.spec.ts
+++ b/src/stylesheet.spec.ts
@@ -338,3 +338,101 @@ describe('DELETE /api/stylesheet/:id', () => {
     expect(res.status).toBe(403);
   });
 });
+
+// ─── AuthorStylesheet (PRD-03 #4a) ────────────────────────────────────────────
+
+const makeAuthorStylesheet = (overrides = {}) => ({
+  id: 1,
+  authorId: 7,
+  name: 'my-theme',
+  description: 'A theme I made',
+  source: 'body { background: #111; }',
+  createdAt: new Date('2026-06-12'),
+  updatedAt: new Date('2026-06-12'),
+  ...overrides
+});
+
+describe('POST /api/stylesheet/author', () => {
+  it('saves the authed user’s stylesheet and returns 201', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+    prismaMock.authorStylesheet.create.mockResolvedValue(
+      makeAuthorStylesheet() as never
+    );
+
+    const res = await request(app).post('/api/stylesheet/author').send({
+      name: 'my-theme',
+      description: 'A theme I made',
+      source: 'body { background: #111; }'
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('my-theme');
+    expect(res.body.authorId).toBe(7);
+    expect(prismaMock.authorStylesheet.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          authorId: 7,
+          name: 'my-theme',
+          source: 'body { background: #111; }'
+        })
+      })
+    );
+  });
+
+  it('returns 409 when the author already has a sheet with that name', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
+      makeAuthorStylesheet() as never
+    );
+
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'my-theme', source: 'body {}' });
+
+    expect(res.status).toBe(409);
+    expect(prismaMock.authorStylesheet.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when source is missing', async () => {
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'my-theme' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when name is empty', async () => {
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: '', source: 'body {}' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/stylesheet/author/:authorId', () => {
+  it('reads an author’s saved stylesheets back', async () => {
+    prismaMock.authorStylesheet.findMany.mockResolvedValue([
+      makeAuthorStylesheet(),
+      makeAuthorStylesheet({ id: 2, name: 'second' })
+    ] as never);
+
+    const res = await request(app).get('/api/stylesheet/author/7');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].name).toBe('my-theme');
+    expect(prismaMock.authorStylesheet.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { authorId: 7 } })
+    );
+  });
+
+  it('returns an empty array when the author has none', async () => {
+    prismaMock.authorStylesheet.findMany.mockResolvedValue([]);
+    const res = await request(app).get('/api/stylesheet/author/99');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it('returns 400 for a non-numeric authorId', async () => {
+    const res = await request(app).get('/api/stylesheet/author/not-a-number');
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the PRD-03 keystone (descent target #4): the user-owned **AuthorStylesheet** model that `scoreStylesheetSelection` (shipped #84) had nothing to hook onto. Save-only — adopt (#119) and score-on-adopt (#120) remain open; **no CRS wiring** in this PR.

- `AuthorStylesheet` Prisma model + migration — author relation, `name`, `source` (the CSS/SCSS, not a URL); `(authorId, name)` unique so an author can save several distinct sheets, same name allowed across authors.
- `POST /api/stylesheet/author` — save the authed user's own stylesheet (409 on duplicate name).
- `GET /api/stylesheet/author/:authorId` — read an author's sheets back.
- `authorStylesheetSchema` + module `create`/`list` helpers; OpenAPI paths + `AuthorStylesheet` response schema registered.

## Acceptance criteria (#118)

- [x] `AuthorStylesheet` model + migration (owner relation, name, source)
- [x] `POST` to create an AuthorStylesheet for the authed user
- [x] `GET` to read an author's stylesheet(s) back
- [x] Integration test: create → fetch round-trips; per-author scoping + unique guard
- [x] No CRS wiring yet (that is #4c / #120)

## Tests

- Route-spec (`src/stylesheet.spec.ts`): create 201, duplicate-name 409, validation 400s, read-back, non-numeric param 400.
- DB integration (`src/integration/authorStylesheet.integration.ts`): create → fetch round-trip, multiple sheets per author, per-author scoping, unique guard.
- Gate clean: format, lint, `tsc --noEmit`, full unit suite (1436), integration suite for this slice.

Closes #118. PRD-03 descent target #4a marked shipped in the docs in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)