### PR TITLE
feat(stylesheets): AuthorStylesheet keystone — save → adopt → score (PRD-03 #118/#119/#120)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,6 +95,26 @@ _Avoid_: reputation tier, warning level, standing score, rank
 The invite-tree suspicion that flows from an infected _trunk_ (a banned or ban-evading inviter) down to its _branches_ (the invitees). A **graded**, distance-decaying signal — suspect, not condemned — owned by the InviteTree. Distinct from a member's own **confirmed** ban-evasion, which alone reaches the terminal `hammer` **Standing**.
 _Avoid_: tree poisoning, ban inheritance, guilt by association
 
+**CommunityScore**:
+A *deferred* (#75) CRS **Dimension Scorer** that folds a Community's read-time health pulse (`getCommunityHealthPulse`, ADR-0002) into a member's **single, global** Community Reputation Score. It is **not** a separate per-community reputation: a member has one CRS; "their CommunityScore *for* a Community" is that community's health contributing one capped term to it. No parallel per-community score exists.
+_Avoid_: community reputation, per-community CRS, community ranking
+
+**Site Theme**:
+A built-in, admin-managed stylesheet (`Stylesheet` model: `Sublime`/Default + alternatives, referenced by `cssUrl`, one flagged `isDefault`). The base layer of the cascade, applied site-wide until a member or page context selects something else. Authored by staff/SysOps, not members.
+_Avoid_: default css, base skin, system stylesheet
+
+**Authored Stylesheet**:
+A `.scss`/`.css` theme written by a member — the **StylesheetAuthor** (shorthand for any User who has authored one, not a distinct role/entity). Stored as `source`, sanitized at store-time (ADR-0003) so the persisted artifact is safe; the UI injector + CSP add the inject-time half. A member may author several. Distinct from a **Site Theme** (built-in) and from the **slots** a stylesheet is placed into.
+_Avoid_: user theme, custom css, skin
+
+**Stylesheet Slot**:
+One of three single-valued placements a stylesheet occupies, chosen by **page context**, not a global toggle: the **Profile Stylesheet** (set by a profile's owner; rendered to any visitor on *that* profile), the **Site Stylesheet** (set by the viewer; rendered on the general site, falling back to the **Site Theme**/Default when unset), and the **Community Stylesheet** (set by a Community's Staff; rendered to anyone on *that* community's pages). Page context wins: a profile or community page shows its own slot to every viewer regardless of the viewer's Site Stylesheet.
+_Avoid_: active stylesheet, theme preference, selected skin
+
+**Stylesheet Adoption**:
+A viewer setting their **Site Stylesheet** slot to another member's **Authored Stylesheet** — the scoring event that credits the author's CRS (stylesheet dimension) and fires the Friends **Controlled Vector**. Deduplicated **once per distinct (adopter, author) pair** in the `CRS_*` event ledger (ADR-0007); self-adoption (using your own sheet) renders but earns the author nothing (anti-farm). Site-wide, so the accrual is a global-CRS event — it carries no `communityId`.
+_Avoid_: applying a theme, selecting a stylesheet, using a skin
+
 ## Relationships
 
 - A **Contract Schema** directly structures incoming inputs and dictates the programmatic generation of the schema served by `swagger-ui-express`.

--- a/docs/prd/01-Community-Score.md
+++ b/docs/prd/01-Community-Score.md
@@ -453,3 +453,13 @@ Out of Scope
 - Moderation scoring
 - Automated weighting algorithms
 - CommunityValueIndex calculation
+
+## Future direction — making CRS *bite* (noted 2026-06-13, not scoped)
+
+Today CRS only *accrues* — unlike the **Ratio Mechanism**, which has real teeth (gates downloads, warns, bans), the reputation dimensions (stylesheet, IRC, …) sum into a number with no monitoring, display, or downstream effect yet. Recorded so the gap is explicit, not designed:
+
+- **Positive-reinforcement teeth (privilege-granting).** High reputation should *unlock capability*, not gate downloads (CRS never gates downloads — that stays the Ratio Mechanism's job). E.g. a high **IRCScore** earns rights to create official channels or moderate specific community channels (see PRD-02). This is a distinct lever from ratio enforcement.
+- **Staff Toolbox.** CRS (and its dimensions) surface to staff for monitoring/triage in a **Staff Toolbox** — the display/admin surface for the whole reputation system. Out of purview today.
+- **Community Toolbox.** A forward-looking surface letting **Community Staff** manage their *own* community (a la the Community Do-Not-Contribute list) — where Community-scoped levers (the Community Stylesheet slot, channel moderation grants) would live. Much further down the path.
+
+These are the home for the eventual "what does a score *do*" decisions; capturing them here keeps the dimension work (stylesheet #120, IRC) honest about being substrate, not yet consequence.

--- a/docs/prd/02-irc-and-announce.md
+++ b/docs/prd/02-irc-and-announce.md
@@ -70,6 +70,7 @@ Anti-farming is structural: the per-channel/day cap defeats flooding, `consisten
 
 - Greenfield network, or is there an existing IRC network / nick reservations to migrate?
 - `IRCScore` magnitudes + the channel-weight map — TBD with the other CRS magnitudes (HITL, like #121/#122/#126).
+- **IRCScore teeth (positive reinforcement) — noted 2026-06-13, not scoped.** Today IRCScore only feeds CRS as substrate. The intended downstream: high scorers *earn capability* — rights to create new official channels, moderation in specific community channels — administered via the **Staff Toolbox** / **Community Toolbox** (see [PRD-01 → Future direction: making CRS bite](01-Community-Score.md)). Privilege-granting, never a download gate.
 
 ## Resolved decisions
 

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -60,7 +60,7 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
 
-**Friends × Stylesheet — controlled vector (decided).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — *separate from and additive to* the stylesheet-dimension weights above:
+**Friends × Stylesheet — controlled vector (decided; not yet built — [#147](https://github.com/orphic-inc/stellar-api/issues/147)).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — *separate from and additive to* the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is the follow-up:
 
 - **Adopter: +0.2** (rewards active, organic curation — the adopter earns slightly more than the author, to favour participation).
 - **Author: +0.1** (recognition that someone vouched for your sheet).
@@ -126,7 +126,7 @@ First testable slices (much of the substrate already exists):
    - **4b adopt (#119, ✅ shipped):** many-per-author (cardinality fixed here — `@unique authorId` dropped); a viewer adopts a sheet into their **Site Stylesheet** slot (`UserSettings.activeAuthorStylesheetId`) via `POST /api/stylesheet/author-stylesheet/:id/adopt`, idempotent.
    - **4c score (#120, ✅ shipped):** adoption fires `scoreStylesheetSelection`; non-self adoptions write a `CRS_STYLESHEET_ADOPTION` ledger row deduped **once per (adopter, author)** (ADR-0007), and a read-time **stylesheet** CRS dimension counts them → author's global CRS. Self-adoption renders, earns nothing.
 
-   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — *ADR-when-built*: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension — the §"Friends × Stylesheet" decision; the `CRS_STYLESHEET_ADOPTION` ledger built here is its substrate, but the second Friends-dimension accrual is not yet wired — [#147](https://github.com/orphic-inc/stellar-api/issues/147)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — *ADR-when-built*: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -16,9 +16,23 @@ Stellar is an invite-only `/private/` community site. Users want to theme their 
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Built-in / site stylesheets**            | Seeded themes: `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`. **Sublime = default/base + selectable + contest reference** (net-new authoring; reset target).                  |
 | **ExternalStylesheet**                     | A URL on the user's profile (`profile.externalStylesheet`).                                                                                                                          |
-| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` (one per author) saved for others to adopt. **Shape TBD** — depends on ExternalStylesheet + global-reset findings against the current Tailwind theme. |
-| **CommunityStylesheet**                    | Community-scoped theme (TBD — tied to Contests).                                                                                                                                     |
+| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` saved for others to adopt. **Many per author** (cardinality decided 2026-06-13; rank-gated *count limit* deferred). The author is a **StylesheetAuthor** — shorthand for any member who has authored one, not a distinct role. |
+| **CommunityStylesheet**                    | Community-scoped theme, set by that Community's Staff; rendered to any viewer on that community's pages. Slot deferred (TBD — tied to Contests / Community Toolbox).                  |
 | **Global SCSS/CSS reset flag**             | Per-injection boundary so a user sheet can't leak into app chrome (see ADR-0003).                                                                                                    |
+
+### Slots & cascade (decided 2026-06-13)
+
+A stylesheet renders by being placed into one of three single-valued **slots**, selected by **page context** — not a single global "active theme":
+
+| Slot                     | Set by                | Rendered when                                            |
+| ------------------------ | --------------------- | ------------------------------------------------------- |
+| **Profile Stylesheet**   | the profile's owner   | any viewer is on *that owner's* profile page            |
+| **Site Stylesheet**      | the viewer            | the viewer is on the general site                       |
+| **Community Stylesheet** | that Community's Staff | any viewer is on *that* community's pages                |
+
+**Precedence is page-context-first:** a Profile or Community page shows its own slot to *every* viewer, regardless of the viewer's Site Stylesheet. On the general site the viewer sees their own Site Stylesheet, falling back to the **Site Theme** (`Sublime`/Default) when they have not adopted one. A member has exactly one stylesheet per slot.
+
+**Only the Site Stylesheet slot scores** (a **Stylesheet Adoption**): the viewer adopting another member's AuthorStylesheet credits the author. Slotting your own sheet as your Profile Stylesheet is not an adoption. Profile-slot and Community-slot designation are **deferred** (named here, not built in #119/#120).
 
 ## Community-Score weights (proposed by PRD owner)
 
@@ -107,7 +121,12 @@ First testable slices (much of the substrate already exists):
 1. ✅ **Stylesheet selection → CRS accrual** — pure `scoreStylesheetSelection` (no DB), table-driven over each multiplier. **Shipped: [#84](https://github.com/orphic-inc/stellar-api/pull/84)** (tier-0 multipliers; external/self decisions applied).
 2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
 3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
-4. **AuthorStylesheet save + adopt** — model + endpoint (extends `schemas/stylesheet.ts`); integration test for adopt → author/site accrual. **Currently the keystone gap:** `scoreStylesheetSelection` (shipped #84) is wired to *nothing* — no `AuthorStylesheet` model, no adopt event. This slice wires it, and **unblocks** the Friends×Stylesheet controlled vector + the `CRS_*` adoption ledger (PRD-01 / ADR-0007), which have no event to hook onto until adoption exists.
+4. **AuthorStylesheet save → adopt → score** (the keystone — wires shipped `scoreStylesheetSelection` #84 to a real event). Three slices:
+   - **4a save (#118, ✅ shipped):** `AuthorStylesheet` model + `POST`/`GET /api/stylesheet/author`.
+   - **4b adopt (#119, ✅ shipped):** many-per-author (cardinality fixed here — `@unique authorId` dropped); a viewer adopts a sheet into their **Site Stylesheet** slot (`UserSettings.activeAuthorStylesheetId`) via `POST /api/stylesheet/author-stylesheet/:id/adopt`, idempotent.
+   - **4c score (#120, ✅ shipped):** adoption fires `scoreStylesheetSelection`; non-self adoptions write a `CRS_STYLESHEET_ADOPTION` ledger row deduped **once per (adopter, author)** (ADR-0007), and a read-time **stylesheet** CRS dimension counts them → author's global CRS. Self-adoption renders, earns nothing.
+
+   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — *ADR-when-built*: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions

--- a/prisma/migrations/20260613100000_add_author_stylesheet/migration.sql
+++ b/prisma/migrations/20260613100000_add_author_stylesheet/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "author_stylesheets" (
+    "id" SERIAL NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "author_stylesheets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "author_stylesheets_authorId_key" ON "author_stylesheets"("authorId");
+
+-- AddForeignKey
+ALTER TABLE "author_stylesheets" ADD CONSTRAINT "author_stylesheets_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260613120000_stylesheet_adoption/migration.sql
+++ b/prisma/migrations/20260613120000_stylesheet_adoption/migration.sql
@@ -1,0 +1,17 @@
+-- AlterEnum
+ALTER TYPE "EconomyTransactionReason" ADD VALUE 'CRS_STYLESHEET_ADOPTION';
+
+-- DropIndex: AuthorStylesheet is now many-per-author (PRD-03 #119)
+DROP INDEX "author_stylesheets_authorId_key";
+
+-- CreateIndex
+CREATE INDEX "author_stylesheets_authorId_idx" ON "author_stylesheets"("authorId");
+
+-- AlterTable: a member's adopted Site Stylesheet slot
+ALTER TABLE "user_settings" ADD COLUMN "activeAuthorStylesheetId" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "user_settings_activeAuthorStylesheetId_idx" ON "user_settings"("activeAuthorStylesheetId");
+
+-- AddForeignKey
+ALTER TABLE "user_settings" ADD CONSTRAINT "user_settings_activeAuthorStylesheetId_fkey" FOREIGN KEY ("activeAuthorStylesheetId") REFERENCES "author_stylesheets"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260613130000_stylesheet_adoption_unique_pair/migration.sql
+++ b/prisma/migrations/20260613130000_stylesheet_adoption_unique_pair/migration.sql
@@ -1,0 +1,16 @@
+-- Make the once-per-(adopter, author) stylesheet-adoption dedup atomic.
+--
+-- The CRS_STYLESHEET_ADOPTION ledger row records the durable (author = userId,
+-- adopter = actorUserId) pair exactly once. Without a DB constraint, two
+-- concurrent adopts (a double-click) both pass the application-level existence
+-- check and both insert, double-crediting the author on read (breaks the
+-- ADR-0007 "durable once-per-pair" guarantee). A partial unique index makes the
+-- dedup atomic so the second insert raises P2002 and is swallowed as "already
+-- scored".
+--
+-- This is a partial unique index, which Prisma cannot model in schema.prisma,
+-- so it is created with raw SQL here. Expect a benign drift warning on the next
+-- `prisma migrate dev` — accepted trade-off.
+CREATE UNIQUE INDEX "economy_transactions_stylesheet_adoption_pair_key"
+  ON "economy_transactions" ("userId", "actorUserId")
+  WHERE "reason" = 'CRS_STYLESHEET_ADOPTION';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -436,6 +436,7 @@ model User {
   rulesPagesAuthored       RulesPage[]                      @relation("RulesPageAuthor")
   userStatSnapshots        UserStatSnapshot[]
   tagAliasesCreated        TagAlias[]                       @relation("TagAliasCreator")
+  authoredStylesheet       AuthorStylesheet?
 
   @@index([userRankId])
   @@map("users")
@@ -520,6 +521,22 @@ model Stylesheet {
   createdAt   DateTime @default(now())
 
   @@map("stylesheets")
+}
+
+/// A user-authored stylesheet saved for others to adopt (PRD-03, descent
+/// target #4). One per author (@unique authorId). The keystone the shipped
+/// `scoreStylesheetSelection` (#84) hooks onto: #118 saves it, #119 adopts it,
+/// #120 scores the adoption.
+model AuthorStylesheet {
+  id        Int      @id @default(autoincrement())
+  authorId  Int      @unique
+  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  name      String
+  source    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("author_stylesheets")
 }
 
 // ─── Forum ────────────────────────────────────────────────────────────────────

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,6 +161,7 @@ enum EconomyTransactionReason {
   DOWNLOAD_DEBIT
   DOWNLOAD_CREDIT
   STAFF_REVERSAL
+  CRS_STYLESHEET_ADOPTION
 }
 
 enum DownloadGrantStatus {
@@ -310,7 +311,14 @@ model UserSettings {
   showConsumedStats    Boolean            @default(true)
   showRatioStats       Boolean            @default(true)
   user                 User?
+  // The AuthorStylesheet adopted into this member's Site Stylesheet slot
+  // (PRD-03 #119): what they see on the general site. Null = on the Site Theme
+  // (Sublime/Default). SetNull on delete so a pruned sheet clears its adopters'
+  // pointers rather than orphaning them. Profile/Community slots are deferred.
+  activeAuthorStylesheetId Int?
+  activeAuthorStylesheet   AuthorStylesheet? @relation(fields: [activeAuthorStylesheetId], references: [id])
 
+  @@index([activeAuthorStylesheetId])
   @@map("user_settings")
 }
 
@@ -436,7 +444,7 @@ model User {
   rulesPagesAuthored       RulesPage[]                      @relation("RulesPageAuthor")
   userStatSnapshots        UserStatSnapshot[]
   tagAliasesCreated        TagAlias[]                       @relation("TagAliasCreator")
-  authoredStylesheet       AuthorStylesheet?
+  authoredStylesheets      AuthorStylesheet[]
 
   @@index([userRankId])
   @@map("users")
@@ -524,18 +532,22 @@ model Stylesheet {
 }
 
 /// A user-authored stylesheet saved for others to adopt (PRD-03, descent
-/// target #4). One per author (@unique authorId). The keystone the shipped
-/// `scoreStylesheetSelection` (#84) hooks onto: #118 saves it, #119 adopts it,
-/// #120 scores the adoption.
+/// target #4). Many per author (cardinality fixed in #119; the rank-gated count
+/// limit is deferred). The keystone the shipped `scoreStylesheetSelection` (#84)
+/// hooks onto: #118 saves it, #119 adopts it into a viewer's Site Stylesheet
+/// slot, #120 scores the adoption. `adopters` are the UserSettings currently
+/// pointing their Site slot here.
 model AuthorStylesheet {
-  id        Int      @id @default(autoincrement())
-  authorId  Int      @unique
-  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  id        Int            @id @default(autoincrement())
+  authorId  Int
+  author    User           @relation(fields: [authorId], references: [id], onDelete: Cascade)
   name      String
   source    String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+  adopters  UserSettings[]
 
+  @@index([authorId])
   @@map("author_stylesheets")
 }
 

--- a/src/authorStylesheet.spec.ts
+++ b/src/authorStylesheet.spec.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import {
   request,
   app,
@@ -115,11 +116,10 @@ describe('GET /api/stylesheet/author-stylesheet/:id', () => {
 
 describe('POST /api/stylesheet/author-stylesheet/:id/adopt', () => {
   beforeEach(() => {
-    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
-      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
-    );
+    // The Site-slot pointer update and the ledger write are no longer wrapped
+    // in one transaction — each runs directly against the client (the partial
+    // unique index, not an app-level findFirst, enforces dedup).
     prismaMock.user.update.mockResolvedValue({} as never);
-    prismaMock.economyTransaction.findFirst.mockResolvedValue(null);
     prismaMock.economyTransaction.create.mockResolvedValue({} as never);
   });
 
@@ -155,13 +155,18 @@ describe('POST /api/stylesheet/author-stylesheet/:id/adopt', () => {
     );
   });
 
-  it('is idempotent: re-adopting the same author writes no second ledger row', async () => {
+  it('is idempotent: a duplicate (adopter, author) pair (P2002) is not a second credit', async () => {
     prismaMock.authorStylesheet.findUnique.mockResolvedValue(
       mockSheet as never
     );
-    prismaMock.economyTransaction.findFirst.mockResolvedValue({
-      id: 99
-    } as never);
+    // The partial unique index rejects the second insert; the module swallows
+    // P2002 and reports scored: false rather than double-crediting the author.
+    prismaMock.economyTransaction.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '5.0.0'
+      })
+    );
 
     const res = await request(app).post(
       '/api/stylesheet/author-stylesheet/1/adopt'
@@ -170,7 +175,6 @@ describe('POST /api/stylesheet/author-stylesheet/:id/adopt', () => {
     expect(res.status).toBe(200);
     expect(res.body.scored).toBe(false);
     expect(prismaMock.user.update).toHaveBeenCalled(); // slot still updated
-    expect(prismaMock.economyTransaction.create).not.toHaveBeenCalled();
   });
 
   it('self-adoption renders but credits nothing (anti-farm)', async () => {
@@ -188,7 +192,6 @@ describe('POST /api/stylesheet/author-stylesheet/:id/adopt', () => {
     expect(res.body.scored).toBe(false);
     expect(prismaMock.user.update).toHaveBeenCalled(); // own sheet still rendered
     expect(prismaMock.economyTransaction.create).not.toHaveBeenCalled();
-    expect(prismaMock.economyTransaction.findFirst).not.toHaveBeenCalled();
   });
 
   it('404s when adopting a non-existent stylesheet', async () => {

--- a/src/authorStylesheet.spec.ts
+++ b/src/authorStylesheet.spec.ts
@@ -1,0 +1,87 @@
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock
+} from './test/apiTestHarness';
+
+beforeEach(() => resetApiTestState());
+
+const mockSheet = {
+  id: 1,
+  authorId: 7,
+  name: 'Midnight',
+  source: 'body { background: #000; }',
+  createdAt: new Date('2026-06-13T00:00:00Z'),
+  updatedAt: new Date('2026-06-13T00:00:00Z')
+};
+
+// ─── POST /api/stylesheet/author ──────────────────────────────────────────────
+
+describe('POST /api/stylesheet/author', () => {
+  it('saves the authed user’s AuthorStylesheet (201)', async () => {
+    prismaMock.authorStylesheet.upsert.mockResolvedValue(mockSheet as never);
+
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'Midnight', source: 'body { background: #000; }' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.authorId).toBe(7);
+    expect(res.body.name).toBe('Midnight');
+    // upsert keyed on the author → one per author.
+    expect(prismaMock.authorStylesheet.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { authorId: 7 } })
+    );
+  });
+
+  it('rejects an empty name (400)', async () => {
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: '', source: 'x' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a missing source (400)', async () => {
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'Midnight' });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── GET /api/stylesheet/author/:userId ───────────────────────────────────────
+
+describe('GET /api/stylesheet/author/:userId', () => {
+  it('returns an author’s stylesheet', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
+      mockSheet as never
+    );
+
+    const res = await request(app).get('/api/stylesheet/author/7');
+
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('body { background: #000; }');
+  });
+
+  it('404s when the author has no stylesheet', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+    const res = await request(app).get('/api/stylesheet/author/999');
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a non-numeric userId (400)', async () => {
+    const res = await request(app).get('/api/stylesheet/author/notanumber');
+    expect(res.status).toBe(400);
+  });
+
+  it('does not collide with GET /:id (author segment routed first)', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
+      mockSheet as never
+    );
+    const res = await request(app).get('/api/stylesheet/author/7');
+    expect(res.status).toBe(200);
+    // The site-stylesheet /:id handler must not have run.
+    expect(prismaMock.stylesheet.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/authorStylesheet.spec.ts
+++ b/src/authorStylesheet.spec.ts
@@ -7,9 +7,11 @@ import {
 
 beforeEach(() => resetApiTestState());
 
+// The default authed user is id 7 (see apiTestHarness). authorId 5 ≠ 7 → a
+// cross-user (non-self) adoption.
 const mockSheet = {
   id: 1,
-  authorId: 7,
+  authorId: 5,
   name: 'Midnight',
   source: 'body { background: #000; }',
   createdAt: new Date('2026-06-13T00:00:00Z'),
@@ -19,19 +21,19 @@ const mockSheet = {
 // ─── POST /api/stylesheet/author ──────────────────────────────────────────────
 
 describe('POST /api/stylesheet/author', () => {
-  it('saves the authed user’s AuthorStylesheet (201)', async () => {
-    prismaMock.authorStylesheet.upsert.mockResolvedValue(mockSheet as never);
+  it('authors a new stylesheet (201) — many per author, not an upsert', async () => {
+    prismaMock.authorStylesheet.create.mockResolvedValue(mockSheet as never);
 
     const res = await request(app)
       .post('/api/stylesheet/author')
       .send({ name: 'Midnight', source: 'body { background: #000; }' });
 
     expect(res.status).toBe(201);
-    expect(res.body.authorId).toBe(7);
     expect(res.body.name).toBe('Midnight');
-    // upsert keyed on the author → one per author.
-    expect(prismaMock.authorStylesheet.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { authorId: 7 } })
+    expect(prismaMock.authorStylesheet.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ authorId: 7, name: 'Midnight' })
+      })
     );
   });
 
@@ -53,35 +55,147 @@ describe('POST /api/stylesheet/author', () => {
 // ─── GET /api/stylesheet/author/:userId ───────────────────────────────────────
 
 describe('GET /api/stylesheet/author/:userId', () => {
-  it('returns an author’s stylesheet', async () => {
-    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
-      mockSheet as never
-    );
+  it("lists an author's stylesheets", async () => {
+    prismaMock.authorStylesheet.findMany.mockResolvedValue([
+      mockSheet
+    ] as never);
 
-    const res = await request(app).get('/api/stylesheet/author/7');
+    const res = await request(app).get('/api/stylesheet/author/5');
 
     expect(res.status).toBe(200);
-    expect(res.body.source).toBe('body { background: #000; }');
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(1);
+    expect(prismaMock.authorStylesheet.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { authorId: 5 } })
+    );
   });
 
-  it('404s when the author has no stylesheet', async () => {
-    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+  it('returns an empty list for an author with no stylesheets', async () => {
+    prismaMock.authorStylesheet.findMany.mockResolvedValue([] as never);
     const res = await request(app).get('/api/stylesheet/author/999');
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
   });
 
   it('rejects a non-numeric userId (400)', async () => {
     const res = await request(app).get('/api/stylesheet/author/notanumber');
     expect(res.status).toBe(400);
   });
+});
+
+// ─── GET /api/stylesheet/author-stylesheet/:id ────────────────────────────────
+
+describe('GET /api/stylesheet/author-stylesheet/:id', () => {
+  it('reads one authored stylesheet', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
+      mockSheet as never
+    );
+    const res = await request(app).get('/api/stylesheet/author-stylesheet/1');
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('body { background: #000; }');
+  });
+
+  it('404s when the stylesheet does not exist', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+    const res = await request(app).get('/api/stylesheet/author-stylesheet/999');
+    expect(res.status).toBe(404);
+  });
 
   it('does not collide with GET /:id (author segment routed first)', async () => {
     prismaMock.authorStylesheet.findUnique.mockResolvedValue(
       mockSheet as never
     );
-    const res = await request(app).get('/api/stylesheet/author/7');
-    expect(res.status).toBe(200);
+    await request(app).get('/api/stylesheet/author-stylesheet/1');
     // The site-stylesheet /:id handler must not have run.
     expect(prismaMock.stylesheet.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /api/stylesheet/author-stylesheet/:id/adopt ─────────────────────────
+
+describe('POST /api/stylesheet/author-stylesheet/:id/adopt', () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(async (cb: unknown) =>
+      (cb as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock)
+    );
+    prismaMock.user.update.mockResolvedValue({} as never);
+    prismaMock.economyTransaction.findFirst.mockResolvedValue(null);
+    prismaMock.economyTransaction.create.mockResolvedValue({} as never);
+  });
+
+  it('adopts a cross-user sheet: points the Site slot + credits the author', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
+      mockSheet as never
+    );
+
+    const res = await request(app).post(
+      '/api/stylesheet/author-stylesheet/1/adopt'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.scored).toBe(true);
+    // Site Stylesheet slot points at the adopted sheet.
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 7 },
+        data: {
+          userSettings: { update: { activeAuthorStylesheetId: 1 } }
+        }
+      })
+    );
+    // Ledger row credits the author (5), actor is the adopter (7).
+    expect(prismaMock.economyTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 5,
+          actorUserId: 7,
+          reason: 'CRS_STYLESHEET_ADOPTION'
+        })
+      })
+    );
+  });
+
+  it('is idempotent: re-adopting the same author writes no second ledger row', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(
+      mockSheet as never
+    );
+    prismaMock.economyTransaction.findFirst.mockResolvedValue({
+      id: 99
+    } as never);
+
+    const res = await request(app).post(
+      '/api/stylesheet/author-stylesheet/1/adopt'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.scored).toBe(false);
+    expect(prismaMock.user.update).toHaveBeenCalled(); // slot still updated
+    expect(prismaMock.economyTransaction.create).not.toHaveBeenCalled();
+  });
+
+  it('self-adoption renders but credits nothing (anti-farm)', async () => {
+    // authorId 7 === the adopter → scoreStylesheetSelection returns author: null.
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue({
+      ...mockSheet,
+      authorId: 7
+    } as never);
+
+    const res = await request(app).post(
+      '/api/stylesheet/author-stylesheet/1/adopt'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.scored).toBe(false);
+    expect(prismaMock.user.update).toHaveBeenCalled(); // own sheet still rendered
+    expect(prismaMock.economyTransaction.create).not.toHaveBeenCalled();
+    expect(prismaMock.economyTransaction.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('404s when adopting a non-existent stylesheet', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+    const res = await request(app).post(
+      '/api/stylesheet/author-stylesheet/999/adopt'
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -837,7 +837,8 @@ describe('API auth/profile/user flows', () => {
       showLastSeen: false,
       showContributedStats: true,
       showConsumedStats: true,
-      showRatioStats: true
+      showRatioStats: true,
+      activeAuthorStylesheetId: null
     });
 
     const res = await request(app).get('/api/users/settings');
@@ -860,7 +861,8 @@ describe('API auth/profile/user flows', () => {
       showLastSeen: true,
       showContributedStats: false,
       showConsumedStats: false,
-      showRatioStats: false
+      showRatioStats: false,
+      activeAuthorStylesheetId: null
     });
 
     const res = await request(app).put('/api/users/settings').send({

--- a/src/integration/authorStylesheet.integration.ts
+++ b/src/integration/authorStylesheet.integration.ts
@@ -1,0 +1,65 @@
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import {
+  upsertAuthorStylesheet,
+  getAuthorStylesheet
+} from '../modules/authorStylesheet';
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const createUser = async () => {
+  const rank = await testPrisma.userRank.findFirstOrThrow();
+  const settings = await testPrisma.userSettings.create({ data: {} });
+  const profile = await testPrisma.profile.create({ data: {} });
+  return testPrisma.user.create({
+    data: {
+      username: `user-${Date.now()}-${Math.random()}`,
+      email: `user-${Date.now()}-${Math.random()}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id
+    }
+  });
+};
+
+describe('AuthorStylesheet save → fetch (PRD-03 #118)', () => {
+  it('round-trips: save then read back the same source', async () => {
+    const user = await createUser();
+    await upsertAuthorStylesheet(user.id, {
+      name: 'Midnight',
+      source: 'body { background: #000; }'
+    });
+
+    const fetched = await getAuthorStylesheet(user.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.name).toBe('Midnight');
+    expect(fetched!.source).toBe('body { background: #000; }');
+    expect(fetched!.authorId).toBe(user.id);
+  });
+
+  it('is one-per-author: re-saving replaces in place, never duplicates', async () => {
+    const user = await createUser();
+    await upsertAuthorStylesheet(user.id, { name: 'First', source: 'a {}' });
+    await upsertAuthorStylesheet(user.id, { name: 'Second', source: 'b {}' });
+
+    const all = await testPrisma.authorStylesheet.findMany({
+      where: { authorId: user.id }
+    });
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe('Second');
+    expect(all[0].source).toBe('b {}');
+  });
+
+  it('returns null for an author with no stylesheet', async () => {
+    const user = await createUser();
+    expect(await getAuthorStylesheet(user.id)).toBeNull();
+  });
+});

--- a/src/integration/authorStylesheet.integration.ts
+++ b/src/integration/authorStylesheet.integration.ts
@@ -1,8 +1,10 @@
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
 import {
-  upsertAuthorStylesheet,
-  getAuthorStylesheet
+  createAuthorStylesheet,
+  listAuthorStylesheets,
+  adoptAuthorStylesheet
 } from '../modules/authorStylesheet';
+import { getReputation } from '../modules/reputation';
 
 beforeEach(async () => {
   await truncateAll();
@@ -13,14 +15,16 @@ afterAll(async () => {
   await testPrisma.$disconnect();
 });
 
+let seq = 0;
 const createUser = async () => {
+  seq += 1;
   const rank = await testPrisma.userRank.findFirstOrThrow();
   const settings = await testPrisma.userSettings.create({ data: {} });
   const profile = await testPrisma.profile.create({ data: {} });
   return testPrisma.user.create({
     data: {
-      username: `user-${Date.now()}-${Math.random()}`,
-      email: `user-${Date.now()}-${Math.random()}@example.com`,
+      username: `user-${seq}-${Date.now()}`,
+      email: `user-${seq}-${Date.now()}@example.com`,
       password: 'x',
       avatar: '',
       userRankId: rank.id,
@@ -30,36 +34,101 @@ const createUser = async () => {
   });
 };
 
-describe('AuthorStylesheet save → fetch (PRD-03 #118)', () => {
-  it('round-trips: save then read back the same source', async () => {
-    const user = await createUser();
-    await upsertAuthorStylesheet(user.id, {
+const activeSlotOf = async (userId: number): Promise<number | null> => {
+  const user = await testPrisma.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: { userSettings: { select: { activeAuthorStylesheetId: true } } }
+  });
+  return user.userSettings.activeAuthorStylesheetId;
+};
+
+describe('AuthorStylesheet save → list (PRD-03 #118, many per author)', () => {
+  it('an author can save several stylesheets and list them all', async () => {
+    const author = await createUser();
+    await createAuthorStylesheet(author.id, { name: 'First', source: 'a {}' });
+    await createAuthorStylesheet(author.id, { name: 'Second', source: 'b {}' });
+
+    const all = await listAuthorStylesheets(author.id);
+    expect(all).toHaveLength(2);
+    expect(all.map((s) => s.name)).toEqual(['First', 'Second']);
+  });
+});
+
+describe('AuthorStylesheet adopt → score (PRD-03 #119/#120)', () => {
+  it('adopt points the adopter Site slot at the sheet and credits the author', async () => {
+    const author = await createUser();
+    const adopter = await createUser();
+    const sheet = await createAuthorStylesheet(author.id, {
       name: 'Midnight',
       source: 'body { background: #000; }'
     });
 
-    const fetched = await getAuthorStylesheet(user.id);
-    expect(fetched).not.toBeNull();
-    expect(fetched!.name).toBe('Midnight');
-    expect(fetched!.source).toBe('body { background: #000; }');
-    expect(fetched!.authorId).toBe(user.id);
-  });
+    const before = await getReputation(author.id);
+    const beforeStyle = before.dimensions.find(
+      (d) => d.name === 'stylesheet'
+    )!.subScore;
 
-  it('is one-per-author: re-saving replaces in place, never duplicates', async () => {
-    const user = await createUser();
-    await upsertAuthorStylesheet(user.id, { name: 'First', source: 'a {}' });
-    await upsertAuthorStylesheet(user.id, { name: 'Second', source: 'b {}' });
+    const result = await adoptAuthorStylesheet(adopter.id, sheet.id);
+    expect(result.scored).toBe(true);
 
-    const all = await testPrisma.authorStylesheet.findMany({
-      where: { authorId: user.id }
+    // #119 — adopter's Site Stylesheet slot now reflects the author's sheet.
+    expect(await activeSlotOf(adopter.id)).toBe(sheet.id);
+
+    // #120 — exactly one ledger row, crediting the author, actor = adopter.
+    const ledger = await testPrisma.economyTransaction.findMany({
+      where: { reason: 'CRS_STYLESHEET_ADOPTION' }
     });
-    expect(all).toHaveLength(1);
-    expect(all[0].name).toBe('Second');
-    expect(all[0].source).toBe('b {}');
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0].userId).toBe(author.id);
+    expect(ledger[0].actorUserId).toBe(adopter.id);
+
+    // Author CRS reflects the accrued adoption.
+    const after = await getReputation(author.id);
+    const afterStyle = after.dimensions.find(
+      (d) => d.name === 'stylesheet'
+    )!.subScore;
+    expect(afterStyle).toBeGreaterThan(beforeStyle);
   });
 
-  it('returns null for an author with no stylesheet', async () => {
-    const user = await createUser();
-    expect(await getAuthorStylesheet(user.id)).toBeNull();
+  it('re-adopting the same author is idempotent — no second ledger row', async () => {
+    const author = await createUser();
+    const adopter = await createUser();
+    const sheetA = await createAuthorStylesheet(author.id, {
+      name: 'A',
+      source: 'a {}'
+    });
+    const sheetB = await createAuthorStylesheet(author.id, {
+      name: 'B',
+      source: 'b {}'
+    });
+
+    const first = await adoptAuthorStylesheet(adopter.id, sheetA.id);
+    expect(first.scored).toBe(true);
+    // Switch to another sheet by the SAME author — slot updates cleanly...
+    const second = await adoptAuthorStylesheet(adopter.id, sheetB.id);
+    expect(second.scored).toBe(false); // ...but no new (adopter, author) credit
+    expect(await activeSlotOf(adopter.id)).toBe(sheetB.id);
+
+    const ledger = await testPrisma.economyTransaction.count({
+      where: { reason: 'CRS_STYLESHEET_ADOPTION' }
+    });
+    expect(ledger).toBe(1);
+  });
+
+  it('self-adoption renders the sheet but credits nothing (anti-farm)', async () => {
+    const author = await createUser();
+    const sheet = await createAuthorStylesheet(author.id, {
+      name: 'Mine',
+      source: 'c {}'
+    });
+
+    const result = await adoptAuthorStylesheet(author.id, sheet.id);
+    expect(result.scored).toBe(false);
+    expect(await activeSlotOf(author.id)).toBe(sheet.id); // own sheet still active
+
+    const ledger = await testPrisma.economyTransaction.count({
+      where: { reason: 'CRS_STYLESHEET_ADOPTION' }
+    });
+    expect(ledger).toBe(0);
   });
 });

--- a/src/integration/authorStylesheet.integration.ts
+++ b/src/integration/authorStylesheet.integration.ts
@@ -115,6 +115,31 @@ describe('AuthorStylesheet adopt → score (PRD-03 #119/#120)', () => {
     expect(ledger).toBe(1);
   });
 
+  it('concurrent double-adopt credits the author exactly once (F1: partial unique index)', async () => {
+    const author = await createUser();
+    const adopter = await createUser();
+    const sheet = await createAuthorStylesheet(author.id, {
+      name: 'Race',
+      source: 'r {}'
+    });
+
+    // Two simultaneous adopts (a double-click). Without the DB-level partial
+    // unique index both check-then-insert would pass and double-credit; with
+    // it, the loser raises P2002 and is swallowed as scored: false.
+    const [a, b] = await Promise.all([
+      adoptAuthorStylesheet(adopter.id, sheet.id),
+      adoptAuthorStylesheet(adopter.id, sheet.id)
+    ]);
+
+    // Exactly one of the two recorded a credit.
+    expect([a.scored, b.scored].filter(Boolean)).toHaveLength(1);
+
+    const ledger = await testPrisma.economyTransaction.count({
+      where: { reason: 'CRS_STYLESHEET_ADOPTION' }
+    });
+    expect(ledger).toBe(1);
+  });
+
   it('self-adoption renders the sheet but credits nothing (anti-farm)', async () => {
     const author = await createUser();
     const sheet = await createAuthorStylesheet(author.id, {

--- a/src/lib/cssSanitize.spec.ts
+++ b/src/lib/cssSanitize.spec.ts
@@ -1,0 +1,64 @@
+import { sanitizeStylesheetSource } from './cssSanitize';
+
+describe('sanitizeStylesheetSource (ADR-0003 store-time CSS sanitizer)', () => {
+  it('strips @import at-rules (url and quoted forms)', () => {
+    expect(
+      sanitizeStylesheetSource(
+        '@import url("https://evil.test/x.css");\nbody{color:red}'
+      )
+    ).not.toMatch(/@import/i);
+    expect(
+      sanitizeStylesheetSource(
+        "@import 'https://evil.test/x.css';\nbody{color:red}"
+      )
+    ).not.toMatch(/@import/i);
+    // the legitimate rule survives
+    expect(
+      sanitizeStylesheetSource('@import url(x.css);\nbody{color:red}')
+    ).toMatch(/body\{color:red\}/);
+  });
+
+  it('strips @charset at-rules', () => {
+    expect(sanitizeStylesheetSource('@charset "UTF-8";\nbody{}')).not.toMatch(
+      /@charset/i
+    );
+  });
+
+  it('neutralizes remote url() references (the exfiltration vector)', () => {
+    expect(
+      sanitizeStylesheetSource('body{background:url(https://evil.test/p.gif)}')
+    ).toBe('body{background:url()}');
+    expect(
+      sanitizeStylesheetSource('body{background:url("http://evil.test/p.gif")}')
+    ).toBe('body{background:url()}');
+    // protocol-relative and javascript: are remote too
+    expect(sanitizeStylesheetSource('a{cursor:url(//evil.test/c)}')).toBe(
+      'a{cursor:url()}'
+    );
+    expect(
+      sanitizeStylesheetSource('a{background:url("javascript:alert(1)")}')
+    ).toBe('a{background:url()}');
+  });
+
+  it('keeps data: URIs and same-origin relative references', () => {
+    const dataUri = 'body{background:url(data:image/png;base64,AAAA)}';
+    expect(sanitizeStylesheetSource(dataUri)).toBe(dataUri);
+    const relative = 'body{background:url(/assets/bg.png)}';
+    expect(sanitizeStylesheetSource(relative)).toBe(relative);
+    const relativeDot = 'body{background:url("./img/x.png")}';
+    expect(sanitizeStylesheetSource(relativeDot)).toBe(relativeDot);
+  });
+
+  it('neutralizes a remote @font-face src', () => {
+    const out = sanitizeStylesheetSource(
+      '@font-face{font-family:x;src:url(https://evil.test/f.woff2)}'
+    );
+    expect(out).toContain('src:url()');
+    expect(out).not.toContain('evil.test');
+  });
+
+  it('leaves clean CSS untouched', () => {
+    const clean = '.theme{color:#abc;margin:0}\n#nav{display:flex}';
+    expect(sanitizeStylesheetSource(clean)).toBe(clean);
+  });
+});

--- a/src/lib/cssSanitize.ts
+++ b/src/lib/cssSanitize.ts
@@ -1,0 +1,52 @@
+/**
+ * Store-time CSS sanitizer for user-authored stylesheets (ADR-0003, Arm 2).
+ *
+ * `AuthorStylesheet.source` is raw CSS that stellar-ui injects site-wide, so the
+ * persisted artifact must already be safe (fail-closed) rather than trusting the
+ * render path. This strips the constructs that turn a stylesheet into a fetch /
+ * exfiltration vector:
+ *
+ *   - `@import` / `@charset` at-rules — removed outright (a profile theme never
+ *     legitimately needs to pull another sheet).
+ *   - `url(...)` references (including `@font-face src`) — neutralized to `url()`
+ *     unless they point at a `data:` URI or a same-origin relative path. An
+ *     absolute/remote/`javascript:` URL would fire a request to an arbitrary
+ *     host on every render.
+ *
+ * Source is treated as plain CSS (ADR-0003 scopes server-side SCSS compilation
+ * of untrusted input out). This is the server half of a defense-in-depth
+ * boundary; the inject-time CSP (`img-src`/`font-src`/`connect-src`) and the
+ * protected chrome layer are the other halves, so an escape this regex pass
+ * misses still cannot exfiltrate.
+ */
+
+// `@import ...;` and `@charset ...;` in any form (url(), quoted, bare).
+const AT_RULE_STRIP = /@(?:import|charset)\b[^;]*;?/gi;
+
+// `url( … )` in its three forms: double-quoted, single-quoted (quoted content
+// may legitimately contain `)`), or a bare unquoted token (no whitespace/paren).
+const URL_REF = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)\s]*))\s*\)/gi;
+
+/** A url() target is safe to keep if it is a data: URI or a same-origin relative path. */
+const isSafeUrlTarget = (raw: string): boolean => {
+  const target = raw.trim();
+  if (target === '') return true;
+  if (/^data:/i.test(target)) return true;
+  // Reject protocol-relative (`//host`) and any explicit scheme (`http:`,
+  // `javascript:`, …); everything else is a same-origin relative reference.
+  if (target.startsWith('//')) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return false;
+  return true;
+};
+
+/**
+ * Return a sanitized copy of a user-authored stylesheet's source, safe to
+ * persist and inject. Never throws — like `sanitizeHtml`, it cleans rather than
+ * rejects, so an honest author's save is not blocked by a stray reference.
+ */
+export const sanitizeStylesheetSource = (source: string): string =>
+  source
+    .replace(AT_RULE_STRIP, '')
+    .replace(URL_REF, (match, dq: string, sq: string, bare: string) =>
+      isSafeUrlTarget(dq ?? sq ?? bare ?? '') ? match : 'url()'
+    );

--- a/src/modules/authorStylesheet.ts
+++ b/src/modules/authorStylesheet.ts
@@ -1,0 +1,26 @@
+/**
+ * AuthorStylesheet — a user-authored stylesheet saved for others to adopt
+ * (PRD-03, descent target #4a / #118).
+ *
+ * One per author: a member has at most one AuthorStylesheet, so saving is an
+ * upsert keyed on the author. This is the keystone the shipped
+ * `scoreStylesheetSelection` (#84) hooks onto — #119 adds adoption, #120 scores
+ * it. No CRS wiring lives here yet.
+ */
+import { prisma } from '../lib/prisma';
+import type { AuthorStylesheetInput } from '../schemas/stylesheet';
+
+/** Save (create or replace) the calling author's single AuthorStylesheet. */
+export const upsertAuthorStylesheet = (
+  authorId: number,
+  input: AuthorStylesheetInput
+) =>
+  prisma.authorStylesheet.upsert({
+    where: { authorId },
+    create: { authorId, name: input.name, source: input.source },
+    update: { name: input.name, source: input.source }
+  });
+
+/** Read an author's stylesheet, or null if they have not saved one. */
+export const getAuthorStylesheet = (authorId: number) =>
+  prisma.authorStylesheet.findUnique({ where: { authorId } });

--- a/src/modules/authorStylesheet.ts
+++ b/src/modules/authorStylesheet.ts
@@ -15,16 +15,26 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
+import { sanitizeStylesheetSource } from '../lib/cssSanitize';
 import { scoreStylesheetSelection } from './stylesheetScore';
 import type { AuthorStylesheetInput } from '../schemas/stylesheet';
 
-/** Create a new AuthorStylesheet for the calling author (many per author). */
+/**
+ * Create a new AuthorStylesheet for the calling author (many per author).
+ *
+ * `source` is sanitized at store-time (ADR-0003): the injected artifact is kept
+ * safe in the database, not just at render. See `lib/cssSanitize.ts`.
+ */
 export const createAuthorStylesheet = (
   authorId: number,
   input: AuthorStylesheetInput
 ) =>
   prisma.authorStylesheet.create({
-    data: { authorId, name: input.name, source: input.source }
+    data: {
+      authorId,
+      name: input.name,
+      source: sanitizeStylesheetSource(input.source)
+    }
   });
 
 /** List an author's stylesheets, oldest first. */

--- a/src/modules/authorStylesheet.ts
+++ b/src/modules/authorStylesheet.ts
@@ -12,6 +12,7 @@
  *     once in the `CRS_*` event ledger (ADR-0007); the author's read-time
  *     stylesheet CRS dimension counts those pairs.
  */
+import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import { scoreStylesheetSelection } from './stylesheetScore';
@@ -53,6 +54,13 @@ export interface AdoptionResult {
  * row is written. A cross-user adoption records the (adopter, author) pair once
  * (deduped); re-adopting the same author's sheets never double-credits, which
  * is exactly the once-per-distinct-pair rule the controlled vector needs.
+ *
+ * The Site-slot pointer update and the CRS ledger write are deliberately NOT
+ * in one transaction: changing your theme is the user-facing effect and must
+ * not be rolled back or blocked by a hiccup in the (advisory) author accrual.
+ * The dedup is enforced atomically by a partial unique index on
+ * (userId, actorUserId) WHERE reason = 'CRS_STYLESHEET_ADOPTION', so concurrent
+ * double-adopts insert-and-catch P2002 rather than both crediting the author.
  */
 export const adoptAuthorStylesheet = async (
   adopterId: number,
@@ -63,31 +71,26 @@ export const adoptAuthorStylesheet = async (
   });
   if (!sheet) throw new AppError(404, 'Author stylesheet not found');
 
-  const accrual = scoreStylesheetSelection({
+  // #119 — point the adopter's Site Stylesheet slot at this sheet (idempotent).
+  // Done unconditionally and independently of the ledger write below.
+  await prisma.user.update({
+    where: { id: adopterId },
+    data: { userSettings: { update: { activeAuthorStylesheetId: sheet.id } } }
+  });
+
+  const authorAccrual = scoreStylesheetSelection({
     userId: adopterId,
     origin: { kind: 'author', authorId: sheet.authorId }
-  });
-  const authorAccrual = accrual.author;
+  }).author;
+  // Self-adoption (author: null) renders but earns nothing — no ledger row.
+  if (!authorAccrual) return { authorStylesheet: sheet, scored: false };
 
-  const scored = await prisma.$transaction(async (tx) => {
-    // #119 — point the adopter's Site Stylesheet slot at this sheet (idempotent).
-    await tx.user.update({
-      where: { id: adopterId },
-      data: { userSettings: { update: { activeAuthorStylesheetId: sheet.id } } }
-    });
-
-    // #120 — record the durable adoption event, once per (adopter, author).
-    if (!authorAccrual) return false;
-    const existing = await tx.economyTransaction.findFirst({
-      where: {
-        userId: authorAccrual.userId,
-        actorUserId: adopterId,
-        reason: 'CRS_STYLESHEET_ADOPTION'
-      },
-      select: { id: true }
-    });
-    if (existing) return false;
-    await tx.economyTransaction.create({
+  // #120 — record the durable adoption event, once per (adopter, author).
+  // Insert-and-catch: the partial unique index turns a duplicate (the same
+  // adopter re-adopting this author, or a concurrent double-click) into P2002,
+  // which we treat as "already scored".
+  try {
+    await prisma.economyTransaction.create({
       data: {
         userId: authorAccrual.userId, // CRS recipient = the author
         actorUserId: adopterId, // who adopted
@@ -97,8 +100,14 @@ export const adoptAuthorStylesheet = async (
         contextId: sheet.id
       }
     });
-    return true;
-  });
-
-  return { authorStylesheet: sheet, scored };
+    return { authorStylesheet: sheet, scored: true };
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2002'
+    ) {
+      return { authorStylesheet: sheet, scored: false };
+    }
+    throw err;
+  }
 };

--- a/src/modules/authorStylesheet.ts
+++ b/src/modules/authorStylesheet.ts
@@ -1,26 +1,104 @@
 /**
- * AuthorStylesheet — a user-authored stylesheet saved for others to adopt
- * (PRD-03, descent target #4a / #118).
+ * AuthorStylesheet — user-authored stylesheets saved for others to adopt
+ * (PRD-03, descent target #4).
  *
- * One per author: a member has at most one AuthorStylesheet, so saving is an
- * upsert keyed on the author. This is the keystone the shipped
- * `scoreStylesheetSelection` (#84) hooks onto — #119 adds adoption, #120 scores
- * it. No CRS wiring lives here yet.
+ * A member may author MANY stylesheets (cardinality fixed in #119; the
+ * rank-gated count limit is deferred). Adoption is the keystone the shipped
+ * `scoreStylesheetSelection` (#84) hooks onto:
+ *   - #118 save:  create / list / read an author's sheets.
+ *   - #119 adopt: a viewer points their Site Stylesheet slot
+ *     (`UserSettings.activeAuthorStylesheetId`) at a chosen sheet, idempotently.
+ *   - #120 score: a non-self adoption records the durable (adopter, author) pair
+ *     once in the `CRS_*` event ledger (ADR-0007); the author's read-time
+ *     stylesheet CRS dimension counts those pairs.
  */
 import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
+import { scoreStylesheetSelection } from './stylesheetScore';
 import type { AuthorStylesheetInput } from '../schemas/stylesheet';
 
-/** Save (create or replace) the calling author's single AuthorStylesheet. */
-export const upsertAuthorStylesheet = (
+/** Create a new AuthorStylesheet for the calling author (many per author). */
+export const createAuthorStylesheet = (
   authorId: number,
   input: AuthorStylesheetInput
 ) =>
-  prisma.authorStylesheet.upsert({
-    where: { authorId },
-    create: { authorId, name: input.name, source: input.source },
-    update: { name: input.name, source: input.source }
+  prisma.authorStylesheet.create({
+    data: { authorId, name: input.name, source: input.source }
   });
 
-/** Read an author's stylesheet, or null if they have not saved one. */
-export const getAuthorStylesheet = (authorId: number) =>
-  prisma.authorStylesheet.findUnique({ where: { authorId } });
+/** List an author's stylesheets, oldest first. */
+export const listAuthorStylesheets = (authorId: number) =>
+  prisma.authorStylesheet.findMany({
+    where: { authorId },
+    orderBy: { createdAt: 'asc' }
+  });
+
+/** Read a single AuthorStylesheet by its id, or null if it does not exist. */
+export const getAuthorStylesheetById = (id: number) =>
+  prisma.authorStylesheet.findUnique({ where: { id } });
+
+export interface AdoptionResult {
+  /** The adopted stylesheet (now in the adopter's Site Stylesheet slot). */
+  authorStylesheet: Awaited<ReturnType<typeof getAuthorStylesheetById>>;
+  /** Whether this adoption recorded a new (adopter, author) CRS ledger event. */
+  scored: boolean;
+}
+
+/**
+ * Adopt a stylesheet into the adopter's Site Stylesheet slot, and — for a
+ * non-self adoption — accrue to the author (#120).
+ *
+ * The pure scorer decides recipient: a self-adoption returns `author: null`
+ * (using your own sheet renders but earns nothing — anti-farm), so no ledger
+ * row is written. A cross-user adoption records the (adopter, author) pair once
+ * (deduped); re-adopting the same author's sheets never double-credits, which
+ * is exactly the once-per-distinct-pair rule the controlled vector needs.
+ */
+export const adoptAuthorStylesheet = async (
+  adopterId: number,
+  stylesheetId: number
+): Promise<AdoptionResult> => {
+  const sheet = await prisma.authorStylesheet.findUnique({
+    where: { id: stylesheetId }
+  });
+  if (!sheet) throw new AppError(404, 'Author stylesheet not found');
+
+  const accrual = scoreStylesheetSelection({
+    userId: adopterId,
+    origin: { kind: 'author', authorId: sheet.authorId }
+  });
+  const authorAccrual = accrual.author;
+
+  const scored = await prisma.$transaction(async (tx) => {
+    // #119 — point the adopter's Site Stylesheet slot at this sheet (idempotent).
+    await tx.user.update({
+      where: { id: adopterId },
+      data: { userSettings: { update: { activeAuthorStylesheetId: sheet.id } } }
+    });
+
+    // #120 — record the durable adoption event, once per (adopter, author).
+    if (!authorAccrual) return false;
+    const existing = await tx.economyTransaction.findFirst({
+      where: {
+        userId: authorAccrual.userId,
+        actorUserId: adopterId,
+        reason: 'CRS_STYLESHEET_ADOPTION'
+      },
+      select: { id: true }
+    });
+    if (existing) return false;
+    await tx.economyTransaction.create({
+      data: {
+        userId: authorAccrual.userId, // CRS recipient = the author
+        actorUserId: adopterId, // who adopted
+        amount: 1n, // one adoption event; CRS magnitude lives in the read-time scorer
+        reason: 'CRS_STYLESHEET_ADOPTION',
+        contextType: 'AuthorStylesheet',
+        contextId: sheet.id
+      }
+    });
+    return true;
+  });
+
+  return { authorStylesheet: sheet, scored };
+};

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -5,9 +5,14 @@
 
 const mockPrismaUser = { findUnique: jest.fn() };
 const mockPrismaFriend = { count: jest.fn() };
+const mockPrismaEconomy = { count: jest.fn() };
 
 jest.mock('../lib/prisma', () => ({
-  prisma: { user: mockPrismaUser, friend: mockPrismaFriend }
+  prisma: {
+    user: mockPrismaUser,
+    friend: mockPrismaFriend,
+    economyTransaction: mockPrismaEconomy
+  }
 }));
 
 import { computeCrs, getReputation } from './reputation';
@@ -162,10 +167,38 @@ describe('computeCrs — Friends dimension', () => {
   });
 });
 
+// ─── StylesheetScore dimension ────────────────────────────────────────────────
+
+describe('computeCrs — Stylesheet dimension', () => {
+  const styleOf = (stylesheetAdoptions: number): number =>
+    computeCrs({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      stylesheetAdoptions
+    }).dimensions.find((d) => d.name === 'stylesheet')!.subScore;
+
+  it('an author with no adoptions scores 0', () => {
+    expect(styleOf(0)).toBeCloseTo(0, 10);
+  });
+
+  it('rises with each distinct adoption', () => {
+    expect(styleOf(3)).toBeGreaterThan(styleOf(1));
+    expect(styleOf(1)).toBeGreaterThan(0);
+  });
+
+  it('is bounded: mass adoption cannot dominate (STYLESHEET_CAP = 6)', () => {
+    expect(styleOf(1000)).toBeLessThanOrEqual(6);
+  });
+});
+
 // ─── getReputation (read-time assembler) ──────────────────────────────────────
 
 describe('getReputation', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrismaEconomy.count.mockResolvedValue(0);
+  });
 
   it('computes CRS from the user createdAt + ratio + friends', async () => {
     mockPrismaUser.findUnique.mockResolvedValue({
@@ -192,5 +225,26 @@ describe('getReputation', () => {
     mockPrismaFriend.count.mockResolvedValue(0);
     const result = await getReputation(999);
     expect(result).toEqual({ score: 0, dimensions: [] });
+  });
+
+  it('reflects stylesheet adoptions from the CRS_* ledger count', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({
+      createdAt: NOW,
+      contributed: 0n,
+      consumed: 0n
+    });
+    mockPrismaFriend.count.mockResolvedValue(0);
+    mockPrismaEconomy.count.mockResolvedValue(4); // 4 distinct adopters
+
+    const result = await getReputation(1);
+
+    expect(mockPrismaEconomy.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 1, reason: 'CRS_STYLESHEET_ADOPTION' }
+      })
+    );
+    expect(
+      result.dimensions.find((d) => d.name === 'stylesheet')!.subScore
+    ).toBeGreaterThan(0);
   });
 });

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -153,6 +153,11 @@ const ircScorer: DimensionScorer = {
 // (ADR-0007): nothing stores a denormalized stylesheet score. Anti-farm is the
 // `/private` invite + report model's job (PRD-03), not a bespoke cap — the cap
 // here is the module's standard "no single dimension dominates" guardrail.
+//
+// PROVISIONAL (tier-0): the per-adoption magnitude and cap are interim. The
+// real reward shape is PRD-03 target #2 (BonusPoints tiering, TBD), which will
+// swap these constants without touching the ledger — the ledger row stays a
+// pure (adopter, author) event marker.
 const STYLESHEET_AUTHOR_PER_ADOPTION =
   scoreStylesheetSelection({
     userId: 0,

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -18,6 +18,7 @@
 import { prisma } from '../lib/prisma';
 import { computeRatio } from './ratio';
 import { getIrcScore } from './irc';
+import { scoreStylesheetSelection } from './stylesheetScore';
 
 /** What dimension scorers may read. Grows as dimensions are added; the
  *  assembler (`getReputation`) fetches it, keeping each scorer pure. */
@@ -32,6 +33,9 @@ export interface DimensionInput {
   friendCount?: number;
   /** IRC nick linked to this account — used to look up the cached IRCScore. */
   ircNick?: string | null;
+  /** Distinct (adopter, author) adoptions of this member's stylesheets — the
+   *  durable count from the CRS_* ledger (ADR-0007). Defaults to 0. */
+  stylesheetAdoptions?: number;
   /** Injectable for deterministic tests; defaults to now. */
   now?: Date;
 }
@@ -140,13 +144,39 @@ const ircScorer: DimensionScorer = {
   }
 };
 
+// ─── StylesheetScore ──────────────────────────────────────────────────────────
+// An author's reward for others adopting their stylesheets (PRD-03). The CRS
+// magnitude is sourced from the shared pure scorer `scoreStylesheetSelection`
+// (the per-adoption author delta of a non-self `author` selection) so the value
+// has a single home; this dimension only multiplies it by the durable count of
+// distinct (adopter, author) adoptions read from the ledger. Computed on read
+// (ADR-0007): nothing stores a denormalized stylesheet score. Anti-farm is the
+// `/private` invite + report model's job (PRD-03), not a bespoke cap — the cap
+// here is the module's standard "no single dimension dominates" guardrail.
+const STYLESHEET_AUTHOR_PER_ADOPTION =
+  scoreStylesheetSelection({
+    userId: 0,
+    origin: { kind: 'author', authorId: 1 }
+  }).author?.delta ?? 0;
+const STYLESHEET_CAP = 6;
+const STYLESHEET_WEIGHT = 1.0;
+
+const stylesheetScorer: DimensionScorer = {
+  name: 'stylesheet',
+  weight: STYLESHEET_WEIGHT,
+  cap: STYLESHEET_CAP,
+  compute: ({ stylesheetAdoptions = 0 }) =>
+    STYLESHEET_AUTHOR_PER_ADOPTION * Math.max(0, stylesheetAdoptions)
+};
+
 // Registry — add a dimension here (Invite, Donation, …) and the aggregator
 // picks it up unchanged.
 const REGISTRY: DimensionScorer[] = [
   longevityScorer,
   ratioScorer,
   friendsScorer,
-  ircScorer
+  ircScorer,
+  stylesheetScorer
 ];
 
 /** Pure aggregator: sum each capped dimension's weighted subScore. */
@@ -161,7 +191,7 @@ export const computeCrs = (input: DimensionInput): CrsResult => {
 
 /** Read-time CRS for a user. Assembles the dimension input, then computes. */
 export const getReputation = async (userId: number): Promise<CrsResult> => {
-  const [user, friendCount] = await Promise.all([
+  const [user, friendCount, stylesheetAdoptions] = await Promise.all([
     prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -171,7 +201,13 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
         ircNick: true
       }
     }),
-    prisma.friend.count({ where: { userId } })
+    prisma.friend.count({ where: { userId } }),
+    // Distinct (adopter, author) pairs where this user is the author — one
+    // ledger row per pair (deduped at write), so a plain count is the distinct
+    // adoption count.
+    prisma.economyTransaction.count({
+      where: { userId, reason: 'CRS_STYLESHEET_ADOPTION' }
+    })
   ]);
   if (!user) return { score: 0, dimensions: [] };
   return computeCrs({
@@ -180,6 +216,7 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     ratio: computeRatio(user.contributed, user.consumed),
     contributed: user.contributed,
     friendCount,
-    ircNick: user.ircNick
+    ircNick: user.ircNick,
+    stylesheetAdoptions
   });
 };

--- a/src/routes/api/stylesheet.ts
+++ b/src/routes/api/stylesheet.ts
@@ -24,8 +24,10 @@ import {
   getStylesheetStats
 } from '../../modules/stylesheet';
 import {
-  upsertAuthorStylesheet,
-  getAuthorStylesheet
+  createAuthorStylesheet,
+  listAuthorStylesheets,
+  getAuthorStylesheetById,
+  adoptAuthorStylesheet
 } from '../../modules/authorStylesheet';
 import { prisma } from '../../lib/prisma';
 
@@ -37,33 +39,57 @@ const authorIdParamsSchema = z.object({
   userId: z.coerce.number().int().positive()
 });
 
-// ─── AuthorStylesheet (PRD-03 #118) — registered before /:id ──────────────────
+// ─── AuthorStylesheet (PRD-03 #118/#119/#120) — registered before /:id ────────
 
-// POST /api/stylesheet/author — save (create or replace) my AuthorStylesheet.
+// POST /api/stylesheet/author — author a new stylesheet (many per author).
 router.post(
   '/author',
   requireAuth,
   validate(authorStylesheetSchema),
   authHandler(async (req, res) => {
     const data = parsedBody<AuthorStylesheetInput>(res);
-    const sheet = await upsertAuthorStylesheet(req.user.id, data);
+    const sheet = await createAuthorStylesheet(req.user.id, data);
     res.status(201).json(sheet);
   })
 );
 
-// GET /api/stylesheet/author/:userId — read an author's stylesheet.
+// GET /api/stylesheet/author/:userId — list an author's stylesheets.
 router.get(
   '/author/:userId',
   requireAuth,
   validateParams(authorIdParamsSchema),
   authHandler(async (_req, res) => {
     const { userId } = parsedParams<{ userId: number }>(res);
-    const sheet = await getAuthorStylesheet(userId);
+    res.json(await listAuthorStylesheets(userId));
+  })
+);
+
+// GET /api/stylesheet/author-stylesheet/:id — read one authored stylesheet.
+router.get(
+  '/author-stylesheet/:id',
+  requireAuth,
+  validateParams(stylesheetIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const sheet = await getAuthorStylesheetById(id);
     if (!sheet) {
       res.status(404).json({ msg: 'Author stylesheet not found' });
       return;
     }
     res.json(sheet);
+  })
+);
+
+// POST /api/stylesheet/author-stylesheet/:id/adopt — adopt a stylesheet into my
+// Site Stylesheet slot (#119); a non-self adoption accrues to the author (#120).
+router.post(
+  '/author-stylesheet/:id/adopt',
+  requireAuth,
+  validateParams(stylesheetIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const result = await adoptAuthorStylesheet(req.user.id, id);
+    res.json(result);
   })
 );
 

--- a/src/routes/api/stylesheet.ts
+++ b/src/routes/api/stylesheet.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
-import { asyncHandler } from '../../modules/asyncHandler';
+import { asyncHandler, authHandler } from '../../modules/asyncHandler';
 import { requireAuth } from '../../middleware/auth';
 import { requireStrictAdmin } from '../../middleware/permissions';
 import {
@@ -12,8 +12,10 @@ import {
 import {
   stylesheetSchema,
   stylesheetUpdateSchema,
+  authorStylesheetSchema,
   type StylesheetInput,
-  type StylesheetUpdateInput
+  type StylesheetUpdateInput,
+  type AuthorStylesheetInput
 } from '../../schemas/stylesheet';
 import {
   createStylesheet,
@@ -21,12 +23,49 @@ import {
   deleteStylesheet,
   getStylesheetStats
 } from '../../modules/stylesheet';
+import {
+  upsertAuthorStylesheet,
+  getAuthorStylesheet
+} from '../../modules/authorStylesheet';
 import { prisma } from '../../lib/prisma';
 
 const router = express.Router();
 const stylesheetIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
 });
+const authorIdParamsSchema = z.object({
+  userId: z.coerce.number().int().positive()
+});
+
+// ─── AuthorStylesheet (PRD-03 #118) — registered before /:id ──────────────────
+
+// POST /api/stylesheet/author — save (create or replace) my AuthorStylesheet.
+router.post(
+  '/author',
+  requireAuth,
+  validate(authorStylesheetSchema),
+  authHandler(async (req, res) => {
+    const data = parsedBody<AuthorStylesheetInput>(res);
+    const sheet = await upsertAuthorStylesheet(req.user.id, data);
+    res.status(201).json(sheet);
+  })
+);
+
+// GET /api/stylesheet/author/:userId — read an author's stylesheet.
+router.get(
+  '/author/:userId',
+  requireAuth,
+  validateParams(authorIdParamsSchema),
+  authHandler(async (_req, res) => {
+    const { userId } = parsedParams<{ userId: number }>(res);
+    const sheet = await getAuthorStylesheet(userId);
+    if (!sheet) {
+      res.status(404).json({ msg: 'Author stylesheet not found' });
+      return;
+    }
+    res.json(sheet);
+  })
+);
 
 // GET /api/stylesheet/admin/stats — must be before /:id
 router.get(

--- a/src/schemas/stylesheet.ts
+++ b/src/schemas/stylesheet.ts
@@ -22,3 +22,13 @@ export const stylesheetUpdateSchema = z
 
 export type StylesheetInput = z.infer<typeof stylesheetSchema>;
 export type StylesheetUpdateInput = z.infer<typeof stylesheetUpdateSchema>;
+
+// PRD-03 #118 — a user-authored stylesheet (one per author) saved for others to
+// adopt. `source` is the raw CSS/SCSS; injection isolation is the UI injector's
+// job (ADR-0003), so it is stored verbatim, not sanitized here.
+export const authorStylesheetSchema = z.object({
+  name: z.string().min(1).max(100),
+  source: z.string().min(1).max(100_000)
+});
+
+export type AuthorStylesheetInput = z.infer<typeof authorStylesheetSchema>;


### PR DESCRIPTION
Completes the **PRD-03 stylesheet keystone**: an authored stylesheet can now be saved, adopted, and the adoption scores the author's Community Reputation Score — wiring the shipped pure `scoreStylesheetSelection` (#84) to a real event for the first time. Three slices on one branch:

- **#118 save** *(already on branch)* — `AuthorStylesheet` model + `POST`/`GET /api/stylesheet/author`.
- **#119 adopt** — a viewer adopts a sheet into their **Site Stylesheet** slot (`UserSettings.activeAuthorStylesheetId`); idempotent; `GET`/`POST /api/stylesheet/author-stylesheet/:id`.
- **#120 score** — adoption → `scoreStylesheetSelection` → a once-per-(adopter, author) `CRS_STYLESHEET_ADOPTION` ledger row (ADR-0007) → a new read-time **stylesheet** CRS dimension.

### Grilled design decisions (2026-06-13)
A `/grill-with-docs` pass settled the model before code (docs updated in this PR):
- **Cardinality fixed:** an author owns **many** stylesheets — `@unique authorId` dropped, #118's `upsert` → `create`, `GET /author/:userId` lists. Rank-gated count limit + byte-identical cross-author dedup **deferred** (named in PRD-03).
- **Stylesheet slots & cascade:** Profile / Site / Community slots, page-context-first precedence (only the Site slot scores). Profile/Community slots deferred.
- **CRS scope pinned:** CRS is one **global** per-user score; **CommunityScore** is a *deferred dimension* of it (ADR-0002 health pulse), **not** a parallel per-community score — so the adoption ledger carries **no `communityId`**.
- **Self-adoption** renders but earns nothing (the pure scorer returns `author: null`) — anti-farm.
- Forward "CRS teeth" (privilege-granting, Staff/Community Toolbox) + IRC positive-reinforcement noted as **not scoped** in PRD-01/02.

### Docs
CONTEXT.md gains `Site Theme`, `Authored Stylesheet`, `Stylesheet Slot`, `Stylesheet Adoption`, `CommunityScore`. PRD-03 records the slot cascade + 4a/4b/4c descent (4b/4c struck ✅). PRD-01/02 note the deferred teeth/toolbox directions.

### Gate
- `format` / `lint` / `tsc --noEmit` / `typecheck:test` — clean
- unit: **1491 passed** (75 suites)
- integration: **102 passed** (15 suites) against real `stellar_test`
- migration `20260613120000_stylesheet_adoption` (drop unique, add Site-slot FK, add `CRS_STYLESHEET_ADOPTION`) — pre-alpha, destructive-safe on a fresh DB

Closes #119, closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)