### PR TITLE
fix(seed): correct install URL port to :9000

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,7 @@
 /**
  * Dev seed — recreates default user ranks and forum structure so the /install
  * flow is available after a database reset.  Does NOT create users; complete
- * the install flow at http://localhost:3000/install after running this.
+ * the install flow at http://localhost:9000/install after running this.
  *
  * Runs automatically after `prisma migrate dev` resets the database.
  * Can also be run manually: npx prisma db seed
@@ -14,7 +14,7 @@ const prisma = new PrismaClient();
 async function main() {
   await seedRanks(prisma);
   await seedForums(prisma);
-  console.log('→ Complete setup at http://localhost:3000/install');
+  console.log('→ Complete setup at http://localhost:9000/install');
 }
 
 main()


### PR DESCRIPTION
The dev seed printed the post-reset install hint as `localhost:3000`, but the stellar-ui dev server runs on `:9000` (webpack `devServer.port`). Updated both the header comment and the `console.log`.

Salvaged from a parked local stash during a repo-state sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)