### PR TITLE
feat(friends): response contracts + mutual-friend detection (#60)

### DIFF
--- a/src/friends.spec.ts
+++ b/src/friends.spec.ts
@@ -30,7 +30,10 @@ describe('GET /api/friends', () => {
       comment: 'Good person',
       friend: { id: 42, username: 'alice', avatar: null }
     };
-    prismaMock.friend.findMany.mockResolvedValue([mockFriend] as never);
+    // First findMany = page query; second = reverse mutual lookup (none)
+    prismaMock.friend.findMany
+      .mockResolvedValueOnce([mockFriend] as never)
+      .mockResolvedValueOnce([] as never);
     prismaMock.friend.count.mockResolvedValue(1);
 
     const res = await request(app).get('/api/friends');
@@ -38,35 +41,80 @@ describe('GET /api/friends', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].friend.username).toBe('alice');
+    expect(res.body.data[0].isMutual).toBe(false);
     expect(res.body.meta.total).toBe(1);
     expect(res.body.meta).toHaveProperty('totalPages');
+  });
+
+  it('flags isMutual true when the friend follows back', async () => {
+    const mockFriend = {
+      id: 1,
+      userId: 7,
+      friendId: 42,
+      comment: '',
+      friend: { id: 42, username: 'alice', avatar: null }
+    };
+    prismaMock.friend.findMany
+      .mockResolvedValueOnce([mockFriend] as never)
+      .mockResolvedValueOnce([{ userId: 42 }] as never);
+    prismaMock.friend.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/friends');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].isMutual).toBe(true);
   });
 });
 
 // ─── GET /api/friends/status/:userId ─────────────────────────────────────────
 
 describe('GET /api/friends/status/:userId', () => {
-  it('returns isFriend: false when not friends', async () => {
+  it('returns isFriend/isMutual false when not friends', async () => {
+    // forward + reverse both null
     prismaMock.friend.findUnique.mockResolvedValue(null);
 
     const res = await request(app).get('/api/friends/status/42');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ isFriend: false });
+    expect(res.body).toEqual({ isFriend: false, isMutual: false });
   });
 
-  it('returns isFriend: true when friendship exists', async () => {
-    prismaMock.friend.findUnique.mockResolvedValue({
-      id: 1,
-      userId: 7,
-      friendId: 42,
-      comment: ''
-    } as never);
+  it('returns isFriend true, isMutual false when only the user follows', async () => {
+    // forward exists, reverse null
+    prismaMock.friend.findUnique
+      .mockResolvedValueOnce({
+        id: 1,
+        userId: 7,
+        friendId: 42,
+        comment: ''
+      } as never)
+      .mockResolvedValueOnce(null);
 
     const res = await request(app).get('/api/friends/status/42');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ isFriend: true });
+    expect(res.body).toEqual({ isFriend: true, isMutual: false });
+  });
+
+  it('returns isMutual true when both follow each other', async () => {
+    prismaMock.friend.findUnique
+      .mockResolvedValueOnce({
+        id: 1,
+        userId: 7,
+        friendId: 42,
+        comment: ''
+      } as never)
+      .mockResolvedValueOnce({
+        id: 2,
+        userId: 42,
+        friendId: 7,
+        comment: ''
+      } as never);
+
+    const res = await request(app).get('/api/friends/status/42');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ isFriend: true, isMutual: true });
   });
 
   it('rejects non-numeric userId with 400', async () => {
@@ -78,18 +126,36 @@ describe('GET /api/friends/status/:userId', () => {
 // ─── POST /api/friends/:userId ────────────────────────────────────────────────
 
 describe('POST /api/friends/:userId', () => {
-  it('adds a friend and returns 201', async () => {
+  it('adds a friend and returns 201 with the created resource', async () => {
     prismaMock.user.findUnique.mockResolvedValue({
       id: 42,
       disabled: false
     } as never);
-    prismaMock.friend.create.mockResolvedValue({} as never);
+    prismaMock.friend.create.mockResolvedValue({
+      id: 5,
+      userId: 7,
+      friendId: 42,
+      comment: '',
+      friend: { id: 42, username: 'alice', avatar: null }
+    } as never);
+    // reverse mutual lookup — not followed back
+    prismaMock.friend.findUnique.mockResolvedValue(null);
 
     const res = await request(app).post('/api/friends/42');
 
     expect(res.status).toBe(201);
     expect(prismaMock.friend.create).toHaveBeenCalledWith({
-      data: { userId: 7, friendId: 42 }
+      data: { userId: 7, friendId: 42 },
+      include: {
+        friend: { select: { id: true, username: true, avatar: true } }
+      }
+    });
+    expect(res.body).toMatchObject({
+      id: 5,
+      friendId: 42,
+      comment: '',
+      friend: { username: 'alice' },
+      isMutual: false
     });
   });
 
@@ -203,6 +269,7 @@ describe('PUT /api/friends/:userId/comment', () => {
       .send({ comment: 'Great contributor' });
 
     expect(res.status).toBe(200);
+    expect(res.body.msg).toMatch(/updated/i);
     expect(prismaMock.friend.updateMany).toHaveBeenCalledWith({
       where: { userId: 7, friendId: 42 },
       data: { comment: 'Great contributor' }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -5323,6 +5323,7 @@ const FriendEntry = registry.register(
     userId: z.number(),
     friendId: z.number(),
     comment: z.string(),
+    isMutual: z.boolean(),
     friend: z.object({
       id: z.number(),
       username: z.string(),
@@ -5367,7 +5368,7 @@ registry.registerPath({
       description: 'Friend status',
       content: {
         'application/json': {
-          schema: z.object({ isFriend: z.boolean() })
+          schema: z.object({ isFriend: z.boolean(), isMutual: z.boolean() })
         }
       }
     },
@@ -5384,7 +5385,10 @@ registry.registerPath({
   tags: ['Friends'],
   request: { params: z.object({ userId: z.string() }) },
   responses: {
-    201: { description: 'Friend added' },
+    201: {
+      description: 'Friend added',
+      content: { 'application/json': { schema: FriendEntry } }
+    },
     400: {
       description: 'Cannot add self',
       content: { 'application/json': { schema: MsgResponse } }
@@ -5429,7 +5433,10 @@ registry.registerPath({
     }
   },
   responses: {
-    200: { description: 'Comment updated' },
+    200: {
+      description: 'Comment updated',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
     400: {
       description: 'Validation error',
       content: { 'application/json': { schema: ValidationError } }

--- a/src/routes/api/friends.ts
+++ b/src/routes/api/friends.ts
@@ -38,10 +38,18 @@ router.get(
   validateParams(userIdParams),
   authHandler(async (req, res) => {
     const { userId: friendId } = parsedParams<{ userId: number }>(res);
-    const existing = await prisma.friend.findUnique({
-      where: { userId_friendId: { userId: req.user.id, friendId } }
+    const [forward, reverse] = await Promise.all([
+      prisma.friend.findUnique({
+        where: { userId_friendId: { userId: req.user.id, friendId } }
+      }),
+      prisma.friend.findUnique({
+        where: { userId_friendId: { userId: friendId, friendId: req.user.id } }
+      })
+    ]);
+    res.json({
+      isFriend: forward !== null,
+      isMutual: forward !== null && reverse !== null
     });
-    res.json({ isFriend: existing !== null });
   })
 );
 
@@ -63,7 +71,21 @@ router.get(
       }),
       prisma.friend.count({ where: { userId: req.user.id } })
     ]);
-    paginatedResponse(res, friends, total, pg);
+
+    const friendIds = friends.map((f) => f.friendId);
+    const mutuals = friendIds.length
+      ? await prisma.friend.findMany({
+          where: { userId: { in: friendIds }, friendId: req.user.id },
+          select: { userId: true }
+        })
+      : [];
+    const mutualSet = new Set(mutuals.map((m) => m.userId));
+    const data = friends.map((f) => ({
+      ...f,
+      isMutual: mutualSet.has(f.friendId)
+    }));
+
+    paginatedResponse(res, data, total, pg);
   })
 );
 
@@ -87,8 +109,14 @@ router.post(
       throw new AppError(404, 'User not found');
     }
 
+    let created;
     try {
-      await prisma.friend.create({ data: { userId: req.user.id, friendId } });
+      created = await prisma.friend.create({
+        data: { userId: req.user.id, friendId },
+        include: {
+          friend: { select: { id: true, username: true, avatar: true } }
+        }
+      });
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError) {
         if (err.code === 'P2002') throw new AppError(409, 'Already friends');
@@ -97,7 +125,18 @@ router.post(
       throw err;
     }
 
-    res.status(201).json({});
+    const reverse = await prisma.friend.findUnique({
+      where: { userId_friendId: { userId: friendId, friendId: req.user.id } }
+    });
+
+    res.status(201).json({
+      id: created.id,
+      userId: created.userId,
+      friendId: created.friendId,
+      comment: created.comment,
+      friend: created.friend,
+      isMutual: reverse !== null
+    });
   })
 );
 
@@ -132,7 +171,7 @@ router.put(
       throw new AppError(404, 'Friend not found');
     }
 
-    res.json({});
+    res.json({ msg: 'Comment updated' });
   })
 );
 


### PR DESCRIPTION
Closes #60.

Rounds out the friend-system stub. Per product call with Kai: **mutual detection, no migration** — keep the one-directional follow model and surface a computed `isMutual`; the pending/accept request model is explicitly deferred (no schema change, no UI break).

## Work remaining (from #60)
- [x] Standardise POST/PUT response envelopes
- [x] Evaluate mutual-friend / pending-request state — shipped as *detection*; pending-request deferred
- [x] OpenAPI contracts for POST/PUT response bodies

## Changes
- `POST /:userId` → `201` + created resource (`id, userId, friendId, comment, friend{...}, isMutual`) instead of `201 {}`
- `PUT /:userId/comment` → `{ msg: 'Comment updated' }` instead of `200 {}`
- `GET /` → each row gains `isMutual` (one batched reverse-row lookup over the page)
- `GET /status/:userId` → adds `isMutual` (parallel forward/reverse `findUnique`)
- `DELETE /:userId` unchanged (already `204`)
- `src/lib/openapi.ts`: `FriendEntry.isMutual`, status `isMutual`, POST 201 body schema, PUT 200 `MsgResponse`

## Notes
- No schema change → no `db:erd` regen. `openapi.json` is gitignored; the registry edit is the source of truth — stellar-ui `api:generate` resync is a post-merge follow-up.
- Logic kept inline in `friends.ts` to match that file's established route-inline style (too small for a new module).

## Tests
`src/friends.spec.ts` updated for the new contracts + added mutual-true/false cases for `GET /`, `GET /status`, and `POST`. Full suite green (1573 passed); `lint` / `tsc --noEmit` / `typecheck:test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQTJsBVrQij84uRKaCqQq