### PR TITLE
fix(erd): regenerate docs/erd.md — unblock Publish-to-GHCR on main

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -440,6 +440,9 @@ Yearly Yearly
     String lastIp "❓"
     Boolean disablePm 
     String ircNick "❓"
+    String pendingIrcNick "❓"
+    String ircNickNonce "❓"
+    DateTime ircNickNonceExpiresAt "❓"
     DateTime createdAt 
     DateTime updatedAt 
     }


### PR DESCRIPTION
## Problem

The `Publish packages to GHCR` workflow's `test` job has been failing on every push to `main` since the verified-IRC-nick-link work (#175 / ADR-0015) merged. That work added `User.pendingIrcNick`, `ircNickNonce`, and `ircNickNonceExpiresAt` to `schema.prisma` but did not regenerate the committed ERD.

The `ERD freshness` step runs:
```
npm run db:erd && git diff --exit-code docs/erd.md
```
which regenerates the ERD and fails if it differs from the committed copy. It's been exiting 1 ever since, blocking the publish job (everything else — format, lint, type-check, OpenAPI freshness, unit tests — passes).

## Fix

Regenerated `docs/erd.md` from the current schema (3 added `User` fields). Output is byte-identical to what CI generates; reproduced the gate locally and it now passes clean. ERD-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)