### PR TITLE
feat(classes): automated rank progression sweep job + notifications (#169)

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -123,6 +123,15 @@ comment_sub comment_sub
 artist_release artist_release
 site_news site_news
 global_notice global_notice
+rank_promoted rank_promoted
+rank_demoted rank_demoted
+        }
+    
+
+
+        RankExtraPredicate {
+            DISTINCT_RELEASES_500 DISTINCT_RELEASES_500
+QUALITY_CONTRIB_500 QUALITY_CONTRIB_500
         }
     
 
@@ -398,6 +407,19 @@ Yearly Yearly
     }
   
 
+  "rank_promotion_rules" {
+    Int id "🗝️"
+    BigInt minContributed 
+    Float minRatio 
+    Int minContributions 
+    Int minAccountAgeDays 
+    RankExtraPredicate extra "❓"
+    Boolean enabled 
+    DateTime createdAt 
+    DateTime updatedAt 
+    }
+  
+
   "user_settings" {
     Int id "🗝️"
     String siteAppearance 
@@ -431,6 +453,7 @@ Yearly Yearly
     Boolean isArtist 
     Boolean isDonor 
     Boolean canDownload 
+    Boolean rankLocked 
     String adminComment "❓"
     String staffBio "❓"
     DateTime banDate "❓"
@@ -440,6 +463,9 @@ Yearly Yearly
     String lastIp "❓"
     Boolean disablePm 
     String ircNick "❓"
+    String pendingIrcNick "❓"
+    String ircNickNonce "❓"
+    DateTime ircNickNonceExpiresAt "❓"
     DateTime createdAt 
     DateTime updatedAt 
     }
@@ -1539,6 +1565,9 @@ Yearly Yearly
     }
   
     "user_ranks" }o--|o staff_groups : "staffGroup"
+    "rank_promotion_rules" }o--|| user_ranks : "fromRank"
+    "rank_promotion_rules" }o--|| user_ranks : "toRank"
+    "rank_promotion_rules" |o--|o "RankExtraPredicate" : "enum:extra"
     "user_settings" |o--|| "NotificationMethod" : "enum:notificationMethod"
     "user_settings" }o--|o author_stylesheets : "activeAuthorStylesheet"
     "users" }o--|| user_ranks : "userRank"

--- a/prisma/migrations/20260619013207_rank_promotion_rules/migration.sql
+++ b/prisma/migrations/20260619013207_rank_promotion_rules/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "RankExtraPredicate" AS ENUM ('DISTINCT_RELEASES_500', 'QUALITY_CONTRIB_500');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "NotificationType" ADD VALUE 'rank_promoted';
+ALTER TYPE "NotificationType" ADD VALUE 'rank_demoted';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "rankLocked" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "rank_promotion_rules" (
+    "id" SERIAL NOT NULL,
+    "fromRankId" INTEGER NOT NULL,
+    "toRankId" INTEGER NOT NULL,
+    "minContributed" BIGINT NOT NULL DEFAULT 0,
+    "minRatio" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "minContributions" INTEGER NOT NULL DEFAULT 0,
+    "minAccountAgeDays" INTEGER NOT NULL DEFAULT 0,
+    "extra" "RankExtraPredicate",
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rank_promotion_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "rank_promotion_rules_fromRankId_idx" ON "rank_promotion_rules"("fromRankId");
+
+-- CreateIndex
+CREATE INDEX "rank_promotion_rules_toRankId_idx" ON "rank_promotion_rules"("toRankId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rank_promotion_rules_fromRankId_toRankId_key" ON "rank_promotion_rules"("fromRankId", "toRankId");
+
+-- AddForeignKey
+ALTER TABLE "rank_promotion_rules" ADD CONSTRAINT "rank_promotion_rules_fromRankId_fkey" FOREIGN KEY ("fromRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rank_promotion_rules" ADD CONSTRAINT "rank_promotion_rules_toRankId_fkey" FOREIGN KEY ("toRankId") REFERENCES "user_ranks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,17 @@ enum NotificationType {
   artist_release
   site_news
   global_notice
+  rank_promoted
+  rank_demoted
+}
+
+// Extra, non-numeric criteria a promotion rule may layer on top of the stock
+// byte/ratio/contribution/age thresholds — the prestige-tier gates encoded by
+// the evaluator (rankProgression.ts RankExtraPredicate). Mirrors that TS union
+// exactly so a Prisma row maps onto the evaluator's rule shape unchanged.
+enum RankExtraPredicate {
+  DISTINCT_RELEASES_500
+  QUALITY_CONTRIB_500
 }
 
 enum ThreadType {
@@ -300,6 +311,8 @@ model UserRank {
   staffGroup           StaffGroup?         @relation(fields: [staffGroupId], references: [id], onDelete: SetNull)
   users                User[]
   secondaryUsers       UserSecondaryRank[]
+  promotionRulesFrom   RankPromotionRule[] @relation("RankPromotionFrom")
+  promotionRulesTo     RankPromotionRule[] @relation("RankPromotionTo")
 
   @@unique([level])
   @@unique([name])
@@ -308,73 +321,105 @@ model UserRank {
   @@map("user_ranks")
 }
 
+// Declarative, data-driven criteria for one rung of automated class progression
+// (USER_CLASSES_PLAN §4). One row = "a user on fromRank advances to toRank once
+// they clear these thresholds." Tunable without a deploy. The pure evaluator in
+// rankProgression.ts owns the decision logic; rankProgressionJob loads these rows
+// and maps them onto the evaluator's RankPromotionRule interface field-for-field.
+// minContributed is BigInt (bytes) — deliberately NOT UserRank.uploadRequired Int,
+// which overflows past ~2 GiB.
+model RankPromotionRule {
+  id                Int                 @id @default(autoincrement())
+  fromRankId        Int
+  fromRank          UserRank            @relation("RankPromotionFrom", fields: [fromRankId], references: [id], onDelete: Cascade)
+  toRankId          Int
+  toRank            UserRank            @relation("RankPromotionTo", fields: [toRankId], references: [id], onDelete: Cascade)
+  minContributed    BigInt              @default(0)
+  minRatio          Float               @default(0)
+  minContributions  Int                 @default(0)
+  minAccountAgeDays Int                 @default(0)
+  extra             RankExtraPredicate?
+  enabled           Boolean             @default(true)
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+
+  @@unique([fromRankId, toRankId])
+  @@index([fromRankId])
+  @@index([toRankId])
+  @@map("rank_promotion_rules")
+}
+
 model UserSettings {
-  id                   Int                @id @default(autoincrement())
-  siteAppearance       String             @default("sublime")
-  externalStylesheet   String?
-  styledTooltips       Boolean            @default(true)
-  paranoia             Int                @default(0)
-  notificationMethod   NotificationMethod @default(Traditional)
-  showEmail            Boolean            @default(false)
-  showLastSeen         Boolean            @default(false)
-  showContributedStats Boolean            @default(true)
-  showConsumedStats    Boolean            @default(true)
-  showRatioStats       Boolean            @default(true)
-  user                 User?
+  id                       Int                @id @default(autoincrement())
+  siteAppearance           String             @default("sublime")
+  externalStylesheet       String?
+  styledTooltips           Boolean            @default(true)
+  paranoia                 Int                @default(0)
+  notificationMethod       NotificationMethod @default(Traditional)
+  showEmail                Boolean            @default(false)
+  showLastSeen             Boolean            @default(false)
+  showContributedStats     Boolean            @default(true)
+  showConsumedStats        Boolean            @default(true)
+  showRatioStats           Boolean            @default(true)
+  user                     User?
   // The AuthorStylesheet adopted into this member's Site Stylesheet slot
   // (PRD-03 #119): what they see on the general site. Null = on the Site Theme
   // (Sublime/Default). SetNull on delete so a pruned sheet clears its adopters'
   // pointers rather than orphaning them. Profile/Community slots are deferred.
   activeAuthorStylesheetId Int?
-  activeAuthorStylesheet   AuthorStylesheet? @relation(fields: [activeAuthorStylesheetId], references: [id])
+  activeAuthorStylesheet   AuthorStylesheet?  @relation(fields: [activeAuthorStylesheetId], references: [id])
 
   @@index([activeAuthorStylesheetId])
   @@map("user_settings")
 }
 
 model User {
-  id                 Int                 @id @default(autoincrement())
-  username           String              @unique
-  email              String              @unique
-  password           String
-  avatar             String?
-  userRankId         Int
-  userRank           UserRank            @relation(fields: [userRankId], references: [id])
-  secondaryRanks     UserSecondaryRank[]
-  userSettingsId     Int                 @unique
-  userSettings       UserSettings        @relation(fields: [userSettingsId], references: [id])
-  profileId          Int                 @unique
-  profile            Profile             @relation(fields: [profileId], references: [id])
-  inviteCount        Int                 @default(0)
-  contributed        BigInt              @default(0)
-  consumed           BigInt              @default(0)
-  totalEarned        BigInt              @default(0)
-  ratio              Float               @default(1)
-  ratioWatchDownload Int?
-  lastLogin          DateTime?
-  dateRegistered     DateTime            @default(now())
-  disabled           Boolean             @default(false)
-  isArtist           Boolean             @default(false)
-  isDonor            Boolean             @default(false)
-  canDownload        Boolean             @default(true)
-  adminComment       String?
-  staffBio           String?             @db.VarChar(500)
-  banDate            DateTime?
-  banReason          String?
-  warned             DateTime?
-  warnedTimes        Int                 @default(0)
-  lastIp             String?
-  disablePm          Boolean             @default(false)
+  id                    Int                 @id @default(autoincrement())
+  username              String              @unique
+  email                 String              @unique
+  password              String
+  avatar                String?
+  userRankId            Int
+  userRank              UserRank            @relation(fields: [userRankId], references: [id])
+  secondaryRanks        UserSecondaryRank[]
+  userSettingsId        Int                 @unique
+  userSettings          UserSettings        @relation(fields: [userSettingsId], references: [id])
+  profileId             Int                 @unique
+  profile               Profile             @relation(fields: [profileId], references: [id])
+  inviteCount           Int                 @default(0)
+  contributed           BigInt              @default(0)
+  consumed              BigInt              @default(0)
+  totalEarned           BigInt              @default(0)
+  ratio                 Float               @default(1)
+  ratioWatchDownload    Int?
+  lastLogin             DateTime?
+  dateRegistered        DateTime            @default(now())
+  disabled              Boolean             @default(false)
+  isArtist              Boolean             @default(false)
+  isDonor               Boolean             @default(false)
+  canDownload           Boolean             @default(true)
+  // Staff-pinned rank: when true the automated progression engine
+  // (rankProgressionJob) will not promote or demote this user (USER_CLASSES_PLAN
+  // §4). Set by staff via the manual override; the evaluator treats it as a freeze.
+  rankLocked            Boolean             @default(false)
+  adminComment          String?
+  staffBio              String?             @db.VarChar(500)
+  banDate               DateTime?
+  banReason             String?
+  warned                DateTime?
+  warnedTimes           Int                 @default(0)
+  lastIp                String?
+  disablePm             Boolean             @default(false)
   // Verified IRC Link (ADR-0015): ircNick holds only a *verified* nick, written
   // on promotion. A Nick Claim (unproven) lives in pendingIrcNick + nonce, which
   // reserve nothing — pendingIrcNick is intentionally NOT unique, so multiple
   // members may claim the same nick; first to verify wins the unique ircNick slot.
-  ircNick               String?          @unique
+  ircNick               String?             @unique
   pendingIrcNick        String?
   ircNickNonce          String?
   ircNickNonceExpiresAt DateTime?
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
 
   invitesSent              Invite[]
   inviteTree               InviteTree?                      @relation("InviteTreeMember")
@@ -467,7 +512,6 @@ model User {
   @@index([userRankId])
   @@map("users")
 }
-
 
 model UserSecondaryRank {
   userId       Int
@@ -887,22 +931,22 @@ model SimilarArtist {
 // ─── Community ────────────────────────────────────────────────────────────────
 
 model Community {
-  id                    Int                 @id @default(autoincrement())
-  name                  String              @unique
-  description           String?             @db.Text
+  id                    Int                       @id @default(autoincrement())
+  name                  String                    @unique
+  description           String?                   @db.Text
   image                 String
   registrationStatus    RegistrationStatus
   type                  CommunityType
-  allowDuplicateFormats Boolean             @default(true)
-  consumers             Consumer[]          @relation("CommunityConsumers")
+  allowDuplicateFormats Boolean                   @default(true)
+  consumers             Consumer[]                @relation("CommunityConsumers")
   contributors          Contributor[]
   releases              Release[]
   comments              Comment[]
-  staff                 User[]              @relation("CommunityStaff")
+  staff                 User[]                    @relation("CommunityStaff")
   doNotContribute       DoNotContribute[]
   bookmarks             BookmarkCommunity[]
-  createdAt             DateTime            @default(now())
-  updatedAt             DateTime            @updatedAt
+  createdAt             DateTime                  @default(now())
+  updatedAt             DateTime                  @updatedAt
   Request               Request[]
   healthSnapshots       CommunityHealthSnapshot[]
 
@@ -2187,19 +2231,19 @@ model RulesPage {
 /// (src/modules/ruleImpact.ts) reads these weights — no logic lives in the row.
 /// Magnitudes are PRD-05 TBD; the model is the shape, the values are placeholders.
 model Rule {
-  id          Int    @id @default(autoincrement())
+  id               Int       @id @default(autoincrement())
   /// Machine-stable key, e.g. "golden.accounts" — distinct from the display title.
-  code        String @unique @db.VarChar(100)
-  title       String @db.VarChar(200)
-  description String @default("") @db.Text
+  code             String    @unique @db.VarChar(100)
+  title            String    @db.VarChar(200)
+  description      String    @default("") @db.Text
   /// CRS reward when the rule is adhered to (>= 0). Magnitude PRD-05 TBD.
-  complianceWeight Float @default(0)
+  complianceWeight Float     @default(0)
   /// CRS penalty magnitude when the rule is breached (>= 0; ruleImpact negates it).
-  violationWeight  Float @default(0)
-  sortOrder        Int   @default(0)
+  violationWeight  Float     @default(0)
+  sortOrder        Int       @default(0)
   subRules         SubRule[]
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   @@index([sortOrder])
   @@map("rules")
@@ -2208,16 +2252,16 @@ model Rule {
 /// A child node of a `Rule` (PRD-05: "5 rules with 2 SubRules each"). Its weight
 /// composes additively on top of its parent rule's in `ruleImpact()`.
 model SubRule {
-  id          Int    @id @default(autoincrement())
-  ruleId      Int
-  rule        Rule   @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+  id               Int      @id @default(autoincrement())
+  ruleId           Int
+  rule             Rule     @relation(fields: [ruleId], references: [id], onDelete: Cascade)
   /// Stable key, unique within the parent rule (e.g. "no-sharing").
-  code        String @db.VarChar(100)
-  title       String @db.VarChar(200)
-  description String @default("") @db.Text
-  complianceWeight Float @default(0)
-  violationWeight  Float @default(0)
-  sortOrder        Int   @default(0)
+  code             String   @db.VarChar(100)
+  title            String   @db.VarChar(200)
+  description      String   @default("") @db.Text
+  complianceWeight Float    @default(0)
+  violationWeight  Float    @default(0)
+  sortOrder        Int      @default(0)
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,12 +7,17 @@
  * Can also be run manually: npx prisma db seed
  */
 import { PrismaClient } from '@prisma/client';
-import { seedRanks, seedForums } from '../src/modules/bootstrap';
+import {
+  seedRanks,
+  seedRankPromotionRules,
+  seedForums
+} from '../src/modules/bootstrap';
 
 const prisma = new PrismaClient();
 
 async function main() {
   await seedRanks(prisma);
+  await seedRankPromotionRules(prisma);
   await seedForums(prisma);
   console.log('→ Complete setup at http://localhost:3000/install');
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,7 @@ import { startStatsJob } from './modules/statsJob';
 import { startDonorExpiryJob } from './modules/donorExpiryJob';
 import { startIrcJob } from './modules/ircJob';
 import { startAnnounceJob } from './modules/announceJob';
+import { startRankProgressionJob } from './modules/rankProgressionJob';
 
 import installRouter from './routes/api/install';
 import homeRouter from './routes/api/home';
@@ -222,6 +223,7 @@ export const createApp = () => {
     startDonorExpiryJob();
     startIrcJob();
     startAnnounceJob();
+    startRankProgressionJob();
   }
 
   return app;

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -4,6 +4,7 @@ import {
   resetApiTestState,
   prismaMock
 } from './test/apiTestHarness';
+import { DEFAULT_RANKS } from './modules/bootstrap';
 
 beforeEach(() => resetApiTestState());
 
@@ -20,6 +21,9 @@ function mockPreseededBootstrap() {
     level: 1000,
     name: 'SysOp'
   } as never);
+  // seedRankPromotionRules loads the seeded ranks; empty is fine for these tests
+  // (no rule rungs resolve, nothing to assert on here).
+  prismaMock.userRank.findMany.mockResolvedValue([] as never);
 }
 
 function mockSysopTransaction() {
@@ -239,17 +243,14 @@ describe('POST /api/install', () => {
     prismaMock.user.count.mockResolvedValue(0);
     prismaMock.user.findFirst.mockResolvedValue(null);
 
-    // seedRanks checks canonical levels individually.
-    prismaMock.userRank.findUnique
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
-    prismaMock.userRank.create
-      .mockResolvedValueOnce({ id: 10, level: 100 } as never)
-      .mockResolvedValueOnce({ id: 11, level: 200 } as never)
-      .mockResolvedValueOnce({ id: 12, level: 500 } as never)
-      .mockResolvedValueOnce({ id: 13, level: 1000 } as never);
+    // seedRanks checks each canonical level individually; none exist yet.
+    prismaMock.userRank.findUnique.mockResolvedValue(null);
+    prismaMock.userRank.create.mockResolvedValue({
+      id: 13,
+      level: 1000
+    } as never);
+    // seedRankPromotionRules then loads the freshly seeded ranks.
+    prismaMock.userRank.findMany.mockResolvedValue([] as never);
 
     // seedForums: no existing categories → creates them
     prismaMock.forumCategory.count.mockResolvedValue(0);
@@ -269,7 +270,10 @@ describe('POST /api/install', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(prismaMock.userRank.create).toHaveBeenCalledTimes(4);
+    // One create per rung of the full class ladder.
+    expect(prismaMock.userRank.create).toHaveBeenCalledTimes(
+      DEFAULT_RANKS.length
+    );
     expect(prismaMock.forumCategory.create).toHaveBeenCalled();
   });
 

--- a/src/integration/rankProgressionJob.integration.ts
+++ b/src/integration/rankProgressionJob.integration.ts
@@ -1,0 +1,201 @@
+import {
+  ReleaseType,
+  FileType,
+  CommunityType,
+  RegistrationStatus
+} from '@prisma/client';
+import { truncateAll, testPrisma } from '../test/dbHelpers';
+import { seedRanks, seedRankPromotionRules } from '../modules/bootstrap';
+import { createContributionSubmission } from '../modules/contribution';
+import { runRankProgressionSweep } from '../modules/rankProgressionJob';
+import type { CreateContributionInput } from '../schemas/contribution';
+
+// The async link-health HTTP check fires after each contribution and holds a
+// connection that blocks the next TRUNCATE — stub it (mirrors contributions.integration).
+jest.mock('../modules/linkHealth', () => ({
+  checkContributionLink: jest.fn().mockResolvedValue(undefined)
+}));
+
+const GiB = BigInt(1024 ** 3);
+
+beforeEach(async () => {
+  await truncateAll();
+  // Seed the real ladder + promotion rules (#168 seeders) — the sweep reads them.
+  await seedRanks(testPrisma);
+  await seedRankPromotionRules(testPrisma);
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const rankIdByLevel = async (level: number): Promise<number> => {
+  const rank = await testPrisma.userRank.findFirstOrThrow({ where: { level } });
+  return rank.id;
+};
+
+let userSeq = 0;
+const createUserAt = async (
+  level: number,
+  opts: { rankLocked?: boolean; consumed?: bigint; ageDays?: number } = {}
+) => {
+  userSeq += 1;
+  const tag = `rp-${userSeq}-${Date.now()}`;
+  const [rankId, settings, profile] = await Promise.all([
+    rankIdByLevel(level),
+    testPrisma.userSettings.create({ data: {} }),
+    testPrisma.profile.create({ data: {} })
+  ]);
+  return testPrisma.user.create({
+    data: {
+      username: tag,
+      email: `${tag}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rankId,
+      userSettingsId: settings.id,
+      profileId: profile.id,
+      consumed: opts.consumed ?? 0n,
+      rankLocked: opts.rankLocked ?? false,
+      dateRegistered: new Date(Date.now() - (opts.ageDays ?? 0) * 86_400_000)
+    }
+  });
+};
+
+const createCommunity = () =>
+  testPrisma.community.create({
+    data: {
+      name: `Community-${Date.now()}-${userSeq}`,
+      image: '',
+      registrationStatus: RegistrationStatus.open,
+      type: CommunityType.Music
+    }
+  });
+
+const baseInput = (communityId: number): CreateContributionInput => ({
+  communityId,
+  type: ReleaseType.Music,
+  title: `Album-${Date.now()}-${userSeq}`,
+  year: 2020,
+  fileType: FileType.flac,
+  downloadUrl: 'https://example.com/file.torrent',
+  sizeInBytes: 1_000_000,
+  tags: 'rock',
+  releaseDescription: 'desc',
+  image: undefined,
+  description: undefined,
+  bitrate: undefined,
+  media: undefined,
+  releaseCategory: undefined,
+  recordLabel: undefined,
+  catalogueNumber: undefined,
+  editionTitle: undefined,
+  editionYear: undefined,
+  isRemaster: false,
+  hasLog: false,
+  hasCue: false,
+  isScene: false,
+  collaborators: [{ artist: 'Test Artist', importance: 'main' }]
+});
+
+// Give a user an accounted, link-healthy, past-the-72h-window contribution so it
+// counts toward eligible bytes (ADR-0006).
+const giveEligibleBytes = async (
+  userId: number,
+  communityId: number,
+  bytes: bigint
+) => {
+  const contribution = await createContributionSubmission({
+    userId,
+    input: baseInput(communityId)
+  });
+  if (!contribution) throw new Error('fixture contribution failed');
+  await testPrisma.contribution.update({
+    where: { id: contribution.id },
+    data: {
+      approvedAccountingBytes: bytes,
+      createdAt: new Date(Date.now() - 10 * 86_400_000) // 10 days old > 72h window
+    }
+  });
+};
+
+describe('runRankProgressionSweep', () => {
+  it('promotes, demotes, and respects Staff / locked freezes in one pass', async () => {
+    const [userLevel, memberLevel, staffLevel] = await Promise.all([
+      rankIdByLevel(100),
+      rankIdByLevel(150),
+      rankIdByLevel(500)
+    ]);
+
+    // System actor: the install SysOp must exist for the sweep to attribute changes.
+    await createUserAt(1000);
+
+    const community = await createCommunity();
+
+    // 1) A User who clears every User→Member bar (10 GiB / 0.70 / 0 / 7d).
+    const promoting = await createUserAt(100, { ageDays: 30 });
+    await giveEligibleBytes(promoting.id, community.id, 20n * GiB);
+
+    // 2) A Member with no eligible bytes — lapsed the stock criteria for Member.
+    const demoting = await createUserAt(150, { ageDays: 60 });
+
+    // 3) A Staff user — assigned, never auto-managed.
+    const staff = await createUserAt(500, { ageDays: 365 });
+
+    // 4) A fully-eligible User who is rankLocked — the engine must not touch them.
+    const locked = await createUserAt(100, { ageDays: 30, rankLocked: true });
+    await giveEligibleBytes(locked.id, community.id, 20n * GiB);
+
+    const result = await runRankProgressionSweep();
+
+    expect(result).toEqual({ scanned: 3, promoted: 1, demoted: 1 });
+
+    const after = async (id: number) =>
+      (await testPrisma.user.findUniqueOrThrow({ where: { id } })).userRankId;
+
+    expect(await after(promoting.id)).toBe(memberLevel); // → Member
+    expect(await after(demoting.id)).toBe(userLevel); // → User (demoted)
+    expect(await after(staff.id)).toBe(staffLevel); // unchanged
+    expect(await after(locked.id)).toBe(userLevel); // unchanged (frozen)
+
+    // Audit trail: one rank_changed per actual move, flagged auto.
+    const auditRows = await testPrisma.auditLog.findMany({
+      where: { action: 'user.rank_changed' }
+    });
+    expect(auditRows).toHaveLength(2);
+    expect(
+      auditRows.every((r) => (r.metadata as { auto?: boolean }).auto === true)
+    ).toBe(true);
+
+    // Notifications: the promoted user gets rank_promoted, the demoted rank_demoted.
+    const promoteNotif = await testPrisma.notification.findFirst({
+      where: { userId: promoting.id, type: 'rank_promoted' }
+    });
+    const demoteNotif = await testPrisma.notification.findFirst({
+      where: { userId: demoting.id, type: 'rank_demoted' }
+    });
+    expect(promoteNotif).not.toBeNull();
+    expect(demoteNotif).not.toBeNull();
+
+    // The locked user got no notification.
+    const lockedNotif = await testPrisma.notification.findFirst({
+      where: { userId: locked.id }
+    });
+    expect(lockedNotif).toBeNull();
+  });
+
+  it('no-ops cleanly when there is no SysOp actor', async () => {
+    const community = await createCommunity();
+    const eligible = await createUserAt(100, { ageDays: 30 });
+    await giveEligibleBytes(eligible.id, community.id, 20n * GiB);
+
+    const result = await runRankProgressionSweep();
+
+    expect(result).toEqual({ scanned: 0, promoted: 0, demoted: 0 });
+    const userLevel = await rankIdByLevel(100);
+    expect(
+      (await testPrisma.user.findUniqueOrThrow({ where: { id: eligible.id } }))
+        .userRankId
+    ).toBe(userLevel);
+  });
+});

--- a/src/modules/bootstrap.spec.ts
+++ b/src/modules/bootstrap.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the class-ladder bootstrap (USER_CLASSES_PLAN §5). seedRanks /
+ * seedForums are exercised by the install integration path; these specs pin the
+ * ladder shape and the promotion-rule seeding (which projects the evaluator's
+ * DEFAULT_RULES onto real DB rank ids by level).
+ */
+import { PrismaClient } from '@prisma/client';
+import { DEFAULT_RANKS, seedRankPromotionRules } from './bootstrap';
+import { DEFAULT_RULES } from './rankProgression';
+
+const GiB = BigInt(1024 ** 3);
+
+describe('DEFAULT_RANKS ladder', () => {
+  it('covers the full primary class ladder at the confirmed levels', () => {
+    expect(DEFAULT_RANKS.map((r) => r.level)).toEqual([
+      100, 150, 200, 300, 350, 400, 450, 500, 1000
+    ]);
+  });
+
+  it('uses the §11-confirmed prestige-tier names', () => {
+    const nameByLevel = new Map(DEFAULT_RANKS.map((r) => [r.level, r.name]));
+    expect(nameByLevel.get(150)).toBe('Member');
+    expect(nameByLevel.get(300)).toBe('Elite');
+    expect(nameByLevel.get(350)).toBe('Stellarific');
+    expect(nameByLevel.get(400)).toBe('Stellartastic');
+    expect(nameByLevel.get(450)).toBe('Stellarige');
+  });
+
+  it('keeps personal-collage headroom monotonic up the ladder', () => {
+    const limits = DEFAULT_RANKS.filter((r) => r.level <= 450).map(
+      (r) => r.personalCollageLimit
+    );
+    const sorted = [...limits].sort((a, b) => a - b);
+    expect(limits).toEqual(sorted);
+  });
+});
+
+describe('seedRankPromotionRules', () => {
+  // Real DB ids deliberately differ from the evaluator's fixture ids (1–9) to
+  // prove the seeder resolves rungs by level, not by hard-coded id.
+  const fullRanks = [
+    { id: 11, level: 100 },
+    { id: 12, level: 150 },
+    { id: 13, level: 200 },
+    { id: 14, level: 300 },
+    { id: 15, level: 350 },
+    { id: 16, level: 400 },
+    { id: 17, level: 450 },
+    { id: 18, level: 500 },
+    { id: 19, level: 1000 }
+  ];
+
+  const makeClient = (ranks: { id: number; level: number }[]) => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      userRank: { findMany: jest.fn().mockResolvedValue(ranks) },
+      rankPromotionRule: { upsert }
+    } as unknown as PrismaClient;
+    return { client, upsert };
+  };
+
+  it('seeds one rule per DEFAULT_RULES rung, resolving from/to ids by level', async () => {
+    const { client, upsert } = makeClient(fullRanks);
+    await seedRankPromotionRules(client);
+
+    expect(upsert).toHaveBeenCalledTimes(DEFAULT_RULES.length);
+    const first = upsert.mock.calls[0][0];
+    // User(100)→Member(150) projected onto DB ids 11→12.
+    expect(first.where.fromRankId_toRankId).toEqual({
+      fromRankId: 11,
+      toRankId: 12
+    });
+    expect(first.create.minContributed).toBe(10n * GiB);
+    expect(first.create.minAccountAgeDays).toBe(7);
+  });
+
+  it('is create-if-absent so runtime tuning survives a re-seed', async () => {
+    const { client, upsert } = makeClient(fullRanks);
+    await seedRankPromotionRules(client);
+    for (const call of upsert.mock.calls) expect(call[0].update).toEqual({});
+  });
+
+  it('carries the prestige Extra predicates onto the top two rungs', async () => {
+    const { client, upsert } = makeClient(fullRanks);
+    await seedRankPromotionRules(client);
+    expect(upsert.mock.calls.map((c) => c[0].create.extra)).toEqual([
+      null,
+      null,
+      null,
+      null,
+      'DISTINCT_RELEASES_500',
+      'QUALITY_CONTRIB_500'
+    ]);
+  });
+
+  it('skips rungs whose ranks are not seeded yet instead of throwing', async () => {
+    // Only User + Member exist — only the 100→150 rung is seedable.
+    const { client, upsert } = makeClient([
+      { id: 11, level: 100 },
+      { id: 12, level: 150 }
+    ]);
+    await seedRankPromotionRules(client);
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -4,6 +4,10 @@
  */
 import { PrismaClient } from '@prisma/client';
 import { ALL_PERMISSIONS } from '../lib/rankPermissions';
+import {
+  DEFAULT_RANKS as EVALUATOR_RANKS,
+  DEFAULT_RULES
+} from './rankProgression';
 
 export const DEFAULT_RANKS = [
   {
@@ -23,6 +27,25 @@ export const DEFAULT_RANKS = [
     }
   },
   {
+    level: 150,
+    name: 'Member',
+    secondary: false,
+    permittedForumIds: [],
+    color: '',
+    badge: '',
+    personalCollageLimit: 1,
+    // One step past User: unlocks advanced discovery. Identity stays understated
+    // (no color/badge) — the first earned rung, not yet a "notable" tier.
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      collages_create: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
     level: 200,
     name: 'Power User',
     secondary: false,
@@ -34,6 +57,87 @@ export const DEFAULT_RANKS = [
       forums_read: true,
       forums_post: true,
       advanced_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
+    level: 300,
+    name: 'Elite',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#3a9bd9',
+    badge: '',
+    personalCollageLimit: 3,
+    // Top of the "earns new powers" range: adds elevated user search and collage
+    // management. The auto ladder above Elite is prestige — identity, not new perms.
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  // Prestige tiers (USER_CLASSES_PLAN §11, names confirmed): no member-level
+  // permissions remain to grant below staff, so these differentiate on identity
+  // (color/badge) and personal-collage headroom rather than new capability.
+  {
+    level: 350,
+    name: 'Stellarific',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#9b59d0',
+    badge: '',
+    personalCollageLimit: 4,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
+    level: 400,
+    name: 'Stellartastic',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#c061e8',
+    badge: '',
+    personalCollageLimit: 5,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
+      collages_create: true,
+      collages_manage: true,
+      requests_create: true,
+      wiki_edit: true
+    }
+  },
+  {
+    level: 450,
+    name: 'Stellarige',
+    secondary: false,
+    permittedForumIds: [],
+    color: '#d4a5ff',
+    badge: '',
+    personalCollageLimit: 6,
+    permissions: {
+      forums_read: true,
+      forums_post: true,
+      advanced_search: true,
+      users_search: true,
       collages_create: true,
       collages_manage: true,
       requests_create: true,
@@ -303,6 +407,55 @@ export async function seedRanks(client: PrismaClient): Promise<void> {
         badge: rank.badge,
         personalCollageLimit: rank.personalCollageLimit,
         permissions: rank.permissions
+      }
+    });
+  }
+}
+
+// The evaluator (rankProgression.ts) encodes the ladder against fixture rank ids
+// 1–9; the DB assigns real autoincrement ids. Map fixture id → ladder level so the
+// seeded rules are exactly DEFAULT_RULES, projected onto whatever ids the DB gave
+// each level — one source of truth for the thresholds, no duplicated magnitudes.
+const evaluatorLevelOf = (fixtureRankId: number): number => {
+  const rank = EVALUATOR_RANKS.find((r) => r.id === fixtureRankId);
+  if (!rank)
+    throw new Error(
+      `rankProgression DEFAULT_RANKS has no rank id ${fixtureRankId}`
+    );
+  return rank.level;
+};
+
+/**
+ * Seed the promotion-rule ladder (USER_CLASSES_PLAN §5). Create-if-absent: once a
+ * rule exists, re-seeding leaves it alone so runtime tuning via the admin editor
+ * (#170) stays authoritative. A rung whose from/to rank isn't seeded yet is
+ * skipped rather than failing the bootstrap.
+ */
+export async function seedRankPromotionRules(
+  client: PrismaClient
+): Promise<void> {
+  const ranks = await client.userRank.findMany({
+    select: { id: true, level: true }
+  });
+  const idByLevel = new Map(ranks.map((r) => [r.level, r.id]));
+
+  for (const rule of DEFAULT_RULES) {
+    const fromRankId = idByLevel.get(evaluatorLevelOf(rule.fromRankId));
+    const toRankId = idByLevel.get(evaluatorLevelOf(rule.toRankId));
+    if (fromRankId === undefined || toRankId === undefined) continue;
+
+    await client.rankPromotionRule.upsert({
+      where: { fromRankId_toRankId: { fromRankId, toRankId } },
+      update: {},
+      create: {
+        fromRankId,
+        toRankId,
+        minContributed: rule.minContributed,
+        minRatio: rule.minRatio,
+        minContributions: rule.minContributions,
+        minAccountAgeDays: rule.minAccountAgeDays,
+        extra: rule.extra,
+        enabled: rule.enabled
       }
     });
   }

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -31,6 +31,15 @@ export const economy = {
   minimumBounty: parseInt(process.env.STELLAR_MINIMUM_BOUNTY || '104857600', 10)
 };
 
+export const ranks = {
+  // Interval for the automated rank-progression sweep (USER_CLASSES_PLAN §6).
+  // Default hourly — promotion is not time-critical and the sweep is read-heavy.
+  progressionIntervalMs: parseInt(
+    process.env.RANK_PROGRESSION_INTERVAL_MS ?? '3600000',
+    10
+  )
+};
+
 export const sentry = {
   dsn: process.env.STELLAR_SENTRY_DSN ?? ''
 };

--- a/src/modules/rankProgression.spec.ts
+++ b/src/modules/rankProgression.spec.ts
@@ -124,41 +124,41 @@ describe('evaluateRankChange — demotion', () => {
 // ─── extra predicates ───────────────────────────────────────────────────────────
 
 describe('evaluateRankChange — extra predicates', () => {
-  it('holds a Curator below Master Curator without 500 distinct releases', () => {
+  it('holds a Stellarific below Stellartastic without 500 distinct releases', () => {
     const result = evaluateRankChange(
-      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 499 })
+      maxed({ currentRankId: rankId('Stellarific'), distinctReleaseCount: 499 })
     );
     expect(result.direction).toBe('none');
   });
 
-  it('promotes a Curator to Master Curator once 500 distinct releases is met', () => {
+  it('promotes a Stellarific to Stellartastic once 500 distinct releases is met', () => {
     const result = evaluateRankChange(
-      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 500 })
+      maxed({ currentRankId: rankId('Stellarific'), distinctReleaseCount: 500 })
     );
     expect(result.direction).toBe('promote');
-    expect(result.targetRankId).toBe(rankId('Master Curator'));
+    expect(result.targetRankId).toBe(rankId('Stellartastic'));
   });
 
-  it('demotes a Master Curator who falls below 500 distinct releases', () => {
+  it('demotes a Stellartastic who falls below 500 distinct releases', () => {
     const result = evaluateRankChange(
       maxed({
-        currentRankId: rankId('Master Curator'),
+        currentRankId: rankId('Stellartastic'),
         distinctReleaseCount: 499
       })
     );
     expect(result.direction).toBe('demote');
-    expect(result.targetRankId).toBe(rankId('Curator'));
+    expect(result.targetRankId).toBe(rankId('Stellarific'));
   });
 
-  it('promotes a Master Curator to Grand Curator on 500 quality contributions', () => {
+  it('promotes a Stellartastic to Stellarige on 500 quality contributions', () => {
     const result = evaluateRankChange(
       maxed({
-        currentRankId: rankId('Master Curator'),
+        currentRankId: rankId('Stellartastic'),
         qualityContributionCount: 500
       })
     );
     expect(result.direction).toBe('promote');
-    expect(result.targetRankId).toBe(rankId('Grand Curator'));
+    expect(result.targetRankId).toBe(rankId('Stellarige'));
   });
 });
 
@@ -176,9 +176,9 @@ describe('evaluateRankChange — guards', () => {
     expect(result.direction).toBe('none');
   });
 
-  it('never promotes into an assigned class (Grand Curator → Staff)', () => {
+  it('never promotes into an assigned class (Stellarige → Staff)', () => {
     const result = evaluateRankChange(
-      maxed({ currentRankId: rankId('Grand Curator') })
+      maxed({ currentRankId: rankId('Stellarige') })
     );
     expect(result.direction).toBe('none');
   });
@@ -223,15 +223,15 @@ describe('describeGapToNext', () => {
 
   it('surfaces the unmet Extra predicate on prestige rungs', () => {
     const gap = describeGapToNext(
-      maxed({ currentRankId: rankId('Curator'), distinctReleaseCount: 10 })
+      maxed({ currentRankId: rankId('Stellarific'), distinctReleaseCount: 10 })
     );
-    expect(gap?.toRankName).toBe('Master Curator');
+    expect(gap?.toRankName).toBe('Stellartastic');
     expect(gap?.extraUnmet).toBe('DISTINCT_RELEASES_500');
   });
 
-  it('returns null at the top of the auto ladder (Grand Curator)', () => {
+  it('returns null at the top of the auto ladder (Stellarige)', () => {
     expect(
-      describeGapToNext(maxed({ currentRankId: rankId('Grand Curator') }))
+      describeGapToNext(maxed({ currentRankId: rankId('Stellarige') }))
     ).toBeNull();
   });
 });

--- a/src/modules/rankProgression.ts
+++ b/src/modules/rankProgression.ts
@@ -61,9 +61,9 @@ export const DEFAULT_RANKS: Rank[] = [
   { id: 2, level: 150, name: 'Member', autoManaged: true },
   { id: 3, level: 200, name: 'Power User', autoManaged: true },
   { id: 4, level: 300, name: 'Elite', autoManaged: true },
-  { id: 5, level: 350, name: 'Curator', autoManaged: true },
-  { id: 6, level: 400, name: 'Master Curator', autoManaged: true },
-  { id: 7, level: 450, name: 'Grand Curator', autoManaged: true },
+  { id: 5, level: 350, name: 'Stellarific', autoManaged: true },
+  { id: 6, level: 400, name: 'Stellartastic', autoManaged: true },
+  { id: 7, level: 450, name: 'Stellarige', autoManaged: true },
   { id: 8, level: 500, name: 'Staff', autoManaged: false },
   { id: 9, level: 1000, name: 'SysOp', autoManaged: false }
 ];

--- a/src/modules/rankProgressionJob.spec.ts
+++ b/src/modules/rankProgressionJob.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for the rank-progression sweep wiring. The decision logic is the
+ * pure evaluator's job (rankProgression.spec.ts) and the real end-to-end DB path
+ * is covered by rankProgressionJob.integration.ts; here we pin the DB-bound shell:
+ * ladder mapping, the system-actor gate, and — most importantly — that an auto
+ * change is a primary-rank-only update that never touches secondary ranks.
+ */
+import { prismaMock, resetApiTestState } from '../test/apiTestHarness';
+
+jest.mock('./ratio', () => ({
+  getEligibleContributionBytes: jest.fn()
+}));
+import { getEligibleContributionBytes } from './ratio';
+import {
+  loadLadder,
+  resolveSystemActorId,
+  runRankProgressionSweep
+} from './rankProgressionJob';
+
+const GiB = BigInt(1024 ** 3);
+const mockedEligibleBytes = getEligibleContributionBytes as jest.Mock;
+
+beforeEach(() => {
+  resetApiTestState();
+  mockedEligibleBytes.mockReset();
+});
+
+// A four-rung ladder: User(1)→Member(2), plus assigned Staff(8)/SysOp(9).
+const ladderRanks = [
+  { id: 1, level: 100, name: 'User' },
+  { id: 2, level: 150, name: 'Member' },
+  { id: 8, level: 500, name: 'Staff' },
+  { id: 9, level: 1000, name: 'SysOp' }
+];
+const userToMemberRule = {
+  id: 1,
+  fromRankId: 1,
+  toRankId: 2,
+  minContributed: 10n * GiB,
+  minRatio: 0.7,
+  minContributions: 0,
+  minAccountAgeDays: 7,
+  extra: null,
+  enabled: true
+};
+
+const mockLadder = () => {
+  prismaMock.userRank.findMany.mockResolvedValue(ladderRanks as never);
+  prismaMock.rankPromotionRule.findMany.mockResolvedValue([
+    userToMemberRule
+  ] as never);
+};
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000);
+
+describe('loadLadder', () => {
+  it('marks ranks below Staff (500) as auto-managed and the rest assigned', async () => {
+    mockLadder();
+    const { ranks } = await loadLadder();
+    const autoByName = Object.fromEntries(
+      ranks.map((r) => [r.name, r.autoManaged])
+    );
+    expect(autoByName).toEqual({
+      User: true,
+      Member: true,
+      Staff: false,
+      SysOp: false
+    });
+  });
+});
+
+describe('resolveSystemActorId', () => {
+  it('returns the lowest-id SysOp-level user', async () => {
+    prismaMock.user.findFirst.mockResolvedValue({ id: 3 } as never);
+    expect(await resolveSystemActorId()).toBe(3);
+  });
+
+  it('returns null when no SysOp user exists', async () => {
+    prismaMock.user.findFirst.mockResolvedValue(null);
+    expect(await resolveSystemActorId()).toBeNull();
+  });
+});
+
+describe('runRankProgressionSweep', () => {
+  const mockSweepFor = (
+    user: {
+      id: number;
+      userRankId: number;
+      consumed: bigint;
+      dateRegistered: Date;
+      rankLocked: boolean;
+    },
+    stats: {
+      eligibleBytes: bigint;
+      contributionCount: number;
+      qualityCount: number;
+      distinctReleases: number;
+      activeWarnings: number;
+    }
+  ) => {
+    mockLadder();
+    prismaMock.user.findFirst.mockResolvedValue({ id: 9 } as never); // system actor
+    prismaMock.user.findMany.mockResolvedValueOnce([user] as never);
+    mockedEligibleBytes.mockResolvedValue(stats.eligibleBytes);
+    // buildProgressionInput issues contribution.count twice (accounted, then
+    // quality) in array order under Promise.all.
+    prismaMock.contribution.count
+      .mockResolvedValueOnce(stats.contributionCount as never)
+      .mockResolvedValueOnce(stats.qualityCount as never);
+    prismaMock.contribution.findMany.mockResolvedValue(
+      Array.from({ length: stats.distinctReleases }, (_, i) => ({
+        releaseId: i + 1
+      })) as never
+    );
+    prismaMock.userWarning.count.mockResolvedValue(
+      stats.activeWarnings as never
+    );
+  };
+
+  const promotingUser = {
+    id: 5,
+    userRankId: 1,
+    consumed: 0n,
+    dateRegistered: daysAgo(30),
+    rankLocked: false
+  };
+
+  it('promotes an eligible user with a primary-only update — never touching secondary ranks', async () => {
+    mockSweepFor(promotingUser, {
+      eligibleBytes: 20n * GiB,
+      contributionCount: 0,
+      qualityCount: 0,
+      distinctReleases: 0,
+      activeWarnings: 0
+    });
+
+    const result = await runRankProgressionSweep();
+
+    expect(result).toEqual({ scanned: 1, promoted: 1, demoted: 0 });
+    // Primary rank moved to Member (id 2)…
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: 5 },
+      data: { userRankId: 2 }
+    });
+    // …and the secondary-rank set was left untouched (the setUserRank trap).
+    expect(prismaMock.userSecondaryRank.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('notifies and audits the promotion as an automated change', async () => {
+    mockSweepFor(promotingUser, {
+      eligibleBytes: 20n * GiB,
+      contributionCount: 0,
+      qualityCount: 0,
+      distinctReleases: 0,
+      activeWarnings: 0
+    });
+
+    await runRankProgressionSweep();
+
+    expect(prismaMock.notification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 5,
+        type: 'rank_promoted',
+        actorId: 9
+      })
+    });
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorId: 9,
+        action: 'user.rank_changed',
+        targetType: 'User',
+        targetId: 5,
+        metadata: expect.objectContaining({ auto: true, direction: 'promote' })
+      })
+    });
+  });
+
+  it('leaves a user who meets no threshold unchanged', async () => {
+    mockSweepFor(
+      { ...promotingUser, dateRegistered: daysAgo(1) }, // too young (needs 7d)
+      {
+        eligibleBytes: 1n * GiB, // under 10 GiB
+        contributionCount: 0,
+        qualityCount: 0,
+        distinctReleases: 0,
+        activeWarnings: 0
+      }
+    );
+
+    const result = await runRankProgressionSweep();
+
+    expect(result).toEqual({ scanned: 1, promoted: 0, demoted: 0 });
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+  });
+
+  it('freezes a rankLocked user even when fully eligible', async () => {
+    mockSweepFor(
+      { ...promotingUser, rankLocked: true },
+      {
+        eligibleBytes: 20n * GiB,
+        contributionCount: 0,
+        qualityCount: 0,
+        distinctReleases: 0,
+        activeWarnings: 0
+      }
+    );
+
+    const result = await runRankProgressionSweep();
+
+    expect(result.promoted).toBe(0);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when there is no SysOp actor to attribute changes to', async () => {
+    mockLadder();
+    prismaMock.user.findFirst.mockResolvedValue(null);
+
+    const result = await runRankProgressionSweep();
+
+    expect(result).toEqual({ scanned: 0, promoted: 0, demoted: 0 });
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/rankProgressionJob.ts
+++ b/src/modules/rankProgressionJob.ts
@@ -1,0 +1,292 @@
+/**
+ * Automated rank-progression sweep (USER_CLASSES_PLAN §6). The thin, DB-bound
+ * shell around the pure evaluator (rankProgression.ts): it loads the ladder and
+ * rules from the DB, builds each eligible user's RankProgressionInput, asks the
+ * evaluator for a decision, and applies one-step promotions/demotions.
+ *
+ * The evaluator owns ALL the policy (one-step-per-pass, stock-only demotion,
+ * demotion-wins precedence, Staff/SysOp & rankLocked & active-warning freezes);
+ * this module only supplies inputs and persists the outcome.
+ */
+import { Bitrate, NotificationType, SubscriptionPage } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { audit } from '../lib/audit';
+import { getLogger } from './logging';
+import { getEligibleContributionBytes } from './ratio';
+import { ranks as ranksConfig } from './config';
+import {
+  evaluateRankChange,
+  Rank,
+  RankProgressionInput,
+  RankProgressionResult,
+  RankExtraPredicate,
+  RankPromotionRule
+} from './rankProgression';
+
+const log = getLogger('rankProgressionJob');
+
+const STARTUP_DELAY_MS = 45_000;
+const BATCH_SIZE = 500;
+const DAY_MS = 86_400_000;
+const STAFF_LEVEL = 500; // ranks at/above this are assigned, never auto-managed
+const LOSSLESS_BITRATES: Bitrate[] = [Bitrate.Lossless, Bitrate.Lossless24];
+
+/**
+ * Project the DB ranks/rules onto the evaluator's interfaces. autoManaged is
+ * derived from level: everything below Staff (500) is on the auto ladder; Staff
+ * and SysOp are assigned and never auto-reached or auto-demoted.
+ */
+export const loadLadder = async (): Promise<{
+  ranks: Rank[];
+  rules: RankPromotionRule[];
+}> => {
+  const [rankRows, ruleRows] = await Promise.all([
+    prisma.userRank.findMany({
+      where: { secondary: false },
+      select: { id: true, level: true, name: true }
+    }),
+    prisma.rankPromotionRule.findMany()
+  ]);
+
+  const ranks: Rank[] = rankRows.map((r) => ({
+    id: r.id,
+    level: r.level,
+    name: r.name,
+    autoManaged: r.level < STAFF_LEVEL
+  }));
+
+  const rules: RankPromotionRule[] = ruleRows.map((r) => ({
+    fromRankId: r.fromRankId,
+    toRankId: r.toRankId,
+    minContributed: r.minContributed,
+    minRatio: r.minRatio,
+    minContributions: r.minContributions,
+    minAccountAgeDays: r.minAccountAgeDays,
+    extra: r.extra as RankExtraPredicate | null,
+    enabled: r.enabled
+  }));
+
+  return { ranks, rules };
+};
+
+type SweepUser = {
+  id: number;
+  userRankId: number;
+  consumed: bigint;
+  dateRegistered: Date;
+  rankLocked: boolean;
+};
+
+/**
+ * Build a user's evaluator input. Per the §11 product decisions (#172):
+ * - "contributed" toward promotion is link-health-eligible bytes (ADR-0006),
+ *   NOT raw User.contributed — getEligibleContributionBytes already applies the
+ *   72h age + approved + not-FAIL filter.
+ * - QUALITY_CONTRIB_500 counts contributions that are lossless OR have log+cue,
+ *   and are not scene.
+ * Contribution count / distinct releases also count only accounted contributions
+ * (approvedAccountingBytes set), to stay consistent with the eligible-bytes pool.
+ */
+export const buildProgressionInput = async (
+  user: SweepUser
+): Promise<RankProgressionInput> => {
+  const accounted = { userId: user.id, approvedAccountingBytes: { not: null } };
+
+  const [
+    eligibleBytes,
+    contributionCount,
+    distinctReleases,
+    qualityContributionCount,
+    activeWarnings
+  ] = await Promise.all([
+    getEligibleContributionBytes(user.id),
+    prisma.contribution.count({ where: accounted }),
+    prisma.contribution.findMany({
+      where: accounted,
+      select: { releaseId: true },
+      distinct: ['releaseId']
+    }),
+    prisma.contribution.count({
+      where: {
+        ...accounted,
+        releaseFile: {
+          isScene: false,
+          OR: [
+            { bitrate: { in: LOSSLESS_BITRATES } },
+            { AND: [{ hasLog: true }, { hasCue: true }] }
+          ]
+        }
+      }
+    }),
+    prisma.userWarning.count({
+      where: {
+        userId: user.id,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }]
+      }
+    })
+  ]);
+
+  return {
+    currentRankId: user.userRankId,
+    contributed: eligibleBytes,
+    consumed: user.consumed,
+    contributionCount,
+    distinctReleaseCount: distinctReleases.length,
+    qualityContributionCount,
+    accountAgeDays: Math.floor(
+      (Date.now() - user.dateRegistered.getTime()) / DAY_MS
+    ),
+    hasActiveWarning: activeWarnings > 0,
+    rankLocked: user.rankLocked
+  };
+};
+
+/**
+ * The reserved system actor for auto rank changes: the install SysOp (the
+ * lowest-id user at SysOp level). Audit rows and notifications attribute to it.
+ * Returns null when no such user exists — the sweep then no-ops.
+ */
+export const resolveSystemActorId = async (): Promise<number | null> => {
+  const sysop = await prisma.user.findFirst({
+    where: { userRank: { level: { gte: 1000 } } },
+    orderBy: { id: 'asc' },
+    select: { id: true }
+  });
+  return sysop?.id ?? null;
+};
+
+/**
+ * Persist one auto rank change. Deliberately a primary-rank-only update — NOT a
+ * call to setUserRank, which replaces the user's whole secondary-rank set and
+ * would silently strip a Donor/VIP secondary on every auto-promotion. We reuse
+ * the same `user.rank_changed` audit action so the trail stays uniform, and the
+ * meta records that the engine (not a human) made the move.
+ */
+const applyRankChange = async (
+  userId: number,
+  result: RankProgressionResult,
+  systemActorId: number
+): Promise<void> => {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { userRankId: result.targetRankId }
+  });
+
+  await audit(prisma, systemActorId, 'user.rank_changed', 'User', userId, {
+    userRankId: result.targetRankId,
+    auto: true,
+    direction: result.direction,
+    reason: result.reason
+  });
+
+  await prisma.notification.create({
+    data: {
+      userId,
+      type:
+        result.direction === 'promote'
+          ? NotificationType.rank_promoted
+          : NotificationType.rank_demoted,
+      actorId: systemActorId,
+      // Notification is subscription-shaped (page + pageId); a rank change has no
+      // natural subscription page, so we map it to the site-level notice channel
+      // with the new rank id as the target.
+      page: SubscriptionPage.global_notices,
+      pageId: result.targetRankId
+    }
+  });
+};
+
+export type SweepResult = {
+  scanned: number;
+  promoted: number;
+  demoted: number;
+};
+
+/**
+ * Run one full sweep. Batched by ascending id over the auto-managed cohort
+ * (active users whose primary rank is below Staff). Each user is evaluated once
+ * per sweep — the evaluator's one-step rule does the rest.
+ */
+export const runRankProgressionSweep = async (): Promise<SweepResult> => {
+  const { ranks, rules } = await loadLadder();
+  const autoManagedRankIds = ranks
+    .filter((r) => r.autoManaged)
+    .map((r) => r.id);
+  if (autoManagedRankIds.length === 0) {
+    return { scanned: 0, promoted: 0, demoted: 0 };
+  }
+
+  const systemActorId = await resolveSystemActorId();
+  if (systemActorId === null) {
+    log.warn('No SysOp actor — skipping rank progression sweep');
+    return { scanned: 0, promoted: 0, demoted: 0 };
+  }
+
+  let cursor: number | undefined;
+  let scanned = 0;
+  let promoted = 0;
+  let demoted = 0;
+
+  for (;;) {
+    const batch: SweepUser[] = await prisma.user.findMany({
+      where: { disabled: false, userRankId: { in: autoManagedRankIds } },
+      orderBy: { id: 'asc' },
+      take: BATCH_SIZE,
+      ...(cursor !== undefined ? { skip: 1, cursor: { id: cursor } } : {}),
+      select: {
+        id: true,
+        userRankId: true,
+        consumed: true,
+        dateRegistered: true,
+        rankLocked: true
+      }
+    });
+    if (batch.length === 0) break;
+
+    for (const user of batch) {
+      scanned++;
+      const input = await buildProgressionInput(user);
+      const result = evaluateRankChange(input, rules, ranks);
+      if (result.direction === 'none') continue;
+
+      await applyRankChange(user.id, result, systemActorId);
+      if (result.direction === 'promote') promoted++;
+      else demoted++;
+
+      log.info('Auto rank change', {
+        userId: user.id,
+        direction: result.direction,
+        fromRankId: user.userRankId,
+        toRankId: result.targetRankId,
+        reason: result.reason
+      });
+    }
+
+    cursor = batch[batch.length - 1].id;
+    if (batch.length < BATCH_SIZE) break;
+  }
+
+  if (promoted > 0 || demoted > 0) {
+    log.info('Rank progression sweep complete', { scanned, promoted, demoted });
+  }
+  return { scanned, promoted, demoted };
+};
+
+export const startRankProgressionJob = (): void => {
+  const run = (): void => {
+    runRankProgressionSweep().catch((err) =>
+      log.error('Rank progression sweep failed', { err })
+    );
+  };
+
+  const outer = setTimeout(() => {
+    run();
+    setInterval(run, ranksConfig.progressionIntervalMs).unref();
+  }, STARTUP_DELAY_MS);
+  outer.unref();
+
+  log.info('Rank progression job scheduled', {
+    startupDelayMs: STARTUP_DELAY_MS,
+    intervalMs: ranksConfig.progressionIntervalMs
+  });
+};

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -13,7 +13,11 @@ import { requirePermission } from '../../middleware/permissions';
 import { validate, parsedBody } from '../../middleware/validate';
 import { installSchema, type InstallInput } from '../../schemas/install';
 import { getSettings } from '../../modules/settings';
-import { seedRanks, seedForums } from '../../modules/bootstrap';
+import {
+  seedRanks,
+  seedRankPromotionRules,
+  seedForums
+} from '../../modules/bootstrap';
 import { AppError } from '../../lib/errors';
 import { authUserSelect, toAuthUser } from '../../modules/auth';
 import { getDefaultStylesheetName } from '../../modules/stylesheet';
@@ -169,6 +173,7 @@ router.post(
     // Bootstrap ranks and forums outside the user transaction so they exist
     // even if user creation fails, and so the transaction stays minimal.
     await seedRanks(prisma);
+    await seedRankPromotionRules(prisma);
     await seedForums(prisma);
 
     const sysopRank = await prisma.userRank.findFirst({

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -153,6 +153,7 @@ jest.mock('../modules/config', () => ({
   http: { port: 8080, corsOrigin: 'http://localhost:3000' },
   logging: { level: 'error', timestampFormat: undefined },
   economy: { minimumBounty: 104857600 },
+  ranks: { progressionIntervalMs: 3600000 },
   sentry: { dsn: '' },
   email: {
     smtpHost: '',

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -80,6 +80,7 @@ export function makeUser(overrides: Partial<User> = {}): User {
     isArtist: false,
     isDonor: false,
     canDownload: true,
+    rankLocked: false,
     adminComment: null,
     staffBio: null,
     banDate: null,


### PR DESCRIPTION
Core slice — the engine that actually moves members. The thin DB-bound shell around the already-tested pure evaluator (`rankProgression.ts`).

> **Stacked on #186 (#168) → #185 (#167).** Cross-fork PR, so its base is `main` and the diff currently includes the #167 + #168 commits; it narrows to just #169 once those merge. **Merge order: #185 → #186 → #169.**

## What it does (`src/modules/rankProgressionJob.ts`)
- **`loadLadder`** — projects DB ranks/rules onto the evaluator interfaces; `autoManaged` derived from level (< Staff 500).
- **`buildProgressionInput`** — maps each user to a `RankProgressionInput`. The **§11 (#172) criteria land here**: "contributed" toward promotion is **link-health-eligible bytes** (`getEligibleContributionBytes` / ADR-0006), not raw `User.contributed`; `QUALITY_CONTRIB_500` counts **non-scene** contributions that are **lossless OR have log+cue**. Contribution-count / distinct-releases also count only accounted contributions, consistent with the eligible-bytes pool.
- **`runRankProgressionSweep`** — batches by ascending id over the auto-managed cohort, evaluates each user once; `evaluateRankChange` owns all policy (one-step, stock-only demotion, demotion-wins, freezes).
- Wired into `app.ts`; interval via `RANK_PROGRESSION_INTERVAL_MS` (default hourly).

## ⚠️ For review — deliberate deviation from the issue text
The issue says "delegate to `setUserRank`". I **didn't**, on purpose: `setUserRank` *replaces* the entire secondary-rank set (`deleteMany`→`createMany`), so routing auto-promotions through it would **silently strip a user's Donor/VIP secondary rank on every move**. Instead this does a primary-rank-only update and reuses the same `user.rank_changed` audit action (`meta.auto = true`) so the trail stays uniform without that side effect.

Also flagging: `Notification` is subscription-shaped (`page`+`pageId`) with no natural fit for a rank change — mapped to `global_notices` + the new rank id. Easy to revisit.

System actor = the install SysOp (lowest-id SysOp-level user); the sweep no-ops if none exists.

## Tests
- **Unit** (`rankProgressionJob.spec.ts`): ladder mapping, system-actor gate, **primary-only update / no secondary wipe**, notify + audit, rankLocked freeze, no-actor no-op.
- **Integration** (`rankProgressionJob.integration.ts`): real seed + a single sweep that **promotes** (User→Member), **demotes** (lapsed Member→User), and leaves **Staff** and **rankLocked** users untouched — asserting audit rows + notifications.

format / lint / `tsc --noEmit` / `typecheck:test` clean; 1565 unit tests + 2 integration tests green.

Closes #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)