### PR TITLE
chore(agents): cross-repo CONTEXT-MAP + multi-context agent-skills config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ These Prisma models exist in `schema.prisma` but have no API routes:
 
 ### Issue tracker
 
-Issues live in GitHub Issues at `orphic-inc/stellar-api`. See `docs/agents/issue-tracker.md`.
+Issues live in GitHub Issues at `orphic-inc/stellar-api` (external PRs are not a triage surface). See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
@@ -303,4 +303,4 @@ Default label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-h
 
 ### Domain docs
 
-Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+Multi-context — `CONTEXT-MAP.md` at the repo root indexes the per-repo `CONTEXT.md` files across the Stellar constellation (stellar-api, stellar-ui, external korin.pink). See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,13 @@
+# Context Map — the Stellar constellation
+
+Stellar's domain spans multiple repositories; one of them (`korin.pink`) is **external to the orphic-inc origin** (owned under obrien-k, its own deploy/cadence). This map points to the per-context `CONTEXT.md` for each. Skills that read domain language should consult this map, then the relevant repo's `CONTEXT.md` and ADRs. See `docs/agents/domain.md` for the consumer rules.
+
+| Context                      | Repo                                 | Glossary                                                                                    | Decisions                  | Role                                                                          |
+| ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------- |
+| **Platform / API**           | `orphic-inc/stellar-api` (this repo) | [`CONTEXT.md`](./CONTEXT.md)                                                                | [`docs/adr/`](./docs/adr/) | System of record — API, durable state, the contribution / ratio / CRS domain  |
+| **Frontend**                 | `orphic-inc/stellar-ui`              | [stellar-ui `CONTEXT.md`](https://github.com/orphic-inc/stellar-ui/blob/main/CONTEXT.md)    | stellar-ui `docs/adr/`     | React/TS client; the theming subsystem glossary                               |
+| **IRC + accounting sidecar** | `obrien-k/korin-pink` _(external)_   | [korin `docs/CONTEXT.md`](https://github.com/obrien-k/korin-pink/blob/main/docs/CONTEXT.md) | korin `docs/adr/`          | IRC substrate (Ergo + bridge + wiki) and the Go `ledger` accounting authority |
+
+**Cross-repo / system-wide decisions live in this repo's `docs/adr/`** — notably [ADR-0013](./docs/adr/0013-korin-pink-irc-integration.md) (the korin↔stellar integration boundary) and [ADR-0016](./docs/adr/0016-ledger-accounting-contract.md) (the consumption-accounting & ratio-gate contract). Each other repo carries its own context-scoped ADRs.
+
+> stellar-ui's `CONTEXT.md` currently lands via the `wip/theming-corpus` branch (PR pending); the link resolves once merged.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,34 +1,40 @@
 # Domain Docs
 
-How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+How the engineering skills should consume this project's domain documentation when exploring the codebase. Stellar is a **multi-context** project spread across repositories; one context (`korin.pink`) is external to the orphic-inc origin.
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+- **`CONTEXT-MAP.md`** at the repo root — it indexes one `CONTEXT.md` per context (this repo's platform/API context, stellar-ui's frontend context, and external korin.pink's IRC+ledger context). Read the context(s) relevant to your topic.
+- The relevant repo's **`CONTEXT.md`** for its domain glossary.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. Cross-repo / system-wide decisions (e.g. ADR-0013 korin integration, ADR-0016 accounting contract) live in **this** repo's `docs/adr/`; each other repo carries its own context-scoped ADRs.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
 ## File structure
 
-Single-context repo:
+Multi-context, cross-repo (presence of `CONTEXT-MAP.md` at the root):
 
 ```
-/
-├── CONTEXT.md
-├── docs/adr/
-│   └── 0001-granular-permission-checks.md
-└── src/
+stellar-api/   (this repo · orphic-inc)
+├── CONTEXT-MAP.md       ← indexes every context's CONTEXT.md
+├── CONTEXT.md           ← platform / API context
+└── docs/adr/            ← system-wide + API-scoped decisions
+
+stellar-ui/    (orphic-inc)
+└── CONTEXT.md           ← frontend / theming context
+
+korin.pink/    (obrien-k · external)
+└── docs/CONTEXT.md      ← IRC + ledger accounting context
 ```
 
 ## Use the glossary's vocabulary
 
-When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in the relevant context's `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids, and don't reach for legacy-reference vocabulary in anything committed.
 
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
 
 ## Flag ADR conflicts
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0001 (granular-permission-checks) — but worth reopening because…_
+> _Contradicts ADR-0013 (korin-pink-irc-integration) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,6 +2,8 @@
 
 Issues and PRDs for this repo live as GitHub issues at `orphic-inc/stellar-api`. Use the `gh` CLI for all operations.
 
+**External PRs are not a triage surface.** `/triage` processes GitHub Issues only; pull requests (including external/feature-request PRs) are left out of the triage queue.
+
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.


### PR DESCRIPTION
Scaffolds the per-repo config the engineering skills (`triage`, `to-issues`, `to-prd`, `qa`, `improve-codebase-architecture`, `diagnosing-bugs`, `tdd`) read.

- **`CONTEXT-MAP.md`** (new) — indexes the per-repo `CONTEXT.md` across the constellation: stellar-api (this repo), stellar-ui, and **external** obrien-k/korin-pink. Notes the cross-repo ADRs (0013, 0016) live here.
- **`docs/agents/domain.md`** — flipped to multi-context (cross-repo) layout + consumer rules.
- **`docs/agents/issue-tracker.md`** — records that external PRs are **not** a triage surface (issues-only).
- **`CLAUDE.md` `## Agent skills`** — issue-tracker + domain-docs summary lines updated.

Triage labels keep the canonical defaults (already in live use). Note: stellar-ui's `CONTEXT.md` link resolves once the `wip/theming-corpus` PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)