### PR TITLE
feat(governance): Rule/SubRule model + pure ruleImpact() (PRD-05 #1)

### DIFF
--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -68,7 +68,7 @@ GoldenRule (site-wide, 1..7)
 
 ## Red-green descent targets
 
-1. **Rule model** — a `Rule`/`SubRule` tree with a CRS-weight field + a pure `ruleImpact(...)` function (table-driven, mirroring the PRD-03 stylesheet slice).
+1. ~~**Rule model** — a `Rule`/`SubRule` tree with a CRS-weight field + a pure `ruleImpact(...)` function (table-driven, mirroring the PRD-03 stylesheet slice).~~ **Shipped: [#123](https://github.com/orphic-inc/stellar-api/issues/123).** `Rule`/`SubRule` models (compliance/violation weights, `onDelete: Cascade`), the pure table-driven `ruleImpact()` (`src/modules/ruleImpact.ts` — standing-tier × per-node weights, magnitudes still TBD per the open questions below), and `GET /api/rules/tree`. The standing tier it consumes is computed by descent target #2 (ADR-0004).
 2. **Warning/Ban model** + standing computation (ADR-0004).
 3. **Document ForumRules/StaffRules** against the built code; spec IRCRules + InterviewRules as net-new.
 

--- a/prisma/migrations/20260612120000_rule_subrule/migration.sql
+++ b/prisma/migrations/20260612120000_rule_subrule/migration.sql
@@ -1,0 +1,46 @@
+-- CreateTable
+CREATE TABLE "rules" (
+    "id" SERIAL NOT NULL,
+    "code" VARCHAR(100) NOT NULL,
+    "title" VARCHAR(200) NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "complianceWeight" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "violationWeight" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sub_rules" (
+    "id" SERIAL NOT NULL,
+    "ruleId" INTEGER NOT NULL,
+    "code" VARCHAR(100) NOT NULL,
+    "title" VARCHAR(200) NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "complianceWeight" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "violationWeight" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sub_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rules_code_key" ON "rules"("code");
+
+-- CreateIndex
+CREATE INDEX "rules_sortOrder_idx" ON "rules"("sortOrder");
+
+-- CreateIndex
+CREATE INDEX "sub_rules_ruleId_idx" ON "sub_rules"("ruleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sub_rules_ruleId_code_key" ON "sub_rules"("ruleId", "code");
+
+-- AddForeignKey
+ALTER TABLE "sub_rules" ADD CONSTRAINT "sub_rules_ruleId_fkey" FOREIGN KEY ("ruleId") REFERENCES "rules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2144,6 +2144,52 @@ model RulesPage {
   @@map("rules_pages")
 }
 
+/// The composable, CRS-weighted rule tree (PRD-05 #1 — the governance substrate
+/// in docs/prd/05-rules-and-governance.md). A `Rule` is a node (e.g. one of the 7
+/// GoldenRules); each carries its own compliance/violation CRS micro-impact so
+/// governance is data-driven, not hardcoded. The pure `ruleImpact()` scorer
+/// (src/modules/ruleImpact.ts) reads these weights — no logic lives in the row.
+/// Magnitudes are PRD-05 TBD; the model is the shape, the values are placeholders.
+model Rule {
+  id          Int    @id @default(autoincrement())
+  /// Machine-stable key, e.g. "golden.accounts" — distinct from the display title.
+  code        String @unique @db.VarChar(100)
+  title       String @db.VarChar(200)
+  description String @default("") @db.Text
+  /// CRS reward when the rule is adhered to (>= 0). Magnitude PRD-05 TBD.
+  complianceWeight Float @default(0)
+  /// CRS penalty magnitude when the rule is breached (>= 0; ruleImpact negates it).
+  violationWeight  Float @default(0)
+  sortOrder        Int   @default(0)
+  subRules         SubRule[]
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([sortOrder])
+  @@map("rules")
+}
+
+/// A child node of a `Rule` (PRD-05: "5 rules with 2 SubRules each"). Its weight
+/// composes additively on top of its parent rule's in `ruleImpact()`.
+model SubRule {
+  id          Int    @id @default(autoincrement())
+  ruleId      Int
+  rule        Rule   @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+  /// Stable key, unique within the parent rule (e.g. "no-sharing").
+  code        String @db.VarChar(100)
+  title       String @db.VarChar(200)
+  description String @default("") @db.Text
+  complianceWeight Float @default(0)
+  violationWeight  Float @default(0)
+  sortOrder        Int   @default(0)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@unique([ruleId, code])
+  @@index([ruleId])
+  @@map("sub_rules")
+}
+
 // ─── Top 10 ───────────────────────────────────────────────────────────────────
 
 model ReleaseVote {

--- a/src/integration/rules.integration.ts
+++ b/src/integration/rules.integration.ts
@@ -1,0 +1,98 @@
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+
+// PRD-05 #1 — the Rule/SubRule substrate against a real DB: round-trips the tree
+// (the shape GET /api/rules/tree reads) and proves the cascade + uniqueness the
+// migration declares. The pure scorer is covered in modules/ruleImpact.spec.ts.
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+// Mirrors the route's read query (orderBy + nested sub-rules).
+const readTree = () =>
+  testPrisma.rule.findMany({
+    orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+    include: { subRules: { orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }] } }
+  });
+
+describe('Rule/SubRule tree', () => {
+  it('persists a CRS-weighted rule with nested sub-rules and reads it back', async () => {
+    const rule = await testPrisma.rule.create({
+      data: {
+        code: 'golden.accounts',
+        title: 'Accounts',
+        description: 'One account per person per lifetime.',
+        complianceWeight: 1,
+        violationWeight: 5,
+        sortOrder: 0,
+        subRules: {
+          create: [
+            { code: 'no-sharing', title: 'No sharing', violationWeight: 3 },
+            {
+              code: 'keep-active',
+              title: 'Keep it active',
+              complianceWeight: 0.5
+            }
+          ]
+        }
+      }
+    });
+
+    const tree = await readTree();
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe(rule.id);
+    expect(tree[0].violationWeight).toBe(5);
+    expect(tree[0].subRules).toHaveLength(2);
+    expect(tree[0].subRules.map((s) => s.code)).toEqual([
+      'no-sharing',
+      'keep-active'
+    ]);
+  });
+
+  it('orders rules by sortOrder then id', async () => {
+    await testPrisma.rule.create({
+      data: { code: 'b', title: 'B', sortOrder: 1 }
+    });
+    await testPrisma.rule.create({
+      data: { code: 'a', title: 'A', sortOrder: 0 }
+    });
+
+    const tree = await readTree();
+    expect(tree.map((r) => r.code)).toEqual(['a', 'b']);
+  });
+
+  it('cascade-deletes sub-rules when the parent rule is removed', async () => {
+    const rule = await testPrisma.rule.create({
+      data: {
+        code: 'golden.invites',
+        title: 'Invites',
+        subRules: { create: [{ code: 'no-trading', title: 'No trading' }] }
+      }
+    });
+
+    await testPrisma.rule.delete({ where: { id: rule.id } });
+    const orphans = await testPrisma.subRule.findMany();
+    expect(orphans).toHaveLength(0);
+  });
+
+  it('rejects a duplicate sub-rule code within the same parent', async () => {
+    const rule = await testPrisma.rule.create({
+      data: {
+        code: 'golden.conduct',
+        title: 'Conduct',
+        subRules: { create: [{ code: 'civil', title: 'Be civil' }] }
+      }
+    });
+
+    await expect(
+      testPrisma.subRule.create({
+        data: { ruleId: rule.id, code: 'civil', title: 'Duplicate' }
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -5119,6 +5119,56 @@ const RulesPage = registry.register(
   })
 );
 
+// PRD-05 #1 — the composable, CRS-weighted rule tree (Rule + nested SubRule).
+const SubRule = registry.register(
+  'SubRule',
+  z.object({
+    id: z.number(),
+    ruleId: z.number(),
+    code: z.string(),
+    title: z.string(),
+    description: z.string(),
+    complianceWeight: z.number(),
+    violationWeight: z.number(),
+    sortOrder: z.number(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
+const Rule = registry.register(
+  'Rule',
+  z.object({
+    id: z.number(),
+    code: z.string(),
+    title: z.string(),
+    description: z.string(),
+    complianceWeight: z.number(),
+    violationWeight: z.number(),
+    sortOrder: z.number(),
+    subRules: z.array(SubRule),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/rules/tree',
+  tags: ['Rules'],
+  description: 'The composable Rule/SubRule tree with CRS weights (PRD-05 #1)',
+  responses: {
+    200: {
+      description: 'Rule tree, each rule with its nested sub-rules',
+      content: {
+        'application/json': {
+          schema: z.object({ rules: z.array(Rule) })
+        }
+      }
+    }
+  }
+});
+
 registry.registerPath({
   method: 'get',
   path: '/rules',

--- a/src/modules/ruleImpact.spec.ts
+++ b/src/modules/ruleImpact.spec.ts
@@ -1,0 +1,91 @@
+import { ruleImpact } from './ruleImpact';
+
+// PRD-05 rule scoring (docs/prd/05-rules-and-governance.md, descent target #1).
+// Pure: signed CRS delta from a rule/sub-rule outcome + standing tier. Magnitudes
+// are PRD-05 TBD (compliance ×{pristine10,clean3,neutral1,poor.5,hammer.25};
+// violation ×{neutral1,poor3,hammer10}); change the tables + this spec together.
+
+describe('ruleImpact', () => {
+  it('rewards adherence at face value for a neutral-standing actor', () => {
+    const r = ruleImpact({
+      outcome: 'compliance',
+      rule: { complianceWeight: 2, violationWeight: 5 }
+    });
+    expect(r.crs).toBeCloseTo(2, 10); // 2 × neutral(1)
+    expect(r.outcome).toBe('compliance');
+    expect(r.standing).toBe('neutral'); // defaulted
+  });
+
+  it('penalizes a violation as a NEGATIVE delta from the violation weight', () => {
+    const r = ruleImpact({
+      outcome: 'violation',
+      rule: { complianceWeight: 2, violationWeight: 5 }
+    });
+    expect(r.crs).toBeCloseTo(-5, 10); // -(5 × neutral(1))
+    expect(r.outcome).toBe('violation');
+  });
+
+  it('amplifies adherence ×10 for a pristine record (the strongest positive)', () => {
+    const r = ruleImpact({
+      outcome: 'compliance',
+      rule: { complianceWeight: 2, violationWeight: 5 },
+      standing: 'pristine'
+    });
+    expect(r.crs).toBeCloseTo(20, 10); // 2 × 10
+  });
+
+  it('shrinks the adherence reward for poor standing', () => {
+    const r = ruleImpact({
+      outcome: 'compliance',
+      rule: { complianceWeight: 2, violationWeight: 5 },
+      standing: 'poor'
+    });
+    expect(r.crs).toBeCloseTo(1, 10); // 2 × 0.5
+  });
+
+  it('brings the mighty hammer ×10 down on a repeat offender’s violation', () => {
+    const r = ruleImpact({
+      outcome: 'violation',
+      rule: { complianceWeight: 2, violationWeight: 5 },
+      standing: 'hammer'
+    });
+    expect(r.crs).toBeCloseTo(-50, 10); // -(5 × 10)
+  });
+
+  it('does NOT amplify a pristine actor’s violation (face-value hit)', () => {
+    const r = ruleImpact({
+      outcome: 'violation',
+      rule: { complianceWeight: 2, violationWeight: 5 },
+      standing: 'pristine'
+    });
+    expect(r.crs).toBeCloseTo(-5, 10); // -(5 × 1) — pristine doesn't soften the breach
+  });
+
+  it('composes a sub-rule weight additively on top of the parent rule', () => {
+    const r = ruleImpact({
+      outcome: 'compliance',
+      rule: { complianceWeight: 2, violationWeight: 5 },
+      subRule: { complianceWeight: 1.5, violationWeight: 3 }
+    });
+    expect(r.crs).toBeCloseTo(3.5, 10); // (2 + 1.5) × neutral(1)
+  });
+
+  it('composes sub-rule violation weight then amplifies by standing', () => {
+    const r = ruleImpact({
+      outcome: 'violation',
+      rule: { complianceWeight: 2, violationWeight: 5 },
+      subRule: { complianceWeight: 1.5, violationWeight: 3 },
+      standing: 'poor'
+    });
+    expect(r.crs).toBeCloseTo(-24, 10); // -((5 + 3) × 3)
+  });
+
+  it('returns a zero delta for a zero-weighted node (documentation-only rule)', () => {
+    const r = ruleImpact({
+      outcome: 'violation',
+      rule: { complianceWeight: 0, violationWeight: 0 },
+      standing: 'hammer'
+    });
+    expect(r.crs).toBeCloseTo(0, 10); // -(0 × 10) — no impact regardless of standing
+  });
+});

--- a/src/modules/ruleImpact.ts
+++ b/src/modules/ruleImpact.ts
@@ -1,0 +1,84 @@
+/**
+ * PRD-05 rule scoring — docs/prd/05-rules-and-governance.md (descent target #1).
+ *
+ * Pure function: given a rule/sub-rule outcome (adherence or violation) and the
+ * actor's standing tier, return the Community Reputation Score (CRS) delta. No DB
+ * — the weights live on the `Rule`/`SubRule` rows; this is the table-driven scorer
+ * that reads them, mirroring the PRD-03 `scoreStylesheetSelection` slice.
+ *
+ * Magnitudes (the ×10 pristine reward, the repeat-offender "hammer", per-node
+ * weights) are flagged TBD in PRD-05's open questions. The STRUCTURE is settled;
+ * the constants are placeholders — change the tables here + the spec together.
+ */
+
+export type RuleOutcome = 'compliance' | 'violation';
+
+/**
+ * Standing tier — the PRD-05 backbone. Scales a rule's raw weight: good standing
+ * amplifies rewards (pristine ×10, "the strongest positive"); bad standing
+ * amplifies penalties ("the mighty hammer" — large, compounding negative, the
+ * downside mirror of tiering). Computation of which tier a user is in is ADR-0004
+ * (descent target #2) — this scorer just takes the tier as input.
+ */
+export type Standing = 'pristine' | 'clean' | 'neutral' | 'poor' | 'hammer';
+
+/** The CRS-weight pair carried by any rule-tree node (`Rule` or `SubRule`). */
+export interface RuleWeights {
+  /** CRS reward when adhered to (>= 0). */
+  complianceWeight: number;
+  /** CRS penalty magnitude when breached (>= 0; negated below). */
+  violationWeight: number;
+}
+
+export interface RuleImpactEvent {
+  outcome: RuleOutcome;
+  rule: RuleWeights;
+  /** Optional sub-rule node; its weight composes ADDITIVELY on top of the parent. */
+  subRule?: RuleWeights;
+  /** Actor's standing tier; defaults to 'neutral' (×1, no amplification). */
+  standing?: Standing;
+}
+
+export interface RuleImpact {
+  /** Signed CRS delta: positive for compliance, negative for a violation. */
+  crs: number;
+  outcome: RuleOutcome;
+  standing: Standing;
+}
+
+// Compliance rewards scale UP with good standing — pristine ×10 is the strongest
+// positive; the long-term poor barely earn back. Magnitudes PRD-05 TBD.
+const COMPLIANCE_MULTIPLIER: Record<Standing, number> = {
+  pristine: 10,
+  clean: 3,
+  neutral: 1,
+  poor: 0.5,
+  hammer: 0.25
+};
+
+// Violation penalties scale UP with bad standing — the "mighty hammer": a clean
+// record takes the face-value hit, the repeat offender takes ×10. Magnitudes TBD.
+const VIOLATION_MULTIPLIER: Record<Standing, number> = {
+  pristine: 1,
+  clean: 1,
+  neutral: 1,
+  poor: 3,
+  hammer: 10
+};
+
+export const ruleImpact = (event: RuleImpactEvent): RuleImpact => {
+  const standing = event.standing ?? 'neutral';
+  const compliance = event.outcome === 'compliance';
+
+  // A sub-rule's weight composes additively with its parent rule's (PRD-05:
+  // "each rule / SubRule has its own micro-impact on CRS").
+  const base = compliance
+    ? event.rule.complianceWeight + (event.subRule?.complianceWeight ?? 0)
+    : event.rule.violationWeight + (event.subRule?.violationWeight ?? 0);
+
+  const crs = compliance
+    ? base * COMPLIANCE_MULTIPLIER[standing]
+    : -(base * VIOLATION_MULTIPLIER[standing]);
+
+  return { crs, outcome: event.outcome, standing };
+};

--- a/src/routes/api/rules.ts
+++ b/src/routes/api/rules.ts
@@ -57,6 +57,24 @@ router.get(
   })
 );
 
+// GET /tree — the composable Rule/SubRule tree with CRS weights (PRD-05 #1).
+// Static segment — MUST be before /:slug or it'd be read as a rules-page slug.
+// Read-only substrate for ruleImpact(); login-gated only (rules are site-wide
+// and visible to every member).
+router.get(
+  '/tree',
+  requireAuth,
+  authHandler(async (_req, res) => {
+    const rules = await prisma.rule.findMany({
+      orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+      include: {
+        subRules: { orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }] }
+      }
+    });
+    res.json({ rules });
+  })
+);
+
 // GET /:slug — single page (static 'manager' would shadow this if registered after; frontend uses 'manager')
 router.get(
   '/:slug',

--- a/src/rules.spec.ts
+++ b/src/rules.spec.ts
@@ -264,3 +264,80 @@ describe('DELETE /api/rules/:id', () => {
     expect(res.status).toBe(403);
   });
 });
+
+// ─── Rule/SubRule tree (PRD-05 #1) ────────────────────────────────────────────
+
+const makeRule = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  code: 'golden.accounts',
+  title: 'Accounts',
+  description: 'One account per person per lifetime.',
+  complianceWeight: 1,
+  violationWeight: 5,
+  sortOrder: 0,
+  createdAt: new Date('2026-06-12'),
+  updatedAt: new Date('2026-06-12'),
+  subRules: [],
+  ...overrides
+});
+
+describe('GET /api/rules/tree', () => {
+  it('returns the rule tree with nested sub-rules, ordered', async () => {
+    prismaMock.rule.findMany.mockResolvedValue([
+      makeRule({
+        subRules: [
+          {
+            id: 10,
+            ruleId: 1,
+            code: 'no-sharing',
+            title: 'No sharing',
+            description: '',
+            complianceWeight: 0,
+            violationWeight: 3,
+            sortOrder: 0,
+            createdAt: new Date('2026-06-12'),
+            updatedAt: new Date('2026-06-12')
+          }
+        ]
+      }),
+      makeRule({
+        id: 2,
+        code: 'golden.invites',
+        title: 'Invites',
+        sortOrder: 1
+      })
+    ] as never);
+
+    const res = await request(app).get('/api/rules/tree');
+
+    expect(res.status).toBe(200);
+    expect(res.body.rules).toHaveLength(2);
+    expect(res.body.rules[0].code).toBe('golden.accounts');
+    expect(res.body.rules[0].subRules[0].code).toBe('no-sharing');
+    expect(res.body.rules[0].violationWeight).toBe(5);
+    // tree is read ordered by sortOrder then id, sub-rules nested + ordered
+    expect(prismaMock.rule.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+        include: {
+          subRules: { orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }] }
+        }
+      })
+    );
+  });
+
+  it('returns an empty rules array when no rules are defined', async () => {
+    prismaMock.rule.findMany.mockResolvedValue([]);
+    const res = await request(app).get('/api/rules/tree');
+    expect(res.status).toBe(200);
+    expect(res.body.rules).toEqual([]);
+  });
+
+  it('is not shadowed by GET /:slug (static segment wins)', async () => {
+    prismaMock.rule.findMany.mockResolvedValue([]);
+    const res = await request(app).get('/api/rules/tree');
+    // a 200 with { rules } proves /tree resolved here, not the rules-page handler
+    expect(res.body).toHaveProperty('rules');
+    expect(prismaMock.rulesPage.findUnique).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #123. PRD-05 descent target #1 — the composable, CRS-weighted rule substrate, mirroring the PRD-03 `scoreStylesheetSelection` slice.

## What shipped
- **`Rule` / `SubRule` Prisma models** — a tree, each node carrying its own `complianceWeight` / `violationWeight` (CRS micro-impact). `SubRule` cascades on parent delete; `code` is unique within a parent. Migration `20260612120000_rule_subrule`.
- **Pure `ruleImpact()`** (`src/modules/ruleImpact.ts`) — table-driven, no DB. `standing tier × per-node weight → signed CRS delta`. Compliance scales up with good standing (pristine ×10, the strongest positive); violations scale up with bad standing (the "mighty hammer" ×10). A sub-rule's weight composes additively on its parent's. **Magnitudes are PRD-05 TBD** — the structure is settled, the constants are flagged placeholders (change the tables + the spec together).
- **`GET /api/rules/tree`** — read the rule tree with nested sub-rules (registered before `/:slug` so it isn't shadowed).
- **PRD-05 descent target #1 marked shipped** in `docs/prd/05-rules-and-governance.md` (same PR).

## Tests
- `ruleImpact.spec.ts` (9) — impact pinned per outcome / standing / sub-rule composition.
- `rules.spec.ts` (+3) — tree read, ordering/nesting, not-shadowed-by-`/:slug`.
- `rules.integration.ts` (4) — real-DB round-trip of the tree, cascade delete, unique-code constraint.
- Full gate clean: format, lint, `tsc --noEmit`, unit (1441), integration (102).

## Follow-on
The standing tier `ruleImpact()` consumes is computed by descent target #2 (ADR-0004, #124) — the Warning/Ban standing model. This PR is the substrate that #124 will feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)