### PR TITLE
feat(classes): pure rank-progression evaluator (evaluateRankChange)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Automated user-class progression — pure evaluator** — `src/modules/rankProgression.ts`: a pure, table-driven engine (`evaluateRankChange`) that decides whether a member promotes one step, demotes one step, or stays, given their stats and the rule set, plus `describeGapToNext` for a member-facing "progress to next class" widget. Encodes one-step-per-pass climbing, stock-only demotion (ratio drift and account age never demote), demotion-takes-precedence-over-promotion on the prestige tiers, and rankLocked / active-warning / Staff-SysOp guards. No DB or I/O — 20 unit specs, built test-first. The data-model migration, ladder seed, sweep job, and admin/member UI are tracked as rollout slices [#167, #168, #169, #170, #171]; product decisions gating the seed are in [#172].
+
 ## [0.5.5] — 2026-06-16
 
 ### Added

--- a/src/modules/rankProgression.spec.ts
+++ b/src/modules/rankProgression.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for the rank-progression evaluator (USER_CLASSES_PLAN.md §6).
+ *
+ * The evaluator is pure — no DB, no I/O — so these tests need no Prisma mock.
+ * They read against the default class ladder (DEFAULT_RANKS / DEFAULT_RULES).
+ */
+import {
+  evaluateRankChange,
+  describeGapToNext,
+  DEFAULT_RANKS,
+  RankProgressionInput
+} from './rankProgression';
+
+const GiB = BigInt(1024 ** 3);
+
+const rankId = (name: string): number => {
+  const r = DEFAULT_RANKS.find((x) => x.name === name);
+  if (!r) throw new Error(`no such rank: ${name}`);
+  return r.id;
+};
+
+/** A user who clears every numeric/extra criterion on the ladder. */
+const maxed = (
+  over: Partial<RankProgressionInput> = {}
+): RankProgressionInput => ({
+  currentRankId: rankId('User'),
+  contributed: 1000n * GiB,
+  consumed: 500n * GiB, // ratio 2.0 — clears the 1.05 rungs
+  contributionCount: 1000,
+  distinctReleaseCount: 1000,
+  qualityContributionCount: 1000,
+  accountAgeDays: 365,
+  hasActiveWarning: false,
+  rankLocked: false,
+  ...over
+});
+
+// ─── promotion ────────────────────────────────────────────────────────────────
+
+describe('evaluateRankChange — promotion', () => {
+  it('promotes a User who meets all Member criteria one step to Member', () => {
+    const result = evaluateRankChange(maxed());
+    expect(result.direction).toBe('promote');
+    expect(result.targetRankId).toBe(rankId('Member'));
+  });
+
+  it('climbs only one rung per pass — a maxed User reaches Member, not beyond', () => {
+    const result = evaluateRankChange(maxed());
+    expect(result.targetRankId).toBe(rankId('Member'));
+    expect(result.targetRankId).not.toBe(rankId('Power User'));
+  });
+
+  it('stays when criteria are not yet met', () => {
+    const result = evaluateRankChange(maxed({ contributed: 1n * GiB }));
+    expect(result.direction).toBe('none');
+  });
+
+  it('promotes at the exact threshold (>= is inclusive)', () => {
+    // Member → Power User needs 25 GiB, 5 contributions, 14 days, ratio 1.05.
+    const result = evaluateRankChange(
+      maxed({
+        currentRankId: rankId('Member'),
+        contributed: 25n * GiB,
+        consumed: 20n * GiB, // ratio 1.25 ≥ 1.05
+        contributionCount: 5,
+        accountAgeDays: 14
+      })
+    );
+    expect(result.direction).toBe('promote');
+    expect(result.targetRankId).toBe(rankId('Power User'));
+  });
+
+  it('stalls a never-consumed Member at Member (ratio 1.0 < 1.05)', () => {
+    // Faithful port of the 1.0-when-unconsumed convention: a user who has never
+    // consumed cannot clear the 1.05 rungs no matter how much they contribute.
+    const result = evaluateRankChange(
+      maxed({
+        currentRankId: rankId('Member'),
+        contributed: 10_000n * GiB,
+        consumed: 0n,
+        contributionCount: 10_000,
+        accountAgeDays: 365
+      })
+    );
+    expect(result.direction).toBe('none');
+  });
+});
+
+// ─── demotion ─────────────────────────────────────────────────────────────────
+
+describe('evaluateRankChange — demotion', () => {
+  it('demotes one step when the stock criteria for the current class lapse', () => {
+    // Elite was reached via Power User → Elite (100 GiB, 50 contributions).
+    const result = evaluateRankChange(
+      maxed({ currentRankId: rankId('Elite'), contributed: 1n * GiB })
+    );
+    expect(result.direction).toBe('demote');
+    expect(result.targetRankId).toBe(rankId('Power User'));
+  });
+
+  it('does not demote for ratio drift (ratio is not a stock criterion)', () => {
+    const result = evaluateRankChange(
+      maxed({
+        currentRankId: rankId('Elite'),
+        contributed: 1000n * GiB,
+        consumed: 100_000n * GiB // ratio ~0.01, well under 1.05
+      })
+    );
+    expect(result.direction).toBe('none');
+  });
+
+  it('does not demote a User (base class has no incoming rule)', () => {
+    const result = evaluateRankChange(
+      maxed({
+        currentRankId: rankId('User'),
+        contributed: 0n,
+        contributionCount: 0
+      })
+    );
+    expect(result.direction).toBe('none');
+  });
+});
+
+// ─── extra predicates ───────────────────────────────────────────────────────────
+
+describe('evaluateRankChange — extra predicates', () => {
+  it('holds a Curator below Master Curator without 500 distinct releases', () => {
+    const result = evaluateRankChange(
+      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 499 })
+    );
+    expect(result.direction).toBe('none');
+  });
+
+  it('promotes a Curator to Master Curator once 500 distinct releases is met', () => {
+    const result = evaluateRankChange(
+      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 500 })
+    );
+    expect(result.direction).toBe('promote');
+    expect(result.targetRankId).toBe(rankId('Master Curator'));
+  });
+
+  it('demotes a Master Curator who falls below 500 distinct releases', () => {
+    const result = evaluateRankChange(
+      maxed({
+        currentRankId: rankId('Master Curator'),
+        distinctReleaseCount: 499
+      })
+    );
+    expect(result.direction).toBe('demote');
+    expect(result.targetRankId).toBe(rankId('Curator'));
+  });
+
+  it('promotes a Master Curator to Grand Curator on 500 quality contributions', () => {
+    const result = evaluateRankChange(
+      maxed({
+        currentRankId: rankId('Master Curator'),
+        qualityContributionCount: 500
+      })
+    );
+    expect(result.direction).toBe('promote');
+    expect(result.targetRankId).toBe(rankId('Grand Curator'));
+  });
+});
+
+// ─── guards ─────────────────────────────────────────────────────────────────────
+
+describe('evaluateRankChange — guards', () => {
+  it('does not touch a rankLocked user even when they qualify to promote', () => {
+    const result = evaluateRankChange(maxed({ rankLocked: true }));
+    expect(result.direction).toBe('none');
+    expect(result.targetRankId).toBe(rankId('User'));
+  });
+
+  it('freezes a user with an active warning', () => {
+    const result = evaluateRankChange(maxed({ hasActiveWarning: true }));
+    expect(result.direction).toBe('none');
+  });
+
+  it('never promotes into an assigned class (Grand Curator → Staff)', () => {
+    const result = evaluateRankChange(
+      maxed({ currentRankId: rankId('Grand Curator') })
+    );
+    expect(result.direction).toBe('none');
+  });
+
+  it('never auto-manages a user already in an assigned class (Staff)', () => {
+    const result = evaluateRankChange(
+      maxed({ currentRankId: rankId('Staff') })
+    );
+    expect(result.direction).toBe('none');
+  });
+});
+
+// ─── describeGapToNext ──────────────────────────────────────────────────────────
+
+describe('describeGapToNext', () => {
+  it('reports what a fresh User still needs for Member', () => {
+    const gap = describeGapToNext({
+      currentRankId: rankId('User'),
+      contributed: 4n * GiB,
+      consumed: 0n,
+      contributionCount: 0,
+      distinctReleaseCount: 0,
+      qualityContributionCount: 0,
+      accountAgeDays: 2,
+      hasActiveWarning: false,
+      rankLocked: false
+    });
+    expect(gap?.toRankName).toBe('Member');
+    expect(gap?.contributedShortBytes).toBe(6n * GiB); // 10 needed − 4 held
+    expect(gap?.ageShortDays).toBe(5); // 7 needed − 2 held
+    expect(gap?.ratioShort).toBe(0); // 1.0 already ≥ 0.70
+    expect(gap?.extraUnmet).toBeNull();
+  });
+
+  it('clamps satisfied criteria to zero shortfall', () => {
+    const gap = describeGapToNext(maxed());
+    expect(gap?.contributedShortBytes).toBe(0n);
+    expect(gap?.contributionsShort).toBe(0);
+    expect(gap?.ageShortDays).toBe(0);
+    expect(gap?.ratioShort).toBe(0);
+  });
+
+  it('surfaces the unmet Extra predicate on prestige rungs', () => {
+    const gap = describeGapToNext(
+      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 10 })
+    );
+    expect(gap?.toRankName).toBe('Master Curator');
+    expect(gap?.extraUnmet).toBe('DISTINCT_RELEASES_500');
+  });
+
+  it('returns null at the top of the auto ladder (Grand Curator)', () => {
+    expect(
+      describeGapToNext(maxed({ currentRankId: rankId('Grand Curator') }))
+    ).toBeNull();
+  });
+});

--- a/src/modules/rankProgression.ts
+++ b/src/modules/rankProgression.ts
@@ -1,0 +1,246 @@
+/**
+ * Rank-progression evaluator — the pure, table-driven core of automated user
+ * class progression (USER_CLASSES_PLAN.md §6).
+ *
+ * Given a user's stats plus the rule set, it decides whether the user promotes
+ * one step, demotes one step, or stays put. No DB and no I/O live here so the
+ * decision is deterministically unit-testable; the DB-bound sweep
+ * (rankProgressionJob) supplies the inputs and delegates changes to setUserRank.
+ */
+
+export const GiB = BigInt(1024 ** 3);
+
+export type RankExtraPredicate =
+  | 'DISTINCT_RELEASES_500'
+  | 'QUALITY_CONTRIB_500';
+
+export interface Rank {
+  id: number;
+  level: number;
+  name: string;
+  /** false for Staff/SysOp — never auto-reached, never auto-demoted into. */
+  autoManaged: boolean;
+}
+
+export interface RankPromotionRule {
+  fromRankId: number;
+  toRankId: number;
+  minContributed: bigint; // bytes
+  minRatio: number;
+  minContributions: number;
+  minAccountAgeDays: number;
+  extra: RankExtraPredicate | null;
+  enabled: boolean;
+}
+
+export interface RankProgressionInput {
+  currentRankId: number;
+  contributed: bigint;
+  consumed: bigint;
+  contributionCount: number;
+  distinctReleaseCount: number;
+  qualityContributionCount: number;
+  accountAgeDays: number;
+  hasActiveWarning: boolean;
+  rankLocked: boolean;
+}
+
+export type Direction = 'promote' | 'demote' | 'none';
+
+export interface RankProgressionResult {
+  targetRankId: number;
+  direction: Direction;
+  /** Human-readable why — for audit notes. Not load-bearing. */
+  reason: string;
+}
+
+// ─── default ladder (USER_CLASSES_PLAN.md §2 + §5) ──────────────────────────────
+
+export const DEFAULT_RANKS: Rank[] = [
+  { id: 1, level: 100, name: 'User', autoManaged: true },
+  { id: 2, level: 150, name: 'Member', autoManaged: true },
+  { id: 3, level: 200, name: 'Power User', autoManaged: true },
+  { id: 4, level: 300, name: 'Elite', autoManaged: true },
+  { id: 5, level: 350, name: 'Curator', autoManaged: true },
+  { id: 6, level: 400, name: 'Master Curator', autoManaged: true },
+  { id: 7, level: 450, name: 'Grand Curator', autoManaged: true },
+  { id: 8, level: 500, name: 'Staff', autoManaged: false },
+  { id: 9, level: 1000, name: 'SysOp', autoManaged: false }
+];
+
+export const DEFAULT_RULES: RankPromotionRule[] = [
+  promotionRule(1, 2, 10n * GiB, 0.7, 0, 7, null),
+  promotionRule(2, 3, 25n * GiB, 1.05, 5, 14, null),
+  promotionRule(3, 4, 100n * GiB, 1.05, 50, 28, null),
+  promotionRule(4, 5, 500n * GiB, 1.05, 500, 56, null),
+  promotionRule(5, 6, 500n * GiB, 1.05, 500, 56, 'DISTINCT_RELEASES_500'),
+  promotionRule(6, 7, 500n * GiB, 1.05, 500, 56, 'QUALITY_CONTRIB_500')
+];
+
+function promotionRule(
+  fromRankId: number,
+  toRankId: number,
+  minContributed: bigint,
+  minRatio: number,
+  minContributions: number,
+  minAccountAgeDays: number,
+  extra: RankExtraPredicate | null
+): RankPromotionRule {
+  return {
+    fromRankId,
+    toRankId,
+    minContributed,
+    minRatio,
+    minContributions,
+    minAccountAgeDays,
+    extra,
+    enabled: true
+  };
+}
+
+// ─── pure helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Mirrors `ratio.computeRatio` but kept local so this module stays free of the
+ * Prisma client that ratio.ts pulls in — the evaluator must remain pure.
+ */
+export const computeRatio = (contributed: bigint, consumed: bigint): number => {
+  if (consumed === 0n) return 1.0;
+  return Number(contributed) / Number(consumed);
+};
+
+const extraMet = (
+  extra: RankExtraPredicate | null,
+  input: RankProgressionInput
+): boolean => {
+  switch (extra) {
+    case 'DISTINCT_RELEASES_500':
+      return input.distinctReleaseCount >= 500;
+    case 'QUALITY_CONTRIB_500':
+      return input.qualityContributionCount >= 500;
+    case null:
+      return true;
+  }
+};
+
+/** All criteria — the bar for a PROMOTION. */
+const meetsAll = (
+  rule: RankPromotionRule,
+  input: RankProgressionInput
+): boolean =>
+  input.contributed >= rule.minContributed &&
+  computeRatio(input.contributed, input.consumed) >= rule.minRatio &&
+  input.contributionCount >= rule.minContributions &&
+  input.accountAgeDays >= rule.minAccountAgeDays &&
+  extraMet(rule.extra, input);
+
+/**
+ * "Stock" criteria only — bytes, contribution count, extra predicate. Ratio and
+ * age are deliberately excluded: they gate promotion but never trigger demotion
+ * (you do not lose a class for ratio drift or the passage of time).
+ */
+const meetsStock = (
+  rule: RankPromotionRule,
+  input: RankProgressionInput
+): boolean =>
+  input.contributed >= rule.minContributed &&
+  input.contributionCount >= rule.minContributions &&
+  extraMet(rule.extra, input);
+
+// ─── the evaluator ──────────────────────────────────────────────────────────────
+
+export const evaluateRankChange = (
+  input: RankProgressionInput,
+  rules: RankPromotionRule[] = DEFAULT_RULES,
+  ranks: Rank[] = DEFAULT_RANKS
+): RankProgressionResult => {
+  const stay = (reason: string): RankProgressionResult => ({
+    targetRankId: input.currentRankId,
+    direction: 'none',
+    reason
+  });
+
+  const current = ranks.find((r) => r.id === input.currentRankId);
+  if (!current) return stay('unknown rank');
+  if (input.rankLocked)
+    return stay('rankLocked — engine will not touch this user');
+  if (input.hasActiveWarning) return stay('active warning — frozen');
+  if (!current.autoManaged)
+    return stay(`${current.name} is assigned, never auto-managed`);
+
+  // Demotion takes precedence over promotion: a user must remain a valid
+  // member of their current class before they can advance. This only diverges
+  // from promotion in the prestige tiers, where the Extra predicates let the
+  // outgoing rule pass while the incoming (current-class) one has lapsed.
+  const incoming = rules.find(
+    (r) => r.enabled && r.toRankId === input.currentRankId
+  );
+  if (incoming && !meetsStock(incoming, input)) {
+    return {
+      targetRankId: incoming.fromRankId,
+      direction: 'demote',
+      reason: `no longer meets stock criteria for ${current.name}`
+    };
+  }
+
+  // Promotion: the outgoing rule from the current rank. One step only.
+  const outgoing = rules.find(
+    (r) => r.enabled && r.fromRankId === input.currentRankId
+  );
+  if (outgoing) {
+    const target = ranks.find((r) => r.id === outgoing.toRankId);
+    if (target?.autoManaged && meetsAll(outgoing, input)) {
+      return {
+        targetRankId: outgoing.toRankId,
+        direction: 'promote',
+        reason: `meets all ${target.name} criteria`
+      };
+    }
+  }
+
+  return stay(outgoing ? 'criteria not yet met' : 'top of the auto ladder');
+};
+
+// ─── member-facing "gap to next class" (USER_CLASSES_PLAN.md §7) ─────────────────
+
+export interface Gap {
+  toRankName: string | null;
+  contributedShortBytes: bigint;
+  ratioShort: number;
+  contributionsShort: number;
+  ageShortDays: number;
+  extraUnmet: RankExtraPredicate | null;
+}
+
+/**
+ * What the user still needs to reach the next rung — for a motivational
+ * read-time widget. Returns null when there is no rung above (top of the auto
+ * ladder). Mirrors `meetsAll`'s criteria, reported as remaining shortfalls.
+ */
+export const describeGapToNext = (
+  input: RankProgressionInput,
+  rules: RankPromotionRule[] = DEFAULT_RULES,
+  ranks: Rank[] = DEFAULT_RANKS
+): Gap | null => {
+  const outgoing = rules.find(
+    (r) => r.enabled && r.fromRankId === input.currentRankId
+  );
+  if (!outgoing) return null;
+  const target = ranks.find((r) => r.id === outgoing.toRankId);
+  const ratio = computeRatio(input.contributed, input.consumed);
+  const shortBytes = outgoing.minContributed - input.contributed;
+  return {
+    toRankName: target?.name ?? null,
+    contributedShortBytes: shortBytes < 0n ? 0n : shortBytes,
+    ratioShort: Math.max(0, outgoing.minRatio - ratio),
+    contributionsShort: Math.max(
+      0,
+      outgoing.minContributions - input.contributionCount
+    ),
+    ageShortDays: Math.max(
+      0,
+      outgoing.minAccountAgeDays - input.accountAgeDays
+    ),
+    extraUnmet: extraMet(outgoing.extra, input) ? null : outgoing.extra
+  };
+};


### PR DESCRIPTION
First slice of automated user-class progression: the **pure, table-driven evaluator** that the whole feature pivots on. Built test-first.

## What this adds
- **`src/modules/rankProgression.ts`** — `evaluateRankChange(input, rules?, ranks?)` returns `{ direction: 'promote' | 'demote' | 'none', targetRankId, reason }`. No DB, no I/O — deterministically unit-testable; the future sweep job supplies inputs and delegates changes to `setUserRank`.
- **`describeGapToNext`** — remaining bytes / ratio / contributions / age + any unmet Extra predicate, for a member-facing "progress to next class" widget. Returns null at the top of the auto ladder.
- Embedded default ladder (`DEFAULT_RANKS` / `DEFAULT_RULES`) so it's callable bare; the real rules/ranks will come from DB once the schema lands.
- **`src/modules/rankProgression.spec.ts`** — 20 specs covering promotion, one-step-per-pass, exact-threshold inclusivity, stock-only demotion, Extra predicates both directions, all guards, and the gap widget.

## Behaviour locked by the specs
- **One-step-per-pass** — at most one rung moves per evaluation.
- **Stock-only demotion** — only contributed bytes / contribution count / Extra predicate can demote; ratio drift and account age never do.
- **Demotion takes precedence over promotion** — when a user both qualifies for the next rung and has lapsed their current class's stock criteria (reachable only via the divergent prestige-tier Extra predicates), they drop rather than advance: you must remain a valid member of your current class before climbing.
- **Guards** — `rankLocked`, active warning, and assigned classes (Staff/SysOp) are never auto-managed.
- **Ratio convention** — faithful `1.0`-when-unconsumed port; a never-consumed member stalls below the 1.05 rungs (the spec asserts this). Whether to carve that out is a product decision (#172).

## Scope / follow-ups
Pure evaluator only. Tracked separately: schema + migration (#167), ladder seed (#168), sweep job + notifications (#169), admin editor (#170), member widget (#171), and the §11 product decisions that gate the seed (#172).

## Checks
`prettier` · `eslint` · `tsc --noEmit` · `typecheck:test` · full suite **1541 passed / 79 suites** (20 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)