### PR TITLE
docs(ratio): settle Freepass/Neutralpass + restate PRD-06/ADR-0006 in domain terms

### DIFF
--- a/docs/adr/0006-linkhealth-gated-ratio-relief.md
+++ b/docs/adr/0006-linkhealth-gated-ratio-relief.md
@@ -1,24 +1,24 @@
-# LinkHealth-gated ratio relief (effective-seeding analog)
+# LinkHealth-gated ratio relief
 
 **Status: Accepted.** Serves [PRD-06 Ratio](../prd/06-ratio.md) and [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md). Relates to the LinkHealth lifecycle ([`linkHealth.ts`](../../src/modules/linkHealth.ts), [`linkHealthJob.ts`](../../src/modules/linkHealthJob.ts)).
 
 ## Context
 
-Stellar's required-ratio model (`src/modules/ratio.ts`) follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)), in which required ratio is `maximum required ratio × (1 − X)` and depends on **downloaded amount, how many things you are seeding, and how long you have seeded them over the trailing window** — a release is *effectively seeded* if it has been available for at least 72 hours in the past seven days.
+Stellar's required-ratio model (`src/modules/ratio.ts`) follows the classic ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)), in which required ratio is `maximum required ratio × (1 − X)` and depends on **amount consumed, how many contributions you keep available, and how long they have stayed available over the trailing window** — a contribution counts while it has been available for at least 72 hours in the past seven days.
 
-Our implementation captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief term `X` as a **static, permanent byte-credit**: `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` is the sum of a user's staff-approved, 72h-old contribution bytes. Once approved, a contribution lowers the user's required ratio **forever** — even if its download link died years ago. That misses the central pillar: relief comes from *ongoing availability*, not a one-time act of uploading.
+Our implementation captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief term `X` as a **static, permanent byte-credit**: `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` is the sum of a user's staff-approved, 72h-old contribution bytes. Once approved, a contribution lowers the user's required ratio **forever** — even if its download link died years ago. That misses the central pillar: relief comes from _ongoing availability_, not a one-time act of uploading.
 
-Stellar has no peer-to-peer transfers — contributions are hosted links, and `downloads.ts` accrues a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**: `linkStatus` already tracks whether a contribution's link is reachable (`PASS`), suspect (`WARN`), unchecked (`UNKNOWN`), or dead (`FAIL`), rechecked every 24h by `linkHealthJob.ts`.
+Contributions are hosted links, and `downloads.ts` accrues a contributor's `contributed` bytes each time someone consumes from their link. So **a live link is a continuously-available contribution**, and **LinkHealth is the availability substrate**: `linkStatus` already tracks whether a contribution's link is reachable (`PASS`), suspect (`WARN`), unchecked (`UNKNOWN`), or dead (`FAIL`), rechecked every 24h by `linkHealthJob.ts`.
 
 ## Decision
 
 Gate ratio relief on current link health. A contribution's approved bytes count toward `eligibleContributionBytes` **only while its latest `linkStatus ≠ FAIL`**.
 
-1. **Revocable relief.** A contribution flipping to `FAIL` drops its bytes out of the relief pool, so a user's required ratio can *rise* as their links rot — with no new download on their part. This mirrors a release losing its seeding credit when nobody keeps it available.
+1. **Revocable relief.** A contribution flipping to `FAIL` drops its bytes out of the relief pool, so a user's required ratio can _rise_ as their links rot — with no new consumption on their part. This mirrors a contribution losing its relief credit once it is no longer available.
 2. **Suspicion does not revoke.** `WARN` (including the ≥3-distinct-reporter auto-warn) and `UNKNOWN` keep counting. Only a machine-confirmed dead link (`FAIL`) revokes. Community reports therefore cannot be weaponized to inflate a rival's required ratio — only an actual failed HEAD check can.
 3. **Persistent suspicion is promoted.** A contribution stuck at `WARN` and unresolved for **72 hours** is swept to `FAIL` by the link-health job (PM the contributor, file the staff report), which then revokes relief. This closes the "returns 200 but the file is gone" hole without making reports a weapon.
 4. **Current status only.** Ratio relief reads the latest `linkStatus`; the 24h recheck keeps it fresh. We do **not** build a link-health history series for ratio. Cumulative-uptime-over-account-lifetime is a separate, slower CRS dimension (`LinkHealthBonusPoints`) tracked elsewhere.
-5. **No clawback of `contributed`.** Revocation affects only the *relief pool* (`eligibleContributionBytes`, which lowers required ratio). A user's lifetime `contributed` — bytes others actually downloaded from them — is historical and is never reduced when a link dies; already-earned upload credit is permanent.
+5. **No clawback of `contributed`.** Revocation affects only the _relief pool_ (`eligibleContributionBytes`, which lowers required ratio). A user's lifetime `contributed` — bytes others actually downloaded from them — is historical and is never reduced when a link dies; already-earned upload credit is permanent.
 
 Ratio remains a standalone download gate. It does not read CRS, and CRS does not gate downloads (see [ADR-0007](0007-crs-read-time-and-event-ledger.md)).
 

--- a/docs/prd/06-ratio.md
+++ b/docs/prd/06-ratio.md
@@ -2,33 +2,34 @@
 
 **Status:** Draft · **Owner:** @obrien-k
 **Decisions:** [ADR-0006 LinkHealth-gated ratio relief](../adr/0006-linkhealth-gated-ratio-relief.md)
+**Hot-path accounting:** korin.pink [ADR-004 Go Accounting Service (`ledger`)](https://github.com/obrien-k/korin-pink/blob/main/docs/adr/004-go-accounting-service.md) (Proposed) — the `canConsume` gate + real-time consumption accounting that enforces this at runtime.
 **Feeds:** [PRD-01 Community-Score / CRS](01-Community-Score.md) — a derived `RatioScore` is one CRS/CVI dimension; the ratio _mechanism_ itself is independent of CRS.
 **Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · **PRD-06 Ratio** · PRD-07 Donations · PRD-08 Collages & Cover Art
 
-> Lean PRD. Captures the ratio mechanism as it should be, maps each piece to existing code, and flags the overhaul. Ratio is an **enforcement** mechanism (download gate); CRS is a **reputation** signal. They are layered one-way: a `RatioScore` flows into CRS; CRS never gates downloads and ratio never reads CRS.
+> Lean PRD. Captures the ratio mechanism as it should be, maps each piece to existing code, and flags the overhaul. Ratio is an **enforcement** mechanism (consumption gate); CRS is a **reputation** signal. They are layered one-way: a `RatioScore` flows into CRS; CRS never gates consumption and ratio never reads CRS.
 
 ## Problem
 
-Stellar's required-ratio model follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)) but is incomplete. That model's required ratio depends on three pillars — **downloaded amount**, **how many things you're seeding**, and **how long they've stayed available over the trailing window** (effectively seeded if available ≥ 72h in the past 7 days). The formula was `maximum required ratio × (1 − X)`.
+Stellar's required-ratio model follows the classic ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)) but is incomplete. That model's required ratio depends on three pillars — **amount consumed**, **how many contributions you keep available**, and **how long they've stayed available over the trailing window** (counted while available ≥ 72h in the past 7 days). The formula was `maximum required ratio × (1 − X)`.
 
-`src/modules/ratio.ts` captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The _seeding / ongoing-availability_ pillar is missing.
+`src/modules/ratio.ts` captures the consumption brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The _ongoing-availability_ pillar is missing.
 
-## The seeding analog: LinkHealth
+## The availability substrate: LinkHealth
 
-Stellar has no peer-to-peer transfers — contributions are hosted links. `downloads.ts` credits a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**:
+Contributions are hosted links. `downloads.ts` credits a contributor's `contributed` bytes each time someone consumes from their link. So **a live link is a continuously-available contribution**, and **LinkHealth is the availability substrate** the relief term reads:
 
-| Reference model                        | Stellar                                                                        |
-| -------------------------------------- | ------------------------------------------------------------------------------ |
-| Seeding a release                      | A contribution whose link is reachable (`linkStatus = PASS`)                   |
-| Effectively seeded (available ≥72h/7d) | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh)                       |
-| Stopped seeding → lose relief          | Link `FAIL` → contribution drops from the relief pool                          |
-| Uploaded bytes (others snatched)       | `User.contributed` (others downloaded from you) — permanent, never clawed back |
+| Availability concept              | Stellar mechanic                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------ |
+| Keeping a contribution available  | A contribution whose link is reachable (`linkStatus = PASS`)                   |
+| Sustained availability (≥72h/7d)  | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh)                       |
+| Availability lapses → lose relief | Link `FAIL` → contribution drops from the relief pool                          |
+| Bytes others consumed from you    | `User.contributed` (others downloaded from you) — permanent, never clawed back |
 
 ## Mechanism
 
 ### Required ratio (unchanged shape, gated relief)
 
-- **Download brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). _Bracket values are tuning; current table assumed settled, flagged for review._
+- **Consumption brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). _Bracket values are tuning; current table assumed settled, flagged for review._
 - **Formula:** `requiredRatio = max(minRequired, maxRequired × (1 − coverage))`.
 - **Coverage (the overhaul):** `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` sums a user's staff-approved, 72h-old contribution bytes **whose current `linkStatus ≠ FAIL`**. See [ADR-0006](../adr/0006-linkhealth-gated-ratio-relief.md):
   - `FAIL` revokes relief (required ratio can rise as links rot).
@@ -38,31 +39,44 @@ Stellar has no peer-to-peer transfers — contributions are hosted links. `downl
 
 ### Policy state machine (unchanged)
 
-`ratioPolicy.ts`: `OK → WATCH → LEECH_DISABLED`. `WATCH` lasts 14 days; auto-disable on 10 GiB consumed during watch or watch expiry; `LEECH_DISABLED` reversed by staff only.
+`ratioPolicy.ts`: `OK → WATCH → LEECH_DISABLED`. `WATCH` lasts 14 days; auto-disable on 10 GiB consumed during watch or watch expiry; the disabled state is reversed by staff only.
+
+### Ratio-exempt contributions: Freepass & Neutralpass
+
+Two Contribution-level flags change how a consumption touches ratio — the only points where the consumption-accounting path (`downloads.ts` today; korin.pink `ledger` per ADR-004) conditionally skips accrual:
+
+| Flag            | Consumer's `consumed` | Contributor's `contributed` | Use                                                                                                                       |
+| --------------- | --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Freepass**    | not accrued           | **still accrued**           | Promote selected / staff-featured Contributions; members consume freely while contributors still earn availability credit |
+| **Neutralpass** | not accrued           | not accrued                 | Fully ratio-invisible on both sides — items that should sit outside the ratio economy entirely                            |
+
+Freepass is the lever for letting members rebuild ratio (consume without penalty) while still rewarding the contributor's sustained availability; Neutralpass removes an item from the ratio economy in both directions. The flag lives on the Contribution (king) and is read at consumption time — the accounting path checks it before incrementing `consumed` (both flags) and `contributed` (Neutralpass only).
 
 ### Concepts from the reference model not yet modelled (flagged)
 
-- **Seeding _count_** (the reference factors how many releases you seed, not just bytes) — out of scope for v1; byte-coverage is the lever.
-- **Freeleech / neutral-leech** (download without ratio impact) — a tracker feature; separate concern, not in this overhaul.
+- **Availability count** (the reference factors how many contributions you keep available, not just bytes) — out of scope for v1; byte-coverage is the lever.
 
 ## Concept → existing code (the descent map)
 
-| Concept                                      | Lives in                                                                           |
-| -------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Ratio + required-ratio + brackets            | `src/modules/ratio.ts`                                                             |
-| Policy state machine                         | `src/modules/ratioPolicy.ts`                                                       |
-| `contributed` credit (seeding-snatch analog) | `src/modules/downloads.ts`                                                         |
-| LinkHealth status + 24h recheck + 72h sweep  | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts`                        |
-| Ratio surface                                | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
-| Lifetime uptime (CRS, not ratio)             | deferred — `LinkHealthBonusPoints` dimension, PRD-01                               |
+| Concept                                     | Lives in                                                                           |
+| ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Ratio + required-ratio + brackets           | `src/modules/ratio.ts`                                                             |
+| Policy state machine                        | `src/modules/ratioPolicy.ts`                                                       |
+| `contributed` credit (availability analog)  | `src/modules/downloads.ts`                                                         |
+| Freepass / Neutralpass accrual skip         | `src/modules/downloads.ts` (flag on `Contribution`)                                |
+| LinkHealth status + 24h recheck + 72h sweep | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts`                        |
+| Ratio surface                               | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
+| Lifetime uptime (CRS, not ratio)            | deferred — `LinkHealthBonusPoints` dimension, PRD-01                               |
 
 ## Red-green descent targets
 
 1. ✅ **Relief LinkHealth gate** — `eligibleContributionBytes` filtered by `linkStatus ≠ FAIL`; required ratio rises when a covered contribution flips `FAIL`, `WARN`/`UNKNOWN` still count. **Shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96).**
 2. 🟡 **72h WARN→FAIL sweep** — `linkStatusChangedAt` + `sweepStaleWarnLinks` in `linkHealthJob.ts`. **Promotion shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96)**; the contributor-PM + staff-report notification on promotion is still TODO.
 3. ✅ **`RatioScore` dimension** — bounded CRS sub-score from current ratio health, one-way into PRD-01's registry. **Shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96).**
+4. 🔲 **Freepass / Neutralpass** — boolean flags on `Contribution`; the consumption-accounting path skips `consumed` accrual for both and `contributed` accrual for Neutralpass. Not yet started.
 
 ## Open questions
 
 - Bracket values — keep the current table or re-tune to specific numeric thresholds? (assumed settled for now)
 - Whether the policy `WATCH` thresholds (14d / 10 GiB) change in the overhaul (assumed unchanged).
+- Freepass / Neutralpass granularity — a per-Contribution flag only, or also time-boxed / site-wide promotional events?


### PR DESCRIPTION
## What

- **Freepass / Neutralpass** — settles the two consumption-accounting flags in PRD-06. Freepass waives the consumer's `consumed` but still credits the contributor's `contributed`; Neutralpass waives both. Flag on the Contribution; read on the consumption-accounting path (`downloads.ts` today, korin.pink `ledger` per ADR-004). Added to the descent map, red-green targets, and open questions.
- **Domain-language pass** — PRD-06 and ADR-0006 now describe the ratio mechanism in Stellar's own vocabulary (consumption, availability, the LinkHealth substrate) instead of borrowed reference-model phrasing. No code identifiers changed; the ratio writeup reference is preserved.

## Note

`ratioPolicy.ts`'s `LEECH_DISABLED` enum is cited as-is (live code). Any rename is a separate code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)