### PR TITLE
docs(prd-02): IRC & Announce — PRD + ADR-0011/0012 + glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,6 +63,26 @@ _Avoid_: metric, plugin, scorer module
 A bounded cross-dimension CRS edge — one signal nudging another dimension — capped and deduplicated to resist farming (e.g. stylesheet adoption feeding the Friends dimension).
 _Avoid_: cross-score, bonus link, coupling
 
+**Release-Announce Feed**:
+The out-of-band stream of new Contributions delivered to a member over RSS/XML and IRC — the firehose of the Contribution Spine as it grows. Authenticated by the **AnnounceKey**, not the **Identity State** (the member is not carrying a session cookie on these channels). Distinct from consuming a release, which stays a session-authed accounted download.
+_Avoid_: rss feed, announce stream, the firehose
+
+**AnnounceKey**:
+A per-user credential authenticating a member's **Release-Announce Feed** (RSS + IRC announce). It gates *receiving* the stream of new Contributions; it never authenticates a download — release consumption remains a session-authed grant through the **Ratio Mechanism**. Rotatable; rotating it invalidates the prior feed URL.
+_Avoid_: passkey, download key, torrent key
+
+**IRCKey**:
+A per-user credential authenticating a member's **identity on the IRC network** (presented as the SASL secret to the IRCd, validated against this API). Paired with the **AnnounceKey** it enables personalized release announcements pushed over IRC; alone it only establishes who a nick is. Distinct from the AnnounceKey — different channel, different rotation/threat model.
+_Avoid_: irc password, chat token, drone key
+
+**IRCScore**:
+A bounded CRS **Dimension Scorer** derived from a member's *message* activity on IRC over a trailing window — message volume weighted by channel and scaled by how many distinct days they were active. Presence/idle never contributes (anti-farming); only messages count. Capped with diminishing returns like every dimension, so IRC cannot dominate reputation.
+_Avoid_: irc activity, chat score, presence score
+
+**IRC Activity Rollup**:
+The durable, pre-aggregated substrate **IRCScore** reads — one row per member × channel × day of message counts, upserted by the IRC bot. The append/aggregate surface ADR-0007 calls for when a signal is *irreducible* (not reconstructable from current state) yet too high-volume for the `CRS_*` event ledger. The score is still computed on read over a trailing window of these rows; nothing stores a denormalized IRCScore.
+_Avoid_: irc log, activity table, message history
+
 ## Relationships
 
 - A **Contract Schema** directly structures incoming inputs and dictates the programmatic generation of the schema served by `swagger-ui-express`.
@@ -70,6 +90,7 @@ _Avoid_: cross-score, bonus link, coupling
 - **Sanitized Values** must be extracted at the Controller layer using **Contract Schemas** before execution by domain services.
 - The **Ratio Mechanism** reads **Eligible Contribution Bytes** (gated by **Effective Availability**) and never reads CRS; a derived **RatioScore** flows one-way into CRS as one **Dimension Scorer**. CRS never gates downloads.
 - A **Contribution Spine** carries type-agnostic fields only; a music Contribution attaches a **Release File** (per-file) and an **Edition** (per-pressing). Future CommunityTypes attach their own analogous satellites rather than forking the spine (ADR-0008).
+- The **AnnounceKey** authenticates the **Release-Announce Feed** (RSS + IRC) and the **IRCKey** authenticates IRC identity; the two paired enable IRC-delivered release announcements. Neither replaces the **Identity State** on the session-authed download path — they authenticate out-of-band channels only, never a download.
 
 ## Flagged Ambiguities
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The README is the lamp-post; specs and decisions live in [`docs/`](docs/):
 | [ADR-0003 — Stylesheet injection isolation](docs/adr/0003-stylesheet-injection-isolation.md) | user-CSS sandbox/reset _(proposed)_          |
 | [`docs/agents/`](docs/agents/) · [CONTEXT.md](CONTEXT.md) · [AGENTS.md](AGENTS.md)           | domain language, agent/dev guides            |
 
-> PRD numbering: **PRD-01** Community-Score · **PRD-02** Donations/IRC/Announce · **PRD-03** Stylesheets · **PRD-04** Contribution/Release/Music.
+> PRD numbering: **PRD-01** Community-Score · **PRD-02** IRC & Announce · **PRD-03** Stylesheets · **PRD-04** Contribution/Release/Music · **PRD-05** Rules & Governance · **PRD-06** Ratio.
 
 ## Tech Stack
 

--- a/docs/adr/0011-delegated-irc-authentication.md
+++ b/docs/adr/0011-delegated-irc-authentication.md
@@ -1,0 +1,28 @@
+# Delegated IRC authentication — the IRCd validates against this API, no credential mirror
+
+**Status: Accepted (2026-06-13).** Serves [PRD-02 IRC + Announce](../prd/02-irc-and-announce.md) (draft). Motivated by the single-source-of-truth discipline of [ADR-0009](0009-fork-workflow-and-dependency-discipline.md) / [ADR-0010](0010-trunk-based-single-branch-workflow.md); the IRCd + bot are an infra addition governed by ADR-0009's dependency discipline.
+
+## Context
+
+The IRC feature ships as a self-hosted modern IRCd (Ergo) plus a web client (The Lounge). A member authenticates to the network over SASL with `account = userId` / `password = IRCKey` (the **IRCKey** — a per-user credential, sibling of the **AnnounceKey**). The IRCd must validate that credential somehow. Two shapes:
+
+- **Delegated** — the IRCd calls this API on each login to validate; this API stays the sole owner of the credential.
+- **Provisioned** — this API writes/updates an account in the IRCd's own credential store whenever a member sets or rotates their IRCKey; the IRCd validates locally.
+
+This codebase's most expensive recurring failure mode is a **second source of truth drifting** from the first — the `develop ↔ main` divergence that forced the [ADR-0010](0010-trunk-based-single-branch-workflow.md) trunk fold, and the key/state drifts before it. Provisioning IRCKeys into the IRCd's store reintroduces exactly that: the same secret in two datastores, a fan-out on every rotation, and a half-failed-sync state to reconcile.
+
+## Decision
+
+**Delegated authentication.** The IRCd validates every SASL login by calling an **internal** stellar-api endpoint (auth-script / HTTP callback) that returns accept/reject + the resolved `userId`.
+
+1. **Single source of truth.** The IRCKey lives in exactly one place (`User.ircKey`). The IRCd holds no credential store. Rotation is a one-row update, instantly effective — nothing to fan out, nothing to drift.
+2. **Internal-only seam.** The auth endpoint is network-scoped within the compose stack and **never publicly routed**, rate-limited like any automated surface (Golden Rule 5: automated access via the API only).
+3. **One validation seam, reused.** The same delegated callback later authorizes the AnnounceKey-gated **Release-Announce Feed** and bot `!commands` — one place where IRC-side credentials are checked against this API.
+4. **Availability trade accepted.** If this API is unreachable, *new* IRC logins fail; already-connected / always-on sessions persist. There is no offline-auth requirement — we do not trade the single-source guarantee for outage resilience the IRC layer does not need.
+
+## Consequences
+
+- **No credential mirror, no sync job, no drift** — structurally consistent with ADR-0009/0010 rather than fighting them later.
+- The IRCd gains a **runtime dependency on this API at connect time**. Acceptable, and it keeps the IRCd dumb (no user database to back up, migrate, or secure separately).
+- The internal auth endpoint is a **new trust boundary**: it must be network-isolated, rate-limited, and never reachable from the public surface — recorded here so it is not accidentally mounted on the public router.
+- Pairs with [ADR-0012](0012-irc-activity-rollup-substrate.md) (the IRC activity substrate): together they keep IRC identity *and* IRC-derived reputation reading from this API's own state, never from IRCd internals.

--- a/docs/adr/0012-irc-activity-rollup-substrate.md
+++ b/docs/adr/0012-irc-activity-rollup-substrate.md
@@ -1,0 +1,31 @@
+# IRC activity rollup as the CRS durable substrate (messages-only, computed-on-read)
+
+**Status: Accepted (2026-06-13).** **Extends** [ADR-0007 — CRS read-time value + event accrual ledger](0007-crs-read-time-and-event-ledger.md). Serves [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md) (the `IRCScore` dimension) and [PRD-02 IRC + Announce](../prd/02-irc-and-announce.md) (draft).
+
+## Context
+
+`IRCScore` is a planned CRS **Dimension Scorer** over a member's IRC participation. [ADR-0007](0007-crs-read-time-and-event-ledger.md) settled the computed-on-read-vs-event-logged question with one test: **can the signal be reconstructed from current state?**
+
+- Reconstructable (Longevity ← `createdAt`, Ratio ← current ratio) → pure read-time, no durable surface.
+- Not reconstructable (stylesheet adoption — "current sheet" loses the set of past adoptions) → an append-only `CRS_*` row on the `EconomyTransaction` ledger.
+
+IRC activity fails the reconstruction test in the same way the stylesheet edge does: once a day passes, *who said what in which channel* is gone unless it was recorded. So by ADR-0007's own logic it **earns a durable surface**. But it differs from the stylesheet edge in volume and shape: it is **high-volume and continuous**, and it is not dedup-/double-entry-shaped — pushing every message onto the economic `CRS_*` ledger would pollute a double-entry economic ledger with non-economic chatter and distort its row semantics.
+
+ADR-0007 anticipated exactly this as its rule 3 ("time-series … an *additive* layer"), but left the concrete shape for the first dimension that needed it. IRCScore is that dimension.
+
+## Decision
+
+The durable surface for IRC activity is a **purpose-built, pre-aggregated rollup** — not the `CRS_*` ledger and not a denormalized score.
+
+1. **`IrcActivity` rollup.** One row per **member × channel × day** of **message counts**, upserted by the IRC bot. Bounded row count (members × channels × days-in-window), fit-for-purpose shape — distinct from both the economic ledger and a raw message log.
+2. **Messages only — presence never feeds the score.** Idle-in-channel is the most farmable IRC signal (park a bouncer, "be present" 24/7, contribute nothing). Presence may be tracked elsewhere for *"who's online"* UX/ops, but it is **never recorded into the scoring path** and never contributes to `IRCScore`.
+3. **Still computed on read.** `IRCScore` remains a pure `Dimension Scorer`: the assembler (`reputation.ts` `getReputation`) fetches a trailing window (**90 days**) of rollup rows into the `DimensionInput`, and the pure scorer computes from them. There is **no stored `ircScore` column** — ADR-0007 rule 1 (no denormalized, drift-prone score) holds unchanged.
+4. **Anti-farming is structural in the formula**, not a bolt-on: a per-channel/day cap on counted messages (flooding doesn't scale), `consistency = distinctActiveDays / windowDays` (one marathon session scores near-zero; regular presence is the only lever), and a per-channel weight map (`channelQuality`). Channel weights live in the scorer as **tuning constants** (like the existing caps/τ), table-driven and unit-tested against fixture rows. Magnitudes (`CAP`, `TAU`, `DAILY_CAP`, `MIN_MSGS`, weights) are hand-pinned later (HITL), like every other CRS magnitude.
+5. **Old rows aggregate into monthly summaries** (the deferred trend layer, [#94](https://github.com/orphic-inc/stellar-api/issues/94)); they are a read-model for trends, **never** the source of truth for the live score.
+
+## Consequences
+
+- **Extends, does not contradict, ADR-0007.** The rule generalizes cleanly: *reconstructable* → pure read-time; *irreducible + low-volume/dedup-shaped* → the `CRS_*` ledger; *irreducible + high-volume/continuous* → a pre-aggregated rollup. The score is computed-on-read in all three.
+- A new table the IRC bot writes to; the bot's only persistence responsibility. Reads come from this API's own state, never from IRCd internals (pairs with [ADR-0011](0011-delegated-irc-authentication.md)).
+- The scorer stays **pure and table-driven** — the red-green seam: build and unit-test `scoreIrcActivity(rows, weights, window)` against fixtures before any IRC infra exists.
+- **Presence-free scoring is deliberate and surprising** — a future reader will ask "why doesn't idle count?" The answer is recorded here: idle is trivially farmed, so it earns UX visibility but not reputation.

--- a/docs/prd/02-irc-and-announce.md
+++ b/docs/prd/02-irc-and-announce.md
@@ -1,0 +1,73 @@
+# PRD-02 — IRC & Announce
+
+**Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
+**Decisions:** [ADR-0011 delegated IRC authentication](../adr/0011-delegated-irc-authentication.md), [ADR-0012 IRC activity rollup substrate](../adr/0012-irc-activity-rollup-substrate.md), [ADR-0007 CRS read-time + ledger](../adr/0007-crs-read-time-and-event-ledger.md), [ADR-0009 dependency/infra discipline](../adr/0009-fork-workflow-and-dependency-discipline.md)
+**Numbering:** PRD-01 Community-Score · **PRD-02 IRC & Announce** · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · PRD-06 Ratio
+
+> Lean PRD. Covers **IRC + Announce together** (they share the credential + delivery substrate); **Donations are split into their own PRD** (overlaps [#62](https://github.com/orphic-inc/stellar-api/issues/62)); **RSS/XML feeds are a fast-follow slice** here (they reuse the announce substrate). IRC conduct rules live in [PRD-05](05-rules-and-governance.md) (IRCRules / [#126](https://github.com/orphic-inc/stellar-api/issues/126)); this PRD builds the feature, not the rule prose.
+
+## Problem
+
+Stellar is a content-tracker-lineage community: members want a real-time **social hub** and a **release-announce channel** — the out-of-band firehose of new Contributions (the torrent-announce stand-in, Golden Rule 3). Neither exists. The feature was deferred pending a per-user IRC credential and its pairing with a release-feed credential, both of which touch the Contribution/Community model and are net-new on `User`.
+
+## Architecture (decided)
+
+- **Self-hosted modern IRCd (Ergo) + a web client (The Lounge).** Ergo collapses IRCd + accounts/SASL + always-on/bouncer into one component; The Lounge gives web-only members access and is the donor-bouncer surface (donor perks → the split-off Donations PRD). Matrix was considered and set aside (IRC authenticity for a content-tracker-lineage site).
+- **IRC is its own top-level section**, not a forum sub-area — gated on accepting the IRCRules ([PRD-05](05-rules-and-governance.md)) and having an **IRCKey** set.
+- **Infra** lives in stellar-compose as new pinned services (Ergo + bot + The Lounge), per [ADR-0009](../adr/0009-fork-workflow-and-dependency-discipline.md) dependency discipline.
+
+## Identity — the two keys
+
+Two per-user credentials, **net-new** on `User` (the vestigial `communityPass` field is dropped in the same migration). Stored as unique, lazily-generated, rotatable 32-char URL-safe tokens.
+
+- **`AnnounceKey`** — authenticates the **Release-Announce Feed** (RSS + IRC announce): *receiving* the stream of new Contributions. It **never** authenticates a download — release consumption stays a session-authed accounted grant through the Ratio Mechanism. Rotating it dead-links the prior feed URL.
+- **`IRCKey`** — authenticates **IRC identity** (the SASL secret). Validated by **delegated auth**: Ergo calls an internal stellar-api endpoint per login; this API is the single source of truth, no credential mirror in the IRCd ([ADR-0011](../adr/0011-delegated-irc-authentication.md)). Rotating it drops any always-on session.
+- **Paired:** to receive personalized release announcements **pushed over IRC** a member needs both (IRCKey = who you are on IRC; AnnounceKey = authorized to receive the feed).
+
+## Announce
+
+A **Node bot/worker** in stellar-compose bridges this API and the network:
+
+- **Announce relay** — stellar-api emits a new-Contribution event → the bot relays to `#announce` and to the per-member feed; gated by AnnounceKey. Reuses the existing `announcements` surface.
+- **`!commands`** — `!stats` / `!enroll` / support, backed by the public API with a scoped token (Golden Rule 5: automation via the API only).
+- **Activity capture** — the bot upserts the **IRC Activity Rollup** (below). It does **not** store message content — counts only.
+
+## IRCScore (CRS dimension)
+
+`IRCScore` is a bounded CRS **Dimension Scorer** (PRD-01) over **message** activity — presence/idle never counts ([ADR-0012](../adr/0012-irc-activity-rollup-substrate.md)). Durable substrate is the **`IrcActivity` rollup** (one row per member × channel × day of message counts), computed on read over a trailing **90-day** window — no stored score (ADR-0007 rule 1 holds).
+
+```
+IRCScore = CAP × (1 − exp(−(weightedVolume × consistency) / TAU))
+weightedVolume = Σ_channel  min(msgs_per_day, DAILY_CAP) × channelWeight     (over the window)
+consistency    = distinctActiveDays / windowDays      // active day = ≥ MIN_MSGS messages
+```
+
+Anti-farming is structural: the per-channel/day cap defeats flooding, `consistency` defeats one-session marathons, `channelWeight` defeats spamming low-value channels. Magnitudes (`CAP`/`TAU`/`DAILY_CAP`/`MIN_MSGS`/weights) are **HITL/TBD**, hand-pinned like every other CRS magnitude.
+
+## Concept → code (descent map)
+
+| Concept | Lives in / will live in |
+|---|---|
+| IRCKey + AnnounceKey | **net-new** on `User` (`prisma/schema.prisma`); drop vestigial `communityPass` |
+| Delegated SASL validation | **net-new** internal endpoint — [ADR-0011](../adr/0011-delegated-irc-authentication.md) |
+| Release-Announce Feed (RSS + IRC) | net-new feed route, AnnounceKey-gated, reusing `announcements` |
+| Announce relay + `!commands` bot | **net-new** worker in stellar-compose |
+| `IrcActivity` rollup | **net-new** table + bot upsert — [ADR-0012](../adr/0012-irc-activity-rollup-substrate.md) |
+| `IRCScore` dimension | `src/modules/reputation.ts` registry entry (pure scorer) + `DimensionInput` window fetch |
+| Infra (Ergo + bot + The Lounge) | **stellar-compose** — pinned services per [ADR-0009](../adr/0009-fork-workflow-and-dependency-discipline.md) |
+| IRCRules (conduct) | [PRD-05](05-rules-and-governance.md) + [#126](https://github.com/orphic-inc/stellar-api/issues/126) (HITL) |
+
+## Red-green descent targets
+
+1. **`IRCKey` + `AnnounceKey` on `User`** — unique, generate/rotate endpoints, drop `communityPass`. The documented blocker; everything hangs off it.
+2. **Delegated SASL-validate endpoint** — internal, network-scoped; Ergo's auth callback (ADR-0011).
+3. **Release-Announce Feed** — AnnounceKey-gated feed of new Contributions (IRC announce relay first; **RSS/XML fast-follow** reusing the same substrate).
+4. **`IrcActivity` rollup + bot upsert** — messages-only, `user×channel×day` (ADR-0012).
+5. **`scoreIrcActivity(rows, weights, window)`** — pure, table-driven, unit-tested against fixtures **before** any IRC infra; then register `IRCScore` into the CRS registry.
+6. **The Lounge / bouncer** — web client surface; donor perks defer to the Donations PRD.
+
+## Open questions
+
+- Greenfield network, or is there an existing IRC network / nick reservations to migrate?
+- `IRCScore` magnitudes + the channel-weight map — TBD with the other CRS magnitudes (HITL, like #121/#122/#126).
+- Announce delivery: does the IRC announce hand the member a one-shot tokenized link, or just notify-and-link-into-the-app (download still session-authed either way)?

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft · **Owner:** @obrien-k
 **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) · **Decisions:** [ADR-0002 community-health-pulse → CRS](../adr/0002-community-health-pulse.md) (accrual model), [ADR-0003 stylesheet injection isolation](../adr/0003-stylesheet-injection-isolation.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce _(unwritten)_ · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
 
 > Lean PRD. Captures the decided shape + the Community-Score weights, flags TBDs, and maps each concept to existing code so this becomes a red-green descent, not greenfield. Stylesheet scoring is a **dimension of PRD-01's CRS**, not a separate score.
 
@@ -70,7 +70,7 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 
 ## Donor add-ons
 
-**$tylesheets — donor-added slots**: donors unlock additional stylesheet slots (ties to PRD-02 Donations / `donor.ts`).
+**$tylesheets — donor-added slots**: donors unlock additional stylesheet slots (ties to the Donations PRD / `donor.ts`).
 
 ## Concept → existing code (the descent map)
 
@@ -86,7 +86,7 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 
 ## Out of scope (other PRDs)
 
-- LinkHealth lifecycle (cron/flapping/72h/sweep), MusicModel, Donations/IRC scoring → covered by PRD-01 (CRS dimensions), PRD-02, PRD-04. Referenced here only where they feed stylesheet scoring.
+- LinkHealth lifecycle (cron/flapping/72h/sweep), MusicModel, Donations/IRC scoring → covered by PRD-01 (CRS dimensions), PRD-02 (IRC), the Donations PRD, PRD-04. Referenced here only where they feed stylesheet scoring.
 
 ## Red-green descent targets
 

--- a/docs/prd/04-contribution-release-music.md
+++ b/docs/prd/04-contribution-release-music.md
@@ -1,7 +1,7 @@
 # PRD-04 — Contribution, Release & Music Model
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce _(unwritten)_ · PRD-03 Stylesheets · **PRD-04 Contribution/Release/Music**
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · **PRD-04 Contribution/Release/Music**
 
 > Lean PRD. The structured model has **landed on `main`** (#85 music model + ReleaseArtist/Edition, merged via #98 — `develop` retired in the [ADR-0010](../adr/0010-trunk-based-single-branch-workflow.md) trunk fold), with per-file rip metadata split out to a `ReleaseFile` satellite ([ADR-0008](../adr/0008-contribution-metadata-satellites.md)). The quality grade landed on `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86). This documents the model + CRS weighting and flags TBDs. Prod is pre-alpha with disposable data, so the model was migrated destructively (no backfill).
 

--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
 **Decisions:** [ADR-0001 granular permissions](../adr/0001-granular-permission-checks.md) (enforcement), [ADR-0002 community-health-pulse](../adr/0002-community-health-pulse.md) (standing trend), [ADR-0004 standing → CRS + warnings/bans](../adr/0004-standing-warnings-bans.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce _(unwritten)_ · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance**
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance**
 
 > The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose (that lives in `RulesPage`).
 


### PR DESCRIPTION
Drafts **PRD-02 (IRC & Announce)** and the two ADRs it rests on, from a `/grill-with-docs` design session. Docs only — no code.

## What's here
- **`docs/prd/02-irc-and-announce.md`** — PRD-02. Architecture **A+E** (Ergo IRCd + The Lounge), IRC as its own top-level section, the `IRCKey`/`AnnounceKey` identity model, the Release-Announce Feed, and `IRCScore`. **Donations split off** into a future PRD; **RSS/XML a fast-follow** slice.
- **[ADR-0011](https://github.com/orphic-inc/stellar-api/blob/feat/irc-design-docs/docs/adr/0011-delegated-irc-authentication.md)** — delegated IRC auth: Ergo validates SASL against an internal API endpoint; single source of truth, no credential mirror (vs. the provisioned-account drift this repo keeps fighting).
- **[ADR-0012](https://github.com/orphic-inc/stellar-api/blob/feat/irc-design-docs/docs/adr/0012-irc-activity-rollup-substrate.md)** — IRC activity rollup as the CRS durable substrate: **messages-only** (presence never scores — anti-farming), computed-on-read over a 90-day window; framed as *extending* ADR-0007.
- **`CONTEXT.md`** — 5 glossary terms: `AnnounceKey`, `IRCKey`, `Release-Announce Feed`, `IRCScore`, `IRC Activity Rollup`.
- **PRD-03/04/05 + README** — repointed the `PRD-02` references to the real "IRC & Announce" title (the `(unwritten)` markers from #132 are now obsolete) and fixed the stale "PRD-02 Donations" body refs in PRD-03.

## Key decisions (grilled)
- Keys gate the **out-of-band announce channel**, never the session-authed download grant.
- `communityPass` confirmed vestigial → dropped with the key migration.
- `IRCScore` formula sharpened; `presenceSamples` dropped from the scoring path.

Supersedes the now-obsolete `(unwritten)` half of #132 (its `develop→main` fix already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)