### PR TITLE
feat(community-health): persist link-health pulse as a time-series snapshot (#75)

### DIFF
--- a/prisma/migrations/20260616130000_community_health_snapshot/migration.sql
+++ b/prisma/migrations/20260616130000_community_health_snapshot/migration.sql
@@ -1,0 +1,29 @@
+-- #75: persist the community link-health pulse as a time-series snapshot,
+-- mirroring user_stat_snapshots / site_stat_snapshots. Reuses the existing
+-- "StatSnapshotPeriod" enum (Daily/Monthly/Yearly).
+CREATE TABLE "community_health_snapshots" (
+    "id" SERIAL NOT NULL,
+    "communityId" INTEGER NOT NULL,
+    "period" "StatSnapshotPeriod" NOT NULL,
+    "bucketAt" TIMESTAMP(3) NOT NULL,
+    "capturedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "pass" INTEGER NOT NULL DEFAULT 0,
+    "warn" INTEGER NOT NULL DEFAULT 0,
+    "fail" INTEGER NOT NULL DEFAULT 0,
+    "unknown" INTEGER NOT NULL DEFAULT 0,
+    "total" INTEGER NOT NULL DEFAULT 0,
+    "checked" INTEGER NOT NULL DEFAULT 0,
+    "coverage" DOUBLE PRECISION,
+    "pulse" DOUBLE PRECISION,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "community_health_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- One snapshot per (community, period, bucket); the capture is idempotent.
+CREATE UNIQUE INDEX "community_health_snapshots_communityId_period_bucketAt_key" ON "community_health_snapshots"("communityId", "period", "bucketAt");
+
+-- Trend reads: a community's history within a period, oldest-first.
+CREATE INDEX "community_health_snapshots_communityId_period_capturedAt_idx" ON "community_health_snapshots"("communityId", "period", "capturedAt");
+
+ALTER TABLE "community_health_snapshots" ADD CONSTRAINT "community_health_snapshots_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "communities"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -887,6 +887,7 @@ model Community {
   createdAt             DateTime            @default(now())
   updatedAt             DateTime            @updatedAt
   Request               Request[]
+  healthSnapshots       CommunityHealthSnapshot[]
 
   @@map("communities")
 }
@@ -2330,6 +2331,33 @@ model SiteStatSnapshot {
 
   @@index([capturedAt])
   @@map("site_stat_snapshots")
+}
+
+model CommunityHealthSnapshot {
+  id          Int                @id @default(autoincrement())
+  communityId Int
+  period      StatSnapshotPeriod
+  bucketAt    DateTime
+  capturedAt  DateTime           @default(now())
+  pass        Int                @default(0)
+  warn        Int                @default(0)
+  fail        Int                @default(0)
+  unknown     Int                @default(0)
+  total       Int                @default(0)
+  checked     Int                @default(0)
+  // Share of links definitively probed, and share of probed that PASS — both
+  // nullable, mirroring the read-time pulse shape (null when empty/unprobed).
+  coverage    Float?
+  pulse       Float?
+  // The band as computed at capture time (Healthy/Ailing/Critical/Unknown).
+  // Stored, not recomputed, so history is stable against threshold changes.
+  status      String
+
+  community Community @relation(fields: [communityId], references: [id], onDelete: Cascade)
+
+  @@unique([communityId, period, bucketAt])
+  @@index([communityId, period, capturedAt])
+  @@map("community_health_snapshots")
 }
 
 // ─── Dev Tools ────────────────────────────────────────────────────────────────

--- a/src/communities.spec.ts
+++ b/src/communities.spec.ts
@@ -166,6 +166,86 @@ describe('GET /api/communities/:id/health', () => {
   });
 });
 
+describe('GET /api/communities/:id/health/history', () => {
+  it('returns 404 when the community does not exist', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/communities/1/health/history');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the pulse history for a member (default period Daily)', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.communityHealthSnapshot.findMany.mockResolvedValue([
+      {
+        id: 1,
+        communityId: 1,
+        period: 'Daily',
+        bucketAt: new Date('2026-06-16T00:00:00Z'),
+        capturedAt: new Date('2026-06-16T00:00:00Z'),
+        pass: 9,
+        warn: 0,
+        fail: 1,
+        unknown: 0,
+        total: 10,
+        checked: 10,
+        coverage: 1,
+        pulse: 0.9,
+        status: 'Healthy'
+      }
+    ] as never);
+
+    const res = await request(app).get('/api/communities/1/health/history');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ status: 'Healthy', pulse: 0.9 });
+    expect(prismaMock.communityHealthSnapshot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { communityId: 1, period: 'Daily' }
+      })
+    );
+  });
+
+  it('passes a valid period through to the query', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.communityHealthSnapshot.findMany.mockResolvedValue([] as never);
+
+    const res = await request(app).get(
+      '/api/communities/1/health/history?period=Monthly'
+    );
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.communityHealthSnapshot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { communityId: 1, period: 'Monthly' }
+      })
+    );
+  });
+
+  it('rejects an invalid period with 400', async () => {
+    const res = await request(app).get(
+      '/api/communities/1/health/history?period=Hourly'
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when the user is not a member of a restricted community', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ registrationStatus: RegistrationStatus.invite }) as never
+    );
+    prismaMock.consumer.findFirst.mockResolvedValue(null);
+    prismaMock.contributor.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/communities/1/health/history');
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.communityHealthSnapshot.findMany).not.toHaveBeenCalled();
+  });
+});
+
 describe('POST /api/communities/:id/members', () => {
   it('returns 404 when the community does not exist', async () => {
     prismaMock.community.findUnique.mockResolvedValue(null);

--- a/src/communityHealthHistory.spec.ts
+++ b/src/communityHealthHistory.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the community-health snapshot module (#75) — verifies the
+ * capture folds raw per-(community, status) counts into a banded pulse via the
+ * real `computePulse`, writes idempotently, and prunes by retention; and that
+ * the history query reads oldest-first. Prisma is mocked; `computePulse`,
+ * `getBucket`, and `getRetentionCutoff` run for real.
+ */
+
+import { mockDeep, mockReset } from 'jest-mock-extended';
+import type { PrismaClient } from '@prisma/client';
+
+const prismaMock = mockDeep<PrismaClient>();
+jest.mock('./lib/prisma', () => ({ prisma: prismaMock }));
+
+jest.mock('./modules/logging', () => ({
+  getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+}));
+
+import {
+  captureCommunityHealth,
+  getCommunityHealthHistory
+} from './modules/communityHealthHistory';
+
+beforeEach(() => mockReset(prismaMock));
+
+// ─── captureCommunityHealth ───────────────────────────────────────────────────
+
+describe('captureCommunityHealth', () => {
+  it('folds counts into a banded pulse, writes with skipDuplicates, prunes by period', async () => {
+    // Community 1: 9 PASS / 1 FAIL → Healthy. Community 2: 1 PASS / 9 UNKNOWN →
+    // pulse 1.0 but coverage 0.1 < floor → Unknown.
+    prismaMock.$queryRaw.mockResolvedValue([
+      { communityId: 1, linkStatus: 'PASS', count: 9 },
+      { communityId: 1, linkStatus: 'FAIL', count: 1 },
+      { communityId: 2, linkStatus: 'PASS', count: 1 },
+      { communityId: 2, linkStatus: 'UNKNOWN', count: 9 }
+    ] as never);
+    prismaMock.communityHealthSnapshot.createMany.mockResolvedValue({
+      count: 2
+    });
+    prismaMock.communityHealthSnapshot.deleteMany.mockResolvedValue({
+      count: 0
+    });
+
+    await captureCommunityHealth('Daily');
+
+    const createArg = prismaMock.communityHealthSnapshot.createMany.mock
+      .calls[0][0] as {
+      data: Array<Record<string, unknown>>;
+      skipDuplicates: boolean;
+    };
+    expect(createArg.skipDuplicates).toBe(true);
+    expect(createArg.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          communityId: 1,
+          period: 'Daily',
+          checked: 10,
+          total: 10,
+          coverage: 1,
+          pulse: 0.9,
+          status: 'Healthy'
+        }),
+        expect.objectContaining({
+          communityId: 2,
+          checked: 1,
+          total: 10,
+          status: 'Unknown'
+        })
+      ])
+    );
+
+    expect(prismaMock.communityHealthSnapshot.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ period: 'Daily' })
+      })
+    );
+  });
+
+  it('skips createMany when no communities have contributions, still prunes', async () => {
+    prismaMock.$queryRaw.mockResolvedValue([] as never);
+    prismaMock.communityHealthSnapshot.deleteMany.mockResolvedValue({
+      count: 0
+    });
+
+    await captureCommunityHealth('Monthly');
+
+    expect(
+      prismaMock.communityHealthSnapshot.createMany
+    ).not.toHaveBeenCalled();
+    expect(prismaMock.communityHealthSnapshot.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ period: 'Monthly' })
+      })
+    );
+  });
+});
+
+// ─── getCommunityHealthHistory ────────────────────────────────────────────────
+
+describe('getCommunityHealthHistory', () => {
+  it('queries the community + period, oldest-first', async () => {
+    prismaMock.communityHealthSnapshot.findMany.mockResolvedValue([] as never);
+
+    await getCommunityHealthHistory(7, 'Yearly');
+
+    expect(prismaMock.communityHealthSnapshot.findMany).toHaveBeenCalledWith({
+      where: { communityId: 7, period: 'Yearly' },
+      orderBy: { capturedAt: 'asc' }
+    });
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2747,6 +2747,53 @@ registry.registerPath({
   }
 });
 
+const CommunityHealthSnapshot = z
+  .object({
+    id: z.number(),
+    communityId: z.number(),
+    period: z.enum(['Daily', 'Monthly', 'Yearly']),
+    bucketAt: z.string(),
+    capturedAt: z.string(),
+    pass: z.number(),
+    warn: z.number(),
+    fail: z.number(),
+    unknown: z.number(),
+    total: z.number(),
+    checked: z.number(),
+    coverage: z.number().nullable(),
+    pulse: z.number().nullable(),
+    status: z.string()
+  })
+  .openapi('CommunityHealthSnapshot');
+
+registry.registerPath({
+  method: 'get',
+  path: '/communities/{id}/health/history',
+  tags: ['Communities'],
+  request: {
+    params: z.object({ id: z.string() }),
+    query: z.object({
+      period: z.enum(['Daily', 'Monthly', 'Yearly']).optional()
+    })
+  },
+  responses: {
+    200: {
+      description: 'Community link-health pulse history (time series)',
+      content: {
+        'application/json': { schema: z.array(CommunityHealthSnapshot) }
+      }
+    },
+    403: {
+      description: 'Not a member of this community',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 registry.registerPath({
   method: 'get',
   path: '/communities/{id}/releases',

--- a/src/modules/communityHealthHistory.ts
+++ b/src/modules/communityHealthHistory.ts
@@ -1,0 +1,110 @@
+import { LinkHealthStatus, StatSnapshotPeriod } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { computePulse } from './linkHealth';
+import { getBucket, getRetentionCutoff } from './statsHistory';
+
+// ─── Capture ───────────────────────────────────────────────────────────────
+
+type CommunityStatusCountRow = {
+  communityId: number;
+  linkStatus: LinkHealthStatus;
+  count: number;
+};
+
+/**
+ * Snapshot every community's link-health pulse for the given period (#75). The
+ * read-time pulse (`getCommunityHealthPulse`) and this capture share the same
+ * banding via `computePulse`, so a stored snapshot matches what the live
+ * endpoint reports at capture time. Mirrors `captureUserStats`: bucket, write
+ * with `skipDuplicates`, then prune past the period's retention cutoff.
+ *
+ * Contributions on releases with no community (`Release.communityId` is
+ * nullable) carry no community pulse and are excluded.
+ */
+export async function captureCommunityHealth(
+  period: StatSnapshotPeriod
+): Promise<void> {
+  const bucketAt = getBucket(period);
+
+  const rows = await prisma.$queryRaw<CommunityStatusCountRow[]>`
+    SELECT r."communityId" AS "communityId",
+           c."linkStatus"  AS "linkStatus",
+           COUNT(*)::int    AS "count"
+    FROM "contributions" c
+    JOIN "releases" r ON c."releaseId" = r.id
+    WHERE r."communityId" IS NOT NULL
+    GROUP BY r."communityId", c."linkStatus"
+  `;
+
+  // Fold the per-(community, status) rows into per-community counts.
+  const byCommunity = new Map<
+    number,
+    { pass: number; warn: number; fail: number; unknown: number }
+  >();
+  for (const row of rows) {
+    let counts = byCommunity.get(row.communityId);
+    if (!counts) {
+      counts = { pass: 0, warn: 0, fail: 0, unknown: 0 };
+      byCommunity.set(row.communityId, counts);
+    }
+    switch (row.linkStatus) {
+      case LinkHealthStatus.PASS:
+        counts.pass += row.count;
+        break;
+      case LinkHealthStatus.WARN:
+        counts.warn += row.count;
+        break;
+      case LinkHealthStatus.FAIL:
+        counts.fail += row.count;
+        break;
+      default:
+        counts.unknown += row.count; // UNKNOWN — not yet probed
+        break;
+    }
+  }
+
+  if (byCommunity.size > 0) {
+    const data = Array.from(byCommunity, ([communityId, counts]) => {
+      const p = computePulse(counts);
+      return {
+        communityId,
+        period,
+        bucketAt,
+        pass: p.pass,
+        warn: p.warn,
+        fail: p.fail,
+        unknown: p.unknown,
+        total: p.total,
+        checked: p.checked,
+        coverage: p.coverage,
+        pulse: p.pulse,
+        status: p.status
+      };
+    });
+
+    await prisma.communityHealthSnapshot.createMany({
+      data,
+      skipDuplicates: true
+    });
+  }
+
+  await prisma.communityHealthSnapshot.deleteMany({
+    where: { period, capturedAt: { lt: getRetentionCutoff(period) } }
+  });
+}
+
+// ─── Query ─────────────────────────────────────────────────────────────────
+
+/**
+ * A community's health-pulse history for the given period, oldest-first — the
+ * time-series behind the single read-time `GET /:id/health` heartbeat.
+ */
+export async function getCommunityHealthHistory(
+  communityId: number,
+  period: StatSnapshotPeriod
+) {
+  return prisma.communityHealthSnapshot.findMany({
+    where: { communityId, period },
+    orderBy: { capturedAt: 'asc' }
+  });
+}

--- a/src/modules/linkHealth.spec.ts
+++ b/src/modules/linkHealth.spec.ts
@@ -24,7 +24,8 @@ jest.mock('./logging', () => ({
 import {
   sweepStaleWarnLinks,
   checkContributionLink,
-  getCommunityHealthPulse
+  getCommunityHealthPulse,
+  computePulse
 } from './linkHealth';
 
 // ─── sweepStaleWarnLinks ──────────────────────────────────────────────────────
@@ -211,6 +212,50 @@ describe('getCommunityHealthPulse', () => {
     expect(r).toMatchObject({
       total: 0,
       checked: 0,
+      pulse: null,
+      status: 'Unknown'
+    });
+  });
+});
+
+// ─── computePulse (pure) ──────────────────────────────────────────────────────
+// The banding/coverage logic shared by the read-time pulse and the snapshot
+// capture (#75). getCommunityHealthPulse exercises it above; these lock the
+// pure contract directly.
+
+describe('computePulse', () => {
+  it('bands Healthy at/above the healthy threshold', () => {
+    expect(
+      computePulse({ pass: 9, warn: 0, fail: 1, unknown: 0 })
+    ).toMatchObject({
+      checked: 10,
+      total: 10,
+      coverage: 1,
+      pulse: 0.9,
+      status: 'Healthy'
+    });
+  });
+
+  it('bands Critical when failures dominate', () => {
+    const r = computePulse({ pass: 1, warn: 0, fail: 9, unknown: 0 });
+    expect(r.pulse).toBeCloseTo(0.1);
+    expect(r.status).toBe('Critical');
+  });
+
+  it('withholds a band as Unknown below the coverage floor', () => {
+    const r = computePulse({ pass: 1, warn: 0, fail: 0, unknown: 99 });
+    expect(r.pulse).toBe(1);
+    expect(r.coverage).toBeCloseTo(0.01);
+    expect(r.status).toBe('Unknown');
+  });
+
+  it('returns null pulse/coverage for empty counts', () => {
+    expect(
+      computePulse({ pass: 0, warn: 0, fail: 0, unknown: 0 })
+    ).toMatchObject({
+      total: 0,
+      checked: 0,
+      coverage: null,
       pulse: null,
       status: 'Unknown'
     });

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -171,6 +171,38 @@ export interface CommunityHealthPulse {
 }
 
 /**
+ * Pure pulse computation: turn a community's PASS/WARN/FAIL/UNKNOWN counts into
+ * the banded heartbeat. Shared by the read-time pulse and the snapshot capture
+ * (#75) so the coverage floor + banding logic lives in exactly one place.
+ *
+ * Only PASS/FAIL are definitive; WARN (transient) and UNKNOWN (unprobed) are
+ * indeterminate and excluded from the pulse. The band is withheld (`Unknown`)
+ * until coverage clears the floor — otherwise one PASS among thousands of
+ * UNKNOWN would read "Healthy".
+ */
+export const computePulse = (counts: {
+  pass: number;
+  warn: number;
+  fail: number;
+  unknown: number;
+}): CommunityHealthPulse => {
+  const checked = counts.pass + counts.fail;
+  const total = checked + counts.warn + counts.unknown;
+  const coverage = total === 0 ? null : checked / total;
+  const pulse = checked === 0 ? null : counts.pass / checked;
+  const status: CommunityPulseStatus =
+    pulse === null || coverage === null || coverage < PULSE_MIN_COVERAGE
+      ? 'Unknown'
+      : pulse >= PULSE_HEALTHY
+      ? 'Healthy'
+      : pulse >= PULSE_AILING
+      ? 'Ailing'
+      : 'Critical';
+
+  return { ...counts, total, checked, coverage, pulse, status };
+};
+
+/**
  * The community's link-health "pulse": roll every contribution's linkStatus up
  * into a single heartbeat. A living community keeps its links alive; the pulse
  * weakens as they rot. Computed on read — no stored state.
@@ -203,22 +235,5 @@ export const getCommunityHealthPulse = async (
     }
   }
 
-  // Only PASS/FAIL are definitive; WARN (transient) and UNKNOWN (unprobed) are
-  // indeterminate and excluded from the pulse.
-  const checked = counts.pass + counts.fail;
-  const total = checked + counts.warn + counts.unknown;
-  const coverage = total === 0 ? null : checked / total;
-  const pulse = checked === 0 ? null : counts.pass / checked;
-  // Don't claim a confident band until enough links are actually probed —
-  // otherwise one PASS among thousands of UNKNOWN would read "Healthy".
-  const status: CommunityPulseStatus =
-    pulse === null || coverage === null || coverage < PULSE_MIN_COVERAGE
-      ? 'Unknown'
-      : pulse >= PULSE_HEALTHY
-      ? 'Healthy'
-      : pulse >= PULSE_AILING
-      ? 'Ailing'
-      : 'Critical';
-
-  return { ...counts, total, checked, coverage, pulse, status };
+  return computePulse(counts);
 };

--- a/src/modules/statsHistory.ts
+++ b/src/modules/statsHistory.ts
@@ -25,13 +25,13 @@ function weekBucket(d = new Date()): Date {
   );
 }
 
-function getBucket(period: StatSnapshotPeriod): Date {
+export function getBucket(period: StatSnapshotPeriod): Date {
   if (period === 'Daily') return hourBucket();
   if (period === 'Monthly') return dayBucket();
   return weekBucket();
 }
 
-function getRetentionCutoff(period: StatSnapshotPeriod): Date {
+export function getRetentionCutoff(period: StatSnapshotPeriod): Date {
   const now = new Date();
   if (period === 'Daily') return new Date(now.getTime() - 25 * 60 * 60 * 1000);
   if (period === 'Monthly')

--- a/src/modules/statsJob.ts
+++ b/src/modules/statsJob.ts
@@ -1,5 +1,6 @@
 import { getLogger } from './logging';
 import { captureUserStats, captureSiteStats } from './statsHistory';
+import { captureCommunityHealth } from './communityHealthHistory';
 
 const log = getLogger('statsJob');
 
@@ -10,9 +11,11 @@ const WEEKLY_MS = 7 * 24 * 60 * 60 * 1000;
 export const startStatsJob = (): void => {
   // Daily period: captured hourly, 25h retention
   const runHourly = () =>
-    Promise.all([captureUserStats('Daily'), captureSiteStats()]).catch((err) =>
-      log.error('Hourly stats capture failed', { err })
-    );
+    Promise.all([
+      captureUserStats('Daily'),
+      captureSiteStats(),
+      captureCommunityHealth('Daily')
+    ]).catch((err) => log.error('Hourly stats capture failed', { err }));
   const hourlyDelay = setTimeout(() => {
     runHourly();
     setInterval(runHourly, HOURLY_MS).unref();
@@ -21,9 +24,10 @@ export const startStatsJob = (): void => {
 
   // Monthly period: captured daily, 32d retention
   const runDaily = () =>
-    captureUserStats('Monthly').catch((err) =>
-      log.error('Daily stats capture failed', { err })
-    );
+    Promise.all([
+      captureUserStats('Monthly'),
+      captureCommunityHealth('Monthly')
+    ]).catch((err) => log.error('Daily stats capture failed', { err }));
   const dailyDelay = setTimeout(() => {
     runDaily();
     setInterval(runDaily, DAILY_MS).unref();
@@ -32,9 +36,10 @@ export const startStatsJob = (): void => {
 
   // Yearly period: captured weekly, 53w retention
   const runWeekly = () =>
-    captureUserStats('Yearly').catch((err) =>
-      log.error('Weekly stats capture failed', { err })
-    );
+    Promise.all([
+      captureUserStats('Yearly'),
+      captureCommunityHealth('Yearly')
+    ]).catch((err) => log.error('Weekly stats capture failed', { err }));
   const weeklyDelay = setTimeout(() => {
     runWeekly();
     setInterval(runWeekly, WEEKLY_MS).unref();

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -1,9 +1,10 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
-import { RegistrationStatus } from '@prisma/client';
+import { RegistrationStatus, StatSnapshotPeriod } from '@prisma/client';
 import { prisma } from '../../../lib/prisma';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { getCommunityHealthPulse } from '../../../modules/linkHealth';
+import { getCommunityHealthHistory } from '../../../modules/communityHealthHistory';
 import { requireAuth } from '../../../middleware/auth';
 import {
   requirePermission,
@@ -14,7 +15,8 @@ import {
   validate,
   validateParams,
   validateQuery,
-  parsedParams
+  parsedParams,
+  parsedQuery
 } from '../../../middleware/validate';
 import {
   createCommunitySchema,
@@ -44,6 +46,9 @@ const addMemberSchema = z.object({
 router.use('/:communityId/releases', releaseRouter);
 
 const communitiesQuerySchema = z.object({ ...paginationBase });
+const healthHistoryQuerySchema = z.object({
+  period: z.nativeEnum(StatSnapshotPeriod).default(StatSnapshotPeriod.Daily)
+});
 
 export async function isCommunityMember(
   communityId: number,
@@ -140,6 +145,30 @@ router.get(
       return res.status(403).json({ msg: 'Not a member of this community' });
     }
     res.json(await getCommunityHealthPulse(id));
+  })
+);
+
+// GET /api/communities/:id/health/history — the pulse over time (#75).
+// ?period=Daily|Monthly|Yearly (default Daily). Same membership gate as /health.
+router.get(
+  '/:id/health/history',
+  requireAuth,
+  validateParams(communityIdParamsSchema),
+  validateQuery(healthHistoryQuerySchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { period } = parsedQuery<{ period: StatSnapshotPeriod }>(res);
+    const community = await prisma.community.findUnique({
+      where: { id },
+      select: { registrationStatus: true }
+    });
+    if (!community) return res.status(404).json({ msg: 'Community not found' });
+    if (
+      !(await isCommunityMember(id, req.user.id, community.registrationStatus))
+    ) {
+      return res.status(403).json({ msg: 'Not a member of this community' });
+    }
+    res.json(await getCommunityHealthHistory(id, period));
   })
 );
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3542,6 +3542,63 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/communities/{id}/health/history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          period?: 'Daily' | 'Monthly' | 'Yearly';
+        };
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Community link-health pulse history (time series) */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['CommunityHealthSnapshot'][];
+          };
+        };
+        /** @description Not a member of this community */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/communities/{id}/releases': {
     parameters: {
       query?: never;
@@ -12575,6 +12632,23 @@ export interface components {
       pulse: number | null;
       /** @enum {string} */
       status: 'Healthy' | 'Ailing' | 'Critical' | 'Unknown';
+    };
+    CommunityHealthSnapshot: {
+      id: number;
+      communityId: number;
+      /** @enum {string} */
+      period: 'Daily' | 'Monthly' | 'Yearly';
+      bucketAt: string;
+      capturedAt: string;
+      pass: number;
+      warn: number;
+      fail: number;
+      unknown: number;
+      total: number;
+      checked: number;
+      coverage: number | null;
+      pulse: number | null;
+      status: string;
     };
   };
   responses: never;


### PR DESCRIPTION
## What

Implements the **persist/snapshot half of #75** — evolving the computed-on-read community link-health pulse into a stored time-series signal, mirroring the existing `UserStatSnapshot` / `SiteStatSnapshot` pattern.

- **`CommunityHealthSnapshot` model** — one row per community × `StatSnapshotPeriod` × bucket. Captured by the stats job at Daily/Monthly/Yearly cadence (`captureCommunityHealth`), reusing the exact bucketing + retention helpers from `statsHistory`. `status` is stored **as computed at capture time** so history is stable against later threshold changes.
- **`computePulse(counts)`** extracted as a pure helper in `linkHealth.ts`, shared by the read-time `getCommunityHealthPulse` and the snapshot capture — the coverage-floor + banding logic now lives in exactly one place.
- **`GET /api/communities/:id/health/history?period=`** — the pulse over time, behind the same membership gate as `/health`. Registered in `openapi.ts`; `src/types/api.ts` regenerated.
- Unit tests (`computePulse`, capture/query module) + route tests. Full suite green (1516 passing); lint + tsc clean.

## Deferred (intentionally)

The second bullet of #75 — *fold the pulse into the `CommunityScore` dimension of `CommunityReputationScore` → `CommunityValueIndex`* — is **not** built here: no per-community CommunityScore dimension exists yet (CRS is per-*user* today, in `reputation.ts`). There's nothing to fold into. **This snapshot is the substrate** that fold, and **#76**'s quality-weighting, will read from once the per-community dimension lands. Suggest #75 stays open (scoped to the fold) or the fold rides with #76.

## Migration ⚠️

`prisma/migrations/20260616130000_community_health_snapshot/migration.sql` is hand-written. **Apply with `prisma migrate dev` (interactive TTY)** — `prisma generate` has already been run against the schema. `migrate reset` is fine on a dev DB if it flags drift.

## Test plan

- `npm run format && npm run lint && npx tsc --noEmit && npm run test --no-coverage` — all green.
- Manual: `npm run dev`, hit `GET /api/communities/:id/health/history` and confirm rows match `GET /api/communities/:id/health` bands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)