### PR TITLE
docs(adr-0016): consumption accounting & ratio-gate contract (korin ledger ↔ stellar)

### DIFF
--- a/docs/adr/0006-linkhealth-gated-ratio-relief.md
+++ b/docs/adr/0006-linkhealth-gated-ratio-relief.md
@@ -1,24 +1,24 @@
-# LinkHealth-gated ratio relief (effective-seeding analog)
+# LinkHealth-gated ratio relief
 
 **Status: Accepted.** Serves [PRD-06 Ratio](../prd/06-ratio.md) and [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md). Relates to the LinkHealth lifecycle ([`linkHealth.ts`](../../src/modules/linkHealth.ts), [`linkHealthJob.ts`](../../src/modules/linkHealthJob.ts)).
 
 ## Context
 
-Stellar's required-ratio model (`src/modules/ratio.ts`) follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)), in which required ratio is `maximum required ratio × (1 − X)` and depends on **downloaded amount, how many things you are seeding, and how long you have seeded them over the trailing window** — a release is *effectively seeded* if it has been available for at least 72 hours in the past seven days.
+Stellar's required-ratio model (`src/modules/ratio.ts`) follows the classic ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)), in which required ratio is `maximum required ratio × (1 − X)` and depends on **amount consumed, how many contributions you keep available, and how long they have stayed available over the trailing window** — a contribution counts while it has been available for at least 72 hours in the past seven days.
 
-Our implementation captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief term `X` as a **static, permanent byte-credit**: `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` is the sum of a user's staff-approved, 72h-old contribution bytes. Once approved, a contribution lowers the user's required ratio **forever** — even if its download link died years ago. That misses the central pillar: relief comes from *ongoing availability*, not a one-time act of uploading.
+Our implementation captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief term `X` as a **static, permanent byte-credit**: `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` is the sum of a user's staff-approved, 72h-old contribution bytes. Once approved, a contribution lowers the user's required ratio **forever** — even if its download link died years ago. That misses the central pillar: relief comes from _ongoing availability_, not a one-time act of uploading.
 
-Stellar has no peer-to-peer transfers — contributions are hosted links, and `downloads.ts` accrues a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**: `linkStatus` already tracks whether a contribution's link is reachable (`PASS`), suspect (`WARN`), unchecked (`UNKNOWN`), or dead (`FAIL`), rechecked every 24h by `linkHealthJob.ts`.
+Contributions are hosted links, and `downloads.ts` accrues a contributor's `contributed` bytes each time someone consumes from their link. So **a live link is a continuously-available contribution**, and **LinkHealth is the availability substrate**: `linkStatus` already tracks whether a contribution's link is reachable (`PASS`), suspect (`WARN`), unchecked (`UNKNOWN`), or dead (`FAIL`), rechecked every 24h by `linkHealthJob.ts`.
 
 ## Decision
 
 Gate ratio relief on current link health. A contribution's approved bytes count toward `eligibleContributionBytes` **only while its latest `linkStatus ≠ FAIL`**.
 
-1. **Revocable relief.** A contribution flipping to `FAIL` drops its bytes out of the relief pool, so a user's required ratio can *rise* as their links rot — with no new download on their part. This mirrors a release losing its seeding credit when nobody keeps it available.
+1. **Revocable relief.** A contribution flipping to `FAIL` drops its bytes out of the relief pool, so a user's required ratio can _rise_ as their links rot — with no new consumption on their part. This mirrors a contribution losing its relief credit once it is no longer available.
 2. **Suspicion does not revoke.** `WARN` (including the ≥3-distinct-reporter auto-warn) and `UNKNOWN` keep counting. Only a machine-confirmed dead link (`FAIL`) revokes. Community reports therefore cannot be weaponized to inflate a rival's required ratio — only an actual failed HEAD check can.
 3. **Persistent suspicion is promoted.** A contribution stuck at `WARN` and unresolved for **72 hours** is swept to `FAIL` by the link-health job (PM the contributor, file the staff report), which then revokes relief. This closes the "returns 200 but the file is gone" hole without making reports a weapon.
 4. **Current status only.** Ratio relief reads the latest `linkStatus`; the 24h recheck keeps it fresh. We do **not** build a link-health history series for ratio. Cumulative-uptime-over-account-lifetime is a separate, slower CRS dimension (`LinkHealthBonusPoints`) tracked elsewhere.
-5. **No clawback of `contributed`.** Revocation affects only the *relief pool* (`eligibleContributionBytes`, which lowers required ratio). A user's lifetime `contributed` — bytes others actually downloaded from them — is historical and is never reduced when a link dies; already-earned upload credit is permanent.
+5. **No clawback of `contributed`.** Revocation affects only the _relief pool_ (`eligibleContributionBytes`, which lowers required ratio). A user's lifetime `contributed` — bytes others actually downloaded from them — is historical and is never reduced when a link dies; already-earned upload credit is permanent.
 
 Ratio remains a standalone download gate. It does not read CRS, and CRS does not gate downloads (see [ADR-0007](0007-crs-read-time-and-event-ledger.md)).
 

--- a/docs/adr/0016-ledger-accounting-contract.md
+++ b/docs/adr/0016-ledger-accounting-contract.md
@@ -1,0 +1,73 @@
+# ADR-0016: Consumption accounting & ratio-gate contract (korin.pink `ledger` ↔ stellar-api)
+
+**Status:** Proposed
+**Date:** 2026-06-18
+**Repos:** orphic-inc/stellar-api (system of record), obrien-k/korin-pink (`ledger` accounting authority)
+**Extends:** [ADR-0013 — korin.pink IRC integration](0013-korin-pink-irc-integration.md) (the bidirectional boundary this builds on)
+**Serves:** [PRD-06 Ratio](../prd/06-ratio.md), [ADR-0006 LinkHealth-gated ratio relief](0006-linkhealth-gated-ratio-relief.md)
+**Counterpart:** korin.pink [ADR-004 Go Accounting Service (`ledger`)](https://github.com/obrien-k/korin-pink/blob/main/docs/adr/004-go-accounting-service.md) — its Phase-2 dependency is exactly this contract.
+
+---
+
+## Context
+
+ADR-0013 established the stellar-api ↔ korin.pink boundary for **IRC signals**: stellar pulls `GET /irc/metrics`, korin reads CRS / resolves nicks, all over a shared-secret back-channel. korin.pink ADR-004 then proposed the Go `ledger` — a hot-path accounting authority (real-time consumption accounting, a `canConsume` gate, live activity counters) — but explicitly gated its Phase 2 on **stellar-api exposing consumption-event and ratio-gate contracts**. This ADR is that contract.
+
+Today, ratio accounting lives entirely in stellar-api: `downloads.ts` accrues `contributed`/`consumed` at grant time, `ratio.ts` computes required ratio, and `ratioPolicy.ts` evaluates `OK → WATCH → LEECH_DISABLED` **at read time**. There is no real-time gate at grant time, no hot working set, and no live activity stats — and computing those per-request against Postgres is the wrong place for hot, high-churn counters.
+
+**The origin is reversed from the classic ratio model.** In the reference model, clients self-reported transfer to a hot-path daemon, which was therefore the _origin_ of the numbers and had to buffer-flush them back to the durable site. Stellar has no swarm: **stellar issues every consumption grant itself** (`downloads.ts`), so consumption is **server-authoritative** and stellar is already the durable origin of every byte. This collapses two pieces of the reference design:
+
+- There is **no client self-report**, so no cheat surface and no delta-of-cumulative-counter reconciliation.
+- There is **no flush-back of accounting** — stellar already persisted the truth when it issued the grant. korin does not own numbers to return.
+
+So `ledger` is not a parallel authority; it is a **derived, real-time read-model** fed by stellar's authoritative grant events, providing three things stellar's read-time model cannot cheaply provide: a **grant-time gate**, **live activity stats**, and a vantage for **integrity/abuse detection**.
+
+---
+
+## Decision
+
+Define the accounting contract as an **extension of ADR-0013's integration contract**, reusing its auth and key model unchanged. Roles:
+
+- **stellar-api** — durable system of record and the **origin** of every consumption event. Owns `Contribution`/`User` state, the ratio formula and brackets (`ratio.ts`, ADR-0006), the policy state machine (`ratioPolicy.ts`), and the Freepass/Neutralpass/bonus-pass resolution (PRD-06). It **resolves the ratio impact of each grant before emitting it** — korin never re-derives pass logic.
+- **korin.pink `ledger`** — a **derived hot-path read-model**: an in-memory working set seeded from stellar, advanced by stellar's grant events, answering the `canConsume` gate and live-stats reads, and (later) surfacing abuse signals. Holds only recoverable state; on restart it reloads the snapshot from stellar (bounded-loss model, korin ADR-003 / ADR-0013).
+
+### Flows (extends the ADR-0013 contract table; same keys, same fail-closed rules)
+
+| Flow                     | Direction                | Endpoint                                                         | Auth                                               | Notes                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------ | ------------------------ | ---------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Consumption event**    | stellar **pushes** korin | `POST {KORIN_API_URL}/ledger/consumption`                        | `x-pull-key: KORIN_PULL_KEY`                       | Server-authoritative. Body `{grantId, userId, contributorId, contributionId, consumedDelta, contributedDelta, pass: "none"\|"freepass"\|"neutralpass"\|"bonus", at}`. **stellar pre-resolves the deltas** (Freepass → `consumedDelta=0`, `contributedDelta=bytes`; Neutralpass → both 0; bonus-pass → `consumedDelta=0`); korin only sums into the hot working set. Idempotent on `grantId`. |
+| **Ratio gate**           | stellar **pulls** korin  | `GET {KORIN_API_URL}/ledger/can-consume?userId=&contributionId=` | `x-pull-key`                                       | Returns `{allow, reason, currentRatio, requiredRatio, policyState}`. `downloads.ts` calls this before issuing a grant. **Fail-open to stellar's own read-time `ratioPolicy` if korin is unreachable** — a korin outage must never hard-block consumption.                                                                                                                                    |
+| **State sync**           | stellar **pushes** korin | `POST {KORIN_API_URL}/ledger/sync`                               | `x-pull-key`                                       | Working-set mutations that aren't grant events: add/remove/update `Contribution` (bytes, `contributorId`, `linkStatus`, pass flag), user policy-state transitions (`OK`/`WATCH`/disabled), `AnnounceKey` rotation, bonus-pass grant/spend. Keeps korin consistent with stellar's authoritative state between snapshots.                                                                      |
+| **Working-set snapshot** | korin **pulls** stellar  | `GET /api/ledger/snapshot`                                       | `Bearer STELLAR_SERVICE_KEY` (`requireServiceKey`) | Seed/reload on boot. Returns the durable totals + contribution/user state korin needs to rebuild the hot aggregate; korin then advances it with live consumption events.                                                                                                                                                                                                                     |
+| **Live stats**           | stellar **pulls** korin  | `GET {KORIN_API_URL}/ledger/stats`                               | `x-pull-key`                                       | Global + per-user real-time activity (active consumers/contributors, current-window counters) for site/profile surfaces — the degraded-"scrape" analog. Cached like `/irc/metrics`.                                                                                                                                                                                                          |
+
+Auth, key names, and fail-closed semantics are inherited verbatim from ADR-0013 (`KORIN_API_URL`/`KORIN_PULL_KEY` for stellar→korin; `STELLAR_SERVICE_KEY` bearer for korin→stellar; korin mirrors them as `STELLAR_API_URL`/`STELLAR_PULL_KEY`/`STELLAR_API_KEY`).
+
+> **Namespace guard (from ADR-0013 / PRD-02).** The consumption-event ingest above is **not** "announce." korin's `/irc/announce` is the unrelated RSS/IRC _publish_ path. Porting the ledger ingest is not porting announce.
+
+---
+
+## Rationale
+
+- **Server-authoritative ⇒ simpler than the reference model.** No self-report, no per-file balance reconciliation, no buffered flush-back of accounting. The ingest is a stream of pre-resolved deltas stellar already trusts.
+- **The gate moves to grant time, fed by hot state** (PRD-06's intent), without per-request Postgres aggregation. korin's working set is the read-model that makes that cheap.
+- **Outage tolerance, both ways.** korin down → stellar gates from its own read-time `ratioPolicy` (fail-open) and buffers/retries consumption events; korin recovers by re-pulling the snapshot. This preserves ADR-0013's "korin downtime degrades, never breaks core" property.
+- **Pass logic stays in the system of record.** Freepass/Neutralpass/bonus-pass affect the ratio impact; resolving them in stellar (which owns the flags and the bonus economy) keeps korin a dumb summer and avoids split-brain on the economy rules.
+- **One boundary, reused.** No new auth model, no new inbound surface on stellar beyond the existing Bearer reads.
+
+---
+
+## Consequences
+
+- korin gains a `Contribution`-aware working set (not just IRC metrics) and three endpoints (`/ledger/consumption`, `/ledger/can-consume`, `/ledger/stats`); stellar gains a `/api/ledger/snapshot` read and emits events + sync mutations from `downloads.ts` / the contribution + ratio-policy paths.
+- **Phasing.** korin ADR-004 Phase 1 (port IRC metrics) needs **no** new contract. This ADR is the **Phase 2** dependency; it can land incrementally — gate-only first (read path), then event ingest, then live stats, then abuse signals.
+- **Freepass / Neutralpass** (PRD-06 red-green target #4) are realized as the `pass` field on the consumption event + a `Contribution` flag synced via `/ledger/sync`. **Bonus-funded pass** rides the same `pass: "bonus"` value, debited in stellar's (deferred) bonus economy.
+- **Integrity / abuse detection** is enabled but **out of scope for this contract** — korin's hot-state + IRC vantage is the home for it; the signal shape (impossible-consumption, sybil/multi-account) is a follow-on ADR.
+- If korin is never deployed, stellar's existing read-time accounting continues unchanged — this contract is purely additive.
+
+---
+
+## Cross-references
+
+- **stellar-api:** ADR-0013 (boundary, extended here) · ADR-0006 (ratio relief) · PRD-06 (ratio, Freepass/Neutralpass).
+- **korin.pink:** ADR-004 (the `ledger` service this contract unblocks) · ADR-003 (bounded-loss hot-state model).

--- a/docs/prd/06-ratio.md
+++ b/docs/prd/06-ratio.md
@@ -2,33 +2,34 @@
 
 **Status:** Draft · **Owner:** @obrien-k
 **Decisions:** [ADR-0006 LinkHealth-gated ratio relief](../adr/0006-linkhealth-gated-ratio-relief.md)
+**Hot-path accounting:** korin.pink [ADR-004 Go Accounting Service (`ledger`)](https://github.com/obrien-k/korin-pink/blob/main/docs/adr/004-go-accounting-service.md) (Proposed) — the `canConsume` gate + real-time consumption accounting that enforces this at runtime.
 **Feeds:** [PRD-01 Community-Score / CRS](01-Community-Score.md) — a derived `RatioScore` is one CRS/CVI dimension; the ratio _mechanism_ itself is independent of CRS.
 **Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · **PRD-06 Ratio** · PRD-07 Donations · PRD-08 Collages & Cover Art
 
-> Lean PRD. Captures the ratio mechanism as it should be, maps each piece to existing code, and flags the overhaul. Ratio is an **enforcement** mechanism (download gate); CRS is a **reputation** signal. They are layered one-way: a `RatioScore` flows into CRS; CRS never gates downloads and ratio never reads CRS.
+> Lean PRD. Captures the ratio mechanism as it should be, maps each piece to existing code, and flags the overhaul. Ratio is an **enforcement** mechanism (consumption gate); CRS is a **reputation** signal. They are layered one-way: a `RatioScore` flows into CRS; CRS never gates consumption and ratio never reads CRS.
 
 ## Problem
 
-Stellar's required-ratio model follows the classic private-tracker ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)) but is incomplete. That model's required ratio depends on three pillars — **downloaded amount**, **how many things you're seeding**, and **how long they've stayed available over the trailing window** (effectively seeded if available ≥ 72h in the past 7 days). The formula was `maximum required ratio × (1 − X)`.
+Stellar's required-ratio model follows the classic ratio model (see the [ratio writeup](https://kyleobrien.me/%E9%BB%92%E6%98%A5%E5%85%89%E7%90%B3%E6%B5%B7)) but is incomplete. That model's required ratio depends on three pillars — **amount consumed**, **how many contributions you keep available**, and **how long they've stayed available over the trailing window** (counted while available ≥ 72h in the past 7 days). The formula was `maximum required ratio × (1 − X)`.
 
-`src/modules/ratio.ts` captures the download brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The _seeding / ongoing-availability_ pillar is missing.
+`src/modules/ratio.ts` captures the consumption brackets and the `maxRequired × (1 − coverage)` shape, but models the relief `X` as a **static, permanent byte-credit** (`eligibleContributionBytes / consumed`). Once a contribution is staff-approved it lowers required ratio forever — even if its link died. The _ongoing-availability_ pillar is missing.
 
-## The seeding analog: LinkHealth
+## The availability substrate: LinkHealth
 
-Stellar has no peer-to-peer transfers — contributions are hosted links. `downloads.ts` credits a contributor's `contributed` bytes each time someone downloads from their link. So **a live link is an actively-seeded release**, and **LinkHealth is the seeding analog**:
+Contributions are hosted links. `downloads.ts` credits a contributor's `contributed` bytes each time someone consumes from their link. So **a live link is a continuously-available contribution**, and **LinkHealth is the availability substrate** the relief term reads:
 
-| Reference model                        | Stellar                                                                        |
-| -------------------------------------- | ------------------------------------------------------------------------------ |
-| Seeding a release                      | A contribution whose link is reachable (`linkStatus = PASS`)                   |
-| Effectively seeded (available ≥72h/7d) | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh)                       |
-| Stopped seeding → lose relief          | Link `FAIL` → contribution drops from the relief pool                          |
-| Uploaded bytes (others snatched)       | `User.contributed` (others downloaded from you) — permanent, never clawed back |
+| Availability concept              | Stellar mechanic                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------ |
+| Keeping a contribution available  | A contribution whose link is reachable (`linkStatus = PASS`)                   |
+| Sustained availability (≥72h/7d)  | Current `linkStatus ≠ FAIL` (24h recheck keeps it fresh)                       |
+| Availability lapses → lose relief | Link `FAIL` → contribution drops from the relief pool                          |
+| Bytes others consumed from you    | `User.contributed` (others downloaded from you) — permanent, never clawed back |
 
 ## Mechanism
 
 ### Required ratio (unchanged shape, gated relief)
 
-- **Download brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). _Bracket values are tuning; current table assumed settled, flagged for review._
+- **Consumption brackets** (`ratio.ts` `BRACKETS`): 10 consumption tiers (5 GiB steps). `0–5 GiB → 0.0` (no requirement) … `100+ GiB → 0.6` (floor = ceiling). _Bracket values are tuning; current table assumed settled, flagged for review._
 - **Formula:** `requiredRatio = max(minRequired, maxRequired × (1 − coverage))`.
 - **Coverage (the overhaul):** `coverage = eligibleContributionBytes / consumed`, where `eligibleContributionBytes` sums a user's staff-approved, 72h-old contribution bytes **whose current `linkStatus ≠ FAIL`**. See [ADR-0006](../adr/0006-linkhealth-gated-ratio-relief.md):
   - `FAIL` revokes relief (required ratio can rise as links rot).
@@ -38,31 +39,44 @@ Stellar has no peer-to-peer transfers — contributions are hosted links. `downl
 
 ### Policy state machine (unchanged)
 
-`ratioPolicy.ts`: `OK → WATCH → LEECH_DISABLED`. `WATCH` lasts 14 days; auto-disable on 10 GiB consumed during watch or watch expiry; `LEECH_DISABLED` reversed by staff only.
+`ratioPolicy.ts`: `OK → WATCH → LEECH_DISABLED`. `WATCH` lasts 14 days; auto-disable on 10 GiB consumed during watch or watch expiry; the disabled state is reversed by staff only.
+
+### Ratio-exempt contributions: Freepass & Neutralpass
+
+Two Contribution-level flags change how a consumption touches ratio — the only points where the consumption-accounting path (`downloads.ts` today; korin.pink `ledger` per ADR-004) conditionally skips accrual:
+
+| Flag            | Consumer's `consumed` | Contributor's `contributed` | Use                                                                                                                       |
+| --------------- | --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Freepass**    | not accrued           | **still accrued**           | Promote selected / staff-featured Contributions; members consume freely while contributors still earn availability credit |
+| **Neutralpass** | not accrued           | not accrued                 | Fully ratio-invisible on both sides — items that should sit outside the ratio economy entirely                            |
+
+Freepass is the lever for letting members rebuild ratio (consume without penalty) while still rewarding the contributor's sustained availability; Neutralpass removes an item from the ratio economy in both directions. The flag lives on the Contribution (king) and is read at consumption time — the accounting path checks it before incrementing `consumed` (both flags) and `contributed` (Neutralpass only).
 
 ### Concepts from the reference model not yet modelled (flagged)
 
-- **Seeding _count_** (the reference factors how many releases you seed, not just bytes) — out of scope for v1; byte-coverage is the lever.
-- **Freeleech / neutral-leech** (download without ratio impact) — a tracker feature; separate concern, not in this overhaul.
+- **Availability count** (the reference factors how many contributions you keep available, not just bytes) — out of scope for v1; byte-coverage is the lever.
 
 ## Concept → existing code (the descent map)
 
-| Concept                                      | Lives in                                                                           |
-| -------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Ratio + required-ratio + brackets            | `src/modules/ratio.ts`                                                             |
-| Policy state machine                         | `src/modules/ratioPolicy.ts`                                                       |
-| `contributed` credit (seeding-snatch analog) | `src/modules/downloads.ts`                                                         |
-| LinkHealth status + 24h recheck + 72h sweep  | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts`                        |
-| Ratio surface                                | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
-| Lifetime uptime (CRS, not ratio)             | deferred — `LinkHealthBonusPoints` dimension, PRD-01                               |
+| Concept                                     | Lives in                                                                           |
+| ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Ratio + required-ratio + brackets           | `src/modules/ratio.ts`                                                             |
+| Policy state machine                        | `src/modules/ratioPolicy.ts`                                                       |
+| `contributed` credit (availability analog)  | `src/modules/downloads.ts`                                                         |
+| Freepass / Neutralpass accrual skip         | `src/modules/downloads.ts` (flag on `Contribution`)                                |
+| LinkHealth status + 24h recheck + 72h sweep | `src/modules/linkHealth.ts`, `src/modules/linkHealthJob.ts`                        |
+| Ratio surface                               | `GET /api/profile/me/ratio` (`routes/api/profile.ts`), `routes/api/ratioPolicy.ts` |
+| Lifetime uptime (CRS, not ratio)            | deferred — `LinkHealthBonusPoints` dimension, PRD-01                               |
 
 ## Red-green descent targets
 
 1. ✅ **Relief LinkHealth gate** — `eligibleContributionBytes` filtered by `linkStatus ≠ FAIL`; required ratio rises when a covered contribution flips `FAIL`, `WARN`/`UNKNOWN` still count. **Shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96).**
 2. 🟡 **72h WARN→FAIL sweep** — `linkStatusChangedAt` + `sweepStaleWarnLinks` in `linkHealthJob.ts`. **Promotion shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96)**; the contributor-PM + staff-report notification on promotion is still TODO.
 3. ✅ **`RatioScore` dimension** — bounded CRS sub-score from current ratio health, one-way into PRD-01's registry. **Shipped [#96](https://github.com/orphic-inc/stellar-api/pull/96).**
+4. 🔲 **Freepass / Neutralpass** — boolean flags on `Contribution`; the consumption-accounting path skips `consumed` accrual for both and `contributed` accrual for Neutralpass. Not yet started.
 
 ## Open questions
 
 - Bracket values — keep the current table or re-tune to specific numeric thresholds? (assumed settled for now)
 - Whether the policy `WATCH` thresholds (14d / 10 GiB) change in the overhaul (assumed unchanged).
+- Freepass / Neutralpass granularity — a per-Contribution flag only, or also time-boxed / site-wide promotional events?


### PR DESCRIPTION
Proposed ADR. Extends **ADR-0013** with the Phase-2 accounting contract that **korin.pink ADR-004** (the Go `ledger`) is explicitly gated on.

**Key decision:** because stellar *issues* every consumption grant, consumption is **server-authoritative** and stellar is already the durable origin — so korin's `ledger` is a **derived hot-path read-model** (grant-time `canConsume` gate + live activity stats + abuse vantage), not a parallel authority. That removes the self-report cheat surface *and* the buffered accounting flush-back from the reference model.

**Five flows**, all over the existing ADR-0013 shared-secret boundary (same keys, same fail-closed rules): consumption-event push, `can-consume` gate pull (fail-open to stellar's `ratioPolicy` on korin outage), state-sync push, snapshot pull (boot/reload), live-stats pull. Freepass/Neutralpass ride the event's pre-resolved `pass` field; pass logic stays in the system of record. Integrity/abuse detection is enabled but scoped to a follow-on ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)