### PR TITLE
docs(changelog): catch [Unreleased] up to post-v0.5.4 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,26 @@ All notable changes to stellar-api are documented here.
 - `GET /health` now reports the running API `version`, sourced from the manifest via `lib/version.ts`.
 - **IRC reputation via korin.pink** — `User.ircNick` (unique, nullable) links a Stellar account to an Ergo nick through `PUT /api/users/:id/irc-nick` (self or admin; 409 on conflict). The IRCScore CRS dimension (`activity × consistency × channelQuality`, cap 6) is computed read-time from metrics polled from the external korin.pink irc-bridge — `src/modules/irc.ts` client + `src/modules/ircJob.ts` poll job (default 5 min via `KORIN_POLL_INTERVAL_MS`; inert when `KORIN_API_URL`/`KORIN_PULL_KEY` are unset). This **supersedes and removes the in-repo IRC build** (delegated Ergo SASL callback, `IrcActivity` rollup, per-user IRC/Announce keys) [ADR-0013].
 - `prisma/scripts/seed-wiki-irc-community.ts` — seeds 6 korin.pink IRC community wiki pages (intro, overview, connecting, channel directory, etiquette, IRCScore). Idempotent; skips existing slugs. Run: `npm run db:seed-wiki`.
+- **Authored stylesheets** — members can save a named `AuthorStylesheet` [#118] and adopt another member's sheet, crediting the author through a deduped CRS accrual (one credit per distinct adopter→author pair, enforced by a partial unique index) [#119, #120].
+- **Governance model (PRD-05)** — a composable `Rule`/`SubRule` tree with per-node compliance/violation weights plus a pure, table-driven `ruleImpact()` scorer (`GET /api/rules/tree`) [#123]; and a read-time `computeStanding()` that rolls active `UserWarning` rows + ban state into a 5-tier standing surfaced on the profile [#124, ADR-0004].
+- **Invite tree** — an adjacency model with recursive subtree read, exposed per member at `GET /api/users/:id/invite-tree` returning `{ tree, summary }`: recursive nodes (per-node ratio stats, donor/disabled/depth) and a rollup summary (entries, branches, depth, by-rank counts, totals) [#61].
 
 ### Fixed
 
 - OpenAPI `info.version` is now derived from the manifest (`lib/version.ts`) instead of a hardcoded `0.1.0` — the Swagger doc was advertising a version three minor releases stale.
+
+### Security
+
+- Hardened `cssSanitize` against a CSS-escape bypass on stored `AuthorStylesheet` content — escaped sequences could smuggle past the store-time sanitizer [#152].
+
+### Docs
+
+- Accepted **ADR-0003** (stylesheet injection isolation) and **ADR-0004** (standing → CRS).
+- Split Donations into its own **PRD-07** and added **PRD-08** (Collages & Cover Art); normalized the per-PRD numbering index across all PRDs; added a prose-conventions section to `docs/home.md`.
+
+### Internal
+
+- Widened `format`/`lint` to cover `prisma/**/*.ts`.
 
 ---
 


### PR DESCRIPTION
## What

CHANGELOG `[Unreleased]` had drifted — it captured only the IRC/korin and contribution-parity slices. This brings it current with everything merged to `main` since the v0.5.4 release:

### Added
- **Authored stylesheets** — save a named `AuthorStylesheet` (#118); adopt another member's sheet → deduped CRS accrual via partial unique index (#119/#120).
- **Governance (PRD-05)** — `Rule`/`SubRule` model + pure `ruleImpact()` (#123); read-time `computeStanding()` over `UserWarning` + ban state (#124, ADR-0004).
- **Invite tree** — adjacency model + per-member subtree `GET /users/:id/invite-tree` → `{ tree, summary }` (#61).

### Security
- `cssSanitize` CSS-escape bypass hardening (#152).

### Docs
- ADR-0003/0004 accepted; Donations split to PRD-07 + PRD-08 Collages added; PRD numbering normalized; prose-conventions section.

**No tag cut** — `[Unreleased]` only, per the sweep decision. A v0.5.5/v0.6.0 cut is left as a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)