### PR TITLE
feat(crs): Friends×Stylesheet controlled-vector accrual (#147)

### DIFF
--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -167,7 +167,7 @@ describe('computeCrs — Friends dimension', () => {
   });
 
   // Friends × Stylesheet controlled vector (#147)
-  const friendsFull = (input: Parameters<typeof computeCrs>[0]) =>
+  const friendsFull = (input: Partial<Parameters<typeof computeCrs>[0]>) =>
     computeCrs({
       userId: 1,
       createdAt: NOW,

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -161,9 +161,46 @@ describe('computeCrs — Friends dimension', () => {
   });
 
   it('count cannot dominate: even thousands of friends stay under the low cap', () => {
-    // FRIENDS_CAP = 4, far below longevity (10) / ratio (8) — count alone can't win
+    // The friend-count signal asymptotes to FRIENDS_CAP = 4 — count alone can't win
     expect(friendsOf(10_000)).toBeLessThanOrEqual(4);
     expect(friendsOf(10_000)).toBeGreaterThan(3.9);
+  });
+
+  // Friends × Stylesheet controlled vector (#147)
+  const friendsFull = (input: Parameters<typeof computeCrs>[0]) =>
+    computeCrs({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      ...input
+    }).dimensions.find((d) => d.name === 'friends')!.subScore;
+
+  it('adoption is a weak-tie nudge additive to the friend-count signal', () => {
+    const base = friendsFull({ friendCount: 5 });
+    const withAdoption = friendsFull({
+      friendCount: 5,
+      stylesheetAdoptionsMade: 2,
+      stylesheetAdoptions: 1
+    });
+    // adopter 2×0.2 + author 1×0.1 = 0.5 added on top of the friend signal
+    expect(withAdoption - base).toBeCloseTo(0.5, 10);
+  });
+
+  it('adopter is weighted above author (favour active curation)', () => {
+    expect(friendsFull({ stylesheetAdoptionsMade: 1 })).toBeGreaterThan(
+      friendsFull({ stylesheetAdoptions: 1 })
+    );
+  });
+
+  it('the vector is bounded: mass adoption flattens out (ADOPTION_VECTOR_CAP = 2)', () => {
+    // 1000 adoptions as adopter would be 200 unbounded; capped at 2.
+    expect(friendsFull({ stylesheetAdoptionsMade: 1000 })).toBeCloseTo(2, 10);
+  });
+
+  it('friend-count + adoption together stay within the dimension cap (6)', () => {
+    expect(
+      friendsFull({ friendCount: 10_000, stylesheetAdoptionsMade: 1000 })
+    ).toBeLessThanOrEqual(6);
   });
 });
 
@@ -245,6 +282,30 @@ describe('getReputation', () => {
     );
     expect(
       result.dimensions.find((d) => d.name === 'stylesheet')!.subScore
+    ).toBeGreaterThan(0);
+  });
+
+  it('reads the adopter side of the ledger for the Friends controlled vector (#147)', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({
+      createdAt: NOW,
+      contributed: 0n,
+      consumed: 0n
+    });
+    mockPrismaFriend.count.mockResolvedValue(0);
+    mockPrismaEconomy.count.mockResolvedValue(3);
+
+    const result = await getReputation(1);
+
+    // Both ledger sides are queried: author (userId) and adopter (actorUserId).
+    expect(mockPrismaEconomy.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { actorUserId: 1, reason: 'CRS_STYLESHEET_ADOPTION' }
+      })
+    );
+    // With zero friends, a non-zero friends subScore can only come from the
+    // adoption vector.
+    expect(
+      result.dimensions.find((d) => d.name === 'friends')!.subScore
     ).toBeGreaterThan(0);
   });
 });

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -34,8 +34,13 @@ export interface DimensionInput {
   /** IRC nick linked to this account — used to look up the cached IRCScore. */
   ircNick?: string | null;
   /** Distinct (adopter, author) adoptions of this member's stylesheets — the
-   *  durable count from the CRS_* ledger (ADR-0007). Defaults to 0. */
+   *  durable count from the CRS_* ledger (ADR-0007), where this user is the
+   *  author (credited). Defaults to 0. */
   stylesheetAdoptions?: number;
+  /** Distinct adoptions this user *made* as the adopter (the `actorUserId` side
+   *  of the same CRS_* ledger). Feeds the Friends-dimension controlled vector
+   *  (#147). Defaults to 0. */
+  stylesheetAdoptionsMade?: number;
   /** Injectable for deterministic tests; defaults to now. */
   now?: Date;
 }
@@ -116,12 +121,43 @@ const FRIENDS_CAP = 4;
 const FRIENDS_TAU = 5; // 5 friends → ~63% of cap; diminishing hard after
 const FRIENDS_WEIGHT = 1.0;
 
+// Friends × Stylesheet — controlled vector (PRD-03, #147). Adopting another
+// member's AuthorStylesheet is a weak social/trust edge, so each distinct
+// adoption fires a SECOND accrual here in the Friends dimension — additive to,
+// and separate from, the author reward in the `stylesheet` dimension. The
+// adopter earns slightly more than the author (favour active curation), and the
+// whole vector is bounded by its OWN per-user cap so ring/sock-puppet mass
+// adoption flattens out and plain friending stays the stronger signal. Both
+// counts are already deduped once-per-(adopter, author) by the ledger's partial
+// unique index — no extra dedup here.
+// PROVISIONAL (tier-0): the 0.2 / 0.1 weights are PRD-decided; ADOPTION_VECTOR_CAP
+// is an interim magnitude to tune alongside the PRD.
+const ADOPTION_ADOPTER_WEIGHT = 0.2;
+const ADOPTION_AUTHOR_WEIGHT = 0.1;
+const ADOPTION_VECTOR_CAP = 2;
+// The dimension ceiling holds both signals: the friend-count curve (asymptotic
+// to FRIENDS_CAP) plus the bounded adoption nudge, so the nudge is genuinely
+// additive rather than competing with friends under one shared cap.
+const FRIENDS_DIMENSION_CAP = FRIENDS_CAP + ADOPTION_VECTOR_CAP;
+
 const friendsScorer: DimensionScorer = {
   name: 'friends',
   weight: FRIENDS_WEIGHT,
-  cap: FRIENDS_CAP,
-  compute: ({ friendCount = 0 }) =>
-    FRIENDS_CAP * (1 - Math.exp(-Math.max(0, friendCount) / FRIENDS_TAU))
+  cap: FRIENDS_DIMENSION_CAP,
+  compute: ({
+    friendCount = 0,
+    stylesheetAdoptions = 0,
+    stylesheetAdoptionsMade = 0
+  }) => {
+    const friendSignal =
+      FRIENDS_CAP * (1 - Math.exp(-Math.max(0, friendCount) / FRIENDS_TAU));
+    const adoptionVector = Math.min(
+      ADOPTION_VECTOR_CAP,
+      Math.max(0, stylesheetAdoptionsMade) * ADOPTION_ADOPTER_WEIGHT +
+        Math.max(0, stylesheetAdoptions) * ADOPTION_AUTHOR_WEIGHT
+    );
+    return friendSignal + adoptionVector;
+  }
 };
 
 // ─── IRCScore ─────────────────────────────────────────────────────────────
@@ -196,24 +232,31 @@ export const computeCrs = (input: DimensionInput): CrsResult => {
 
 /** Read-time CRS for a user. Assembles the dimension input, then computes. */
 export const getReputation = async (userId: number): Promise<CrsResult> => {
-  const [user, friendCount, stylesheetAdoptions] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        createdAt: true,
-        contributed: true,
-        consumed: true,
-        ircNick: true
-      }
-    }),
-    prisma.friend.count({ where: { userId } }),
-    // Distinct (adopter, author) pairs where this user is the author — one
-    // ledger row per pair (deduped at write), so a plain count is the distinct
-    // adoption count.
-    prisma.economyTransaction.count({
-      where: { userId, reason: 'CRS_STYLESHEET_ADOPTION' }
-    })
-  ]);
+  const [user, friendCount, stylesheetAdoptions, stylesheetAdoptionsMade] =
+    await Promise.all([
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          createdAt: true,
+          contributed: true,
+          consumed: true,
+          ircNick: true
+        }
+      }),
+      prisma.friend.count({ where: { userId } }),
+      // Distinct (adopter, author) pairs where this user is the author — one
+      // ledger row per pair (deduped at write), so a plain count is the distinct
+      // adoption count. Feeds both the stylesheet (author reward) and friends
+      // (weak-tie nudge) dimensions.
+      prisma.economyTransaction.count({
+        where: { userId, reason: 'CRS_STYLESHEET_ADOPTION' }
+      }),
+      // The adopter side of the same ledger: distinct adoptions this user made.
+      // Friends-dimension controlled vector only (#147).
+      prisma.economyTransaction.count({
+        where: { actorUserId: userId, reason: 'CRS_STYLESHEET_ADOPTION' }
+      })
+    ]);
   if (!user) return { score: 0, dimensions: [] };
   return computeCrs({
     userId,
@@ -222,6 +265,7 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     contributed: user.contributed,
     friendCount,
     ircNick: user.ircNick,
-    stylesheetAdoptions
+    stylesheetAdoptions,
+    stylesheetAdoptionsMade
   });
 };


### PR DESCRIPTION
## What

Implements the **Friends × Stylesheet controlled vector** decided in PRD-03 (surfaced in the spec review of #145). Adopting another member's `AuthorStylesheet` is a weak social/trust edge, so each distinct adoption now fires a **second** accrual in the **Friends** CRS dimension — additive to, and separate from, the author reward already paid in the `stylesheet` dimension.

The substrate (the deduped `CRS_STYLESHEET_ADOPTION` ledger, once-per-(adopter, author)) already exists from #120/#145; this wires the second accrual.

## How (`src/modules/reputation.ts`)

- **`friendsScorer`** now reads two ledger counts:
  - **Adopter side** (`actorUserId = me`) × **0.2** — rewards active, organic curation.
  - **Author side** (`userId = me`) × **0.1** — the *same* count the `stylesheet` dimension already reads; both dimensions deliberately draw on it.
- **Own per-user cap** (`ADOPTION_VECTOR_CAP`) on the vector's contribution, so ring/sock-puppet mass-adoption flattens out. The friend-count signal keeps its `FRIENDS_CAP` ceiling; the **dimension cap holds both** so the nudge is genuinely additive rather than competing under one shared cap. Plain friending stays the stronger signal.
- **`getReputation`** fetches the adopter-side count alongside the existing author-side count. Both are already deduped once-per-pair by the ledger's partial unique index — no new dedup.

## Magnitudes

The **0.2 / 0.1** weights are PRD-decided. **`ADOPTION_VECTOR_CAP = 2`** is a **provisional tier-0** magnitude (the issue left the cap "decide during implementation") — consistent with the module's other provisional caps, to tune alongside the PRD.

## Tests

New unit tests in `reputation.spec.ts`: additive nudge, adopter > author, vector bound, combined dimension cap, and `getReputation` reading the adopter (`actorUserId`) ledger side. Full suite green (1509); lint + tsc clean.

## Out of scope

The friend-system API/contracts (mutual-friend state, envelopes) — that's #60. This is purely the CRS scoring vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)