### PR TITLE
feat(classes): seed the class ladder + promotion rules in bootstrap (#168)

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -123,6 +123,15 @@ comment_sub comment_sub
 artist_release artist_release
 site_news site_news
 global_notice global_notice
+rank_promoted rank_promoted
+rank_demoted rank_demoted
+        }
+    
+
+
+        RankExtraPredicate {
+            DISTINCT_RELEASES_500 DISTINCT_RELEASES_500
+QUALITY_CONTRIB_500 QUALITY_CONTRIB_500
         }
     
 
@@ -398,6 +407,19 @@ Yearly Yearly
     }
   
 
+  "rank_promotion_rules" {
+    Int id "🗝️"
+    BigInt minContributed 
+    Float minRatio 
+    Int minContributions 
+    Int minAccountAgeDays 
+    RankExtraPredicate extra "❓"
+    Boolean enabled 
+    DateTime createdAt 
+    DateTime updatedAt 
+    }
+  
+
   "user_settings" {
     Int id "🗝️"
     String siteAppearance 
@@ -431,6 +453,7 @@ Yearly Yearly
     Boolean isArtist 
     Boolean isDonor 
     Boolean canDownload 
+    Boolean rankLocked 
     String adminComment "❓"
     String staffBio "❓"
     DateTime banDate "❓"
@@ -440,6 +463,9 @@ Yearly Yearly
     String lastIp "❓"
     Boolean disablePm 
     String ircNick "❓"
+    String pendingIrcNick "❓"
+    String ircNickNonce "❓"
+    DateTime ircNickNonceExpiresAt "❓"
     DateTime createdAt 
     DateTime updatedAt 
     }
@@ -1539,6 +1565,9 @@ Yearly Yearly
     }
   
     "user_ranks" }o--|o staff_groups : "staffGroup"
+    "rank_promotion_rules" }o--|| user_ranks : "fromRank"
+    "rank_promotion_rules" }o--|| user_ranks : "toRank"
+    "rank_promotion_rules" |o--|o "RankExtraPredicate" : "enum:extra"
     "user_settings" |o--|| "NotificationMethod" : "enum:notificationMethod"
     "user_settings" }o--|o author_stylesheets : "activeAuthorStylesheet"
     "users" }o--|| user_ranks : "userRank"

--- a/prisma/migrations/20260619013207_rank_promotion_rules/migration.sql
+++ b/prisma/migrations/20260619013207_rank_promotion_rules/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "RankExtraPredicate" AS ENUM ('DISTINCT_RELEASES_500', 'QUALITY_CONTRIB_500');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "NotificationType" ADD VALUE 'rank_promoted';
+ALTER TYPE "NotificationType" ADD VALUE 'rank_demoted';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "rankLocked" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "rank_promotion_rules" (
+    "id" SERIAL NOT NULL,
+    "fromRankId" INTEGER NOT NULL,
+    "toRankId" INTEGER NOT NULL,
+    "minContributed" BIGINT NOT NULL DEFAULT 0,
+    "minRatio" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "minContributions" INTEGER NOT NULL DEFAULT 0,
+    "minAccountAgeDays" INTEGER NOT NULL DEFAULT 0,
+    "extra" "RankExtraPredicate",
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rank_promotion_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "rank_promotion_rules_fromRankId_idx" ON "rank_promotion_rules"("fromRankId");
+
+-- CreateIndex
+CREATE INDEX "rank_promotion_rules_toRankId_idx" ON "rank_promotion_rules"("toRankId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rank_promotion_rules_fromRankId_toRankId_key" ON "rank_promotion_rules"("fromRankId", "toRankId");
+
+-- AddForeignKey
+ALTER TABLE "rank_promotion_rules" ADD CONSTRAINT "rank_promotion_rules_fromRankId_fkey" FOREIGN KEY ("fromRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rank_promotion_rules" ADD CONSTRAINT "rank_promotion_rules_toRankId_fkey" FOREIGN KEY ("toRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,17 @@ enum NotificationType {
   artist_release
   site_news
   global_notice
+  rank_promoted
+  rank_demoted
+}
+
+// Extra, non-numeric criteria a promotion rule may layer on top of the stock
+// byte/ratio/contribution/age thresholds — the prestige-tier gates encoded by
+// the evaluator (rankProgression.ts RankExtraPredicate). Mirrors that TS union
+// exactly so a Prisma row maps onto the evaluator's rule shape unchanged.
+enum RankExtraPredicate {
+  DISTINCT_RELEASES_500
+  QUALITY_CONTRIB_500
 }
 
 enum ThreadType {
@@ -300,6 +311,8 @@ model UserRank {
   staffGroup           StaffGroup?         @relation(fields: [staffGroupId], references: [id], onDelete: SetNull)
   users                User[]
   secondaryUsers       UserSecondaryRank[]
+  promotionRulesFrom   RankPromotionRule[] @relation("RankPromotionFrom")
+  promotionRulesTo     RankPromotionRule[] @relation("RankPromotionTo")
 
   @@unique([level])
   @@unique([name])
@@ -308,73 +321,105 @@ model UserRank {
   @@map("user_ranks")
 }
 
+// Declarative, data-driven criteria for one rung of automated class progression
+// (USER_CLASSES_PLAN §4). One row = "a user on fromRank advances to toRank once
+// they clear these thresholds." Tunable without a deploy. The pure evaluator in
+// rankProgression.ts owns the decision logic; rankProgressionJob loads these rows
+// and maps them onto the evaluator's RankPromotionRule interface field-for-field.
+// minContributed is BigInt (bytes) — deliberately NOT UserRank.uploadRequired Int,
+// which overflows past ~2 GiB.
+model RankPromotionRule {
+  id                Int                 @id @default(autoincrement())
+  fromRankId        Int
+  fromRank          UserRank            @relation("RankPromotionFrom", fields: [fromRankId], references: [id], onDelete: Cascade)
+  toRankId          Int
+  toRank            UserRank            @relation("RankPromotionTo", fields: [toRankId], references: [id], onDelete: Cascade)
+  minContributed    BigInt              @default(0)
+  minRatio          Float               @default(0)
+  minContributions  Int                 @default(0)
+  minAccountAgeDays Int                 @default(0)
+  extra             RankExtraPredicate?
+  enabled           Boolean             @default(true)
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+
+  @@unique([fromRankId, toRankId])
+  @@index([fromRankId])
+  @@index([toRankId])
+  @@map("rank_promotion_rules")
+}
+
 model UserSettings {
-  id                   Int                @id @default(autoincrement())
-  siteAppearance       String             @default("sublime")
-  externalStylesheet   String?
-  styledTooltips       Boolean            @default(true)
-  paranoia             Int                @default(0)
-  notificationMethod   NotificationMethod @default(Traditional)
-  showEmail            Boolean            @default(false)
-  showLastSeen         Boolean            @default(false)
-  showContributedStats Boolean            @default(true)
-  showConsumedStats    Boolean            @default(true)
-  showRatioStats       Boolean            @default(true)
-  user                 User?
+  id                       Int                @id @default(autoincrement())
+  siteAppearance           String             @default("sublime")
+  externalStylesheet       String?
+  styledTooltips           Boolean            @default(true)
+  paranoia                 Int                @default(0)
+  notificationMethod       NotificationMethod @default(Traditional)
+  showEmail                Boolean            @default(false)
+  showLastSeen             Boolean            @default(false)
+  showContributedStats     Boolean            @default(true)
+  showConsumedStats        Boolean            @default(true)
+  showRatioStats           Boolean            @default(true)
+  user                     User?
   // The AuthorStylesheet adopted into this member's Site Stylesheet slot
   // (PRD-03 #119): what they see on the general site. Null = on the Site Theme
   // (Sublime/Default). SetNull on delete so a pruned sheet clears its adopters'
   // pointers rather than orphaning them. Profile/Community slots are deferred.
   activeAuthorStylesheetId Int?
-  activeAuthorStylesheet   AuthorStylesheet? @relation(fields: [activeAuthorStylesheetId], references: [id])
+  activeAuthorStylesheet   AuthorStylesheet?  @relation(fields: [activeAuthorStylesheetId], references: [id])
 
   @@index([activeAuthorStylesheetId])
   @@map("user_settings")
 }
 
 model User {
-  id                 Int                 @id @default(autoincrement())
-  username           String              @unique
-  email              String              @unique
-  password           String
-  avatar             String?
-  userRankId         Int
-  userRank           UserRank            @relation(fields: [userRankId], references: [id])
-  secondaryRanks     UserSecondaryRank[]
-  userSettingsId     Int                 @unique
-  userSettings       UserSettings        @relation(fields: [userSettingsId], references: [id])
-  profileId          Int                 @unique
-  profile            Profile             @relation(fields: [profileId], references: [id])
-  inviteCount        Int                 @default(0)
-  contributed        BigInt              @default(0)
-  consumed           BigInt              @default(0)
-  totalEarned        BigInt              @default(0)
-  ratio              Float               @default(1)
-  ratioWatchDownload Int?
-  lastLogin          DateTime?
-  dateRegistered     DateTime            @default(now())
-  disabled           Boolean             @default(false)
-  isArtist           Boolean             @default(false)
-  isDonor            Boolean             @default(false)
-  canDownload        Boolean             @default(true)
-  adminComment       String?
-  staffBio           String?             @db.VarChar(500)
-  banDate            DateTime?
-  banReason          String?
-  warned             DateTime?
-  warnedTimes        Int                 @default(0)
-  lastIp             String?
-  disablePm          Boolean             @default(false)
+  id                    Int                 @id @default(autoincrement())
+  username              String              @unique
+  email                 String              @unique
+  password              String
+  avatar                String?
+  userRankId            Int
+  userRank              UserRank            @relation(fields: [userRankId], references: [id])
+  secondaryRanks        UserSecondaryRank[]
+  userSettingsId        Int                 @unique
+  userSettings          UserSettings        @relation(fields: [userSettingsId], references: [id])
+  profileId             Int                 @unique
+  profile               Profile             @relation(fields: [profileId], references: [id])
+  inviteCount           Int                 @default(0)
+  contributed           BigInt              @default(0)
+  consumed              BigInt              @default(0)
+  totalEarned           BigInt              @default(0)
+  ratio                 Float               @default(1)
+  ratioWatchDownload    Int?
+  lastLogin             DateTime?
+  dateRegistered        DateTime            @default(now())
+  disabled              Boolean             @default(false)
+  isArtist              Boolean             @default(false)
+  isDonor               Boolean             @default(false)
+  canDownload           Boolean             @default(true)
+  // Staff-pinned rank: when true the automated progression engine
+  // (rankProgressionJob) will not promote or demote this user (USER_CLASSES_PLAN
+  // §4). Set by staff via the manual override; the evaluator treats it as a freeze.
+  rankLocked            Boolean             @default(false)
+  adminComment          String?
+  staffBio              String?             @db.VarChar(500)
+  banDate               DateTime?
+  banReason             String?
+  warned                DateTime?
+  warnedTimes           Int                 @default(0)
+  lastIp                String?
+  disablePm             Boolean             @default(false)
   // Verified IRC Link (ADR-0015): ircNick holds only a *verified* nick, written
   // on promotion. A Nick Claim (unproven) lives in pendingIrcNick + nonce, which
   // reserve nothing — pendingIrcNick is intentionally NOT unique, so multiple
   // members may claim the same nick; first to verify wins the unique ircNick slot.
-  ircNick               String?          @unique
+  ircNick               String?             @unique
   pendingIrcNick        String?
   ircNickNonce          String?
   ircNickNonceExpiresAt DateTime?
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
 
   invitesSent              Invite[]
   inviteTree               InviteTree?                      @relation("InviteTreeMember")
@@ -467,7 +512,6 @@ model User {
   @@index([userRankId])
   @@map("users")
 }
-
 
 model UserSecondaryRank {
   userId       Int
@@ -887,22 +931,22 @@ model SimilarArtist {
 // ─── Community ────────────────────────────────────────────────────────────────
 
 model Community {
-  id                    Int                 @id @default(autoincrement())
-  name                  String              @unique
-  description           String?             @db.Text
+  id                    Int                       @id @default(autoincrement())
+  name                  String                    @unique
+  description           String?                   @db.Text
   image                 String
   registrationStatus    RegistrationStatus
   type                  CommunityType
-  allowDuplicateFormats Boolean             @default(true)
-  consumers             Consumer[]          @relation("CommunityConsumers")
+  allowDuplicateFormats Boolean                   @default(true)
+  consumers             Consumer[]                @relation("CommunityConsumers")
   contributors          Contributor[]
   releases              Release[]
   comments              Comment[]
-  staff                 User[]              @relation("CommunityStaff")
+  staff                 User[]                    @relation("CommunityStaff")
   doNotContribute       DoNotContribute[]
   bookmarks             BookmarkCommunity[]
-  createdAt             DateTime            @default(now())
-  updatedAt             DateTime            @updatedAt
+  createdAt             DateTime                  @default(now())
+  updatedAt             DateTime                  @updatedAt
   Request               Request[]
   healthSnapshots       CommunityHealthSnapshot[]
 
@@ -2187,19 +2231,19 @@ model RulesPage {
 /// (src/modules/ruleImpact.ts) reads these weights — no logic lives in the row.
 /// Magnitudes are PRD-05 TBD; the model is the shape, the values are placeholders.
 model Rule {
-  id          Int    @id @default(autoincrement())
+  id               Int       @id @default(autoincrement())
   /// Machine-stable key, e.g. "golden.accounts" — distinct from the display title.
-  code        String @unique @db.VarChar(100)
-  title       String @db.VarChar(200)
-  description String @default("") @db.Text
+  code             String    @unique @db.VarChar(100)
+  title            String    @db.VarChar(200)
+  description      String    @default("") @db.Text
   /// CRS reward when the rule is adhered to (>= 0). Magnitude PRD-05 TBD.
-  complianceWeight Float @default(0)
+  complianceWeight Float     @default(0)
   /// CRS penalty magnitude when the rule is breached (>= 0; ruleImpact negates it).
-  violationWeight  Float @default(0)
-  sortOrder        Int   @default(0)
+  violationWeight  Float     @default(0)
+  sortOrder        Int       @default(0)
   subRules         SubRule[]
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   @@index([sortOrder])
   @@map("rules")
@@ -2208,16 +2252,16 @@ model Rule {
 /// A child node of a `Rule` (PRD-05: "5 rules with 2 SubRules each"). Its weight
 /// composes additively on top of its parent rule's in `ruleImpact()`.
 model SubRule {
-  id          Int    @id @default(autoincrement())
-  ruleId      Int
-  rule        Rule   @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+  id               Int      @id @default(autoincrement())
+  ruleId           Int
+  rule             Rule     @relation(fields: [ruleId], references: [id], onDelete: Cascade)
   /// Stable key, unique within the parent rule (e.g. "no-sharing").
-  code        String @db.VarChar(100)
-  title       String @db.VarChar(200)
-  description String @default("") @db.Text
-  complianceWeight Float @default(0)
-  violationWeight  Float @default(0)
-  sortOrder        Int   @default(0)
+  code             String   @db.VarChar(100)
+  title            String   @db.VarChar(200)
+  description      String   @default("") @db.Text
+  complianceWeight Float    @default(0)
+  violationWeight  Float    @default(0)
+  sortOrder        Int      @default(0)
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,12 +7,17 @@
  * Can also be run manually: npx prisma db seed
  */
 import { PrismaClient } from '@prisma/client';
-import { seedRanks, seedForums } from '../src/modules/bootstrap';
+import {
+  seedRanks,
+  seedRankPromotionRules,
+  seedForums
+} from '../src/modules/bootstrap';
 
 const prisma = new PrismaClient();
 
 async function main() {
   await seedRanks(prisma);
+  await seedRankPromotionRules(prisma);
   await seedForums(prisma);
   console.log('→ Complete setup at http://localhost:3000/install');
 }

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -4,6 +4,7 @@ import {
   resetApiTestState,
   prismaMock
 } from './test/apiTestHarness';
+import { DEFAULT_RANKS } from './modules/bootstrap';
 
 beforeEach(() => resetApiTestState());
 
@@ -20,6 +21,9 @@ function mockPreseededBootstrap() {
     level: 1000,
     name: 'SysOp'
   } as never);
+  // seedRankPromotionRules loads the seeded ranks; empty is fine for these tests
+  // (no rule rungs resolve, nothing to assert on here).
+  prismaMock.userRank.findMany.mockResolvedValue([] as never);
 }
 
 function mockSysopTransaction() {
@@ -239,17 +243,14 @@ describe('POST /api/install', () => {
     prismaMock.user.count.mockResolvedValue(0);
     prismaMock.user.findFirst.mockResolvedValue(null);
 
-    // seedRanks checks canonical levels individually.
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
-    prismaMock.userRank.create
-      .mockResolvedValueOnce({ id: 10, level: 100 } as never)
-      .mockResolvedValueOnce({ id: 11, level: 200 } as never)
-      .mockResolvedValueOnce({ id: 12, level: 500 } as never)
-      .mockResolvedValueOnce({ id: 13, level: 1000 } as never);
+    // seedRanks checks each canonical level individually; none exist yet.
+    prismaMock.userRank.findUnique.mockResolvedValue(null);
+    prismaMock.userRank.create.mockResolvedValue({
+      id: 13,
+      level: 1000
+    } as never);
+    // seedRankPromotionRules then loads the freshly seeded ranks.
+    prismaMock.userRank.findMany.mockResolvedValue([] as never);
 
     // seedForums: no existing categories → creates them
     prismaMock.forumCategory.count.mockResolvedValue(0);
@@ -269,7 +270,10 @@ describe('POST /api/install', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(prismaMock.userRank.create).toHaveBeenCalledTimes(4);
+    // One create per rung of the full class ladder.
+    expect(prismaMock.userRank.create).toHaveBeenCalledTimes(
+      DEFAULT_RANKS.length
+    );
     expect(prismaMock.forumCategory.create).toHaveBeenCalled();
   });
 

--- a/src/modules/bootstrap.spec.ts
+++ b/src/modules/bootstrap.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the class-ladder bootstrap (USER_CLASSES_PLAN §5). seedRanks /
+ * seedForums are exercised by the install integration path; these specs pin the
+ * ladder shape and the promotion-rule seeding (which projects the evaluator's
+ * DEFAULT_RULES onto real DB rank ids by level).
+ */
+import { PrismaClient } from '@prisma/client';
+import { DEFAULT_RANKS, seedRankPromotionRules } from './bootstrap';
+import { DEFAULT_RULES } from './rankProgression';
+
+const GiB = BigInt(1024 ** 3);
+
+describe('DEFAULT_RANKS ladder', () => {
+  it('covers the full primary class ladder at the confirmed levels', () => {
+    expect(DEFAULT_RANKS.map((r) => r.level)).toEqual([
+      100, 150, 200, 300, 350, 400, 450, 500, 1000
+    ]);
+  });
+
+  it('uses the §11-confirmed prestige-tier names', () => {
+    const nameByLevel = new Map(DEFAULT_RANKS.map((r) => [r.level, r.name]));
+    expect(nameByLevel.get(150)).toBe('Member');
+    expect(nameByLevel.get(300)).toBe('Elite');
+    expect(nameByLevel.get(350)).toBe('Stellarific');
+    expect(nameByLevel.get(400)).toBe('Stellartastic');
+    expect(nameByLevel.get(450)).toBe('Stellarige');
+  });
+
+  it('keeps personal-collage headroom monotonic up the ladder', () => {
+    const limits = DEFAULT_RANKS.filter((r) => r.level <= 450).map(
+      (r) => r.personalCollageLimit
+    );
+    const sorted = [...limits].sort((a, b) => a - b);
+    expect(limits).toEqual(sorted);
+  });
+});
+
+describe('seedRankPromotionRules', () => {
+  // Real DB ids deliberately differ from the evaluator's fixture ids (1–9) to
+  // prove the seeder resolves rungs by level, not by hard-coded id.
+  const fullRanks = [
+    { id: 11, level: 100 },
+    { id: 12, level: 150 },
+    { id: 13, level: 200 },
+    { id: 14, level: 300 },
+    { id: 15, level: 350 },
+    { id: 16, level: 400 },
+    { id: 17, level: 450 },
+    { id: 18, level: 500 },
+    { id: 19, level: 1000 }
+  ];
+
+  const makeClient = (ranks: { id: number; level: number }[]) => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      userRank: { findMany: jest.fn().mockResolvedValue(ranks) },
+      rankPromotionRule: { upsert }
+    } as unknown as PrismaClient;
+    return { client, upsert };
+  };
+
+  it('seeds one rule per DEFAULT_RULES rung, resolving from/to ids by level', async () => {
+    const { client, upsert } = makeClient(fullRanks);
+    await seedRankPromotionRules(client);
+
+    expect(upsert).toHaveBeenCalledTimes(DEFAULT_RULES.length);
+    const first = upsert.mock.calls[0][0];
+    // User(100)→Member(150) projected onto DB ids 11→12.
+    expect(first.where.fromRankId_toRankId).toEqual({
+      fromRankId: 11,
+      toRankId: 12
+    });
+    expect(first.create.minContributed).toBe(10n * GiB);
+    expect(first.create.minAccountAgeDays).toBe(7);
+  });
+
+  it('is create-if-absent so runtime tuning survives a re-seed', async () => {
+    const { client, upsert } = makeClient(fullRanks);
+    await seedRankPromotionRules(client);
+    for (const call of upsert.mock.calls) expect(call[0].update).toEqual({});
+  });
+
+  it('carries the prestige Extra predicates onto the top two rungs', async () => {
+    const { client, upsert } = makeClient(fullRanks);
+    await seedRankPromotionRules(client);
+    expect(upsert.mock.calls.map((c) => c[0].create.extra)).toEqual([
+      null,
+      null,
+      null,
+      null,
+      'DISTINCT_RELEASES_500',
+      'QUALITY_CONTRIB_500'
+    ]);
+  });
+
+  it('skips rungs whose ranks are not seeded yet instead of throwing', async () => {
+    // Only User + Member exist — only the 100→150 rung is seedable.
+    const { client, upsert } = makeClient([
+      { id: 11, level: 100 },
+      { id: 12, level: 150 }
+    ]);
+    await seedRankPromotionRules(client);
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -4,6 +4,10 @@
  */
 import { PrismaClient } from '@prisma/client';
 import { ALL_PERMISSIONS } from '../lib/rankPermissions';
+import {
+  DEFAULT_RANKS as EVALUATOR_RANKS,
+  DEFAULT_RULES
+} from './rankProgression';
 
 export const DEFAULT_RANKS = [
   {
@@ -23,6 +27,25 @@ export const DEFAULT_RANKS = [
     }
   },
   {
+    level: 150,
+    name: 'Member',
+    secondary: false,
+    permittedForumIds: [],
+    color: '',
+    badge: '',
+    personalCollageLimit: 1,
+    // One step past User: unlocks advanced discovery. Identity stays understated
+    // (no color/badge) — the first earned rung, not yet a "notable" tier.
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      collages_create: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
     level: 200,
     name: 'Power User',
     secondary: false,
@@ -34,6 +57,87 @@ export const DEFAULT_RANKS = [
       forums_read: true,
       forums_post: true,
       advanced_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
+    level: 300,
+    name: 'Elite',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#3a9bd9',
+    badge: '',
+    personalCollageLimit: 3,
+    // Top of the "earns new powers" range: adds elevated user search and collage
+    // management. The auto ladder above Elite is prestige — identity, not new perms.
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  // Prestige tiers (USER_CLASSES_PLAN §11, names confirmed): no member-level
+  // permissions remain to grant below staff, so these differentiate on identity
+  // (color/badge) and personal-collage headroom rather than new capability.
+  {
+    level: 350,
+    name: 'Stellarific',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#9b59d0',
+    badge: '',
+    personalCollageLimit: 4,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
+    level: 400,
+    name: 'Stellartastic',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#c061e8',
+    badge: '',
+    personalCollageLimit: 5,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
+    level: 450,
+    name: 'Stellarige',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#d4a5ff',
+    badge: '',
+    personalCollageLimit: 6,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
       collages_create: true,
       collages_manage: true,
       requests_create: true,
@@ -303,6 +407,55 @@ export async function seedRanks(client: PrismaClient): Promise<void> {
         badge: rank.badge,
         personalCollageLimit: rank.personalCollageLimit,
         permissions: rank.permissions
+      }
+    });
+  }
+}
+
+// The evaluator (rankProgression.ts) encodes the ladder against fixture rank ids
+// 1–9; the DB assigns real autoincrement ids. Map fixture id → ladder level so the
+// seeded rules are exactly DEFAULT_RULES, projected onto whatever ids the DB gave
+// each level — one source of truth for the thresholds, no duplicated magnitudes.
+const evaluatorLevelOf = (fixtureRankId: number): number => {
+  const rank = EVALUATOR_RANKS.find((r) => r.id === fixtureRankId);
+  if (!rank)
+    throw new Error(
+      `rankProgression DEFAULT_RANKS has no rank id ${fixtureRankId}`
+    );
+  return rank.level;
+};
+
+/**
+ * Seed the promotion-rule ladder (USER_CLASSES_PLAN §5). Create-if-absent: once a
+ * rule exists, re-seeding leaves it alone so runtime tuning via the admin editor
+ * (#170) stays authoritative. A rung whose from/to rank isn't seeded yet is
+ * skipped rather than failing the bootstrap.
+ */
+export async function seedRankPromotionRules(
+  client: PrismaClient
+): Promise<void> {
+  const ranks = await client.userRank.findMany({
+    select: { id: true, level: true }
+  });
+  const idByLevel = new Map(ranks.map((r) => [r.level, r.id]));
+
+  for (const rule of DEFAULT_RULES) {
+    const fromRankId = idByLevel.get(evaluatorLevelOf(rule.fromRankId));
+    const toRankId = idByLevel.get(evaluatorLevelOf(rule.toRankId));
+    if (fromRankId === undefined || toRankId === undefined) continue;
+
+    await client.rankPromotionRule.upsert({
+      where: { fromRankId_toRankId: { fromRankId, toRankId } },
+      update: {},
+      create: {
+        fromRankId,
+        toRankId,
+        minContributed: rule.minContributed,
+        minRatio: rule.minRatio,
+        minContributions: rule.minContributions,
+        minAccountAgeDays: rule.minAccountAgeDays,
+        extra: rule.extra,
+        enabled: rule.enabled
       }
     });
   }

--- a/src/modules/rankProgression.spec.ts
+++ b/src/modules/rankProgression.spec.ts
@@ -124,41 +124,41 @@ describe('evaluateRankChange — demotion', () => {
 // ─── extra predicates ───────────────────────────────────────────────────────────
 
 describe('evaluateRankChange — extra predicates', () => {
-  it('holds a Curator below Master Curator without 500 distinct releases', () => {
+  it('holds a Stellarific below Stellartastic without 500 distinct releases', () => {
     const result = evaluateRankChange(
-      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 499 })
+      maxed({ currentRankId: rankId('Stellarific'), distinctReleaseCount: 499 })
     );
     expect(result.direction).toBe('none');
   });
 
-  it('promotes a Curator to Master Curator once 500 distinct releases is met', () => {
+  it('promotes a Stellarific to Stellartastic once 500 distinct releases is met', () => {
     const result = evaluateRankChange(
-      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 500 })
+      maxed({ currentRankId: rankId('Stellarific'), distinctReleaseCount: 500 })
     );
     expect(result.direction).toBe('promote');
-    expect(result.targetRankId).toBe(rankId('Master Curator'));
+    expect(result.targetRankId).toBe(rankId('Stellartastic'));
   });
 
-  it('demotes a Master Curator who falls below 500 distinct releases', () => {
+  it('demotes a Stellartastic who falls below 500 distinct releases', () => {
     const result = evaluateRankChange(
       maxed({
-        currentRankId: rankId('Master Curator'),
+        currentRankId: rankId('Stellartastic'),
         distinctReleaseCount: 499
       })
     );
     expect(result.direction).toBe('demote');
-    expect(result.targetRankId).toBe(rankId('Curator'));
+    expect(result.targetRankId).toBe(rankId('Stellarific'));
   });
 
-  it('promotes a Master Curator to Grand Curator on 500 quality contributions', () => {
+  it('promotes a Stellartastic to Stellarige on 500 quality contributions', () => {
     const result = evaluateRankChange(
       maxed({
-        currentRankId: rankId('Master Curator'),
+        currentRankId: rankId('Stellartastic'),
         qualityContributionCount: 500
       })
     );
     expect(result.direction).toBe('promote');
-    expect(result.targetRankId).toBe(rankId('Grand Curator'));
+    expect(result.targetRankId).toBe(rankId('Stellarige'));
   });
 });
 
@@ -176,9 +176,9 @@ describe('evaluateRankChange — guards', () => {
     expect(result.direction).toBe('none');
   });
 
-  it('never promotes into an assigned class (Grand Curator → Staff)', () => {
+  it('never promotes into an assigned class (Stellarige → Staff)', () => {
     const result = evaluateRankChange(
-      maxed({ currentRankId: rankId('Grand Curator') })
+      maxed({ currentRankId: rankId('Stellarige') })
     );
     expect(result.direction).toBe('none');
   });
@@ -223,15 +223,15 @@ describe('describeGapToNext', () => {
 
   it('surfaces the unmet Extra predicate on prestige rungs', () => {
     const gap = describeGapToNext(
-      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 10 })
+      maxed({ currentRankId: rankId('Stellarific'), distinctReleaseCount: 10 })
     );
-    expect(gap?.toRankName).toBe('Master Curator');
+    expect(gap?.toRankName).toBe('Stellartastic');
     expect(gap?.extraUnmet).toBe('DISTINCT_RELEASES_500');
   });
 
-  it('returns null at the top of the auto ladder (Grand Curator)', () => {
+  it('returns null at the top of the auto ladder (Stellarige)', () => {
     expect(
-      describeGapToNext(maxed({ currentRankId: rankId('Grand Curator') }))
+      describeGapToNext(maxed({ currentRankId: rankId('Stellarige') }))
     ).toBeNull();
   });
 });

--- a/src/modules/rankProgression.ts
+++ b/src/modules/rankProgression.ts
@@ -61,9 +61,9 @@ export const DEFAULT_RANKS: Rank[] = [
   { id: 2, level: 150, name: 'Member', autoManaged: true },
   { id: 3, level: 200, name: 'Power User', autoManaged: true },
   { id: 4, level: 300, name: 'Elite', autoManaged: true },
-  { id: 5, level: 350, name: 'Curator', autoManaged: true },
-  { id: 6, level: 400, name: 'Master Curator', autoManaged: true },
-  { id: 7, level: 450, name: 'Grand Curator', autoManaged: true },
+  { id: 5, level: 350, name: 'Stellarific', autoManaged: true },
+  { id: 6, level: 400, name: 'Stellartastic', autoManaged: true },
+  { id: 7, level: 450, name: 'Stellarige', autoManaged: true },
   { id: 8, level: 500, name: 'Staff', autoManaged: false },
   { id: 9, level: 1000, name: 'SysOp', autoManaged: false }
 ];

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -13,7 +13,11 @@ import { requirePermission } from '../../middleware/permissions';
 import { validate, parsedBody } from '../../middleware/validate';
 import { installSchema, type InstallInput } from '../../schemas/install';
 import { getSettings } from '../../modules/settings';
-import { seedRanks, seedForums } from '../../modules/bootstrap';
+import {
+  seedRanks,
+  seedRankPromotionRules,
+  seedForums
+} from '../../modules/bootstrap';
 import { AppError } from '../../lib/errors';
 import { authUserSelect, toAuthUser } from '../../modules/auth';
 import { getDefaultStylesheetName } from '../../modules/stylesheet';
@@ -169,6 +173,7 @@ router.post(
     // Bootstrap ranks and forums outside the user transaction so they exist
     // even if user creation fails, and so the transaction stays minimal.
     await seedRanks(prisma);
+    await seedRankPromotionRules(prisma);
     await seedForums(prisma);
 
     const sysopRank = await prisma.userRank.findFirst({

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -80,6 +80,7 @@ export function makeUser(overrides: Partial<User> = {}): User {
     isArtist: false,
     isDonor: false,
     canDownload: true,
+    rankLocked: false,
     adminComment: null,
     staffBio: null,
     banDate: null,


### PR DESCRIPTION
Second rollout slice for automated user-class progression. Gives the engine real ranks and rules to run against.

> **Stacked on #185 (#167).** This is a cross-fork PR, so its base is `main` and the diff currently includes #167's commit too — it'll narrow to just the #168 commit once #185 merges. **Merge #185 first.**

## Changes
- **`DEFAULT_RANKS`** gains the missing rungs: Member (150), Elite (300), and the three prestige tiers. Prestige-tier names follow the **§11 product decision confirmed in #172**: **Stellarific** (350) / **Stellartastic** (400) / **Stellarige** (450) — replacing the earlier Curator draft. The evaluator's `DEFAULT_RANKS` + its spec are renamed to match so DB and fixtures agree.
- Realistic non-staff permissions are exhausted by Elite (`advanced_search`, `users_search`, `collages_manage`), so the prestige tiers **intentionally share Elite's permission set** and differentiate on identity (color) + personal-collage headroom (4/5/6) rather than new powers.
- **`seedRankPromotionRules`** — projects the evaluator's `DEFAULT_RULES` onto real DB rank ids **by level** (one source of truth for the thresholds, no duplicated magnitudes). **Create-if-absent**, so runtime tuning via the admin editor (#170) survives a re-seed. Wired into `prisma/seed.ts` and the install route after `seedRanks`.
- The Power User (200) / Elite (300) community forum gates already key on `userRankLevel`, so they bind correctly now that those levels are real classes.
- `bootstrap.spec.ts` (new): ladder shape + rule-seeding (id-by-level resolution, Extra predicates on the top two rungs, create-if-absent, partial-ladder skip). `install.spec` + `factories` updated for the 9-rung ladder and `User.rankLocked`.

## ⚠️ For review
Identity values (tier **colors**, **collage limits**) are my picks — easy to tweak, and become runtime-editable once #170 lands. The **names** are per the #172 decision.

## Verification
format / lint / `tsc --noEmit` / `typecheck:test` clean; full suite green (1557 tests).

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)