### PR TITLE
fix(test): raise devTools integration hook timeout to stop flake (#165)

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -440,6 +440,9 @@ Yearly Yearly
     String lastIp "❓"
     Boolean disablePm 
     String ircNick "❓"
+    String pendingIrcNick "❓"
+    String ircNickNonce "❓"
+    DateTime ircNickNonceExpiresAt "❓"
     DateTime createdAt 
     DateTime updatedAt 
     }

--- a/src/integration/devTools.integration.ts
+++ b/src/integration/devTools.integration.ts
@@ -55,7 +55,12 @@ beforeEach(async () => {
     }
   });
   actorId = actor.id;
-}, 30_000);
+  // truncateAll + seed + a few inserts, run before every test in the suite that
+  // generates the most data. It can run slow (not hung) when the CI box is
+  // loaded or a prior test's fire-and-forget query still holds a lock the
+  // truncate waits on; the original 30s ceiling tipped over there (#165). 60s of
+  // headroom absorbs that variance without masking a genuine hang.
+}, 60_000);
 
 afterAll(async () => {
   await testPrisma.$disconnect();

--- a/src/test/dbHelpers.ts
+++ b/src/test/dbHelpers.ts
@@ -7,7 +7,17 @@ export const testPrisma = new PrismaClient({
   log: []
 });
 
-/** Truncates every table (except _prisma_migrations) and resets sequences. */
+/**
+ * Truncates every table (except _prisma_migrations) and resets sequences.
+ *
+ * Deliberately a per-table loop, NOT a single `TRUNCATE a, b, c … CASCADE`: the
+ * batched form takes ACCESS EXCLUSIVE locks on every table at once, which
+ * deadlocks (40P01) under CI when a prior test's fire-and-forget query (e.g. the
+ * downloads ratio-policy eval) still holds a lock. Truncating one table at a
+ * time keeps the lock set per statement small enough to avoid that. The #165
+ * flake was setup running slow under load, not this being wrong — the fix is the
+ * hook-timeout headroom in devTools.integration.ts, not batching the locks.
+ */
 export const truncateAll = async (): Promise<void> => {
   await testPrisma.$executeRawUnsafe(`
     DO $$ DECLARE r RECORD; BEGIN


### PR DESCRIPTION
## Problem
`devTools.integration.ts`'s `beforeEach` (`truncateAll` + seed + a few inserts) runs before **every** test and intermittently exceeded its 30s hook timeout under CI load (the job dragged to ~21 min, then a plain re-run passed in ~5.5 min — a flake, not a real failure).

## Fix
Raise the hook timeout **30s → 60s** for headroom — the issue's suggested fix #1. The setup is slow under load, or briefly waits on a lock a prior test's fire-and-forget query still holds (e.g. the downloads ratio-policy eval); it is never hung, so headroom is the right lever.

### Why `truncateAll` is left as the per-table loop (and a comment saying so)
An earlier cut of this PR batched it into a single `TRUNCATE a, b, c … RESTART IDENTITY CASCADE` to speed setup up. That takes `ACCESS EXCLUSIVE` locks on **every** table at once and **deadlocked (`40P01`)** under CI concurrency — it broke `downloads.integration.ts`. Reverted to the per-table loop (smaller lock set per statement) and documented the trap in the helper so it isn't re-attempted.

### Also: regenerates a stale `docs/erd.md`
`main`'s ERD was missing the ADR-0015 verified-nick columns (`pendingIrcNick`, `ircNickNonce`, `ircNickNonceExpiresAt`) — the IRC commits never regenerated it. The freshness gate blocks any PR with a stale ERD, so it's regenerated here.

## Validation
`downloads.integration.ts` + `devTools.integration.ts` green locally (no deadlock); format / lint / tsc / typecheck:test clean.

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)