### PR TITLE
chore(release): v0.5.5 + reconcile docs to the merged batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.5.5] — 2026-06-16
+
 ### Added
 
 - **Contribution submission parity** — `POST /contributions` now accepts the full legacy upload-form metadata: release category (Album/Single/EP/…), record label, catalogue number, and edition info (title/year/remaster), persisting them to the `Release`/`Edition` tier. Each collaborator is credited as a role-typed `ReleaseArtist` (Main/Guest/Remixer/…, mapped case-insensitively) instead of only the first artist as Main [#72].
@@ -15,6 +17,8 @@ All notable changes to stellar-api are documented here.
 - **Authored stylesheets** — members can save a named `AuthorStylesheet` [#118] and adopt another member's sheet, crediting the author through a deduped CRS accrual (one credit per distinct adopter→author pair, enforced by a partial unique index) [#119, #120].
 - **Governance model (PRD-05)** — a composable `Rule`/`SubRule` tree with per-node compliance/violation weights plus a pure, table-driven `ruleImpact()` scorer (`GET /api/rules/tree`) [#123]; and a read-time `computeStanding()` that rolls active `UserWarning` rows + ban state into a 5-tier standing surfaced on the profile [#124, ADR-0004].
 - **Invite tree** — an adjacency model with recursive subtree read, exposed per member at `GET /api/users/:id/invite-tree` returning `{ tree, summary }`: recursive nodes (per-node ratio stats, donor/disabled/depth) and a rollup summary (entries, branches, depth, by-rank counts, totals) [#61].
+- **Community health snapshots** — the read-time link-health pulse is now persisted as a time series (`CommunityHealthSnapshot`, per community × period × bucket), captured by the stats job at Daily/Monthly/Yearly cadence mirroring the user/site snapshots, and read via `GET /api/communities/:id/health/history?period=`. A shared `computePulse` single-sources the banding for the live pulse and the snapshot [#75]. _(Folding the pulse into a CommunityScore CRS dimension stays deferred — #75.)_
+- **Friends × Stylesheet controlled vector** — adopting another member's stylesheet now also accrues a bounded, additive nudge in the Friends CRS dimension (adopter ×0.2 / author ×0.1), capped separately so plain friending stays the stronger signal and mass adoption flattens out [#147, PRD-03].
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ src/
     asyncHandler.ts         # Wraps async routes; catches errors, 10s timeout
     installState.ts         # In-memory cache for isInstalled() check
     logging.ts              # Winston logger factory (JSON in prod, pretty in dev)
-    linkHealth.ts           # HEAD-request link checker + auto-warn on 3+ reports
+    linkHealth.ts           # HEAD-request link checker + auto-warn on 3+ reports; computePulse + getCommunityHealthPulse
     linkHealthJob.ts        # Background job: recheck stale contribution links every 24h
+    communityHealthHistory.ts # Persist/query the community health pulse as a time-series snapshot (#75); captured by statsJob
     auth.ts                 # Password validation, auth user DB query helpers
     artist.ts               # Artist creation/update with history tracking
     comment.ts              # Comment soft-delete with audit logging

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,8 +96,12 @@ The invite-tree suspicion that flows from an infected _trunk_ (a banned or ban-e
 _Avoid_: tree poisoning, ban inheritance, guilt by association
 
 **CommunityScore**:
-A *deferred* (#75) CRS **Dimension Scorer** that folds a Community's read-time health pulse (`getCommunityHealthPulse`, ADR-0002) into a member's **single, global** Community Reputation Score. It is **not** a separate per-community reputation: a member has one CRS; "their CommunityScore *for* a Community" is that community's health contributing one capped term to it. No parallel per-community score exists.
+A _deferred_ (#75) CRS **Dimension Scorer** that folds a Community's read-time health pulse (`getCommunityHealthPulse`, ADR-0002) into a member's **single, global** Community Reputation Score. It is **not** a separate per-community reputation: a member has one CRS; "their CommunityScore _for_ a Community" is that community's health contributing one capped term to it. No parallel per-community score exists. The pulse is now also **persisted** over time (see **Community Health Snapshot**), which is the trend substrate this fold will read — but the dimension itself is still unbuilt (#75).
 _Avoid_: community reputation, per-community CRS, community ranking
+
+**Community Health Snapshot**:
+A persisted time-series point of a Community's link-health pulse (`CommunityHealthSnapshot`: counts + `coverage`/`pulse`/`status`, per community × `StatSnapshotPeriod` × bucket), captured by the stats job at Daily/Monthly/Yearly cadence and read at `GET /api/communities/:id/health/history`. The live `getCommunityHealthPulse` and the snapshot share one banding via `computePulse` (`linkHealth.ts`); the snapshot stores the band **as computed at capture time**. It is a derived trend layer, never the source of truth (ADR-0007).
+_Avoid_: stored health score, community health table, denormalized pulse
 
 **Site Theme**:
 A built-in, admin-managed stylesheet (`Stylesheet` model: `Sublime`/Default + alternatives, referenced by `cssUrl`, one flagged `isDefault`). The base layer of the cascade, applied site-wide until a member or page context selects something else. Authored by staff/SysOps, not members.
@@ -108,7 +112,7 @@ A `.scss`/`.css` theme written by a member — the **StylesheetAuthor** (shortha
 _Avoid_: user theme, custom css, skin
 
 **Stylesheet Slot**:
-One of three single-valued placements a stylesheet occupies, chosen by **page context**, not a global toggle: the **Profile Stylesheet** (set by a profile's owner; rendered to any visitor on *that* profile), the **Site Stylesheet** (set by the viewer; rendered on the general site, falling back to the **Site Theme**/Default when unset), and the **Community Stylesheet** (set by a Community's Staff; rendered to anyone on *that* community's pages). Page context wins: a profile or community page shows its own slot to every viewer regardless of the viewer's Site Stylesheet.
+One of three single-valued placements a stylesheet occupies, chosen by **page context**, not a global toggle: the **Profile Stylesheet** (set by a profile's owner; rendered to any visitor on _that_ profile), the **Site Stylesheet** (set by the viewer; rendered on the general site, falling back to the **Site Theme**/Default when unset), and the **Community Stylesheet** (set by a Community's Staff; rendered to anyone on _that_ community's pages). Page context wins: a profile or community page shows its own slot to every viewer regardless of the viewer's Site Stylesheet.
 _Avoid_: active stylesheet, theme preference, selected skin
 
 **Stylesheet Adoption**:

--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -60,7 +60,7 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 
 **Staff** (context): community staff earn **+50 CRS per week served** (Standards/Communities — cross-ref PRD-01).
 
-**Friends × Stylesheet — controlled vector (decided; not yet built — [#147](https://github.com/orphic-inc/stellar-api/issues/147)).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — _separate from and additive to_ the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is the follow-up:
+**Friends × Stylesheet — controlled vector (decided; shipped — [#147](https://github.com/orphic-inc/stellar-api/issues/147) / PR #162).** Adopting another user's AuthorStylesheet is also a weak social/trust edge, so it fires a **second** accrual in PRD-01's **Friends** dimension — _separate from and additive to_ the stylesheet-dimension weights above. The keystone (#120) built the deduped adoption ledger this vector reads from, but wired only the stylesheet dimension; the Friends-dimension accrual is now wired in `reputation.ts` (`friendsScorer` reads both ledger sides):
 
 - **Adopter: +0.2** (rewards active, organic curation — the adopter earns slightly more than the author, to favour participation).
 - **Author: +0.1** (recognition that someone vouched for your sheet).
@@ -127,7 +127,9 @@ First testable slices (much of the substrate already exists):
    - **4b adopt (#119, ✅ shipped):** many-per-author (cardinality fixed here — `@unique authorId` dropped); a viewer adopts a sheet into their **Site Stylesheet** slot (`UserSettings.activeAuthorStylesheetId`) via `POST /api/stylesheet/author-stylesheet/:id/adopt`, idempotent.
    - **4c score (#120, ✅ shipped):** adoption fires `scoreStylesheetSelection`; non-self adoptions write a `CRS_STYLESHEET_ADOPTION` ledger row deduped **once per (adopter, author)** (ADR-0007), and a read-time **stylesheet** CRS dimension counts them → author's global CRS. Self-adoption renders, earns nothing.
 
-   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension — the §"Friends × Stylesheet" decision; the `CRS_STYLESHEET_ADOPTION` ledger built here is its substrate, but the second Friends-dimension accrual is not yet wired — [#147](https://github.com/orphic-inc/stellar-api/issues/147)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — _ADR-when-built_: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+   **Deferred** (named, not built): Profile-slot + Community-slot designation · rank-gated stylesheet **count limit** + list pagination ([#146](https://github.com/orphic-inc/stellar-api/issues/146)) · **byte-identical cross-author dedup** on submit (reject a duplicate sheet under a second author's name; UI offers the existing one — _ADR-when-built_: hard to reverse, needs a content hash + index, "is identical = exact bytes or normalized?" is a real trade-off).
+
+   **Shipped since:** the **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1 into the Friends dimension) is now wired — see the §"Friends × Stylesheet" decision above ([#147](https://github.com/orphic-inc/stellar-api/issues/147) / PR #162).
 
 5. **Injection isolation** (ADR-0003) — StylesheetInjector spec in stellar-ui asserting the global reset boundary.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.5.3",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
mr-robot housekeeping pass after merging #160, #161 (#75), #162 (#147).

## Release — v0.5.5

- `package.json` 0.5.4 → **0.5.5**; `package-lock.json` 0.5.3 → 0.5.5 (also clears the lockfile version lag, #79).
- `CHANGELOG.md`: added the two post-#160 entries (community-health snapshots; Friends×Stylesheet controlled vector), then rolled `[Unreleased]` into a dated **`[0.5.5] — 2026-06-16`** section.
- **Tag `v0.5.5` to be cut after merge** (annotated, on the merge commit — I can't push tags to protected `main`).

## Docs reconciled against the merged work

- **PRD-03**: Friends×Stylesheet controlled vector marked **shipped** (#147 / #162); removed from the deferred list.
- **CONTEXT.md**: noted the pulse is now persisted; added a **Community Health Snapshot** term.
- **CLAUDE.md**: added `communityHealthHistory.ts` + `computePulse` to the module map.

## Not in this PR (tracked separately)

- PRD-02 **and** the CONTEXT.md IRC glossary terms (`AnnounceKey`/`IRCKey`/`IRC Activity Rollup`/`IRCScore` formula) still describe the pre-korin in-repo build → **#163** (docs-only rewrite, done deliberately).
- Issue reconciliation done out-of-band: #147 closed; #75 re-scoped to the CommunityScore fold; #76/#94 commented.

## Checks
Docs/manifest only — no `.ts` changed. Local: format no-op, lint clean, `tsc --noEmit` + `typecheck:test` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)