### PR TITLE
fix(security): harden cssSanitize against CSS-escape bypass

### DIFF
--- a/src/lib/cssSanitize.spec.ts
+++ b/src/lib/cssSanitize.spec.ts
@@ -61,4 +61,38 @@ describe('sanitizeStylesheetSource (ADR-0003 store-time CSS sanitizer)', () => {
     const clean = '.theme{color:#abc;margin:0}\n#nav{display:flex}';
     expect(sanitizeStylesheetSource(clean)).toBe(clean);
   });
+
+  // ─── CSS-escape bypass (#152) ───────────────────────────────────────────────
+  it('strips @import hidden behind an escaped @ (\\40 import)', () => {
+    const out = sanitizeStylesheetSource(
+      '\\40 import url("https://evil.test/x.css");\nbody{color:red}'
+    );
+    expect(out).not.toMatch(/@import/i);
+    expect(out).not.toContain('evil.test');
+    expect(out).toMatch(/body\{color:red\}/);
+  });
+
+  it('strips @import with an escaped keyword letter (@\\69mport)', () => {
+    const out = sanitizeStylesheetSource(
+      '@\\69mport url("https://evil.test/x.css");\nbody{}'
+    );
+    expect(out).not.toMatch(/@import/i);
+    expect(out).not.toContain('evil.test');
+  });
+
+  it('neutralizes a url() whose scheme is escaped (\\68 ttp:)', () => {
+    const out = sanitizeStylesheetSource(
+      'a{background:url(\\68ttp://evil.test/p.gif)}'
+    );
+    expect(out).not.toContain('evil.test');
+  });
+
+  it('reaches a fixed point when an escape decodes into another escape', () => {
+    // `\5c` → `\`, so this becomes `\40import …` then `@import …` across passes.
+    const out = sanitizeStylesheetSource(
+      '\\5c 40import url(http://evil.test/x)'
+    );
+    expect(out).not.toMatch(/@import/i);
+    expect(out).not.toContain('evil.test');
+  });
 });

--- a/src/lib/cssSanitize.ts
+++ b/src/lib/cssSanitize.ts
@@ -6,30 +6,50 @@
  * render path. This strips the constructs that turn a stylesheet into a fetch /
  * exfiltration vector:
  *
- *   - `@import` / `@charset` at-rules — removed outright (a profile theme never
- *     legitimately needs to pull another sheet).
+ *   - `@import` / `@charset` / `@namespace` at-rules — removed outright (a
+ *     profile theme never legitimately needs to pull another sheet).
  *   - `url(...)` references (including `@font-face src`) — neutralized to `url()`
  *     unless they point at a `data:` URI or a same-origin relative path. An
  *     absolute/remote/`javascript:` URL would fire a request to an arbitrary
  *     host on every render.
  *
- * Source is treated as plain CSS (ADR-0003 scopes server-side SCSS compilation
- * of untrusted input out). This is the server half of a defense-in-depth
- * boundary; the inject-time CSP (`img-src`/`font-src`/`connect-src`) and the
- * protected chrome layer are the other halves, so an escape this regex pass
- * misses still cannot exfiltrate.
+ * CSS lets these constructs hide behind **escape sequences** (`\40 import` for
+ * `@import`, `url(\68 ttp://evil)` for `http://…`), which a raw-text regex would
+ * miss while the browser's CSS parser still decodes them at render. So the source
+ * is escape-decoded before matching, and the decode→strip pass repeats to a fixed
+ * point (a decode can expose a fresh escape, e.g. `\5c` → `\`). Decoding yields
+ * equivalent CSS for the cases themes use (color/content/spacing); the rare
+ * escape-dependent identifier is an accepted trade — the inject-time CSP
+ * (`img-src`/`font-src`/`connect-src`) and the protected chrome layer remain the
+ * other halves of this defense-in-depth boundary.
+ *
+ * Source is treated as plain CSS (ADR-0003 scopes server-side SCSS compilation of
+ * untrusted input out).
  */
 
-// `@import ...;` and `@charset ...;` in any form (url(), quoted, bare).
-const AT_RULE_STRIP = /@(?:import|charset)\b[^;]*;?/gi;
+// `@import` / `@charset` / `@namespace` at-rules in any form (url(), quoted, bare).
+const AT_RULE_STRIP = /@(?:import|charset|namespace)\b[^;]*;?/gi;
 
 // `url( … )` in its three forms: double-quoted, single-quoted (quoted content
 // may legitimately contain `)`), or a bare unquoted token (no whitespace/paren).
 const URL_REF = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)\s]*))\s*\)/gi;
 
+// A CSS escape: a hex escape (1–6 hex digits, one optional trailing whitespace)
+// or a single backslash-escaped character.
+const CSS_ESCAPE = /\\([0-9a-fA-F]{1,6})[ \t\n\f\r]?|\\([^\n\f\r])/g;
+
+/** Decode CSS escape sequences to their literal characters (NUL → U+FFFD per spec). */
+const decodeCssEscapes = (value: string): string =>
+  value.replace(CSS_ESCAPE, (_match, hex: string, lit: string) => {
+    if (hex === undefined) return lit;
+    const cp = parseInt(hex, 16);
+    if (!cp || cp > 0x10ffff || (cp >= 0xd800 && cp <= 0xdfff)) return '�';
+    return String.fromCodePoint(cp);
+  });
+
 /** A url() target is safe to keep if it is a data: URI or a same-origin relative path. */
 const isSafeUrlTarget = (raw: string): boolean => {
-  const target = raw.trim();
+  const target = decodeCssEscapes(raw).trim();
   if (target === '') return true;
   if (/^data:/i.test(target)) return true;
   // Reject protocol-relative (`//host`) and any explicit scheme (`http:`,
@@ -39,14 +59,28 @@ const isSafeUrlTarget = (raw: string): boolean => {
   return true;
 };
 
-/**
- * Return a sanitized copy of a user-authored stylesheet's source, safe to
- * persist and inject. Never throws — like `sanitizeHtml`, it cleans rather than
- * rejects, so an honest author's save is not blocked by a stray reference.
- */
-export const sanitizeStylesheetSource = (source: string): string =>
-  source
+const stripOnce = (css: string): string =>
+  decodeCssEscapes(css)
     .replace(AT_RULE_STRIP, '')
     .replace(URL_REF, (match, dq: string, sq: string, bare: string) =>
       isSafeUrlTarget(dq ?? sq ?? bare ?? '') ? match : 'url()'
     );
+
+/**
+ * Return a sanitized copy of a user-authored stylesheet's source, safe to
+ * persist and inject. Never throws — like `sanitizeHtml`, it cleans rather than
+ * rejects, so an honest author's save is not blocked by a stray reference.
+ *
+ * Repeats the decode→strip pass until it stabilizes; each pass is non-increasing
+ * in length (decoding and stripping only shrink), so this terminates — the cap is
+ * a defensive backstop against pathological input.
+ */
+export const sanitizeStylesheetSource = (source: string): string => {
+  let out = source;
+  for (let i = 0; i < 8; i++) {
+    const next = stripOnce(out);
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+};


### PR DESCRIPTION
Closes #152. Follow-up to the automated security review of #145.

## Problem
`sanitizeStylesheetSource` matched `@import`/`@charset` and `url()` on the **raw** source, so CSS escape sequences slipped past while the browser's CSS parser still decodes them at render:
- `\40 import url(...)` — `\40` = `@`
- `url(\68ttp://evil.test/x)` — `\68` = `h` → `http://…`

MEDIUM severity, mitigated short-term by the ADR-0003 inject-time CSP backstop (`img-src`/`font-src`/`connect-src`) — defense-in-depth, not an unguarded hole.

## Fix
- **Escape-decode before matching**, repeated to a **fixed point** (a decode can expose a fresh escape, e.g. `\5c` → `\`). Each pass is non-increasing in length so it terminates; 8-iteration cap as a defensive backstop.
- `url()` targets are decoded before the scheme check.
- Also strips `@namespace`.
- Trade-off documented: decoding yields equivalent CSS for the cases themes use (color/content/spacing); the rare escape-dependent identifier is accepted, with CSP + the chrome layer as the other defense-in-depth halves.

## Tests
4 new escape-bypass cases (escaped `@`, escaped keyword letter, escaped url scheme, nested fixed-point) + the existing 6. Gate clean: format · lint · `tsc --noEmit` · cssSanitize/authorStylesheet suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)