### PR TITLE
chore(release): commit the v0.5.6 manifest bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ All notable changes to stellar-api are documented here.
 
 ### Added
 
+- **Verified IRC nick link (ADR-0015)** — challenge/nonce proof-of-control for `User.ircNick`; only a verified link credits IRCScore or resolves the korin nick→account lookup. Draft [#175].
+
+## [0.5.6] - 2026-06-17
+
+### Added
+
 - **Automated user-class progression — pure evaluator** — `src/modules/rankProgression.ts`: a pure, table-driven engine (`evaluateRankChange`) that decides whether a member promotes one step, demotes one step, or stays, given their stats and the rule set, plus `describeGapToNext` for a member-facing "progress to next class" widget. Encodes one-step-per-pass climbing, stock-only demotion (ratio drift and account age never demote), demotion-takes-precedence-over-promotion on the prestige tiers, and rankLocked / active-warning / Staff-SysOp guards. No DB or I/O — 20 unit specs, built test-first. The data-model migration, ladder seed, sweep job, and admin/member UI are tracked as rollout slices [#167, #168, #169, #170, #171]; product decisions gating the seed are in [#172].
+- **Schema ERD as committed documentation** — `prisma-erd-generator` renders a Mermaid `docs/erd.md` (regenerated on `prisma generate` and `npm run db:erd`), guarded by a CI "ERD freshness" drift-check; the Docker image build is scoped to the client generator so the dev-only ERD generator can't break it [#176].
+
+### Removed
+
+- **Legacy duplicate `TopTenLeaderboard` model** — a dead twin of the live `Top10Snapshot` / `top10.ts` board (it carried legacy `lastTorrent*` columns); removed the model plus a `DROP TABLE` migration [#176].
+
+### Docs
+
+- **ADR-0002** noted as snapshot-shipped (v0.5.5) [#166].
 
 ## [0.5.5] — 2026-06-16
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
The **v0.5.6** tag was cut while the version bump + changelog entry sat **uncommitted**, so the tagged commit's `package.json` still reads `0.5.5` — manifest/tag drift (#79 class). This commits the artifacts so `main` HEAD matches the tag.

- `package.json` → `0.5.6`.
- `CHANGELOG.md` — corrected the v0.5.6 entry to what actually shipped: rank-progression evaluator (#173), committed schema ERD + CI drift-check, and the `TopTenLeaderboard` drop (#176) + ADR-0002 note (#166). The "Verified Nick Link" line was premature (that's #175, an unmerged draft) → moved to `[Unreleased]`.

> Note: the `v0.5.6` tag still points one commit behind this bump. Per Mr. Robot's "don't rewrite history for past drift," leave it; bump the manifest **in** the release commit going forward. If you'd rather, you can force-move the tag onto this commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)