### PR TITLE
docs(prd): fix develop→main staleness + mark PRD-02 unwritten

### DIFF
--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft · **Owner:** @obrien-k
 **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) · **Decisions:** [ADR-0002 community-health-pulse → CRS](../adr/0002-community-health-pulse.md) (accrual model), [ADR-0003 stylesheet injection isolation](../adr/0003-stylesheet-injection-isolation.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
+**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce _(unwritten)_ · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
 
 > Lean PRD. Captures the decided shape + the Community-Score weights, flags TBDs, and maps each concept to existing code so this becomes a red-green descent, not greenfield. Stylesheet scoring is a **dimension of PRD-01's CRS**, not a separate score.
 

--- a/docs/prd/04-contribution-release-music.md
+++ b/docs/prd/04-contribution-release-music.md
@@ -1,9 +1,9 @@
 # PRD-04 — Contribution, Release & Music Model
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · PRD-03 Stylesheets · **PRD-04 Contribution/Release/Music**
+**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce _(unwritten)_ · PRD-03 Stylesheets · **PRD-04 Contribution/Release/Music**
 
-> Lean PRD. The structured model has **landed on `develop`** (#85 music model + ReleaseArtist/Edition, merged via #98), with per-file rip metadata split out to a `ReleaseFile` satellite ([ADR-0008](../adr/0008-contribution-metadata-satellites.md)). The quality grade landed on `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86). This documents the model + CRS weighting and flags TBDs. Prod is pre-alpha with disposable data, so the model was migrated destructively (no backfill).
+> Lean PRD. The structured model has **landed on `main`** (#85 music model + ReleaseArtist/Edition, merged via #98 — `develop` retired in the [ADR-0010](../adr/0010-trunk-based-single-branch-workflow.md) trunk fold), with per-file rip metadata split out to a `ReleaseFile` satellite ([ADR-0008](../adr/0008-contribution-metadata-satellites.md)). The quality grade landed on `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86). This documents the model + CRS weighting and flags TBDs. Prod is pre-alpha with disposable data, so the model was migrated destructively (no backfill).
 
 ## Problem
 
@@ -36,7 +36,7 @@ Contributions/Releases are a **primary lifetime-CRS driver** — `downloads.ts`,
 
 | Concept                                        | Lives in                                                                                                                             |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Release / Edition / ReleaseArtist / ArtistRole | `feat/music-model-edition-tier` (#85) — landed via #98                                                                               |
+| Release / Edition / ReleaseArtist / ArtistRole | `feat/music-model-edition-tier` (#85) — landed on `main` via #98                                                                     |
 | ReleaseFile (per-file rip metadata)            | `schema.prisma` + migration `20260609171357_music_model_release_files` — [ADR-0008](../adr/0008-contribution-metadata-satellites.md) |
 | Contribution quality grade                     | `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86) — `gradeContribution`  |
 | Release editing surface                        | `releaseWorkbench/*`                                                                                                                 |

--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
 **Decisions:** [ADR-0001 granular permissions](../adr/0001-granular-permission-checks.md) (enforcement), [ADR-0002 community-health-pulse](../adr/0002-community-health-pulse.md) (standing trend), [ADR-0004 standing → CRS + warnings/bans](../adr/0004-standing-warnings-bans.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance**
+**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce _(unwritten)_ · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance**
 
 > The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose (that lives in `RulesPage`).
 


### PR DESCRIPTION
Small docs-only cleanup of stale references surfaced while auditing the ADR/PRD set.

## Changes
- **PRD-04** — the intro + descent map still said the structured music model "landed on `develop`"; `develop` was retired in the [ADR-0010](https://github.com/orphic-inc/stellar-api/blob/main/docs/adr/0010-trunk-based-single-branch-workflow.md) trunk fold. Repointed to `main`, with an ADR-0010 pointer for the why.
- **PRD-03 / PRD-04 / PRD-05** — marked `PRD-02 Donations/IRC/Announce` as **_(unwritten)_** in the Numbering lines where it's cross-referenced (PRD-02 has no file yet).

No content/behavior changes — text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)