### PR TITLE
docs(prd): add PRD-08 Collages & Cover Art

### DIFF
--- a/docs/prd/01-Community-Score.md
+++ b/docs/prd/01-Community-Score.md
@@ -19,6 +19,7 @@ Related PRDs
 
 - [PRD-03](03-stylesheet-themes-and-scoring.md) — stylesheet scoring is a dimension of this CRS
 - [PRD-06](06-ratio.md) — the Ratio mechanism; a derived `RatioScore` feeds this CRS (one-way)
+- [PRD-08](08-collages-and-cover-art.md) — Collage contribution weighting feeds the `ContributionScore` dimension
 
 ⸻
 
@@ -177,7 +178,7 @@ CRS is a registry of bounded, pure dimension-scorers — not a hardcoded sum.
 - Dimensions self-register. New dimensions (RatioScore, stylesheet, LinkHealthBonusPoints, IRC, Feed) slot in by adding a registry entry — never by editing the aggregator.
 - v0.0.x dimension set: Friends, Invite, Donation, Longevity.
 
-Computation: the CRS value is always computed on read (no stored, stale score column). Only events that current state cannot reconstruct — e.g. the Friends×Stylesheet adoption edges and their once-per-pair dedup — are append-only logged to a CRS_* reason on the existing EconomyTransaction ledger. Time-series snapshots (trends) are a deferred additive layer. See ADR-0007.
+Computation: the CRS value is always computed on read (no stored, stale score column). Only events that current state cannot reconstruct — e.g. the Friends×Stylesheet adoption edges and their once-per-pair dedup — are append-only logged to a CRS\_\* reason on the existing EconomyTransaction ledger. Time-series snapshots (trends) are a deferred additive layer. See ADR-0007.
 
 Ratio independence (decided)
 
@@ -454,12 +455,12 @@ Out of Scope
 - Automated weighting algorithms
 - CommunityValueIndex calculation
 
-## Future direction — making CRS *bite* (noted 2026-06-13, not scoped)
+## Future direction — making CRS _bite_ (noted 2026-06-13, not scoped)
 
-Today CRS only *accrues* — unlike the **Ratio Mechanism**, which has real teeth (gates downloads, warns, bans), the reputation dimensions (stylesheet, IRC, …) sum into a number with no monitoring, display, or downstream effect yet. Recorded so the gap is explicit, not designed:
+Today CRS only _accrues_ — unlike the **Ratio Mechanism**, which has real teeth (gates downloads, warns, bans), the reputation dimensions (stylesheet, IRC, …) sum into a number with no monitoring, display, or downstream effect yet. Recorded so the gap is explicit, not designed:
 
-- **Positive-reinforcement teeth (privilege-granting).** High reputation should *unlock capability*, not gate downloads (CRS never gates downloads — that stays the Ratio Mechanism's job). E.g. a high **IRCScore** earns rights to create official channels or moderate specific community channels (see PRD-02). This is a distinct lever from ratio enforcement.
+- **Positive-reinforcement teeth (privilege-granting).** High reputation should _unlock capability_, not gate downloads (CRS never gates downloads — that stays the Ratio Mechanism's job). E.g. a high **IRCScore** earns rights to create official channels or moderate specific community channels (see PRD-02). This is a distinct lever from ratio enforcement.
 - **Staff Toolbox.** CRS (and its dimensions) surface to staff for monitoring/triage in a **Staff Toolbox** — the display/admin surface for the whole reputation system. Out of purview today.
-- **Community Toolbox.** A forward-looking surface letting **Community Staff** manage their *own* community (a la the Community Do-Not-Contribute list) — where Community-scoped levers (the Community Stylesheet slot, channel moderation grants) would live. Much further down the path.
+- **Community Toolbox.** A forward-looking surface letting **Community Staff** manage their _own_ community (a la the Community Do-Not-Contribute list) — where Community-scoped levers (the Community Stylesheet slot, channel moderation grants) would live. Much further down the path.
 
-These are the home for the eventual "what does a score *do*" decisions; capturing them here keeps the dimension work (stylesheet #120, IRC) honest about being substrate, not yet consequence.
+These are the home for the eventual "what does a score _do_" decisions; capturing them here keeps the dimension work (stylesheet #120, IRC) honest about being substrate, not yet consequence.

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft · **Owner:** @obrien-k
 **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) · **Decisions:** [ADR-0002 community-health-pulse → CRS](../adr/0002-community-health-pulse.md) (accrual model), [ADR-0003 stylesheet injection isolation](../adr/0003-stylesheet-injection-isolation.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 Donations/IRC/Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · **PRD-03 Stylesheets** · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · PRD-06 Ratio · PRD-07 Donations · [PRD-08 Collages & Cover Art](08-collages-and-cover-art.md)
 
 > Lean PRD. Captures the decided shape + the Community-Score weights, flags TBDs, and maps each concept to existing code so this becomes a red-green descent, not greenfield. Stylesheet scoring is a **dimension of PRD-01's CRS**, not a separate score.
 
@@ -12,25 +12,25 @@ Stellar is an invite-only `/private/` community site. Users want to theme their 
 
 ## Stylesheet types
 
-| Type                                       | Meaning                                                                                                                                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Built-in / site stylesheets**            | Seeded themes: `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`. **Sublime = default/base + selectable + contest reference** (net-new authoring; reset target).                  |
-| **ExternalStylesheet**                     | A URL on the user's profile (`profile.externalStylesheet`).                                                                                                                          |
-| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` saved for others to adopt. **Many per author** (cardinality decided 2026-06-13; rank-gated *count limit* deferred). The author is a **StylesheetAuthor** — shorthand for any member who has authored one, not a distinct role. |
-| **CommunityStylesheet**                    | Community-scoped theme, set by that Community's Staff; rendered to any viewer on that community's pages. Slot deferred (TBD — tied to Contests / Community Toolbox).                  |
-| **Global SCSS/CSS reset flag**             | Per-injection boundary so a user sheet can't leak into app chrome (see ADR-0003).                                                                                                    |
+| Type                                       | Meaning                                                                                                                                                                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Built-in / site stylesheets**            | Seeded themes: `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`. **Sublime = default/base + selectable + contest reference** (net-new authoring; reset target).                                                                                           |
+| **ExternalStylesheet**                     | A URL on the user's profile (`profile.externalStylesheet`).                                                                                                                                                                                                   |
+| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` saved for others to adopt. **Many per author** (cardinality decided 2026-06-13; rank-gated _count limit_ deferred). The author is a **StylesheetAuthor** — shorthand for any member who has authored one, not a distinct role. |
+| **CommunityStylesheet**                    | Community-scoped theme, set by that Community's Staff; rendered to any viewer on that community's pages. Slot deferred (TBD — tied to Contests / Community Toolbox).                                                                                          |
+| **Global SCSS/CSS reset flag**             | Per-injection boundary so a user sheet can't leak into app chrome (see ADR-0003).                                                                                                                                                                             |
 
 ### Slots & cascade (decided 2026-06-13)
 
 A stylesheet renders by being placed into one of three single-valued **slots**, selected by **page context** — not a single global "active theme":
 
-| Slot                     | Set by                | Rendered when                                            |
-| ------------------------ | --------------------- | ------------------------------------------------------- |
-| **Profile Stylesheet**   | the profile's owner   | any viewer is on *that owner's* profile page            |
-| **Site Stylesheet**      | the viewer            | the viewer is on the general site                       |
-| **Community Stylesheet** | that Community's Staff | any viewer is on *that* community's pages                |
+| Slot                     | Set by                 | Rendered when                                |
+| ------------------------ | ---------------------- | -------------------------------------------- |
+| **Profile Stylesheet**   | the profile's owner    | any viewer is on _that owner's_ profile page |
+| **Site Stylesheet**      | the viewer             | the viewer is on the general site            |
+| **Community Stylesheet** | that Community's Staff | any viewer is on _that_ community's pages    |
 
-**Precedence is page-context-first:** a Profile or Community page shows its own slot to *every* viewer, regardless of the viewer's Site Stylesheet. On the general site the viewer sees their own Site Stylesheet, falling back to the **Site Theme** (`Sublime`/Default) when they have not adopted one. A member has exactly one stylesheet per slot.
+**Precedence is page-context-first:** a Profile or Community page shows its own slot to _every_ viewer, regardless of the viewer's Site Stylesheet. On the general site the viewer sees their own Site Stylesheet, falling back to the **Site Theme** (`Sublime`/Default) when they have not adopted one. A member has exactly one stylesheet per slot.
 
 **Only the Site Stylesheet slot scores** (a **Stylesheet Adoption**): the viewer adopting another member's AuthorStylesheet credits the author. Slotting your own sheet as your Profile Stylesheet is not an adoption. Profile-slot and Community-slot designation are **deferred** (named here, not built in #119/#120).
 
@@ -60,7 +60,7 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
 
-**Friends × Stylesheet — controlled vector (decided; not yet built — [#147](https://github.com/orphic-inc/stellar-api/issues/147)).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — *separate from and additive to* the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is the follow-up:
+**Friends × Stylesheet — controlled vector (decided; not yet built — [#147](https://github.com/orphic-inc/stellar-api/issues/147)).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — _separate from and additive to_ the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is the follow-up:
 
 - **Adopter: +0.2** (rewards active, organic curation — the adopter earns slightly more than the author, to favour participation).
 - **Author: +0.1** (recognition that someone vouched for your sheet).
@@ -100,15 +100,15 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 
 ## Concept → existing code (the descent map)
 
-| Concept                                             | Lives in                                                                                                                                            |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`           |
-| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector` |
-| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                           |
-| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102))                                               |
-| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                         |
-| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                               |
-| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                              |
+| Concept                                             | Lives in                                                                                                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`                         |
+| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector`               |
+| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                                         |
+| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102)) |
+| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                                       |
+| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                                             |
+| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                                            |
 
 ## Out of scope (other PRDs)
 
@@ -122,11 +122,13 @@ First testable slices (much of the substrate already exists):
 2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
 3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
 4. **AuthorStylesheet save → adopt → score** (the keystone — wires shipped `scoreStylesheetSelection` #84 to a real event). Three slices:
+
    - **4a save (#118, ✅ shipped):** `AuthorStylesheet` model + `POST`/`GET /api/stylesheet/author`.
    - **4b adopt (#119, ✅ shipped):** many-per-author (cardinality fixed here — `@unique authorId` dropped); a viewer adopts a sheet into their **Site Stylesheet** slot (`UserSettings.activeAuthorStylesheetId`) via `POST /api/stylesheet/author-stylesheet/:id/adopt`, idempotent.
    - **4c score (#120, ✅ shipped):** adoption fires `scoreStylesheetSelection`; non-self adoptions write a `CRS_STYLESHEET_ADOPTION` ledger row deduped **once per (adopter, author)** (ADR-0007), and a read-time **stylesheet** CRS dimension counts them → author's global CRS. Self-adoption renders, earns nothing.
 
-   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension — the §"Friends × Stylesheet" decision; the `CRS_STYLESHEET_ADOPTION` ledger built here is its substrate, but the second Friends-dimension accrual is not yet wired — [#147](https://github.com/orphic-inc/stellar-api/issues/147)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — *ADR-when-built*: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension — the §"Friends × Stylesheet" decision; the `CRS_STYLESHEET_ADOPTION` ledger built here is its substrate, but the second Friends-dimension accrual is not yet wired — [#147](https://github.com/orphic-inc/stellar-api/issues/147)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — _ADR-when-built_: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions

--- a/docs/prd/08-collages-and-cover-art.md
+++ b/docs/prd/08-collages-and-cover-art.md
@@ -1,0 +1,64 @@
+# PRD-08 — Collages & Cover Art
+
+**Status:** Draft · **Owner:** @obrien-k
+**Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md) (contribution weighting) · **Relates:** [PRD-03 Stylesheets](03-stylesheet-themes-and-scoring.md) (CommunityStylesheet ↔ Collage/Contest), [PRD-04 Contribution/Release/Music](04-contribution-release-music.md) (Edition/lossless model — forthcoming)
+**Decisions:** stellar-ui [ADR-0001 Injected Theme Contract](../../../stellar-ui/docs/adr/0001-injected-theme-contract.md) (the `data-st` / `--st-*` contract the Collage surface targets)
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · PRD-06 Ratio · PRD-07 Donations · **PRD-08 Collages & Cover Art**
+
+> Lean PRD. Captures the decided shape of a Collage surface, anchored to a **measured corpus** rather than a greenfield guess, and maps each concept to existing code so this is a red-green descent.
+
+## Problem
+
+A Collage groups Releases around a theme (a label's roster, a forum thread, a chart). Today's `stellar-ui` `CollageDetail` renders a flat list — title + artist + "added by" — which throws away most of what makes a Collage worth building: the Edition richness of each Release, who actually carried the curation, and Cover Art as a browsable surface. We need a decided shape for the Collage surface and how its activity feeds the CRS.
+
+## Wireframe corpus (source of truth)
+
+The field inventory and the activity model are **not invented here** — they're reduced from two real, fully-built reference collages (269 + 330 Releases, 1370 + 593 Editions) parsed into:
+
+- `stellar-ui/docs/data/collage-corpus.json` — every Release + Edition + contributor + comment
+- `stellar-ui/docs/data/collage-analysis.json` — format/category histograms, lossless %, contributor weight-share
+- `stellar-ui/docs/data/README.md` — the source→Stellar field map + the three load-bearing patterns
+
+Three patterns the corpus makes non-negotiable:
+
+1. **A Release is a stack of Editions** (format / encoding / media), with **lossless** as the headline quality axis. The Collage row must disclose this, not collapse it. _(Edition model: PRD-04.)_
+2. **Contribution is power-law.** Every healthy Collage has one or two curators carrying the bulk (one curator 261/330 ≈ 88%; another 90/126 ≈ 71%) over a long tail. The surface must credit **both** — and this weight is exactly the contribution signal **[PRD-01 CRS](01-Community-Score.md)** rewards (`ContributionScore` dimension).
+3. **Discussion is part of the artifact.** Comments are where CommunityLeaders/CommunityStaff curate and report; they carry activity weight alongside entry contributions.
+
+## Collage categories (existing)
+
+`stellar-ui` already enumerates them (`CollageDetail.tsx`): `0` Personal · `1` Theme/Genre · `2` Discography · `3` Label · `4` Charts · `5` Staff Picks · `6` Other. Category `0` (Personal) and locked state already gate entry management — keep.
+
+## Scope
+
+**Cover Art** — first-class weighted mosaic (lead cell may span), not a 12-thumb strip; scroll-to-Release on click (already stubbed). Hook: `[data-st="coverart-*"]`.
+**Collage detail** — Release rows that disclose an **Edition stack** with lossless emphasis; **Top Contributors** box with weight bars; computed **Top Artists / Top Tags** rollups; optional **Collector** (download-in-preferred-format) affordance. Hooks: `[data-st="release-*" | "edition-*" | "contributor-*" | "rollup" | "collector"]`.
+**Activity → CRS** — Collage entry-adds + comments accrue to the contributor's `ContributionScore` (PRD-01), weighted by the power-law share above. Exact weights: TBD with PRD-01.
+
+## Concept → existing code (the descent map)
+
+| Concept                        | Lives in                                                                                                                                                       |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Collage CRUD / entries / subs  | `stellar-api` collage routes; `stellar-ui` `collageApi.ts`, `components/collages/`                                                                             |
+| Collage detail surface         | `stellar-ui` `CollageDetail.tsx` (flat today — the gap)                                                                                                        |
+| **Edition / lossless model**   | **PRD-04** (Contribution/Release/Music) — net-new                                                                                                              |
+| Contribution weighting → CRS   | [PRD-01](01-Community-Score.md) `ContributionScore`, `statsHistory.ts`                                                                                         |
+| Theme contract for the surface | stellar-ui [ADR-0001](../../../stellar-ui/docs/adr/0001-injected-theme-contract.md), `src/stylesheets/common/global.css` (`data-st` hooks seeded for this PRD) |
+| CommunityStylesheet ↔ Collage | [PRD-03](03-stylesheet-themes-and-scoring.md) (CommunityStylesheet is "Community-scoped theme — tied to Contests")                                             |
+| Comments                       | `stellar-ui` `CommentsSection`                                                                                                                                 |
+
+## Red-green descent targets
+
+1. **Cover-art mosaic** — weighted grid against `[data-st="coverart-*"]` (UI-only; data already present).
+2. **Edition disclosure** — Release row → Edition stack; needs the PRD-04 Edition shape on the API.
+3. **Top Contributors weighting** — compute per-contributor entry share; render weight bars (`[data-st="contributor-*"]`); same number that feeds PRD-01 CRS.
+4. **Computed rollups** — Top Artists / Top Tags on read (mirror the reference layout's boxes).
+
+## Open questions
+
+- Edition/lossless model ownership — **PRD-04**; this PRD consumes it, doesn't define it.
+- Contributor-weight → `ContributionScore` exact weighting — **with PRD-01**.
+- Is `Collector` (bulk download in preferred format) in scope v1, or deferred?
+- CommunityStylesheet scoping to a Collage/Contest — **with PRD-03**.
+
+**Resolved:** the surface targets the `data-st`/`--st-*` contract (ADR-0001), not Tailwind overrides · the field inventory + activity model come from the measured corpus, not greenfield.


### PR DESCRIPTION
## What

Adds the **PRD-08 Collages & Cover Art** design doc and cross-links it from the CRS (PRD-01) and stylesheet (PRD-03) PRDs.

This is the recovery of the stale `docs/prd-05-collages-and-cover-art` branch (79 commits behind `main`, and bundling an already-merged `#78` requestId fix). Rebuilt clean off current `main`:

- **Renumbered 05 → 08** to clear the collision with the live PRD-05 "Rules & Governance".
- **Scrubbed legacy-software references** out of the corpus prose into neutral product terms (per the no-legacy-references convention); corpus facts/numbers preserved.
- **Dropped** the redundant `#78` requestId commit — `src/types/express.d.ts` already carries `requestId?` on `main`.
- Brought PRD-03's stale `Numbering:` line up to the current scheme.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)