### PR TITLE
docs(prd-02): mark IRC & Announce shipped + update CLAUDE.md map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ Copy `.env.default` → `.env`.
 | `STELLAR_HTTP_PORT` | Server port (default 8080) |
 | `STELLAR_HTTP_CORS_ORIGIN` | Allowed CORS origin |
 | `STELLAR_LOG_LEVEL` | Winston log level (default `info`) |
+| `STELLAR_IRC_BOT_TOKEN` | Scoped token the announce bot presents to `/api/irc/*` (PRD-02; fails closed when unset) |
+| `STELLAR_IRC_SASL_SECRET` | Shared secret for Ergo's internal SASL-validate callback `/internal/irc/sasl` (ADR-0011; fails closed when unset) |
 
 ## Architecture
 
@@ -76,15 +78,23 @@ src/
     stats.ts                # Stats query helpers
     top10.ts                # Ranked list logic: binomial scoring, TTL caching, snapshots
     user.ts                 # User query helpers
+    reputation.ts           # CRS dimension registry (longevity/ratio/friends/irc); pure scorers + read-time assembler
+    keys.ts                 # Per-user IRC/Announce key generate/rotate (PRD-02)
+    ircActivity.ts          # IrcActivity rollup upsert — messages-only (ADR-0012)
+    ircScore.ts             # Pure scoreIrcActivity() + provisional magnitudes (the IRCScore dimension)
+    ircAuth.ts              # Delegated SASL validation — validateSasl (ADR-0011)
+    announceFeed.ts         # Release-Announce Feed: AnnounceKey resolve, feed query, RSS render
   middleware/
     auth.ts                 # JWT cookie decode → DB lookup → req.user
     permissions.ts          # requirePermission, requireAuth, isModerator
-    rateLimiter.ts          # authLimiter, writeLimiter, installLimiter
+    rateLimiter.ts          # authLimiter, writeLimiter, installLimiter, saslLimiter
+    sharedSecret.ts         # requireBotToken / requireSaslSecret — Bearer shared-secret gate (fails closed)
     validate.ts             # validate(bodySchema), validateParams(paramsSchema)
   lib/
     prisma.ts               # Singleton PrismaClient
     audit.ts                # audit(prisma, actorId, action, targetType, targetId, meta?)
     errors.ts               # AppError class (extends Error with statusCode)
+    secureCompare.ts        # Constant-time string equality (length-tolerant)
     mailer.ts               # SMTP email utility (sendInviteEmail)
     openapi.ts              # Auto-generated OpenAPI type definitions
     pagination.ts           # parsePage(req) → { skip, limit, page }
@@ -137,6 +147,9 @@ src/
     stylesheet.ts           # User stylesheets
     wiki.ts                 # Wiki pages, aliases, revisions
     docs.ts                 # API docs endpoint
+    keys.ts                 # GET / (my keys), POST /:kind (generate), POST /:kind/rotate
+    irc.ts                  # POST /activity — bot-token scoped IrcActivity upsert
+    announce.ts             # GET /feed (JSON), GET /feed.xml (RSS) — AnnounceKey-gated
     communities/
       communities.ts        # Community CRUD
       release.ts            # Release CRUD under /:communityId/releases
@@ -152,6 +165,8 @@ src/
       forumPollVote.ts      # Poll voting
       forumTopicNote.ts     # Moderator notes on topics
       forumLastReadTopic.ts # Read-position tracking
+  routes/internal/          # NOT under /api — network-isolated, never public ingress
+    ircSasl.ts              # POST /sasl — Ergo's delegated SASL-validate callback (ADR-0011)
 ```
 
 ## req.user shape

--- a/docs/prd/02-irc-and-announce.md
+++ b/docs/prd/02-irc-and-announce.md
@@ -1,6 +1,6 @@
 # PRD-02 — IRC & Announce
 
-**Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
+**Status:** In-repo build shipped ([#143](https://github.com/orphic-inc/stellar-api/pull/143)) — credentials, activity rollup, IRCScore, delegated SASL, and the announce feeds (RSS + JSON) are merged. Outstanding: magnitude pinning ([#141](https://github.com/orphic-inc/stellar-api/issues/141), HITL) and infra ([#142](https://github.com/orphic-inc/stellar-api/issues/142), stellar-compose). · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
 **Decisions:** [ADR-0011 delegated IRC authentication](../adr/0011-delegated-irc-authentication.md), [ADR-0012 IRC activity rollup substrate](../adr/0012-irc-activity-rollup-substrate.md), [ADR-0007 CRS read-time + ledger](../adr/0007-crs-read-time-and-event-ledger.md), [ADR-0009 dependency/infra discipline](../adr/0009-fork-workflow-and-dependency-discipline.md)
 **Numbering:** PRD-01 Community-Score · **PRD-02 IRC & Announce** · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · PRD-06 Ratio
 
@@ -59,12 +59,12 @@ Anti-farming is structural: the per-channel/day cap defeats flooding, `consisten
 
 ## Red-green descent targets
 
-1. **`IRCKey` + `AnnounceKey` on `User`** — unique, generate/rotate endpoints, drop `communityPass`. The documented blocker; everything hangs off it.
-2. **Delegated SASL-validate endpoint** — internal, network-scoped; Ergo's auth callback (ADR-0011).
-3. **Release-Announce Feed** — AnnounceKey-gated feed of new Contributions (IRC announce relay first; **RSS/XML fast-follow** reusing the same substrate).
-4. **`IrcActivity` rollup + bot upsert** — messages-only, `user×channel×day` (ADR-0012).
-5. **`scoreIrcActivity(rows, weights, window)`** — pure, table-driven, unit-tested against fixtures **before** any IRC infra; then register `IRCScore` into the CRS registry.
-6. **The Lounge / bouncer** — web client surface; donor perks defer to the Donations PRD.
+1. ✅ **`IRCKey` + `AnnounceKey` on `User`** — unique, generate/rotate endpoints, drop `communityPass`. The documented blocker; everything hangs off it. *(shipped [#134](https://github.com/orphic-inc/stellar-api/issues/134))*
+2. ✅ **Delegated SASL-validate endpoint** — internal, network-scoped; Ergo's auth callback (ADR-0011). *(shipped [#138](https://github.com/orphic-inc/stellar-api/issues/138))*
+3. ✅ **Release-Announce Feed** — AnnounceKey-gated feed of new Contributions (JSON `?since=` cursor for the relay; RSS/XML fast-follow on the same substrate). Notify-and-link delivery ([#136](https://github.com/orphic-inc/stellar-api/issues/136)). *(shipped [#139](https://github.com/orphic-inc/stellar-api/issues/139) + [#140](https://github.com/orphic-inc/stellar-api/issues/140))*
+4. ✅ **`IrcActivity` rollup + bot upsert** — messages-only, `user×channel×day` (ADR-0012). *(shipped [#135](https://github.com/orphic-inc/stellar-api/issues/135))*
+5. ✅ **`scoreIrcActivity(rows, weights, window)`** — pure, table-driven, unit-tested against fixtures **before** any IRC infra; then register `IRCScore` into the CRS registry. Magnitudes provisional, pinned in [#141](https://github.com/orphic-inc/stellar-api/issues/141) (HITL). *(shipped [#137](https://github.com/orphic-inc/stellar-api/issues/137))*
+6. ⏳ **The Lounge / bouncer** — web client surface; donor perks defer to the Donations PRD. *(infra, [#142](https://github.com/orphic-inc/stellar-api/issues/142))*
 
 ## Open questions
 


### PR DESCRIPTION
Post-merge bookkeeping for #143.

- **PRD-02** status → in-repo build shipped; descent targets 1–5 marked ✅ with their issue links, target 6 (The Lounge) flagged as infra (#142).
- **CLAUDE.md** architecture map: adds `reputation.ts`, `keys.ts`, `ircActivity.ts`, `ircScore.ts`, `ircAuth.ts`, `announceFeed.ts` (modules); `sharedSecret.ts` + `saslLimiter` (middleware); `secureCompare.ts` (lib); `keys.ts`/`irc.ts`/`announce.ts` (routes/api) and the new `routes/internal/ircSasl.ts`. Env table gains the two IRC secrets.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)