### PR TITLE
feat(classes): RankPromotionRule + User.rankLocked schema & migration (#167)

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -123,6 +123,15 @@ comment_sub comment_sub
 artist_release artist_release
 site_news site_news
 global_notice global_notice
+rank_promoted rank_promoted
+rank_demoted rank_demoted
+        }
+    
+
+
+        RankExtraPredicate {
+            DISTINCT_RELEASES_500 DISTINCT_RELEASES_500
+QUALITY_CONTRIB_500 QUALITY_CONTRIB_500
         }
     
 
@@ -398,6 +407,19 @@ Yearly Yearly
     }
   
 
+  "rank_promotion_rules" {
+    Int id "🗝️"
+    BigInt minContributed 
+    Float minRatio 
+    Int minContributions 
+    Int minAccountAgeDays 
+    RankExtraPredicate extra "❓"
+    Boolean enabled 
+    DateTime createdAt 
+    DateTime updatedAt 
+    }
+  
+
   "user_settings" {
     Int id "🗝️"
     String siteAppearance 
@@ -431,6 +453,7 @@ Yearly Yearly
     Boolean isArtist 
     Boolean isDonor 
     Boolean canDownload 
+    Boolean rankLocked 
     String adminComment "❓"
     String staffBio "❓"
     DateTime banDate "❓"
@@ -440,6 +463,9 @@ Yearly Yearly
     String lastIp "❓"
     Boolean disablePm 
     String ircNick "❓"
+    String pendingIrcNick "❓"
+    String ircNickNonce "❓"
+    DateTime ircNickNonceExpiresAt "❓"
     DateTime createdAt 
     DateTime updatedAt 
     }
@@ -1539,6 +1565,9 @@ Yearly Yearly
     }
   
     "user_ranks" }o--|o staff_groups : "staffGroup"
+    "rank_promotion_rules" }o--|| user_ranks : "fromRank"
+    "rank_promotion_rules" }o--|| user_ranks : "toRank"
+    "rank_promotion_rules" |o--|o "RankExtraPredicate" : "enum:extra"
     "user_settings" |o--|| "NotificationMethod" : "enum:notificationMethod"
     "user_settings" }o--|o author_stylesheets : "activeAuthorStylesheet"
     "users" }o--|| user_ranks : "userRank"

--- a/prisma/migrations/20260619013207_rank_promotion_rules/migration.sql
+++ b/prisma/migrations/20260619013207_rank_promotion_rules/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "RankExtraPredicate" AS ENUM ('DISTINCT_RELEASES_500', 'QUALITY_CONTRIB_500');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "NotificationType" ADD VALUE 'rank_promoted';
+ALTER TYPE "NotificationType" ADD VALUE 'rank_demoted';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "rankLocked" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "rank_promotion_rules" (
+    "id" SERIAL NOT NULL,
+    "fromRankId" INTEGER NOT NULL,
+    "toRankId" INTEGER NOT NULL,
+    "minContributed" BIGINT NOT NULL DEFAULT 0,
+    "minRatio" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "minContributions" INTEGER NOT NULL DEFAULT 0,
+    "minAccountAgeDays" INTEGER NOT NULL DEFAULT 0,
+    "extra" "RankExtraPredicate",
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rank_promotion_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "rank_promotion_rules_fromRankId_idx" ON "rank_promotion_rules"("fromRankId");
+
+-- CreateIndex
+CREATE INDEX "rank_promotion_rules_toRankId_idx" ON "rank_promotion_rules"("toRankId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rank_promotion_rules_fromRankId_toRankId_key" ON "rank_promotion_rules"("fromRankId", "toRankId");
+
+-- AddForeignKey
+ALTER TABLE "rank_promotion_rules" ADD CONSTRAINT "rank_promotion_rules_fromRankId_fkey" FOREIGN KEY ("fromRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rank_promotion_rules" ADD CONSTRAINT "rank_promotion_rules_toRankId_fkey" FOREIGN KEY ("toRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,17 @@ enum NotificationType {
   artist_release
   site_news
   global_notice
+  rank_promoted
+  rank_demoted
+}
+
+// Extra, non-numeric criteria a promotion rule may layer on top of the stock
+// byte/ratio/contribution/age thresholds — the prestige-tier gates encoded by
+// the evaluator (rankProgression.ts RankExtraPredicate). Mirrors that TS union
+// exactly so a Prisma row maps onto the evaluator's rule shape unchanged.
+enum RankExtraPredicate {
+  DISTINCT_RELEASES_500
+  QUALITY_CONTRIB_500
 }
 
 enum ThreadType {
@@ -300,6 +311,8 @@ model UserRank {
   staffGroup           StaffGroup?         @relation(fields: [staffGroupId], references: [id], onDelete: SetNull)
   users                User[]
   secondaryUsers       UserSecondaryRank[]
+  promotionRulesFrom   RankPromotionRule[] @relation("RankPromotionFrom")
+  promotionRulesTo     RankPromotionRule[] @relation("RankPromotionTo")
 
   @@unique([level])
   @@unique([name])
@@ -308,73 +321,105 @@ model UserRank {
   @@map("user_ranks")
 }
 
+// Declarative, data-driven criteria for one rung of automated class progression
+// (USER_CLASSES_PLAN §4). One row = "a user on fromRank advances to toRank once
+// they clear these thresholds." Tunable without a deploy. The pure evaluator in
+// rankProgression.ts owns the decision logic; rankProgressionJob loads these rows
+// and maps them onto the evaluator's RankPromotionRule interface field-for-field.
+// minContributed is BigInt (bytes) — deliberately NOT UserRank.uploadRequired Int,
+// which overflows past ~2 GiB.
+model RankPromotionRule {
+  id                Int                 @id @default(autoincrement())
+  fromRankId        Int
+  fromRank          UserRank            @relation("RankPromotionFrom", fields: [fromRankId], references: [id], onDelete: Cascade)
+  toRankId          Int
+  toRank            UserRank            @relation("RankPromotionTo", fields: [toRankId], references: [id], onDelete: Cascade)
+  minContributed    BigInt              @default(0)
+  minRatio          Float               @default(0)
+  minContributions  Int                 @default(0)
+  minAccountAgeDays Int                 @default(0)
+  extra             RankExtraPredicate?
+  enabled           Boolean             @default(true)
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+
+  @@unique([fromRankId, toRankId])
+  @@index([fromRankId])
+  @@index([toRankId])
+  @@map("rank_promotion_rules")
+}
+
 model UserSettings {
-  id                   Int                @id @default(autoincrement())
-  siteAppearance       String             @default("sublime")
-  externalStylesheet   String?
-  styledTooltips       Boolean            @default(true)
-  paranoia             Int                @default(0)
-  notificationMethod   NotificationMethod @default(Traditional)
-  showEmail            Boolean            @default(false)
-  showLastSeen         Boolean            @default(false)
-  showContributedStats Boolean            @default(true)
-  showConsumedStats    Boolean            @default(true)
-  showRatioStats       Boolean            @default(true)
-  user                 User?
+  id                       Int                @id @default(autoincrement())
+  siteAppearance           String             @default("sublime")
+  externalStylesheet       String?
+  styledTooltips           Boolean            @default(true)
+  paranoia                 Int                @default(0)
+  notificationMethod       NotificationMethod @default(Traditional)
+  showEmail                Boolean            @default(false)
+  showLastSeen             Boolean            @default(false)
+  showContributedStats     Boolean            @default(true)
+  showConsumedStats        Boolean            @default(true)
+  showRatioStats           Boolean            @default(true)
+  user                     User?
   // The AuthorStylesheet adopted into this member's Site Stylesheet slot
   // (PRD-03 #119): what they see on the general site. Null = on the Site Theme
   // (Sublime/Default). SetNull on delete so a pruned sheet clears its adopters'
   // pointers rather than orphaning them. Profile/Community slots are deferred.
   activeAuthorStylesheetId Int?
-  activeAuthorStylesheet   AuthorStylesheet? @relation(fields: [activeAuthorStylesheetId], references: [id])
+  activeAuthorStylesheet   AuthorStylesheet?  @relation(fields: [activeAuthorStylesheetId], references: [id])
 
   @@index([activeAuthorStylesheetId])
   @@map("user_settings")
 }
 
 model User {
-  id                 Int                 @id @default(autoincrement())
-  username           String              @unique
-  email              String              @unique
-  password           String
-  avatar             String?
-  userRankId         Int
-  userRank           UserRank            @relation(fields: [userRankId], references: [id])
-  secondaryRanks     UserSecondaryRank[]
-  userSettingsId     Int                 @unique
-  userSettings       UserSettings        @relation(fields: [userSettingsId], references: [id])
-  profileId          Int                 @unique
-  profile            Profile             @relation(fields: [profileId], references: [id])
-  inviteCount        Int                 @default(0)
-  contributed        BigInt              @default(0)
-  consumed           BigInt              @default(0)
-  totalEarned        BigInt              @default(0)
-  ratio              Float               @default(1)
-  ratioWatchDownload Int?
-  lastLogin          DateTime?
-  dateRegistered     DateTime            @default(now())
-  disabled           Boolean             @default(false)
-  isArtist           Boolean             @default(false)
-  isDonor            Boolean             @default(false)
-  canDownload        Boolean             @default(true)
-  adminComment       String?
-  staffBio           String?             @db.VarChar(500)
-  banDate            DateTime?
-  banReason          String?
-  warned             DateTime?
-  warnedTimes        Int                 @default(0)
-  lastIp             String?
-  disablePm          Boolean             @default(false)
+  id                    Int                 @id @default(autoincrement())
+  username              String              @unique
+  email                 String              @unique
+  password              String
+  avatar                String?
+  userRankId            Int
+  userRank              UserRank            @relation(fields: [userRankId], references: [id])
+  secondaryRanks        UserSecondaryRank[]
+  userSettingsId        Int                 @unique
+  userSettings          UserSettings        @relation(fields: [userSettingsId], references: [id])
+  profileId             Int                 @unique
+  profile               Profile             @relation(fields: [profileId], references: [id])
+  inviteCount           Int                 @default(0)
+  contributed           BigInt              @default(0)
+  consumed              BigInt              @default(0)
+  totalEarned           BigInt              @default(0)
+  ratio                 Float               @default(1)
+  ratioWatchDownload    Int?
+  lastLogin             DateTime?
+  dateRegistered        DateTime            @default(now())
+  disabled              Boolean             @default(false)
+  isArtist              Boolean             @default(false)
+  isDonor               Boolean             @default(false)
+  canDownload           Boolean             @default(true)
+  // Staff-pinned rank: when true the automated progression engine
+  // (rankProgressionJob) will not promote or demote this user (USER_CLASSES_PLAN
+  // §4). Set by staff via the manual override; the evaluator treats it as a freeze.
+  rankLocked            Boolean             @default(false)
+  adminComment          String?
+  staffBio              String?             @db.VarChar(500)
+  banDate               DateTime?
+  banReason             String?
+  warned                DateTime?
+  warnedTimes           Int                 @default(0)
+  lastIp                String?
+  disablePm             Boolean             @default(false)
   // Verified IRC Link (ADR-0015): ircNick holds only a *verified* nick, written
   // on promotion. A Nick Claim (unproven) lives in pendingIrcNick + nonce, which
   // reserve nothing — pendingIrcNick is intentionally NOT unique, so multiple
   // members may claim the same nick; first to verify wins the unique ircNick slot.
-  ircNick               String?          @unique
+  ircNick               String?             @unique
   pendingIrcNick        String?
   ircNickNonce          String?
   ircNickNonceExpiresAt DateTime?
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
 
   invitesSent              Invite[]
   inviteTree               InviteTree?                      @relation("InviteTreeMember")
@@ -467,7 +512,6 @@ model User {
   @@index([userRankId])
   @@map("users")
 }
-
 
 model UserSecondaryRank {
   userId       Int
@@ -887,22 +931,22 @@ model SimilarArtist {
 // ─── Community ────────────────────────────────────────────────────────────────
 
 model Community {
-  id                    Int                 @id @default(autoincrement())
-  name                  String              @unique
-  description           String?             @db.Text
+  id                    Int                       @id @default(autoincrement())
+  name                  String                    @unique
+  description           String?                   @db.Text
   image                 String
   registrationStatus    RegistrationStatus
   type                  CommunityType
-  allowDuplicateFormats Boolean             @default(true)
-  consumers             Consumer[]          @relation("CommunityConsumers")
+  allowDuplicateFormats Boolean                   @default(true)
+  consumers             Consumer[]                @relation("CommunityConsumers")
   contributors          Contributor[]
   releases              Release[]
   comments              Comment[]
-  staff                 User[]              @relation("CommunityStaff")
+  staff                 User[]                    @relation("CommunityStaff")
   doNotContribute       DoNotContribute[]
   bookmarks             BookmarkCommunity[]
-  createdAt             DateTime            @default(now())
-  updatedAt             DateTime            @updatedAt
+  createdAt             DateTime                  @default(now())
+  updatedAt             DateTime                  @updatedAt
   Request               Request[]
   healthSnapshots       CommunityHealthSnapshot[]
 
@@ -2187,19 +2231,19 @@ model RulesPage {
 /// (src/modules/ruleImpact.ts) reads these weights — no logic lives in the row.
 /// Magnitudes are PRD-05 TBD; the model is the shape, the values are placeholders.
 model Rule {
-  id          Int    @id @default(autoincrement())
+  id               Int       @id @default(autoincrement())
   /// Machine-stable key, e.g. "golden.accounts" — distinct from the display title.
-  code        String @unique @db.VarChar(100)
-  title       String @db.VarChar(200)
-  description String @default("") @db.Text
+  code             String    @unique @db.VarChar(100)
+  title            String    @db.VarChar(200)
+  description      String    @default("") @db.Text
   /// CRS reward when the rule is adhered to (>= 0). Magnitude PRD-05 TBD.
-  complianceWeight Float @default(0)
+  complianceWeight Float     @default(0)
   /// CRS penalty magnitude when the rule is breached (>= 0; ruleImpact negates it).
-  violationWeight  Float @default(0)
-  sortOrder        Int   @default(0)
+  violationWeight  Float     @default(0)
+  sortOrder        Int       @default(0)
   subRules         SubRule[]
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   @@index([sortOrder])
   @@map("rules")
@@ -2208,16 +2252,16 @@ model Rule {
 /// A child node of a `Rule` (PRD-05: "5 rules with 2 SubRules each"). Its weight
 /// composes additively on top of its parent rule's in `ruleImpact()`.
 model SubRule {
-  id          Int    @id @default(autoincrement())
-  ruleId      Int
-  rule        Rule   @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+  id               Int      @id @default(autoincrement())
+  ruleId           Int
+  rule             Rule     @relation(fields: [ruleId], references: [id], onDelete: Cascade)
   /// Stable key, unique within the parent rule (e.g. "no-sharing").
-  code        String @db.VarChar(100)
-  title       String @db.VarChar(200)
-  description String @default("") @db.Text
-  complianceWeight Float @default(0)
-  violationWeight  Float @default(0)
-  sortOrder        Int   @default(0)
+  code             String   @db.VarChar(100)
+  title            String   @db.VarChar(200)
+  description      String   @default("") @db.Text
+  complianceWeight Float    @default(0)
+  violationWeight  Float    @default(0)
+  sortOrder        Int      @default(0)
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -80,6 +80,7 @@ export function makeUser(overrides: Partial<User> = {}): User {
     isArtist: false,
     isDonor: false,
     canDownload: true,
+    rankLocked: false,
     adminComment: null,
     staffBio: null,
     banDate: null,


### PR DESCRIPTION
First rollout slice for automated user-class progression. Gives the already-landed pure evaluator (`src/modules/rankProgression.ts`) a real, data-driven home so promotion criteria are tunable without a deploy.

## Changes
- **`RankPromotionRule`** model — keyed by `@@unique([fromRankId, toRankId])`, cascade FKs to `UserRank`. Fields mirror the evaluator's `RankPromotionRule` interface field-for-field: `minContributed` **BigInt** (bytes — deliberately *not* `UserRank.uploadRequired` Int, which overflows past ~2 GiB), `minRatio`, `minContributions`, `minAccountAgeDays`, `extra`, `enabled`.
- **`RankExtraPredicate`** enum (`DISTINCT_RELEASES_500 | QUALITY_CONTRIB_500`) — exact mirror of the evaluator's TS union, so a Prisma row maps onto the rule shape unchanged.
- **`User.rankLocked`** `Boolean @default(false)` — staff-pinned ranks the engine freezes.
- **`NotificationType`** += `rank_promoted`, `rank_demoted`.
- `docs/erd.md` regenerated (freshness gate); migration `20260619013207_rank_promotion_rules` included and applied.

Expand→contract, additive, idempotent — safe on existing installs; no user's class changes until the sweep job (#169) runs.

## Verification
format / lint / `tsc --noEmit` / `typecheck:test` clean; full suite green.

Closes #167. Blocks #168 (seed) and #169 (sweep job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)