### PR TITLE
feat(ratio): PM contributors when a link is swept WARN→FAIL (#125)

### DIFF
--- a/src/integration/linkHealthSweep.integration.ts
+++ b/src/integration/linkHealthSweep.integration.ts
@@ -1,0 +1,168 @@
+import {
+  ReleaseType,
+  FileType,
+  CommunityType,
+  RegistrationStatus,
+  LinkHealthStatus
+} from '@prisma/client';
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { createContributionSubmission } from '../modules/contribution';
+import type { CreateContributionInput } from '../schemas/contribution';
+
+// Partial-mock: keep the real sweepStaleWarnLinks under test, but stub the
+// fire-and-forget HTTP check that createContributionSubmission triggers (it would
+// hit the network and hold a connection across the next TRUNCATE).
+jest.mock('../modules/linkHealth', () => ({
+  ...jest.requireActual('../modules/linkHealth'),
+  checkContributionLink: jest.fn().mockResolvedValue(undefined)
+}));
+import { sweepStaleWarnLinks } from '../modules/linkHealth';
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+let seq = 0;
+const createUser = async () => {
+  seq += 1;
+  const tag = `lh-${seq}-${Date.now()}`;
+  const [rank, settings, profile] = await Promise.all([
+    testPrisma.userRank.findFirstOrThrow(),
+    testPrisma.userSettings.create({ data: {} }),
+    testPrisma.profile.create({ data: {} })
+  ]);
+  return testPrisma.user.create({
+    data: {
+      username: tag,
+      email: `${tag}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id
+    }
+  });
+};
+
+const createCommunity = () =>
+  testPrisma.community.create({
+    data: {
+      name: `Community-${Date.now()}-${seq}`,
+      image: '',
+      registrationStatus: RegistrationStatus.open,
+      type: CommunityType.Music
+    }
+  });
+
+const baseInput = (
+  communityId: number,
+  title: string
+): CreateContributionInput => ({
+  communityId,
+  type: ReleaseType.Music,
+  title,
+  year: 2020,
+  fileType: FileType.flac,
+  downloadUrl: 'https://example.com/file.torrent',
+  sizeInBytes: 1_000_000,
+  tags: 'rock',
+  releaseDescription: 'desc',
+  image: undefined,
+  description: undefined,
+  bitrate: undefined,
+  media: undefined,
+  releaseCategory: undefined,
+  recordLabel: undefined,
+  catalogueNumber: undefined,
+  editionTitle: undefined,
+  editionYear: undefined,
+  isRemaster: false,
+  hasLog: false,
+  hasCue: false,
+  isScene: false,
+  collaborators: [{ artist: 'Test Artist', importance: 'main' }]
+});
+
+const makeStuckWarn = async (
+  userId: number,
+  communityId: number,
+  title: string
+) => {
+  const contribution = await createContributionSubmission({
+    userId,
+    input: baseInput(communityId, title)
+  });
+  if (!contribution) throw new Error('fixture contribution failed');
+  await testPrisma.contribution.update({
+    where: { id: contribution.id },
+    data: {
+      linkStatus: LinkHealthStatus.WARN,
+      linkStatusChangedAt: new Date(Date.now() - 80 * 60 * 60 * 1000) // 80h > 72h
+    }
+  });
+  return contribution.id;
+};
+
+describe('sweepStaleWarnLinks (integration)', () => {
+  it('promotes a stuck WARN link to FAIL and PMs the contributor from System', async () => {
+    const user = await createUser();
+    const community = await createCommunity();
+    const contributionId = await makeStuckWarn(
+      user.id,
+      community.id,
+      'Dead Link Album'
+    );
+
+    await sweepStaleWarnLinks();
+
+    const after = await testPrisma.contribution.findUniqueOrThrow({
+      where: { id: contributionId }
+    });
+    expect(after.linkStatus).toBe(LinkHealthStatus.FAIL);
+
+    // The contributor has a conversation whose only message has a null sender
+    // (the "System" notice) and names the dead release.
+    const participant =
+      await testPrisma.privateConversationParticipant.findFirst({
+        where: { userId: user.id }
+      });
+    expect(participant).not.toBeNull();
+
+    const message = await testPrisma.privateMessage.findFirstOrThrow({
+      where: { conversationId: participant!.conversationId }
+    });
+    expect(message.senderId).toBeNull();
+    expect(message.body).toContain('Dead Link Album');
+  });
+
+  it('leaves a recently-WARNed link alone and sends no PM', async () => {
+    const user = await createUser();
+    const community = await createCommunity();
+    const contribution = await createContributionSubmission({
+      userId: user.id,
+      input: baseInput(community.id, 'Fresh Warn')
+    });
+    // WARNed just now — inside the 72h window.
+    await testPrisma.contribution.update({
+      where: { id: contribution!.id },
+      data: {
+        linkStatus: LinkHealthStatus.WARN,
+        linkStatusChangedAt: new Date()
+      }
+    });
+
+    await sweepStaleWarnLinks();
+
+    const after = await testPrisma.contribution.findUniqueOrThrow({
+      where: { id: contribution!.id }
+    });
+    expect(after.linkStatus).toBe(LinkHealthStatus.WARN);
+    const convCount = await testPrisma.privateConversation.count();
+    expect(convCount).toBe(0);
+  });
+});

--- a/src/modules/linkHealth.spec.ts
+++ b/src/modules/linkHealth.spec.ts
@@ -8,6 +8,7 @@ import { LinkHealthStatus } from '@prisma/client';
 
 const mockPrismaContribution = {
   findUnique: jest.fn(),
+  findMany: jest.fn(),
   update: jest.fn(),
   updateMany: jest.fn(),
   groupBy: jest.fn()
@@ -21,40 +22,95 @@ jest.mock('./logging', () => ({
   getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
 }));
 
+jest.mock('./pm', () => ({
+  sendSystemMessage: jest.fn().mockResolvedValue({ ok: true })
+}));
+
 import {
   sweepStaleWarnLinks,
   checkContributionLink,
   getCommunityHealthPulse,
   computePulse
 } from './linkHealth';
+import { sendSystemMessage } from './pm';
+
+const mockSendSystemMessage = sendSystemMessage as jest.Mock;
 
 // ─── sweepStaleWarnLinks ──────────────────────────────────────────────────────
 
 describe('sweepStaleWarnLinks', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('promotes WARN links stuck past the 72h window to FAIL', async () => {
+  const warn = (id: number, userId: number, title: string) => ({
+    id,
+    userId,
+    release: { title }
+  });
+
+  it('promotes the stuck WARN links it found to FAIL', async () => {
+    mockPrismaContribution.findMany.mockResolvedValue([
+      warn(1, 10, 'A'),
+      warn(2, 11, 'B')
+    ]);
     mockPrismaContribution.updateMany.mockResolvedValue({ count: 2 });
+
     await sweepStaleWarnLinks();
+
     expect(mockPrismaContribution.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          linkStatus: 'WARN',
-          linkStatusChangedAt: expect.objectContaining({ lt: expect.any(Date) })
-        }),
+        where: { id: { in: [1, 2] } },
         data: expect.objectContaining({ linkStatus: 'FAIL' })
       })
     );
   });
 
-  it('uses a cutoff ~72h in the past (not last-checked, but stuck-since)', async () => {
-    mockPrismaContribution.updateMany.mockResolvedValue({ count: 0 });
+  it('selects WARN links stuck since a cutoff ~72h in the past', async () => {
+    mockPrismaContribution.findMany.mockResolvedValue([]);
     await sweepStaleWarnLinks();
-    const arg = mockPrismaContribution.updateMany.mock.calls[0][0];
-    const cutoff: Date = arg.where.linkStatusChangedAt.lt;
-    const ageHours = (Date.now() - cutoff.getTime()) / 3_600_000;
+    const arg = mockPrismaContribution.findMany.mock.calls[0][0];
+    expect(arg.where.linkStatus).toBe('WARN');
+    const ageHours =
+      (Date.now() - arg.where.linkStatusChangedAt.lt.getTime()) / 3_600_000;
     expect(ageHours).toBeGreaterThan(71);
     expect(ageHours).toBeLessThan(73);
+  });
+
+  it('no-ops (no update, no PM) when nothing is stale', async () => {
+    mockPrismaContribution.findMany.mockResolvedValue([]);
+    await sweepStaleWarnLinks();
+    expect(mockPrismaContribution.updateMany).not.toHaveBeenCalled();
+    expect(mockSendSystemMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends one System PM per affected contributor, batching their dead links', async () => {
+    mockPrismaContribution.findMany.mockResolvedValue([
+      warn(1, 10, 'Album One'),
+      warn(2, 10, 'Album Two'),
+      warn(3, 20, 'Album Three')
+    ]);
+    mockPrismaContribution.updateMany.mockResolvedValue({ count: 3 });
+
+    await sweepStaleWarnLinks();
+
+    // One PM to user 10 (covering both their links), one to user 20.
+    expect(mockSendSystemMessage).toHaveBeenCalledTimes(2);
+    const recipients = mockSendSystemMessage.mock.calls.map((c) => c[0]);
+    expect(recipients.sort()).toEqual([10, 20]);
+
+    const user10Body = mockSendSystemMessage.mock.calls.find(
+      (c) => c[0] === 10
+    )![2];
+    expect(user10Body).toContain('Album One');
+    expect(user10Body).toContain('Album Two');
+  });
+
+  it('does not let a PM failure block the sweep', async () => {
+    mockPrismaContribution.findMany.mockResolvedValue([warn(1, 10, 'A')]);
+    mockPrismaContribution.updateMany.mockResolvedValue({ count: 1 });
+    mockSendSystemMessage.mockRejectedValueOnce(new Error('pm down'));
+
+    await expect(sweepStaleWarnLinks()).resolves.toBeUndefined();
+    expect(mockPrismaContribution.updateMany).toHaveBeenCalled();
   });
 });
 

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -1,6 +1,7 @@
 import { LinkHealthStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getLogger } from './logging';
+import { sendSystemMessage } from './pm';
 
 const log = getLogger('linkHealth');
 
@@ -72,14 +73,69 @@ export const checkContributionLink = async (
 export const sweepStaleWarnLinks = async (): Promise<void> => {
   const cutoff = new Date(Date.now() - WARN_SWEEP_AFTER_MS);
   const now = new Date();
-  const { count } = await prisma.contribution.updateMany({
+
+  // Capture who/what is about to be promoted BEFORE the bulk update, so the
+  // affected contributors can be PM'd (updateMany returns only a count). The
+  // window between this read and the update is harmless: at worst a link that
+  // recovered in between is re-PM'd, and the update's own WHERE is the source of
+  // truth for the status change.
+  const promoting = await prisma.contribution.findMany({
     where: {
       linkStatus: LinkHealthStatus.WARN,
       linkStatusChangedAt: { lt: cutoff }
     },
+    select: { id: true, userId: true, release: { select: { title: true } } }
+  });
+  if (promoting.length === 0) return;
+
+  await prisma.contribution.updateMany({
+    where: { id: { in: promoting.map((c) => c.id) } },
     data: { linkStatus: LinkHealthStatus.FAIL, linkStatusChangedAt: now }
   });
-  if (count > 0) log.info('Swept stale WARN links to FAIL', { count });
+  log.info('Swept stale WARN links to FAIL', { count: promoting.length });
+
+  await notifyContributorsOfDeadLinks(promoting);
+};
+
+type PromotedContribution = { userId: number; release: { title: string } };
+
+/**
+ * PRD-06 #2: tell each contributor when a link of theirs is swept to FAIL, so a
+ * silent ratio-relief loss doesn't blindside them. Batched to one System PM per
+ * contributor (a sweep can fail several of a user's links at once). Best-effort:
+ * a PM failure is logged but never blocks the status change, which already
+ * landed above.
+ */
+const notifyContributorsOfDeadLinks = async (
+  promoted: PromotedContribution[]
+): Promise<void> => {
+  const titlesByUser = new Map<number, string[]>();
+  for (const c of promoted) {
+    const titles = titlesByUser.get(c.userId) ?? [];
+    titles.push(c.release.title);
+    titlesByUser.set(c.userId, titles);
+  }
+
+  for (const [userId, titles] of titlesByUser) {
+    const one = titles.length === 1;
+    const list = titles.map((t) => `• ${t}`).join('\n');
+    const subject = `Contribution ${
+      one ? 'link' : 'links'
+    } no longer reachable`;
+    const body =
+      `A health check could not reach the download ${one ? 'link' : 'links'} ` +
+      `for the following contribution${one ? '' : 's'} of yours, so ` +
+      `${one ? 'it has' : 'they have'} been marked dead and no longer count ` +
+      `toward your ratio relief:\n\n${list}\n\n` +
+      `Re-upload or refresh the link to restore relief. This is an automated ` +
+      `notice — replies are not monitored.`;
+
+    try {
+      await sendSystemMessage(userId, subject, body);
+    } catch (err) {
+      log.warn('System link-fail PM failed', { userId, err });
+    }
+  }
 };
 
 export const recheckStaleLinks = async (): Promise<void> => {

--- a/src/modules/pm.spec.ts
+++ b/src/modules/pm.spec.ts
@@ -17,7 +17,8 @@ jest.mock('../lib/prisma', () => ({
     privateConversation: {
       count: jest.fn(),
       findMany: jest.fn(),
-      findUnique: jest.fn()
+      findUnique: jest.fn(),
+      create: jest.fn()
     },
     privateConversationParticipant: {
       findFirst: jest.fn(),
@@ -44,6 +45,7 @@ import {
   listSentbox,
   replyToConversation,
   sendMessage,
+  sendSystemMessage,
   updateConversationFlags,
   viewConversation
 } from './pm';
@@ -53,6 +55,7 @@ const prismaMock = prisma as unknown as {
     count: jest.Mock;
     findMany: jest.Mock;
     findUnique: jest.Mock;
+    create: jest.Mock;
   };
   privateConversationParticipant: {
     findFirst: jest.Mock;
@@ -214,6 +217,47 @@ describe('sendMessage', () => {
         })
       })
     );
+  });
+});
+
+describe('sendSystemMessage', () => {
+  it('creates a no-sender, single-recipient conversation', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 9, disabled: false });
+    prismaMock.privateConversation.create.mockResolvedValue(
+      makeConversation({ id: 5 })
+    );
+
+    const result = await sendSystemMessage(9, 'Subj', 'Body');
+
+    expect(result).toEqual({
+      ok: true,
+      conversation: expect.objectContaining({ id: 5 })
+    });
+    const arg = prismaMock.privateConversation.create.mock.calls[0][0];
+    expect(arg.data.subject).toBe('Subj');
+    // System notice: null sender (unclickable / no-reply), one participant.
+    expect(arg.data.messages.create).toEqual({ senderId: null, body: 'Body' });
+    expect(arg.data.participants.create).toEqual(
+      expect.objectContaining({ userId: 9, inInbox: true, isRead: false })
+    );
+  });
+
+  it('returns recipient_not_found for a missing user', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    await expect(sendSystemMessage(9, 'S', 'B')).resolves.toEqual({
+      ok: false,
+      reason: 'recipient_not_found'
+    });
+    expect(prismaMock.privateConversation.create).not.toHaveBeenCalled();
+  });
+
+  it('returns recipient_disabled for a disabled user', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 9, disabled: true });
+    await expect(sendSystemMessage(9, 'S', 'B')).resolves.toEqual({
+      ok: false,
+      reason: 'recipient_disabled'
+    });
+    expect(prismaMock.privateConversation.create).not.toHaveBeenCalled();
   });
 });
 

--- a/src/modules/pm.ts
+++ b/src/modules/pm.ts
@@ -139,6 +139,51 @@ export async function sendMessage(
   return { ok: true as const, conversation };
 }
 
+/**
+ * Send a one-way "System" private message: a conversation with the recipient as
+ * the sole participant and a message whose senderId is null. A null sender has
+ * no profile to click and no inbox to reply into, so the UI renders it as an
+ * unclickable, no-reply "System" notice. Used for operational notices (e.g. a
+ * contribution link going dead, #125) rather than user-to-user mail, so it
+ * bypasses the recipient's disablePm preference — but still skips disabled
+ * accounts, which can receive nothing.
+ */
+export async function sendSystemMessage(
+  toId: number,
+  subject: string,
+  body: string
+) {
+  const recipient = await prisma.user.findUnique({
+    where: { id: toId },
+    select: { id: true, disabled: true }
+  });
+  if (!recipient) return { ok: false as const, reason: 'recipient_not_found' };
+  if (recipient.disabled)
+    return { ok: false as const, reason: 'recipient_disabled' };
+
+  const conversation = await prisma.privateConversation.create({
+    data: {
+      subject,
+      messages: { create: { senderId: null, body } },
+      participants: {
+        create: {
+          userId: toId,
+          inInbox: true,
+          inSentbox: false,
+          isRead: false,
+          receivedAt: new Date()
+        }
+      }
+    },
+    include: {
+      messages: { include: { sender: { select: senderSelect } } },
+      participants: true
+    }
+  });
+
+  return { ok: true as const, conversation };
+}
+
 export async function replyToConversation(
   conversationId: number,
   senderId: number,


### PR DESCRIPTION
PRD-06 #2. The 72h WARN→FAIL sweep silently dropped a contribution from the ratio-relief pool — the contributor only noticed when their required ratio crept up. Now the sweep tells them, via a **System private message**, not a notification.

## Design (per maintainer call)
A **`senderId: null`** private message = "System": no profile to click, no inbox to reply into. So this needs **no new `NotificationType` / enum migration** — it reuses the PM system.

- **`pm.ts` → `sendSystemMessage(toId, subject, body)`** — conversation with the recipient as the sole participant and a null-sender message. Bypasses the recipient's `disablePm` (operational notice, not user mail) but still skips disabled accounts.
- **`linkHealth.ts` → `sweepStaleWarnLinks`** now reads the to-be-promoted contributions (id + userId + release title) *before* the bulk update (which returns only a count), promotes them, then sends **one System PM per affected contributor**, batching all of that user's links that died in the same sweep. Best-effort — a PM failure is logged, never blocks the status change.

## Tests
- **pm.spec**: null-sender / single-participant shape; not-found & disabled guards.
- **linkHealth.spec**: cutoff now asserted on the `findMany` select; per-user PM batching; no-op (no update, no PM) when nothing's stale; a PM failure doesn't block the sweep.
- **integration** (`linkHealthSweep.integration.ts`): real WARN→FAIL promotion + a System PM naming the dead release; a fresh WARN is left untouched with no PM.

format / lint / tsc / typecheck:test clean; unit + 2 integration tests green.

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)