### PR TITLE
docs(prd): normalize numbering lines across all PRDs + fix stale Donations refs

### DIFF
--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -12,25 +12,25 @@ Stellar is an invite-only `/private/` community site. Users want to theme their 
 
 ## Stylesheet types
 
-| Type                                       | Meaning                                                                                                                                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Built-in / site stylesheets**            | Seeded themes: `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`. **Sublime = default/base + selectable + contest reference** (net-new authoring; reset target).                  |
-| **ExternalStylesheet**                     | A URL on the user's profile (`profile.externalStylesheet`).                                                                                                                          |
-| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` saved for others to adopt. **Many per author** (cardinality decided 2026-06-13; rank-gated *count limit* deferred). The author is a **StylesheetAuthor** — shorthand for any member who has authored one, not a distinct role. |
-| **CommunityStylesheet**                    | Community-scoped theme, set by that Community's Staff; rendered to any viewer on that community's pages. Slot deferred (TBD — tied to Contests / Community Toolbox).                  |
-| **Global SCSS/CSS reset flag**             | Per-injection boundary so a user sheet can't leak into app chrome (see ADR-0003).                                                                                                    |
+| Type                                       | Meaning                                                                                                                                                                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Built-in / site stylesheets**            | Seeded themes: `kuro`, `layer-cake`, `postmod`, `proton`, `sublime`. **Sublime = default/base + selectable + contest reference** (net-new authoring; reset target).                                                                                           |
+| **ExternalStylesheet**                     | A URL on the user's profile (`profile.externalStylesheet`).                                                                                                                                                                                                   |
+| **AuthorStylesheet / AuthorStylesheetUrl** | A user-authored `.scss`/`.css` saved for others to adopt. **Many per author** (cardinality decided 2026-06-13; rank-gated _count limit_ deferred). The author is a **StylesheetAuthor** — shorthand for any member who has authored one, not a distinct role. |
+| **CommunityStylesheet**                    | Community-scoped theme, set by that Community's Staff; rendered to any viewer on that community's pages. Slot deferred (TBD — tied to Contests / Community Toolbox).                                                                                          |
+| **Global SCSS/CSS reset flag**             | Per-injection boundary so a user sheet can't leak into app chrome (see ADR-0003).                                                                                                                                                                             |
 
 ### Slots & cascade (decided 2026-06-13)
 
 A stylesheet renders by being placed into one of three single-valued **slots**, selected by **page context** — not a single global "active theme":
 
-| Slot                     | Set by                | Rendered when                                            |
-| ------------------------ | --------------------- | ------------------------------------------------------- |
-| **Profile Stylesheet**   | the profile's owner   | any viewer is on *that owner's* profile page            |
-| **Site Stylesheet**      | the viewer            | the viewer is on the general site                       |
-| **Community Stylesheet** | that Community's Staff | any viewer is on *that* community's pages                |
+| Slot                     | Set by                 | Rendered when                                |
+| ------------------------ | ---------------------- | -------------------------------------------- |
+| **Profile Stylesheet**   | the profile's owner    | any viewer is on _that owner's_ profile page |
+| **Site Stylesheet**      | the viewer             | the viewer is on the general site            |
+| **Community Stylesheet** | that Community's Staff | any viewer is on _that_ community's pages    |
 
-**Precedence is page-context-first:** a Profile or Community page shows its own slot to *every* viewer, regardless of the viewer's Site Stylesheet. On the general site the viewer sees their own Site Stylesheet, falling back to the **Site Theme** (`Sublime`/Default) when they have not adopted one. A member has exactly one stylesheet per slot.
+**Precedence is page-context-first:** a Profile or Community page shows its own slot to _every_ viewer, regardless of the viewer's Site Stylesheet. On the general site the viewer sees their own Site Stylesheet, falling back to the **Site Theme** (`Sublime`/Default) when they have not adopted one. A member has exactly one stylesheet per slot.
 
 **Only the Site Stylesheet slot scores** (a **Stylesheet Adoption**): the viewer adopting another member's AuthorStylesheet credits the author. Slotting your own sheet as your Profile Stylesheet is not an adoption. Profile-slot and Community-slot designation are **deferred** (named here, not built in #119/#120).
 
@@ -60,7 +60,7 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
 
-**Friends × Stylesheet — controlled vector (decided; not yet built — [#147](https://github.com/orphic-inc/stellar-api/issues/147)).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — *separate from and additive to* the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is the follow-up:
+**Friends × Stylesheet — controlled vector (decided; not yet built — [#147](https://github.com/orphic-inc/stellar-api/issues/147)).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — _separate from and additive to_ the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is the follow-up:
 
 - **Adopter: +0.2** (rewards active, organic curation — the adopter earns slightly more than the author, to favour participation).
 - **Author: +0.1** (recognition that someone vouched for your sheet).
@@ -96,23 +96,23 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 
 ## Donor add-ons
 
-**$tylesheets — donor-added slots**: donors unlock additional stylesheet slots (ties to PRD-02 Donations / `donor.ts`).
+**$tylesheets — donor-added slots**: donors unlock additional stylesheet slots (ties to PRD-07 Donations / `donor.ts`).
 
 ## Concept → existing code (the descent map)
 
-| Concept                                             | Lives in                                                                                                                                            |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`           |
-| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector` |
-| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                           |
-| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102))                                               |
-| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                         |
-| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                               |
-| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                              |
+| Concept                                             | Lives in                                                                                                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CRS / CommunityScore                                | [PRD-01](01-Community-Score.md), [#75](https://github.com/orphic-inc/stellar-api/issues/75), `statsHistory.ts`, `getCommunityHealthPulse`                         |
+| Stylesheet model + admin                            | `schemas/stylesheet.ts`, `schemas/profile.ts`, [#34](https://github.com/orphic-inc/stellar-api/issues/34) (closed), stellar-ui `StylesheetInjector`               |
+| LinkHealth + bonus                                  | `linkHealth.ts`, `linkHealthJob.ts`, branch `feat/community-health-pulse`                                                                                         |
+| ContributionScore / quality                         | [#76](https://github.com/orphic-inc/stellar-api/issues/76), branch `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102)) |
+| AccountingLedger / ratio                            | `ratio.ts`, `ratioPolicy.ts`, BigInt sizeInBytes ([#81](https://github.com/orphic-inc/stellar-api/pull/81))                                                       |
+| Top10 / Wiki / Announce                             | `top10.ts`, wiki workbench, `schemas/announcement.ts`                                                                                                             |
+| **AuthorStylesheetUrl, IRC scoring, exact weights** | **net-new** (this PRD)                                                                                                                                            |
 
 ## Out of scope (other PRDs)
 
-- LinkHealth lifecycle (cron/flapping/72h/sweep), MusicModel, Donations/IRC scoring → covered by PRD-01 (CRS dimensions), PRD-02, PRD-04. Referenced here only where they feed stylesheet scoring.
+- LinkHealth lifecycle (cron/flapping/72h/sweep), MusicModel, Donations/IRC scoring → covered by PRD-01 (CRS dimensions), PRD-02 (IRC), PRD-04, PRD-07 (Donations). Referenced here only where they feed stylesheet scoring.
 
 ## Red-green descent targets
 
@@ -122,11 +122,13 @@ First testable slices (much of the substrate already exists):
 2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
 3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
 4. **AuthorStylesheet save → adopt → score** (the keystone — wires shipped `scoreStylesheetSelection` #84 to a real event). Three slices:
+
    - **4a save (#118, ✅ shipped):** `AuthorStylesheet` model + `POST`/`GET /api/stylesheet/author`.
    - **4b adopt (#119, ✅ shipped):** many-per-author (cardinality fixed here — `@unique authorId` dropped); a viewer adopts a sheet into their **Site Stylesheet** slot (`UserSettings.activeAuthorStylesheetId`) via `POST /api/stylesheet/author-stylesheet/:id/adopt`, idempotent.
    - **4c score (#120, ✅ shipped):** adoption fires `scoreStylesheetSelection`; non-self adoptions write a `CRS_STYLESHEET_ADOPTION` ledger row deduped **once per (adopter, author)** (ADR-0007), and a read-time **stylesheet** CRS dimension counts them → author's global CRS. Self-adoption renders, earns nothing.
 
-   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension — the §"Friends × Stylesheet" decision; the `CRS_STYLESHEET_ADOPTION` ledger built here is its substrate, but the second Friends-dimension accrual is not yet wired — [#147](https://github.com/orphic-inc/stellar-api/issues/147)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — *ADR-when-built*: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension — the §"Friends × Stylesheet" decision; the `CRS_STYLESHEET_ADOPTION` ledger built here is its substrate, but the second Friends-dimension accrual is not yet wired — [#147](https://github.com/orphic-inc/stellar-api/issues/147)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — _ADR-when-built_: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 
 ## Open questions

--- a/docs/prd/04-contribution-release-music.md
+++ b/docs/prd/04-contribution-release-music.md
@@ -1,7 +1,7 @@
 # PRD-04 — Contribution, Release & Music Model
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · **PRD-04 Contribution/Release/Music**
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · **PRD-04 Contribution/Release/Music** · PRD-05 Rules & Governance · PRD-06 Ratio · PRD-07 Donations · PRD-08 Collages & Cover Art
 
 > Lean PRD. The structured model has **landed on `main`** (#85 music model + ReleaseArtist/Edition, merged via #98 — `develop` retired in the [ADR-0010](../adr/0010-trunk-based-single-branch-workflow.md) trunk fold), with per-file rip metadata split out to a `ReleaseFile` satellite ([ADR-0008](../adr/0008-contribution-metadata-satellites.md)). The quality grade landed on `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86). This documents the model + CRS weighting and flags TBDs. Prod is pre-alpha with disposable data, so the model was migrated destructively (no backfill).
 
@@ -38,7 +38,7 @@ Contributions/Releases are a **primary lifetime-CRS driver** — `downloads.ts`,
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Release / Edition / ReleaseArtist / ArtistRole | `feat/music-model-edition-tier` (#85) — landed on `main` via #98                                                                     |
 | ReleaseFile (per-file rip metadata)            | `schema.prisma` + migration `20260609171357_music_model_release_files` — [ADR-0008](../adr/0008-contribution-metadata-satellites.md) |
-| Contribution quality grade                     | `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86) — `gradeContribution`  |
+| Contribution quality grade                     | `feat/contribution-quality-grade` ([#102](https://github.com/orphic-inc/stellar-api/pull/102), supersedes #86) — `gradeContribution` |
 | Release editing surface                        | `releaseWorkbench/*`                                                                                                                 |
 | Contribution create + accounting               | `contribution.ts`, `downloads.ts`, `ratio.ts`, sizeInBytes BigInt (#81)                                                              |
 

--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
 **Decisions:** [ADR-0001 granular permissions](../adr/0001-granular-permission-checks.md) (enforcement), [ADR-0002 community-health-pulse](../adr/0002-community-health-pulse.md) (standing trend), [ADR-0004 standing → CRS + warnings/bans](../adr/0004-standing-warnings-bans.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance**
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance** · PRD-06 Ratio · PRD-07 Donations · PRD-08 Collages & Cover Art
 
 > The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose (that lives in `RulesPage`).
 

--- a/docs/prd/06-ratio.md
+++ b/docs/prd/06-ratio.md
@@ -2,7 +2,8 @@
 
 **Status:** Draft · **Owner:** @obrien-k
 **Decisions:** [ADR-0006 LinkHealth-gated ratio relief](../adr/0006-linkhealth-gated-ratio-relief.md)
-**Feeds:** [PRD-01 Community-Score / CRS](01-Community-Score.md) — a derived `RatioScore` is one CRS/CVI dimension; the ratio *mechanism* itself is independent of CRS.
+**Feeds:** [PRD-01 Community-Score / CRS](01-Community-Score.md) — a derived `RatioScore` is one CRS/CVI dimension; the ratio _mechanism_ itself is independent of CRS.
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · **PRD-06 Ratio** · PRD-07 Donations · PRD-08 Collages & Cover Art
 
 > Lean PRD. Captures the ratio mechanism as it should be, maps each piece to existing code, and flags the overhaul. Ratio is an **enforcement** mechanism (download gate); CRS is a **reputation** signal. They are layered one-way: a `RatioScore` flows into CRS; CRS never gates downloads and ratio never reads CRS.
 
@@ -10,24 +11,24 @@
 
 Stellar's required-ratio model follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)) but is incomplete. That model's required ratio depends on three pillars — **downloaded amount**, **how many things you're seeding**, and **how long they've stayed available over the trailing window** (effectively seeded if available ≥ 72h in the past 7 days). The formula was `maximum required ratio × (1 − X)`.
 
-`src/modules/ratio.ts` captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The *seeding / ongoing-availability* pillar is missing.
+`src/modules/ratio.ts` captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The _seeding / ongoing-availability_ pillar is missing.
 
 ## The seeding analog: LinkHealth
 
 Stellar has no peer-to-peer transfers — contributions are hosted links. `downloads.ts` credits a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**:
 
-| Reference model | Stellar |
-| --- | --- |
-| Seeding a release | A contribution whose link is reachable (`linkStatus = PASS`) |
-| Effectively seeded (available ≥72h/7d) | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh) |
-| Stopped seeding → lose relief | Link `FAIL` → contribution drops from the relief pool |
-| Uploaded bytes (others snatched) | `User.contributed` (others downloaded from you) — permanent, never clawed back |
+| Reference model                        | Stellar                                                                        |
+| -------------------------------------- | ------------------------------------------------------------------------------ |
+| Seeding a release                      | A contribution whose link is reachable (`linkStatus = PASS`)                   |
+| Effectively seeded (available ≥72h/7d) | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh)                       |
+| Stopped seeding → lose relief          | Link `FAIL` → contribution drops from the relief pool                          |
+| Uploaded bytes (others snatched)       | `User.contributed` (others downloaded from you) — permanent, never clawed back |
 
 ## Mechanism
 
 ### Required ratio (unchanged shape, gated relief)
 
-- **Download brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). *Bracket values are tuning; current table assumed settled, flagged for review.*
+- **Download brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). _Bracket values are tuning; current table assumed settled, flagged for review._
 - **Formula:** `requiredRatio = max(minRequired, maxRequired × (1 − coverage))`.
 - **Coverage (the overhaul):** `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` sums a user's staff-approved, 72h-old contribution bytes **whose current `linkStatus ≠ FAIL`**. See [ADR-0006](../adr/0006-linkhealth-gated-ratio-relief.md):
   - `FAIL` revokes relief (required ratio can rise as links rot).
@@ -41,19 +42,19 @@ Stellar has no peer-to-peer transfers — contributions are hosted links. `downl
 
 ### Concepts from the reference model not yet modelled (flagged)
 
-- **Seeding *count*** (the reference factors how many releases you seed, not just bytes) — out of scope for v1; byte-coverage is the lever.
+- **Seeding _count_** (the reference factors how many releases you seed, not just bytes) — out of scope for v1; byte-coverage is the lever.
 - **Freeleech / neutral-leech** (download without ratio impact) — a tracker feature; separate concern, not in this overhaul.
 
 ## Concept → existing code (the descent map)
 
-| Concept | Lives in |
-| --- | --- |
-| Ratio + required-ratio + brackets | `src/modules/ratio.ts` |
-| Policy state machine | `src/modules/ratioPolicy.ts` |
-| `contributed` credit (seeding-snatch analog) | `src/modules/downloads.ts` |
-| LinkHealth status + 24h recheck + 72h sweep | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts` |
-| Ratio surface | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
-| Lifetime uptime (CRS, not ratio) | deferred — `LinkHealthBonusPoints` dimension, PRD-01 |
+| Concept                                      | Lives in                                                                           |
+| -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Ratio + required-ratio + brackets            | `src/modules/ratio.ts`                                                             |
+| Policy state machine                         | `src/modules/ratioPolicy.ts`                                                       |
+| `contributed` credit (seeding-snatch analog) | `src/modules/downloads.ts`                                                         |
+| LinkHealth status + 24h recheck + 72h sweep  | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts`                        |
+| Ratio surface                                | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
+| Lifetime uptime (CRS, not ratio)             | deferred — `LinkHealthBonusPoints` dimension, PRD-01                               |
 
 ## Red-green descent targets
 


### PR DESCRIPTION
## What

Finishes the PRD-numbering sweep started by #156 (Donations→07) and #157 (Collages→08). The per-PRD `Numbering:` mini-index had drifted — several files still listed an older, shorter scheme, and one had none at all.

## Changes

- **PRD-04, PRD-05** — extend the `Numbering:` line through PRD-06/07/08.
- **PRD-06** — add a `Numbering:` line (it had none).
- **PRD-03** — repoint two stale Donations cross-refs (donor slots, out-of-scope list) from PRD-02 → PRD-07.

PRD-03's own `Numbering:` line and the ADR-0013 PRD ref are intentionally left to #157 / #156, which already own those exact lines (avoids a same-line rebase conflict).

Docs-only.

## Merge note

Stacks logically on #156 + #157, but touches disjoint lines, so merge order doesn't matter. The 07/08 labels are plain text (no links) so nothing dangles before #156/#157 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)