### PR TITLE
docs(adr): accept ADR-0003 (stylesheet isolation) + ADR-0004 (standing)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,7 +68,7 @@ The out-of-band stream of new Contributions delivered to a member over RSS/XML a
 _Avoid_: rss feed, announce stream, the firehose
 
 **AnnounceKey**:
-A per-user credential authenticating a member's **Release-Announce Feed** (RSS + IRC announce). It gates *receiving* the stream of new Contributions; it never authenticates a download — release consumption remains a session-authed grant through the **Ratio Mechanism**. Rotatable; rotating it invalidates the prior feed URL.
+A per-user credential authenticating a member's **Release-Announce Feed** (RSS + IRC announce). It gates _receiving_ the stream of new Contributions; it never authenticates a download — release consumption remains a session-authed grant through the **Ratio Mechanism**. Rotatable; rotating it invalidates the prior feed URL.
 _Avoid_: passkey, download key, torrent key
 
 **IRCKey**:
@@ -76,12 +76,24 @@ A per-user credential authenticating a member's **identity on the IRC network** 
 _Avoid_: irc password, chat token, drone key
 
 **IRCScore**:
-A bounded CRS **Dimension Scorer** derived from a member's *message* activity on IRC over a trailing window — message volume weighted by channel and scaled by how many distinct days they were active. Presence/idle never contributes (anti-farming); only messages count. Capped with diminishing returns like every dimension, so IRC cannot dominate reputation.
+A bounded CRS **Dimension Scorer** derived from a member's _message_ activity on IRC over a trailing window — message volume weighted by channel and scaled by how many distinct days they were active. Presence/idle never contributes (anti-farming); only messages count. Capped with diminishing returns like every dimension, so IRC cannot dominate reputation.
 _Avoid_: irc activity, chat score, presence score
 
 **IRC Activity Rollup**:
-The durable, pre-aggregated substrate **IRCScore** reads — one row per member × channel × day of message counts, upserted by the IRC bot. The append/aggregate surface ADR-0007 calls for when a signal is *irreducible* (not reconstructable from current state) yet too high-volume for the `CRS_*` event ledger. The score is still computed on read over a trailing window of these rows; nothing stores a denormalized IRCScore.
+The durable, pre-aggregated substrate **IRCScore** reads — one row per member × channel × day of message counts, upserted by the IRC bot. The append/aggregate surface ADR-0007 calls for when a signal is _irreducible_ (not reconstructable from current state) yet too high-volume for the `CRS_*` event ledger. The score is still computed on read over a trailing window of these rows; nothing stores a denormalized IRCScore.
 _Avoid_: irc log, activity table, message history
+
+**Chrome Layer**:
+The high-priority CSS `@layer` / `all: revert` boundary that renders critical app chrome (navigation, staff/admin and moderation controls) so an injected user stylesheet cannot override or hide it. The isolation half of the stylesheet trust boundary; user themes cascade everywhere else, and a store-time sanitizer + inject-time CSP cover the exfiltration half (ADR-0003).
+_Avoid_: sandbox, shadow root, reset wrapper
+
+**Standing**:
+A member's five-rung governance tier — `pristine | clean | neutral | poor | hammer` — computed on read from active **Warnings**, ban state, and account tenure (never a stored column). It _scales_ rule impact on the CRS (pristine amplifies compliance rewards, hammer amplifies violation penalties); it is not a **Dimension Scorer** and never gates access (ADR-0004).
+_Avoid_: reputation tier, warning level, standing score, rank
+
+**Contagion**:
+The invite-tree suspicion that flows from an infected _trunk_ (a banned or ban-evading inviter) down to its _branches_ (the invitees). A **graded**, distance-decaying signal — suspect, not condemned — owned by the InviteTree. Distinct from a member's own **confirmed** ban-evasion, which alone reaches the terminal `hammer` **Standing**.
+_Avoid_: tree poisoning, ban inheritance, guilt by association
 
 ## Relationships
 
@@ -91,6 +103,7 @@ _Avoid_: irc log, activity table, message history
 - The **Ratio Mechanism** reads **Eligible Contribution Bytes** (gated by **Effective Availability**) and never reads CRS; a derived **RatioScore** flows one-way into CRS as one **Dimension Scorer**. CRS never gates downloads.
 - A **Contribution Spine** carries type-agnostic fields only; a music Contribution attaches a **Release File** (per-file) and an **Edition** (per-pressing). Future CommunityTypes attach their own analogous satellites rather than forking the spine (ADR-0008).
 - The **AnnounceKey** authenticates the **Release-Announce Feed** (RSS + IRC) and the **IRCKey** authenticates IRC identity; the two paired enable IRC-delivered release announcements. Neither replaces the **Identity State** on the session-authed download path — they authenticate out-of-band channels only, never a download.
+- **Standing** is computed on read from **Warnings** / ban state / tenure and _scales_ rule impact on the CRS via `ruleImpact`; it is never a **Dimension Scorer** and never gates access (enforcement stays granular permissions). A member's own **confirmed** ban-evasion feeds the terminal `hammer` rung, whereas invite-tree **Contagion** feeds only a graded suspicion — suspect is not condemned.
 
 ## Flagged Ambiguities
 

--- a/docs/adr/0003-stylesheet-injection-isolation.md
+++ b/docs/adr/0003-stylesheet-injection-isolation.md
@@ -1,12 +1,30 @@
 # Stylesheet injection isolation & sanitization
 
-**Status: Proposed — decision pending.** Records the decision to be made; see [PRD-03](../prd/03-stylesheet-themes-and-scoring.md). (ADR-0002 is reserved for community-health-pulse, [#75](https://github.com/orphic-inc/stellar-api/issues/75).)
+**Status: Accepted.** Records the isolation + sanitization strategy for user-supplied stylesheets; see [PRD-03](../prd/03-stylesheet-themes-and-scoring.md). Resolves decision [#130](https://github.com/orphic-inc/stellar-api/issues/130). (ADR-0002 is reserved for community-health-pulse, [#75](https://github.com/orphic-inc/stellar-api/issues/75).)
 
-User-supplied stylesheets (`profile.externalStylesheet` / AuthorStylesheetUrl) are injected site-wide by the stellar-ui `StylesheetInjector`. This is a trust boundary: an unscoped user stylesheet can break the app chrome or carry an injection/exfiltration vector. The URL is format-validated (`z.string().url()`), but format validation is not safety. Mitigated in part by the `/private/` invite-only model, but the injection mechanics still need a decided isolation strategy.
+## Context
 
-Decision to record here (not yet made):
+User-supplied stylesheets — an inline-stored `AuthorStylesheet.source` (raw CSS) and a `profile.externalStylesheet` URL — are injected site-wide by stellar-ui's `StylesheetInjector`. This is a trust boundary: an unscoped sheet can break or visually hijack app chrome (hide moderation/admin controls, clickjack) or carry an exfiltration vector (`@import`, `url()`, `@font-face` firing requests to arbitrary hosts). The URL is format-validated (`z.string().url()`) and `source` is length-capped (100 KB), but neither is a safety control. The `/private/` invite-only model mitigates but does not eliminate the threat (a compromised or malicious member).
 
-- **Isolation:** how user CSS is scoped so it cannot override app chrome — a global-CSS-reset boundary (e.g. `all: revert` on a container, per MDN) around the injected sheet vs. iframe/shadow-DOM sandbox. This is the "Global SCSS/CSS reset flag" in PRD-03.
-- **Sanitization / fetch policy:** proxy + scan server-side, host allowlist, CSP `style-src`, and handling of `url()` / `@import` inside user CSS.
+The product goal is **site-wide** theming — the theme must cascade into the real DOM — which rules out sandboxing the theme away from the app.
 
-_Fill in the chosen approach and consequences once decided._
+## Decision
+
+A two-arm, defense-in-depth boundary.
+
+### Arm 1 — Isolation: a protected-chrome layer, not a sandbox
+
+User CSS is injected into the real document so theming works, but **critical app chrome** (primary navigation, staff/admin and moderation controls) is rendered inside a high-priority CSS `@layer` and/or an `all: revert` reset container that user sheets cannot override. Themeable regions accept the cascade; chrome is locked. This is the "Global SCSS/CSS reset flag" PRD-03 anticipates. A sandbox (iframe / shadow DOM) is **rejected**: it can only theme content inside the sandbox and cannot theme the app's own chrome, which defeats the feature.
+
+### Arm 2 — Sanitization & fetch: clean at ingestion, constrained at injection
+
+- **Store-time (server, the ingestion path):** `AuthorStylesheet.source` is sanitized **before it is persisted** — `@import` stripped, and `url()` / `@font-face src` constrained to an allowlist or `data:` URIs — so the stored artifact is already safe (fail-closed, matching the API's posture). `source` is treated as **plain CSS**; server-side compilation of untrusted SCSS is out of scope.
+- **Inject-time (UI + headers):** a Content-Security-Policy backstops the injector — `style-src 'unsafe-inline'` for the theme, with `img-src` / `font-src` / `connect-src` locked so any construct the store-time pass misses still cannot exfiltrate.
+- **ExternalStylesheet URL:** the same fetch constraints (host allowlist / CSP) apply; an authorless or dead external URL is a prune/investigate + link-health concern (PRD-03), not a render-time trust grant.
+
+## Consequences
+
+- **#145 changes before merge:** the AuthorStylesheet ingestion path gains a store-time CSS sanitizer; it does **not** merge storing raw `source`.
+- `source` is plain CSS at the boundary; the SCSS-vs-stored-file shape question in PRD-03 narrows to CSS-in, with any authoring-time SCSS compilation happening client-side before submission.
+- The injector spec (PRD-03 descent target #5, stellar-ui) asserts the chrome layer + CSP — the UI half of this boundary.
+- Defense-in-depth: a bypass must defeat the store-time sanitizer, the CSP, and the chrome layer together.

--- a/docs/adr/0004-standing-warnings-bans.md
+++ b/docs/adr/0004-standing-warnings-bans.md
@@ -1,15 +1,46 @@
 # Standing → CRS, and the Warning/Ban model
 
-**Status: Proposed — decision pending.** Serves [PRD-05 Rules & Governance](../prd/05-rules-and-governance.md); the CRS backbone in [PRD-01](../prd/01-Community-Score.md).
+**Status: Accepted.** Serves [PRD-05 Rules & Governance](../prd/05-rules-and-governance.md); the CRS backbone in [PRD-01](../prd/01-Community-Score.md). Computation shape follows [ADR-0007](0007-crs-read-time-and-event-ledger.md). Resolves decision [#131](https://github.com/orphic-inc/stellar-api/issues/131).
 
-Rule compliance must move a user's Community Reputation Score: pristine standing rewards ×10, and long-term poor standing (frequent warnings, ban evasion) draws a large compounding penalty — "the mighty hammer." Today the only datum is `User.warnedTimes`; there is no Warning/Ban entity, no escalation ladder, and no ban-evasion linkage.
+## Context
 
-Decision to record here (not yet finalized):
+Rule compliance must move a user's Community Reputation Score (CRS): a pristine record rewards ×10 (the strongest positive), and long-term poor standing — frequent warnings, ban evasion — draws a large compounding penalty, "the mighty hammer." The only datum today is `User.warnedTimes` alongside the `UserWarning` rows and `User.banDate`; there is no escalation-ladder entity, and no invite-tree linkage feeding standing.
 
-- **Warning/Ban model** — entities for warnings, suspensions, bans; escalation ladder; association to the GoldenRule/CommunityRule violated; ban-evasion linkage (invite-tree + account signals).
-- **Standing → CRS computation** — how rule micro-impacts + warning history compose into the standing multiplier (the ×10 pristine reward and the repeat-offender hammer curve), and whether it is computed-on-read (mirroring the ADR-0002 pulse) or event-logged.
-- **Magnitudes** — the ×10, the hammer curve, and per-rule/SubRule micro-impact weights are TBD.
+Two questions were open: the **shape of standing** (its tiers and how it is computed), and **how invite-tree health feeds it**. This ADR settles the structure; magnitudes and the fuller entity model are deferred (below).
 
-Enforcement remains [ADR-0001](0001-granular-permission-checks.md) (granular permissions); standing trend input comes from [ADR-0002](0002-community-health-pulse.md) (the pulse).
+## Decision
 
-_Fill in the chosen model + computation + consequences once decided._
+### 1. Standing is a five-rung ladder, computed on read
+
+`Standing = pristine | clean | neutral | poor | hammer`, derived by a pure function (`computeStanding`, `src/modules/standing.ts`) over a user's **active** `UserWarning` rows, ban state, and account tenure. There is no denormalized `standing` column. This follows [ADR-0007](0007-crs-read-time-and-event-ledger.md): standing is reconstructable from current state, so it is **computed on read**, never accrued.
+
+| Rung       | Meaning                                                                               |
+| ---------- | ------------------------------------------------------------------------------------- |
+| `hammer`   | Banned, **or** confirmed self ban-evasion, **or** frequent active warnings. Terminal. |
+| `poor`     | Repeated active warnings.                                                             |
+| `neutral`  | A single active warning — the ×1, no-amplification baseline.                          |
+| `clean`    | Zero active warnings, short tenure.                                                   |
+| `pristine` | Zero active warnings, long clean tenure — the ×10 reward.                             |
+
+Tenure distinguishes only the top two rungs (`clean` vs `pristine`); a single warning drops a user to `neutral` regardless of tenure. The rung set and ordering are **settled and canonical** — `Standing` is owned by `standing.ts`, and `ruleImpact()` consumes that same tier. The numeric **thresholds** (active-warning counts, the pristine tenure window) are **deferred magnitudes**: placeholders flagged in code, tuned alongside the CRS magnitudes in PRD-05.
+
+### 2. Standing scales rule impact; it does not gate
+
+`ruleImpact(outcome, weights, standing)` (`src/modules/ruleImpact.ts`) maps a rule/sub-rule's raw CRS weight through standing: good standing amplifies compliance rewards (pristine strongest), bad standing amplifies violation penalties (hammer strongest) — the downside mirror of tiering. A sub-rule's weight composes additively on its parent's. Enforcement remains [ADR-0001](0001-granular-permission-checks.md) (granular permissions); standing only moves CRS, it never gates access. Standing-trend input comes from [ADR-0002](0002-community-health-pulse.md) (the pulse).
+
+### 3. Confirmed evasion is terminal; invite-tree contagion is graded and separate
+
+The terminal-rung `banEvasion` input means **confirmed self ban-evasion** — binary, the worst standing. The broader signal — an inviter (trunk) that is infected makes their invitees (branches) _suspect_ — is **contagion**, and is deliberately **not** wired to the terminal tier. A clean user must not be auto-condemned because a distant inviter was banned long after the invite; **suspect is not condemned**. Contagion is therefore a _graded_ suspicion — a review flag plus a mild, distance-decaying CRS drag — owned by the InviteTree model ([#61](https://github.com/orphic-inc/stellar-api/issues/61)), not a Standing rung. This ADR names #61 as the source of the confirmed-evasion linkage and scopes contagion-suspicion out of the terminal tier.
+
+## Deferred (tracked, not part of this decision)
+
+- **Magnitudes** — the ×10 reward, the hammer curve, warning thresholds, and per-rule/SubRule micro-impact weights (PRD-05 open questions).
+- **The fuller Warning/Ban entity model** — suspension/ban entities and an explicit escalation ladder beyond `UserWarning` + `User.banDate`.
+- **Invite-tree contagion** (the graded suspicion above) and the **positive Invite CRS dimension** (a productive sub-tree reflecting well on the inviter) — both owned by [#61](https://github.com/orphic-inc/stellar-api/issues/61); the latter registers as a future `reputation.ts` dimension.
+
+## Consequences
+
+- The settled structure ships now (#128, #129); the constants change in lockstep with the spec, never silently.
+- `Standing` is defined once in `standing.ts`; `ruleImpact()`'s structurally-identical copy folds into an import from it once both slices are in `main`.
+- No staleness and no recompute job for standing — correctness is structural (ADR-0007).
+- `computeStanding`'s `banEvasion` seam is correct as-is: a binary, terminal, _confirmed-evasion_ input. The unfed contagion signal is new scope under #61, not a gap in this decision.


### PR DESCRIPTION
Settles the two pending decision-ADRs so their gated PRs can land. Both were `Status: Proposed — decision pending` stubs; a `/grill-with-docs` pass drove each to closure (decisions written into the ADRs in product terms; CONTEXT.md glossary extended).

## ADR-0004 — Standing → CRS, and the Warning/Ban model
- **Computation shape follows ADR-0007** (already Accepted): standing is reconstructable from current state (active `UserWarning` rows + ban state + tenure), so it is **computed on read**, never accrued. No new architectural question — cited, not re-litigated.
- **Five-rung ladder ratified:** `pristine | clean | neutral | poor | hammer`. The rung set is canonical (`standing.ts` owns it; `ruleImpact()` consumes the same tier). Numeric thresholds stay **deferred magnitudes**.
- **Confirmed self ban-evasion is terminal** (`hammer`, binary). **Invite-tree contagion is separate and graded** — an infected trunk makes branches *suspect*, not condemned — owned by #61, deliberately **not** wired to the terminal tier.
- Magnitudes + the fuller Warning/Ban entity model are deferred (tracked).
- **Unblocks #128 / #129** — their code already matches this structure.

## ADR-0003 — Stylesheet injection isolation & sanitization
- **Arm 1 — Isolation:** a **protected-chrome layer** (`@layer` + `all: revert`) so user themes cascade everywhere except critical app chrome. A sandbox (iframe / shadow DOM) is rejected — it can't theme the app's own chrome, defeating site-wide theming.
- **Arm 2 — Sanitization:** defense-in-depth — **store-time CSS sanitize at ingestion** (strip `@import`, constrain `url()` / `@font-face`) **+ inject-time CSP**.
- **Consequence for #145:** the `AuthorStylesheet` ingestion path currently stores raw `source` with no content validation; it gains a store-time sanitizer before merge.

## Glossary
CONTEXT.md gains **Standing**, **Contagion**, **Chrome Layer**.

Resolves #130, #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)