### PR TITLE
feat(governance): standing computation over UserWarning (PRD-05 #2 / ADR-0004)

### DIFF
--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -69,7 +69,7 @@ GoldenRule (site-wide, 1..7)
 ## Red-green descent targets
 
 1. ~~**Rule model** — a `Rule`/`SubRule` tree with a CRS-weight field + a pure `ruleImpact(...)` function (table-driven, mirroring the PRD-03 stylesheet slice).~~ **Shipped: [#123](https://github.com/orphic-inc/stellar-api/issues/123).** `Rule`/`SubRule` models (compliance/violation weights, `onDelete: Cascade`), the pure table-driven `ruleImpact()` (`src/modules/ruleImpact.ts` — standing-tier × per-node weights, magnitudes still TBD per the open questions below), and `GET /api/rules/tree`. The standing tier it consumes is computed by descent target #2 (ADR-0004).
-2. **Warning/Ban model** + standing computation (ADR-0004).
+2. ~~**Warning/Ban model** + standing computation (ADR-0004).~~ **Standing computation shipped: [#124](https://github.com/orphic-inc/stellar-api/issues/124).** Pure `computeStanding()` (`src/modules/standing.ts`) rolls active `UserWarning` rows (accrual + expiry) and ban state into the 5-tier `Standing` that `ruleImpact()` (#1) consumes; surfaced on the profile read path (`PublicProfile.standing`). Thresholds are ADR-0004 placeholders (TBD). The fuller Warning/Ban _entity_ model (suspensions, escalation ladder, ban-evasion linkage) remains for ADR-0004 to finalize — this slice computes standing over the existing `UserWarning` + `banDate`.
 3. **Document ForumRules/StaffRules** against the built code; spec IRCRules + InterviewRules as net-new.
 
 ## Open questions

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -608,6 +608,7 @@ describe('API auth/profile/user flows', () => {
       isDonor: false,
       disabled: false,
       warned: null,
+      standing: 'clean',
       inviteCount: 0,
       stats: {
         contributed: '0',
@@ -668,6 +669,7 @@ describe('API auth/profile/user flows', () => {
       isDonor: false,
       disabled: false,
       warned: null,
+      standing: 'clean',
       inviteCount: 1,
       stats: {
         contributed: '100',
@@ -750,6 +752,7 @@ describe('API auth/profile/user flows', () => {
       isDonor: false,
       disabled: false,
       warned: null,
+      standing: 'clean',
       inviteCount: null,
       stats: {
         contributed: null,

--- a/src/integration/standing.integration.ts
+++ b/src/integration/standing.integration.ts
@@ -1,0 +1,91 @@
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { getProfileById } from '../modules/profile';
+
+// PRD-05 #2 / ADR-0004 — standing surfaced on the profile read path, computed from
+// seeded warned/banned users against the real DB. Ladder logic is unit-tested in
+// modules/standing.spec.ts; this proves the wiring (select + compute + expose).
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+let staffId: number;
+
+const createUser = async (
+  username: string,
+  data: Record<string, unknown> = {}
+) => {
+  const rank = await testPrisma.userRank.findFirstOrThrow();
+  const settings = await testPrisma.userSettings.create({ data: {} });
+  const profile = await testPrisma.profile.create({ data: {} });
+  return testPrisma.user.create({
+    data: {
+      username,
+      email: `${username}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id,
+      ...data
+    }
+  });
+};
+
+const warn = (userId: number, expiresAt: Date | null) =>
+  testPrisma.userWarning.create({
+    data: { userId, warnedById: staffId, reason: 'test', expiresAt }
+  });
+
+const YEAR_AGO = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000);
+const NEXT_YEAR = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+const LAST_YEAR = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
+
+beforeEach(async () => {
+  const staff = await createUser('staffer');
+  staffId = staff.id;
+});
+
+describe('standing on the profile read path', () => {
+  it('is pristine for a long-tenured, never-warned user', async () => {
+    const u = await createUser('clean-vet', { dateRegistered: YEAR_AGO });
+    const view = await getProfileById(u.id, u.id);
+    expect(view?.standing).toBe('pristine');
+  });
+
+  it('is clean for a fresh, never-warned user', async () => {
+    const u = await createUser('newbie');
+    const view = await getProfileById(u.id, u.id);
+    expect(view?.standing).toBe('clean');
+  });
+
+  it('is poor for a user with two active warnings', async () => {
+    const u = await createUser('two-strikes', { dateRegistered: YEAR_AGO });
+    await warn(u.id, null);
+    await warn(u.id, NEXT_YEAR);
+    const view = await getProfileById(u.id, u.id);
+    expect(view?.standing).toBe('poor');
+  });
+
+  it('ignores expired warnings — recovers toward pristine', async () => {
+    const u = await createUser('reformed', { dateRegistered: YEAR_AGO });
+    await warn(u.id, LAST_YEAR); // expired
+    await warn(u.id, LAST_YEAR); // expired
+    const view = await getProfileById(u.id, u.id);
+    expect(view?.standing).toBe('pristine');
+  });
+
+  it('is the hammer for a banned user regardless of warnings', async () => {
+    const u = await createUser('banned-acct', {
+      dateRegistered: YEAR_AGO,
+      banDate: new Date()
+    });
+    const view = await getProfileById(u.id, u.id);
+    expect(view?.standing).toBe('hammer');
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -541,6 +541,7 @@ const PublicProfile = registry.register(
     isDonor: z.boolean(),
     disabled: z.boolean(),
     warned: z.string().nullable(),
+    standing: z.enum(['pristine', 'clean', 'neutral', 'poor', 'hammer']),
     inviteCount: z.number().nullable(),
     staffBio: z.string().nullable(),
     stats: ProfileStats,

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -12,6 +12,9 @@ import { sendInviteEmail } from '../lib/mailer';
 import { getLogger } from './logging';
 import { computeRatio } from './ratio';
 import { parsePerks, type PerksMap } from './donor';
+import { computeStanding } from './standing';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const log = getLogger('profile');
 
@@ -151,6 +154,8 @@ const PROFILE_BASE_SELECT = {
   isDonor: true,
   disabled: true,
   warned: true,
+  banDate: true,
+  warnings: { select: { expiresAt: true } },
   inviteCount: true,
   staffBio: true,
   contributed: true,
@@ -799,6 +804,17 @@ const buildProfileView = async (
   const donorPresentation = buildDonorPresentation(user);
   const derivedRatio = computeRatio(user.contributed, user.consumed);
 
+  // PRD-05 #2 / ADR-0004 — governance standing rolled from warnings + ban state.
+  const now = new Date();
+  const standing = computeStanding({
+    warnings: user.warnings,
+    banned: user.banDate !== null,
+    now,
+    accountAgeDays: Math.floor(
+      (now.getTime() - user.dateRegistered.getTime()) / DAY_MS
+    )
+  });
+
   return {
     id: user.id,
     username: user.username,
@@ -811,6 +827,7 @@ const buildProfileView = async (
     isDonor: user.isDonor,
     disabled: user.disabled,
     warned: user.warned?.toISOString() ?? null,
+    standing,
     inviteCount: viewer.isOwner || viewer.isStaff ? user.inviteCount : null,
     staffBio: user.staffBio ?? null,
     stats: {

--- a/src/modules/standing.spec.ts
+++ b/src/modules/standing.spec.ts
@@ -1,0 +1,122 @@
+import { computeStanding, isWarningActive } from './standing';
+
+// PRD-05 #2 / ADR-0004 — pure standing computation over UserWarning + ban state.
+// Ladder is settled; thresholds (POOR_AT=2, HAMMER_AT=4, PRISTINE_TENURE=365d)
+// are ADR-0004 TBD placeholders — change the constants + this spec together.
+
+const NOW = new Date('2026-06-12T00:00:00Z');
+const future = () => new Date('2026-12-31T00:00:00Z');
+const past = () => new Date('2026-01-01T00:00:00Z');
+
+describe('isWarningActive', () => {
+  it('treats a permanent (null-expiry) warning as always active', () => {
+    expect(isWarningActive({ expiresAt: null }, NOW)).toBe(true);
+  });
+  it('treats a future-expiry warning as active', () => {
+    expect(isWarningActive({ expiresAt: future() }, NOW)).toBe(true);
+  });
+  it('treats a past-expiry warning as inactive', () => {
+    expect(isWarningActive({ expiresAt: past() }, NOW)).toBe(false);
+  });
+});
+
+describe('computeStanding', () => {
+  it('is pristine for a long-tenured account with zero active warnings', () => {
+    const s = computeStanding({
+      warnings: [],
+      banned: false,
+      now: NOW,
+      accountAgeDays: 400
+    });
+    expect(s).toBe('pristine');
+  });
+
+  it('is merely clean for a fresh account with zero warnings', () => {
+    const s = computeStanding({
+      warnings: [],
+      banned: false,
+      now: NOW,
+      accountAgeDays: 30
+    });
+    expect(s).toBe('clean');
+  });
+
+  it('accrues to neutral on a single active warning', () => {
+    const s = computeStanding({
+      warnings: [{ expiresAt: null }],
+      banned: false,
+      now: NOW,
+      accountAgeDays: 400
+    });
+    expect(s).toBe('neutral'); // one warning sinks even a long-tenured account
+  });
+
+  it('accrues to poor at two active warnings', () => {
+    const s = computeStanding({
+      warnings: [{ expiresAt: null }, { expiresAt: future() }],
+      banned: false,
+      now: NOW
+    });
+    expect(s).toBe('poor');
+  });
+
+  it('brings the hammer at four active warnings (frequent offender)', () => {
+    const s = computeStanding({
+      warnings: [
+        { expiresAt: null },
+        { expiresAt: null },
+        { expiresAt: future() },
+        { expiresAt: null }
+      ],
+      banned: false,
+      now: NOW
+    });
+    expect(s).toBe('hammer');
+  });
+
+  it('ignores expired warnings when accruing (expiry recovery)', () => {
+    // three warnings, but two already expired → only one active → neutral, not hammer
+    const s = computeStanding({
+      warnings: [
+        { expiresAt: past() },
+        { expiresAt: past() },
+        { expiresAt: future() }
+      ],
+      banned: false,
+      now: NOW,
+      accountAgeDays: 400
+    });
+    expect(s).toBe('neutral');
+  });
+
+  it('drops back to pristine once every warning has expired', () => {
+    const s = computeStanding({
+      warnings: [{ expiresAt: past() }, { expiresAt: past() }],
+      banned: false,
+      now: NOW,
+      accountAgeDays: 400
+    });
+    expect(s).toBe('pristine');
+  });
+
+  it('is the hammer when banned, regardless of warning count', () => {
+    const s = computeStanding({
+      warnings: [],
+      banned: true,
+      now: NOW,
+      accountAgeDays: 400
+    });
+    expect(s).toBe('hammer');
+  });
+
+  it('is the hammer on ban-evasion even when not currently banned', () => {
+    const s = computeStanding({
+      warnings: [],
+      banned: false,
+      banEvasion: true,
+      now: NOW,
+      accountAgeDays: 400
+    });
+    expect(s).toBe('hammer');
+  });
+});

--- a/src/modules/standing.ts
+++ b/src/modules/standing.ts
@@ -32,7 +32,12 @@ export interface StandingInput {
   warnings: WarningRecord[];
   /** True when the user is banned (`User.banDate` is set). */
   banned: boolean;
-  /** ADR-0004 ban-evasion linkage signal — the worst standing (optional). */
+  /**
+   * ADR-0004 ban-evasion linkage signal — the worst standing. NOT yet fed by any
+   * caller: the invite-tree/account linkage that would set it is the unfinished
+   * part of ADR-0004's entity model. Wired here as the seam (and unit-tested) so
+   * the computation is ready; until that model lands it is always undefined.
+   */
   banEvasion?: boolean;
   /** Clock for expiry evaluation — passed in to keep the function pure. */
   now: Date;

--- a/src/modules/standing.ts
+++ b/src/modules/standing.ts
@@ -1,0 +1,68 @@
+/**
+ * PRD-05 #2 / ADR-0004 — governance standing computation.
+ *
+ * Pure function: roll a user's active `UserWarning` rows + ban state into the
+ * `Standing` tier that the PRD-05 CRS backbone reads (and that `ruleImpact()`
+ * consumes — this is the producer for that scorer's `standing` input). No DB; the
+ * caller fetches the rows and passes a clock, so accrual/expiry/ban transitions
+ * are all deterministically testable.
+ *
+ * ADR-0004 is "Proposed — pending": the LADDER (banned/evasion → hammer, frequent
+ * warnings → poor/hammer, long clean tenure → pristine) is the settled structure;
+ * the THRESHOLDS below are flagged placeholders (magnitudes TBD per the ADR + the
+ * PRD-05 open questions). Change the constants here + the spec together.
+ */
+
+/**
+ * The governance standing tier — the PRD-05 CRS backbone. ADR-0004 owns this
+ * concept, so it is defined canonically here. `ruleImpact()` (PRD-05 #1) declares
+ * a structurally-identical `Standing` and consumes this tier as its scaling input;
+ * once both slices land in main, fold ruleImpact's copy into an import from here.
+ */
+export type Standing = 'pristine' | 'clean' | 'neutral' | 'poor' | 'hammer';
+
+/** The subset of a `UserWarning` row the computation needs. */
+export interface WarningRecord {
+  /** null = a permanent warning; a date = expires then (past = no longer active). */
+  expiresAt: Date | null;
+}
+
+export interface StandingInput {
+  /** The user's warning rows (active + expired); filtered by `now` internally. */
+  warnings: WarningRecord[];
+  /** True when the user is banned (`User.banDate` is set). */
+  banned: boolean;
+  /** ADR-0004 ban-evasion linkage signal — the worst standing (optional). */
+  banEvasion?: boolean;
+  /** Clock for expiry evaluation — passed in to keep the function pure. */
+  now: Date;
+  /** Account tenure in days; long clean tenure earns the pristine tier. */
+  accountAgeDays?: number;
+}
+
+// Thresholds — ADR-0004 TBD placeholders; the ladder shape is what's settled.
+const POOR_AT = 2; // 2+ active warnings → poor
+const HAMMER_AT = 4; // 4+ active warnings → "the mighty hammer" (frequent)
+const PRISTINE_TENURE_DAYS = 365; // a clean year → pristine (the ×10 reward)
+
+/** A warning counts while permanent (no expiry) or not yet expired at `now`. */
+export const isWarningActive = (w: WarningRecord, now: Date): boolean =>
+  w.expiresAt === null || w.expiresAt.getTime() > now.getTime();
+
+export const computeStanding = (input: StandingInput): Standing => {
+  // Ban (and ban evasion) is terminal — the hammer, regardless of warning count.
+  if (input.banned || input.banEvasion) return 'hammer';
+
+  const active = input.warnings.filter((w) =>
+    isWarningActive(w, input.now)
+  ).length;
+
+  if (active >= HAMMER_AT) return 'hammer'; // frequent warnings compound to the hammer
+  if (active >= POOR_AT) return 'poor';
+  if (active === 1) return 'neutral';
+
+  // Zero active warnings: long clean tenure is pristine, otherwise merely clean.
+  return (input.accountAgeDays ?? 0) >= PRISTINE_TENURE_DAYS
+    ? 'pristine'
+    : 'clean';
+};


### PR DESCRIPTION
Closes #124. PRD-05 descent target #2 — implements ADR-0004's standing computation over the existing `UserWarning` + ban state.

## What shipped
- **Pure `computeStanding()`** (`src/modules/standing.ts`) — rolls a user's **active** `UserWarning` rows (accrual + expiry, evaluated against a passed-in clock) and ban state into the 5-tier `Standing`: `pristine | clean | neutral | poor | hammer`. Ban / ban-evasion is terminal (the "mighty hammer"); frequent active warnings compound to it; zero active warnings + long clean tenure earns pristine. No DB. Thresholds (`POOR_AT=2`, `HAMMER_AT=4`, `PRISTINE_TENURE=365d`) are **ADR-0004 TBD placeholders** — the ladder is settled, the magnitudes flagged.
- **The producer/consumer bridge**: this is the standing tier `ruleImpact()` (PRD-05 #1, #123) takes as input. `Standing` is defined **canonically here** — ADR-0004 owns the concept, which the #123 review itself flagged. Once both slices land in `main`, fold `ruleImpact`'s structurally-identical copy into an import from this module (noted in both files).
- **Exposed on the read path**: `PublicProfile.standing` (and `MyProfile`, which spreads it). Computed in `buildProfileView` from the `warnings` relation + `banDate` + tenure. Visibility matches the already-public `warned` / `disabled` fields — the tier is a coarser signal than those.

## Tests
- `standing.spec.ts` (12) — `isWarningActive` + accrual / expiry-recovery / ban / ban-evasion transitions.
- `standing.integration.ts` (5) — reads `standing` back over seeded pristine / fresh / two-warning / expired-warning / banned users against the real DB.
- Gate clean: format, lint, `tsc --noEmit`, unit (1441), integration (103).

## Scope note
This is the **computation** slice. The fuller Warning/Ban *entity* model ADR-0004 also anticipates (suspension/ban entities, escalation ladder, ban-evasion linkage via invite-tree/account signals) is left for ADR-0004 to finalize — this computes standing over what exists today (`UserWarning` + `User.banDate`). The `banEvasion` input is wired as an optional signal, ready for that linkage.

## Stacking
Independent of #123/#128 (both branch off `main`); mergeable in either order. The only coupling is the duplicate `Standing` type, with a unification note in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)