### PR TITLE
feat(friends): request/accept lifecycle per PRD-01 spec (#60, corrects #190)

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -313,6 +313,14 @@ WrongSpecifiedMedia WrongSpecifiedMedia
     
 
 
+        FriendStatus {
+            pending pending
+accepted accepted
+rejected rejected
+        }
+    
+
+
         ReleaseTagVoteDirection {
             up up
 down down
@@ -492,9 +500,11 @@ Yearly Yearly
     }
   
 
-  "friends" {
+  "friend_relationships" {
     Int id "🗝️"
+    FriendStatus status 
     String comment 
+    DateTime createdAt 
     }
   
 
@@ -1581,8 +1591,9 @@ Yearly Yearly
     "invites" |o--|| "InviteStatus" : "enum:status"
     "invite_trees" |o--|| users : "user"
     "invite_trees" }o--|o users : "inviter"
-    "friends" }o--|| users : "user"
-    "friends" }o--|| users : "friend"
+    "friend_relationships" }o--|| users : "requester"
+    "friend_relationships" }o--|| users : "recipient"
+    "friend_relationships" |o--|| "FriendStatus" : "enum:status"
     "author_stylesheets" }o--|| users : "author"
     "forums" }o--|| forum_categories : "forumCategory"
     "forums" }o--|o forum_topics : "lastTopic"

--- a/prisma/migrations/20260619130736_friend_request_lifecycle/migration.sql
+++ b/prisma/migrations/20260619130736_friend_request_lifecycle/migration.sql
@@ -1,0 +1,41 @@
+/*
+  Warnings:
+
+  - You are about to drop the `friends` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "FriendStatus" AS ENUM ('pending', 'accepted', 'rejected');
+
+-- DropForeignKey
+ALTER TABLE "friends" DROP CONSTRAINT "friends_friendId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "friends" DROP CONSTRAINT "friends_userId_fkey";
+
+-- DropTable
+DROP TABLE "friends";
+
+-- CreateTable
+CREATE TABLE "friend_relationships" (
+    "id" SERIAL NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "recipientId" INTEGER NOT NULL,
+    "status" "FriendStatus" NOT NULL DEFAULT 'pending',
+    "comment" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "friend_relationships_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "friend_relationships_recipientId_status_idx" ON "friend_relationships"("recipientId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "friend_relationships_requesterId_recipientId_key" ON "friend_relationships"("requesterId", "recipientId");
+
+-- AddForeignKey
+ALTER TABLE "friend_relationships" ADD CONSTRAINT "friend_relationships_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "friend_relationships" ADD CONSTRAINT "friend_relationships_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -424,8 +424,8 @@ model User {
   invitesSent              Invite[]
   inviteTree               InviteTree?                      @relation("InviteTreeMember")
   invitees                 InviteTree[]                     @relation("InviteTreeInviter")
-  friends                  Friend[]                         @relation("UserFriends")
-  friendOf                 Friend[]                         @relation("FriendOf")
+  friendRequestsSent       FriendRelationship[]             @relation("FriendRequester")
+  friendRequestsReceived   FriendRelationship[]             @relation("FriendRecipient")
   communityStaff           Community[]                      @relation("CommunityStaff")
   consumer                 Consumer?
   contributor              Contributor?
@@ -558,16 +558,29 @@ model InviteTree {
   @@map("invite_trees")
 }
 
-model Friend {
-  id       Int    @id @default(autoincrement())
-  userId   Int
-  user     User   @relation("UserFriends", fields: [userId], references: [id])
-  friendId Int
-  friend   User   @relation("FriendOf", fields: [friendId], references: [id])
-  comment  String @default("")
+enum FriendStatus {
+  pending
+  accepted
+  rejected
+}
 
-  @@unique([userId, friendId])
-  @@map("friends")
+// PRD-01 Friends System: a friend-request lifecycle (pending → accepted /
+// rejected). One row per directed request; an accepted row represents the
+// symmetric friendship between requester and recipient. `comment` is a note on
+// the relationship.
+model FriendRelationship {
+  id          Int          @id @default(autoincrement())
+  requesterId Int
+  requester   User         @relation("FriendRequester", fields: [requesterId], references: [id])
+  recipientId Int
+  recipient   User         @relation("FriendRecipient", fields: [recipientId], references: [id])
+  status      FriendStatus @default(pending)
+  comment     String       @default("")
+  createdAt   DateTime     @default(now())
+
+  @@unique([requesterId, recipientId])
+  @@index([recipientId, status])
+  @@map("friend_relationships")
 }
 
 // ─── Profile ──────────────────────────────────────────────────────────────────

--- a/src/friends.spec.ts
+++ b/src/friends.spec.ts
@@ -8,12 +8,17 @@ import { Prisma } from '@prisma/client';
 
 beforeEach(() => resetApiTestState());
 
-// ─── GET /api/friends ─────────────────────────────────────────────────────────
+// Actor is user id 7 (set by the test harness auth stub).
+const ME = 7;
+const OTHER = 42;
+const summary = { id: OTHER, username: 'alice', avatar: null };
+
+// ─── GET /api/friends — accepted friends ──────────────────────────────────────
 
 describe('GET /api/friends', () => {
   it('returns paginated empty list when user has no friends', async () => {
-    prismaMock.friend.findMany.mockResolvedValue([]);
-    prismaMock.friend.count.mockResolvedValue(0);
+    prismaMock.friendRelationship.findMany.mockResolvedValue([]);
+    prismaMock.friendRelationship.count.mockResolvedValue(0);
 
     const res = await request(app).get('/api/friends');
 
@@ -22,99 +27,127 @@ describe('GET /api/friends', () => {
     expect(res.body.meta.total).toBe(0);
   });
 
-  it('returns paginated friend list ordered by username', async () => {
-    const mockFriend = {
-      id: 1,
-      userId: 7,
-      friendId: 42,
-      comment: 'Good person',
-      friend: { id: 42, username: 'alice', avatar: null }
-    };
-    // First findMany = page query; second = reverse mutual lookup (none)
-    prismaMock.friend.findMany
-      .mockResolvedValueOnce([mockFriend] as never)
-      .mockResolvedValueOnce([] as never);
-    prismaMock.friend.count.mockResolvedValue(1);
+  it('maps the friend to the other party when the actor is the requester', async () => {
+    prismaMock.friendRelationship.findMany.mockResolvedValue([
+      {
+        id: 1,
+        requesterId: ME,
+        recipientId: OTHER,
+        status: 'accepted',
+        comment: 'Good person',
+        createdAt: new Date(),
+        requester: { id: ME, username: 'me', avatar: null },
+        recipient: summary
+      }
+    ] as never);
+    prismaMock.friendRelationship.count.mockResolvedValue(1);
 
     const res = await request(app).get('/api/friends');
 
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].friendId).toBe(OTHER);
     expect(res.body.data[0].friend.username).toBe('alice');
-    expect(res.body.data[0].isMutual).toBe(false);
-    expect(res.body.meta.total).toBe(1);
+    expect(res.body.data[0].status).toBe('accepted');
     expect(res.body.meta).toHaveProperty('totalPages');
   });
 
-  it('flags isMutual true when the friend follows back', async () => {
-    const mockFriend = {
-      id: 1,
-      userId: 7,
-      friendId: 42,
-      comment: '',
-      friend: { id: 42, username: 'alice', avatar: null }
-    };
-    prismaMock.friend.findMany
-      .mockResolvedValueOnce([mockFriend] as never)
-      .mockResolvedValueOnce([{ userId: 42 }] as never);
-    prismaMock.friend.count.mockResolvedValue(1);
+  it('maps the friend to the other party when the actor is the recipient', async () => {
+    prismaMock.friendRelationship.findMany.mockResolvedValue([
+      {
+        id: 2,
+        requesterId: OTHER,
+        recipientId: ME,
+        status: 'accepted',
+        comment: '',
+        createdAt: new Date(),
+        requester: summary,
+        recipient: { id: ME, username: 'me', avatar: null }
+      }
+    ] as never);
+    prismaMock.friendRelationship.count.mockResolvedValue(1);
 
     const res = await request(app).get('/api/friends');
 
     expect(res.status).toBe(200);
-    expect(res.body.data[0].isMutual).toBe(true);
+    expect(res.body.data[0].friendId).toBe(OTHER);
+    expect(res.body.data[0].friend.username).toBe('alice');
+  });
+});
+
+// ─── GET /api/friends/requests — incoming pending ─────────────────────────────
+
+describe('GET /api/friends/requests', () => {
+  it('returns incoming pending requests', async () => {
+    prismaMock.friendRelationship.findMany.mockResolvedValue([
+      {
+        id: 9,
+        requesterId: OTHER,
+        recipientId: ME,
+        createdAt: new Date(),
+        requester: summary
+      }
+    ] as never);
+    prismaMock.friendRelationship.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/friends/requests');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].requesterId).toBe(OTHER);
+    expect(res.body.data[0].requester.username).toBe('alice');
   });
 });
 
 // ─── GET /api/friends/status/:userId ─────────────────────────────────────────
 
 describe('GET /api/friends/status/:userId', () => {
-  it('returns isFriend/isMutual false when not friends', async () => {
-    // forward + reverse both null
-    prismaMock.friend.findUnique.mockResolvedValue(null);
+  it('returns none when there is no relationship', async () => {
+    prismaMock.friendRelationship.findFirst.mockResolvedValue(null);
 
-    const res = await request(app).get('/api/friends/status/42');
+    const res = await request(app).get(`/api/friends/status/${OTHER}`);
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ isFriend: false, isMutual: false });
+    expect(res.body).toEqual({ status: 'none', isFriend: false });
   });
 
-  it('returns isFriend true, isMutual false when only the user follows', async () => {
-    // forward exists, reverse null
-    prismaMock.friend.findUnique
-      .mockResolvedValueOnce({
-        id: 1,
-        userId: 7,
-        friendId: 42,
-        comment: ''
-      } as never)
-      .mockResolvedValueOnce(null);
+  it('returns pending_sent when the actor sent the request', async () => {
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 1,
+      requesterId: ME,
+      recipientId: OTHER,
+      status: 'pending'
+    } as never);
 
-    const res = await request(app).get('/api/friends/status/42');
+    const res = await request(app).get(`/api/friends/status/${OTHER}`);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ isFriend: true, isMutual: false });
+    expect(res.body).toEqual({ status: 'pending_sent', isFriend: false });
   });
 
-  it('returns isMutual true when both follow each other', async () => {
-    prismaMock.friend.findUnique
-      .mockResolvedValueOnce({
-        id: 1,
-        userId: 7,
-        friendId: 42,
-        comment: ''
-      } as never)
-      .mockResolvedValueOnce({
-        id: 2,
-        userId: 42,
-        friendId: 7,
-        comment: ''
-      } as never);
+  it('returns pending_received when the other user sent the request', async () => {
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 1,
+      requesterId: OTHER,
+      recipientId: ME,
+      status: 'pending'
+    } as never);
 
-    const res = await request(app).get('/api/friends/status/42');
+    const res = await request(app).get(`/api/friends/status/${OTHER}`);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ isFriend: true, isMutual: true });
+    expect(res.body).toEqual({ status: 'pending_received', isFriend: false });
+  });
+
+  it('returns accepted/isFriend true when friends', async () => {
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 1,
+      requesterId: ME,
+      recipientId: OTHER,
+      status: 'accepted'
+    } as never);
+
+    const res = await request(app).get(`/api/friends/status/${OTHER}`);
+
+    expect(res.body).toEqual({ status: 'accepted', isFriend: true });
   });
 
   it('rejects non-numeric userId with 400', async () => {
@@ -123,44 +156,71 @@ describe('GET /api/friends/status/:userId', () => {
   });
 });
 
-// ─── POST /api/friends/:userId ────────────────────────────────────────────────
+// ─── POST /api/friends/:userId — send request ─────────────────────────────────
 
 describe('POST /api/friends/:userId', () => {
-  it('adds a friend and returns 201 with the created resource', async () => {
+  it('sends a pending request and returns 201', async () => {
     prismaMock.user.findUnique.mockResolvedValue({
-      id: 42,
+      id: OTHER,
       disabled: false
     } as never);
-    prismaMock.friend.create.mockResolvedValue({
+    prismaMock.friendRelationship.findFirst.mockResolvedValue(null);
+    prismaMock.friendRelationship.create.mockResolvedValue({
       id: 5,
-      userId: 7,
-      friendId: 42,
-      comment: '',
-      friend: { id: 42, username: 'alice', avatar: null }
+      requesterId: ME,
+      recipientId: OTHER,
+      status: 'pending',
+      createdAt: new Date(),
+      recipient: summary
     } as never);
-    // reverse mutual lookup — not followed back
-    prismaMock.friend.findUnique.mockResolvedValue(null);
 
-    const res = await request(app).post('/api/friends/42');
+    const res = await request(app).post(`/api/friends/${OTHER}`);
 
     expect(res.status).toBe(201);
-    expect(prismaMock.friend.create).toHaveBeenCalledWith({
-      data: { userId: 7, friendId: 42 },
+    expect(prismaMock.friendRelationship.create).toHaveBeenCalledWith({
+      data: { requesterId: ME, recipientId: OTHER },
       include: {
-        friend: { select: { id: true, username: true, avatar: true } }
+        recipient: { select: { id: true, username: true, avatar: true } }
       }
     });
     expect(res.body).toMatchObject({
       id: 5,
-      friendId: 42,
-      comment: '',
-      friend: { username: 'alice' },
-      isMutual: false
+      status: 'pending',
+      recipient: { username: 'alice' }
     });
   });
 
+  it('accepts a reciprocal pending request instead of duplicating (200)', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: OTHER,
+      disabled: false
+    } as never);
+    // a pending request from OTHER → ME already exists
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 8,
+      requesterId: OTHER,
+      recipientId: ME,
+      status: 'pending'
+    } as never);
+    prismaMock.friendRelationship.update.mockResolvedValue({
+      id: 8,
+      requesterId: OTHER,
+      recipientId: ME,
+      status: 'accepted',
+      comment: '',
+      requester: summary,
+      recipient: { id: ME, username: 'me', avatar: null }
+    } as never);
+
+    const res = await request(app).post(`/api/friends/${OTHER}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: 'accepted', friendId: OTHER });
+    expect(prismaMock.friendRelationship.create).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when adding self (actor id = 7)', async () => {
-    const res = await request(app).post('/api/friends/7');
+    const res = await request(app).post(`/api/friends/${ME}`);
     expect(res.status).toBe(400);
     expect(res.body.msg).toMatch(/yourself/i);
   });
@@ -184,44 +244,56 @@ describe('POST /api/friends/:userId', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 409 on duplicate friendship (P2002)', async () => {
+  it('returns 409 when already friends', async () => {
     prismaMock.user.findUnique.mockResolvedValue({
-      id: 42,
+      id: OTHER,
       disabled: false
     } as never);
-    prismaMock.friend.create.mockRejectedValue(
-      Object.assign(
-        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
-          code: 'P2002',
-          clientVersion: '5.0.0'
-        }),
-        {}
-      )
-    );
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 1,
+      requesterId: ME,
+      recipientId: OTHER,
+      status: 'accepted'
+    } as never);
 
-    const res = await request(app).post('/api/friends/42');
+    const res = await request(app).post(`/api/friends/${OTHER}`);
 
     expect(res.status).toBe(409);
   });
 
-  it('returns 404 on FK violation (P2003 — user deleted between check and create)', async () => {
+  it('returns 409 when a request is already pending from the actor', async () => {
     prismaMock.user.findUnique.mockResolvedValue({
-      id: 42,
+      id: OTHER,
       disabled: false
     } as never);
-    prismaMock.friend.create.mockRejectedValue(
-      new Prisma.PrismaClientKnownRequestError(
-        'Foreign key constraint failed',
-        {
-          code: 'P2003',
-          clientVersion: '5.0.0'
-        }
-      )
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 1,
+      requesterId: ME,
+      recipientId: OTHER,
+      status: 'pending'
+    } as never);
+
+    const res = await request(app).post(`/api/friends/${OTHER}`);
+
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 409 on a duplicate-create race (P2002)', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: OTHER,
+      disabled: false
+    } as never);
+    prismaMock.friendRelationship.findFirst.mockResolvedValue(null);
+    prismaMock.friendRelationship.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '5.0.0'
+      })
     );
 
-    const res = await request(app).post('/api/friends/42');
+    const res = await request(app).post(`/api/friends/${OTHER}`);
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(409);
   });
 
   it('rejects non-numeric userId with 400', async () => {
@@ -230,22 +302,86 @@ describe('POST /api/friends/:userId', () => {
   });
 });
 
-// ─── DELETE /api/friends/:userId ──────────────────────────────────────────────
+// ─── POST /api/friends/:userId/accept ─────────────────────────────────────────
 
-describe('DELETE /api/friends/:userId', () => {
-  it('removes friendship and returns 204', async () => {
-    prismaMock.friend.deleteMany.mockResolvedValue({ count: 1 });
+describe('POST /api/friends/:userId/accept', () => {
+  it('accepts a pending request and returns the friendship', async () => {
+    prismaMock.friendRelationship.findFirst.mockResolvedValue({
+      id: 8,
+      requesterId: OTHER,
+      recipientId: ME,
+      status: 'pending'
+    } as never);
+    prismaMock.friendRelationship.update.mockResolvedValue({
+      id: 8,
+      requesterId: OTHER,
+      recipientId: ME,
+      status: 'accepted',
+      comment: '',
+      requester: summary
+    } as never);
 
-    const res = await request(app).delete('/api/friends/42');
+    const res = await request(app).post(`/api/friends/${OTHER}/accept`);
 
-    expect(res.status).toBe(204);
-    expect(prismaMock.friend.deleteMany).toHaveBeenCalledWith({
-      where: { userId: 7, friendId: 42 }
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'accepted',
+      friendId: OTHER,
+      friend: { username: 'alice' }
     });
   });
 
-  it('returns 204 even when friendship does not exist (graceful)', async () => {
-    prismaMock.friend.deleteMany.mockResolvedValue({ count: 0 });
+  it('returns 404 when there is no pending request from the user', async () => {
+    prismaMock.friendRelationship.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).post(`/api/friends/${OTHER}/accept`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── POST /api/friends/:userId/reject ─────────────────────────────────────────
+
+describe('POST /api/friends/:userId/reject', () => {
+  it('rejects a pending request and returns a message', async () => {
+    prismaMock.friendRelationship.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app).post(`/api/friends/${OTHER}/reject`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.msg).toMatch(/rejected/i);
+  });
+
+  it('returns 404 when there is no pending request', async () => {
+    prismaMock.friendRelationship.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await request(app).post(`/api/friends/${OTHER}/reject`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── DELETE /api/friends/:userId ──────────────────────────────────────────────
+
+describe('DELETE /api/friends/:userId', () => {
+  it('removes the relationship in either direction and returns 204', async () => {
+    prismaMock.friendRelationship.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await request(app).delete(`/api/friends/${OTHER}`);
+
+    expect(res.status).toBe(204);
+    expect(prismaMock.friendRelationship.deleteMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { requesterId: ME, recipientId: OTHER },
+          { requesterId: OTHER, recipientId: ME }
+        ]
+      }
+    });
+  });
+
+  it('returns 204 even when nothing exists (graceful)', async () => {
+    prismaMock.friendRelationship.deleteMany.mockResolvedValue({ count: 0 });
 
     const res = await request(app).delete('/api/friends/999');
 
@@ -261,23 +397,29 @@ describe('DELETE /api/friends/:userId', () => {
 // ─── PUT /api/friends/:userId/comment ────────────────────────────────────────
 
 describe('PUT /api/friends/:userId/comment', () => {
-  it('updates the comment and returns 200', async () => {
-    prismaMock.friend.updateMany.mockResolvedValue({ count: 1 });
+  it('updates the comment on an accepted friendship and returns 200', async () => {
+    prismaMock.friendRelationship.updateMany.mockResolvedValue({ count: 1 });
 
     const res = await request(app)
-      .put('/api/friends/42/comment')
+      .put(`/api/friends/${OTHER}/comment`)
       .send({ comment: 'Great contributor' });
 
     expect(res.status).toBe(200);
     expect(res.body.msg).toMatch(/updated/i);
-    expect(prismaMock.friend.updateMany).toHaveBeenCalledWith({
-      where: { userId: 7, friendId: 42 },
+    expect(prismaMock.friendRelationship.updateMany).toHaveBeenCalledWith({
+      where: {
+        status: 'accepted',
+        OR: [
+          { requesterId: ME, recipientId: OTHER },
+          { requesterId: OTHER, recipientId: ME }
+        ]
+      },
       data: { comment: 'Great contributor' }
     });
   });
 
-  it('returns 404 when friendship does not exist', async () => {
-    prismaMock.friend.updateMany.mockResolvedValue({ count: 0 });
+  it('returns 404 when no accepted friendship exists', async () => {
+    prismaMock.friendRelationship.updateMany.mockResolvedValue({ count: 0 });
 
     const res = await request(app)
       .put('/api/friends/999/comment')
@@ -288,17 +430,17 @@ describe('PUT /api/friends/:userId/comment', () => {
 
   it('rejects comment longer than 500 chars with 400', async () => {
     const res = await request(app)
-      .put('/api/friends/42/comment')
+      .put(`/api/friends/${OTHER}/comment`)
       .send({ comment: 'x'.repeat(501) });
 
     expect(res.status).toBe(400);
   });
 
   it('accepts empty string as comment', async () => {
-    prismaMock.friend.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.friendRelationship.updateMany.mockResolvedValue({ count: 1 });
 
     const res = await request(app)
-      .put('/api/friends/42/comment')
+      .put(`/api/friends/${OTHER}/comment`)
       .send({ comment: '' });
 
     expect(res.status).toBe(200);

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -5316,19 +5316,51 @@ registry.registerPath({
 
 // ─── Friends ──────────────────────────────────────────────────────────────────
 
+const FriendStatusEnum = z.enum(['pending', 'accepted', 'rejected']);
+
+const UserSummary = registry.register(
+  'FriendUserSummary',
+  z.object({
+    id: z.number(),
+    username: z.string(),
+    avatar: z.string().nullable()
+  })
+);
+
+// An accepted friendship as seen by the current user — `friend` is the other party.
 const FriendEntry = registry.register(
   'FriendEntry',
   z.object({
     id: z.number(),
-    userId: z.number(),
     friendId: z.number(),
     comment: z.string(),
-    isMutual: z.boolean(),
-    friend: z.object({
-      id: z.number(),
-      username: z.string(),
-      avatar: z.string().nullable()
-    })
+    status: FriendStatusEnum,
+    createdAt: z.string(),
+    friend: UserSummary
+  })
+);
+
+// An incoming pending request.
+const FriendRequest = registry.register(
+  'FriendRequest',
+  z.object({
+    id: z.number(),
+    requesterId: z.number(),
+    createdAt: z.string(),
+    requester: UserSummary
+  })
+);
+
+// The row returned when a request is sent (still pending).
+const FriendRequestSent = registry.register(
+  'FriendRequestSent',
+  z.object({
+    id: z.number(),
+    requesterId: z.number(),
+    recipientId: z.number(),
+    status: FriendStatusEnum,
+    createdAt: z.string(),
+    recipient: UserSummary
   })
 );
 
@@ -5336,6 +5368,7 @@ registry.registerPath({
   method: 'get',
   path: '/friends',
   tags: ['Friends'],
+  summary: 'List accepted friends',
   request: {
     query: z.object({
       page: z.coerce.number().int().positive().optional(),
@@ -5344,7 +5377,7 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: 'Paginated friends list',
+      description: 'Paginated accepted-friends list',
       content: {
         'application/json': {
           schema: z.object({ data: z.array(FriendEntry), meta: PaginationMeta })
@@ -5360,15 +5393,55 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
+  path: '/friends/requests',
+  tags: ['Friends'],
+  summary: 'List incoming pending friend requests',
+  request: {
+    query: z.object({
+      page: z.coerce.number().int().positive().optional(),
+      limit: z.coerce.number().int().positive().optional()
+    })
+  },
+  responses: {
+    200: {
+      description: 'Paginated incoming-requests list',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(FriendRequest),
+            meta: PaginationMeta
+          })
+        }
+      }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
   path: '/friends/status/{userId}',
   tags: ['Friends'],
+  summary: 'Relationship status with a user',
   request: { params: z.object({ userId: z.string() }) },
   responses: {
     200: {
       description: 'Friend status',
       content: {
         'application/json': {
-          schema: z.object({ isFriend: z.boolean(), isMutual: z.boolean() })
+          schema: z.object({
+            status: z.enum([
+              'none',
+              'pending_sent',
+              'pending_received',
+              'accepted',
+              'rejected'
+            ]),
+            isFriend: z.boolean()
+          })
         }
       }
     },
@@ -5383,10 +5456,16 @@ registry.registerPath({
   method: 'post',
   path: '/friends/{userId}',
   tags: ['Friends'],
+  summary: 'Send a friend request (or accept a reciprocal pending one)',
   request: { params: z.object({ userId: z.string() }) },
   responses: {
     201: {
-      description: 'Friend added',
+      description: 'Friend request sent (pending)',
+      content: { 'application/json': { schema: FriendRequestSent } }
+    },
+    200: {
+      description:
+        'A reciprocal pending request existed and was accepted (now friends)',
       content: { 'application/json': { schema: FriendEntry } }
     },
     400: {
@@ -5398,7 +5477,43 @@ registry.registerPath({
       content: { 'application/json': { schema: MsgResponse } }
     },
     409: {
-      description: 'Already friends',
+      description: 'Already friends or a request is already pending',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/friends/{userId}/accept',
+  tags: ['Friends'],
+  summary: 'Accept a pending request from a user',
+  request: { params: z.object({ userId: z.string() }) },
+  responses: {
+    200: {
+      description: 'Request accepted — now friends',
+      content: { 'application/json': { schema: FriendEntry } }
+    },
+    404: {
+      description: 'No pending request from this user',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/friends/{userId}/reject',
+  tags: ['Friends'],
+  summary: 'Reject a pending request from a user',
+  request: { params: z.object({ userId: z.string() }) },
+  responses: {
+    200: {
+      description: 'Request rejected',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'No pending request from this user',
       content: { 'application/json': { schema: MsgResponse } }
     }
   }
@@ -5408,9 +5523,10 @@ registry.registerPath({
   method: 'delete',
   path: '/friends/{userId}',
   tags: ['Friends'],
+  summary: 'Remove a friend or cancel a request',
   request: { params: z.object({ userId: z.string() }) },
   responses: {
-    204: { description: 'Friend removed' },
+    204: { description: 'Friendship/request removed' },
     401: {
       description: 'Not authenticated',
       content: { 'application/json': { schema: MsgResponse } }
@@ -5422,6 +5538,7 @@ registry.registerPath({
   method: 'put',
   path: '/friends/{userId}/comment',
   tags: ['Friends'],
+  summary: 'Set a note on an accepted friendship',
   request: {
     params: z.object({ userId: z.string() }),
     body: {

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -10,7 +10,7 @@ const mockPrismaEconomy = { count: jest.fn() };
 jest.mock('../lib/prisma', () => ({
   prisma: {
     user: mockPrismaUser,
-    friend: mockPrismaFriend,
+    friendRelationship: mockPrismaFriend,
     economyTransaction: mockPrismaEconomy
   }
 }));

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -114,9 +114,10 @@ const ratioScorer: DimensionScorer = {
 // explicit that "friend count alone should not determine score", so this is
 // deliberately the weakest dimension: a LOW cap and heavy diminishing returns,
 // so even a huge friend list can't dominate longevity/ratio — and ring-farming
-// (the model is a directed add, no reciprocity yet, #60) hits the cap fast.
-// Quality-weighting (mutuality, friend account age, network diversity) is
-// future work per the PRD.
+// hits the cap fast. The count is *accepted* friendships only (#60 request →
+// accept lifecycle), so a one-sided request earns nothing until reciprocated.
+// Further quality-weighting (friend account age, network diversity) is future
+// work per the PRD.
 const FRIENDS_CAP = 4;
 const FRIENDS_TAU = 5; // 5 friends → ~63% of cap; diminishing hard after
 const FRIENDS_WEIGHT = 1.0;
@@ -243,7 +244,13 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
           ircNick: true
         }
       }),
-      prisma.friend.count({ where: { userId } }),
+      // Accepted friendships in either direction (requester or recipient).
+      prisma.friendRelationship.count({
+        where: {
+          status: 'accepted',
+          OR: [{ requesterId: userId }, { recipientId: userId }]
+        }
+      }),
       // Distinct (adopter, author) pairs where this user is the author — one
       // ledger row per pair (deduped at write), so a plain count is the distinct
       // adoption count. Feeds both the stylesheet (author reward) and friends

--- a/src/routes/api/friends.ts
+++ b/src/routes/api/friends.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { z } from 'zod';
-import { Prisma } from '@prisma/client';
+import { Prisma, FriendStatus } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 import { AppError } from '../../lib/errors';
 import { sanitizePlain } from '../../lib/sanitize';
@@ -31,139 +31,283 @@ const commentSchema = z.object({
   comment: z.string().max(500)
 });
 
-// GET /status/:userId before /:userId/* to avoid shadowing
+const userSummary = { id: true, username: true, avatar: true } as const;
+
+// Either-direction match for a relationship between the actor and `otherId`.
+const betweenUsers = (actorId: number, otherId: number) => ({
+  OR: [
+    { requesterId: actorId, recipientId: otherId },
+    { requesterId: otherId, recipientId: actorId }
+  ]
+});
+
+// ─── GET /status/:userId ──────────────────────────────────────────────────────
+// Static/specific segments registered before /:userId to avoid shadowing.
 router.get(
   '/status/:userId',
   requireAuth,
   validateParams(userIdParams),
   authHandler(async (req, res) => {
-    const { userId: friendId } = parsedParams<{ userId: number }>(res);
-    const [forward, reverse] = await Promise.all([
-      prisma.friend.findUnique({
-        where: { userId_friendId: { userId: req.user.id, friendId } }
-      }),
-      prisma.friend.findUnique({
-        where: { userId_friendId: { userId: friendId, friendId: req.user.id } }
-      })
-    ]);
-    res.json({
-      isFriend: forward !== null,
-      isMutual: forward !== null && reverse !== null
+    const { userId: otherId } = parsedParams<{ userId: number }>(res);
+    const rel = await prisma.friendRelationship.findFirst({
+      where: betweenUsers(req.user.id, otherId)
     });
+
+    let status:
+      | 'none'
+      | 'pending_sent'
+      | 'pending_received'
+      | 'accepted'
+      | 'rejected' = 'none';
+    if (rel) {
+      if (rel.status === FriendStatus.accepted) status = 'accepted';
+      else if (rel.status === FriendStatus.rejected) status = 'rejected';
+      else
+        status =
+          rel.requesterId === req.user.id ? 'pending_sent' : 'pending_received';
+    }
+
+    res.json({ status, isFriend: status === 'accepted' });
   })
 );
 
+// ─── GET /requests — incoming pending requests ────────────────────────────────
+router.get(
+  '/requests',
+  requireAuth,
+  validateQuery(friendsQuerySchema),
+  authHandler(async (req, res) => {
+    const pg = parsedPage(res);
+    const where = {
+      recipientId: req.user.id,
+      status: FriendStatus.pending
+    };
+    const [rows, total] = await Promise.all([
+      prisma.friendRelationship.findMany({
+        where,
+        include: { requester: { select: userSummary } },
+        orderBy: { createdAt: 'desc' },
+        skip: pg.skip,
+        take: pg.limit
+      }),
+      prisma.friendRelationship.count({ where })
+    ]);
+    const data = rows.map((r) => ({
+      id: r.id,
+      requesterId: r.requesterId,
+      requester: r.requester,
+      createdAt: r.createdAt
+    }));
+    paginatedResponse(res, data, total, pg);
+  })
+);
+
+// ─── GET / — accepted friends (either direction) ──────────────────────────────
 router.get(
   '/',
   requireAuth,
   validateQuery(friendsQuerySchema),
   authHandler(async (req, res) => {
     const pg = parsedPage(res);
-    const [friends, total] = await Promise.all([
-      prisma.friend.findMany({
-        where: { userId: req.user.id },
+    const where = {
+      status: FriendStatus.accepted,
+      OR: [{ requesterId: req.user.id }, { recipientId: req.user.id }]
+    };
+    const [rows, total] = await Promise.all([
+      prisma.friendRelationship.findMany({
+        where,
         include: {
-          friend: { select: { id: true, username: true, avatar: true } }
+          requester: { select: userSummary },
+          recipient: { select: userSummary }
         },
-        orderBy: { friend: { username: 'asc' } },
+        orderBy: { createdAt: 'desc' },
         skip: pg.skip,
         take: pg.limit
       }),
-      prisma.friend.count({ where: { userId: req.user.id } })
+      prisma.friendRelationship.count({ where })
     ]);
-
-    const friendIds = friends.map((f) => f.friendId);
-    const mutuals = friendIds.length
-      ? await prisma.friend.findMany({
-          where: { userId: { in: friendIds }, friendId: req.user.id },
-          select: { userId: true }
-        })
-      : [];
-    const mutualSet = new Set(mutuals.map((m) => m.userId));
-    const data = friends.map((f) => ({
-      ...f,
-      isMutual: mutualSet.has(f.friendId)
-    }));
-
+    const data = rows.map((r) => {
+      const friend = r.requesterId === req.user.id ? r.recipient : r.requester;
+      return {
+        id: r.id,
+        friendId: friend.id,
+        comment: r.comment,
+        status: r.status,
+        createdAt: r.createdAt,
+        friend
+      };
+    });
     paginatedResponse(res, data, total, pg);
   })
 );
 
+// ─── POST /:userId — send a friend request ────────────────────────────────────
+// If the target has already sent the actor a pending request, this accepts it
+// (so two opposite-direction pending rows never coexist).
 router.post(
   '/:userId',
   requireAuth,
   validateParams(userIdParams),
   authHandler(async (req, res) => {
-    const { userId: friendId } = parsedParams<{ userId: number }>(res);
+    const { userId: otherId } = parsedParams<{ userId: number }>(res);
 
-    if (friendId === req.user.id) {
+    if (otherId === req.user.id) {
       throw new AppError(400, 'Cannot add yourself as a friend');
     }
 
     const target = await prisma.user.findUnique({
-      where: { id: friendId },
+      where: { id: otherId },
       select: { id: true, disabled: true }
     });
-
     if (!target || target.disabled) {
       throw new AppError(404, 'User not found');
     }
 
+    const existing = await prisma.friendRelationship.findFirst({
+      where: betweenUsers(req.user.id, otherId)
+    });
+
+    if (existing) {
+      if (existing.status === FriendStatus.accepted) {
+        throw new AppError(409, 'Already friends');
+      }
+      if (existing.status === FriendStatus.pending) {
+        if (existing.requesterId === req.user.id) {
+          throw new AppError(409, 'Friend request already pending');
+        }
+        // Reverse pending request exists → accept it instead of duplicating.
+        const accepted = await prisma.friendRelationship.update({
+          where: { id: existing.id },
+          data: { status: FriendStatus.accepted },
+          include: {
+            requester: { select: userSummary },
+            recipient: { select: userSummary }
+          }
+        });
+        const friend = accepted.requester;
+        res.status(200).json({
+          id: accepted.id,
+          friendId: friend.id,
+          status: accepted.status,
+          comment: accepted.comment,
+          friend
+        });
+        return;
+      }
+      // A prior rejected row exists — clear it so a fresh request can be made.
+      await prisma.friendRelationship.delete({ where: { id: existing.id } });
+    }
+
     let created;
     try {
-      created = await prisma.friend.create({
-        data: { userId: req.user.id, friendId },
-        include: {
-          friend: { select: { id: true, username: true, avatar: true } }
-        }
+      created = await prisma.friendRelationship.create({
+        data: { requesterId: req.user.id, recipientId: otherId },
+        include: { recipient: { select: userSummary } }
       });
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError) {
-        if (err.code === 'P2002') throw new AppError(409, 'Already friends');
+        if (err.code === 'P2002') {
+          throw new AppError(409, 'Friend request already pending');
+        }
         if (err.code === 'P2003') throw new AppError(404, 'User not found');
       }
       throw err;
     }
 
-    const reverse = await prisma.friend.findUnique({
-      where: { userId_friendId: { userId: friendId, friendId: req.user.id } }
-    });
-
     res.status(201).json({
       id: created.id,
-      userId: created.userId,
-      friendId: created.friendId,
-      comment: created.comment,
-      friend: created.friend,
-      isMutual: reverse !== null
+      requesterId: created.requesterId,
+      recipientId: created.recipientId,
+      status: created.status,
+      createdAt: created.createdAt,
+      recipient: created.recipient
     });
   })
 );
 
+// ─── POST /:userId/accept — accept a pending request from :userId ─────────────
+router.post(
+  '/:userId/accept',
+  requireAuth,
+  validateParams(userIdParams),
+  authHandler(async (req, res) => {
+    const { userId: otherId } = parsedParams<{ userId: number }>(res);
+    const pending = await prisma.friendRelationship.findFirst({
+      where: {
+        requesterId: otherId,
+        recipientId: req.user.id,
+        status: FriendStatus.pending
+      }
+    });
+    if (!pending) {
+      throw new AppError(404, 'No pending friend request from this user');
+    }
+    const accepted = await prisma.friendRelationship.update({
+      where: { id: pending.id },
+      data: { status: FriendStatus.accepted },
+      include: { requester: { select: userSummary } }
+    });
+    res.json({
+      id: accepted.id,
+      friendId: accepted.requester.id,
+      status: accepted.status,
+      comment: accepted.comment,
+      friend: accepted.requester
+    });
+  })
+);
+
+// ─── POST /:userId/reject — reject a pending request from :userId ─────────────
+router.post(
+  '/:userId/reject',
+  requireAuth,
+  validateParams(userIdParams),
+  authHandler(async (req, res) => {
+    const { userId: otherId } = parsedParams<{ userId: number }>(res);
+    const result = await prisma.friendRelationship.updateMany({
+      where: {
+        requesterId: otherId,
+        recipientId: req.user.id,
+        status: FriendStatus.pending
+      },
+      data: { status: FriendStatus.rejected }
+    });
+    if (result.count === 0) {
+      throw new AppError(404, 'No pending friend request from this user');
+    }
+    res.json({ msg: 'Friend request rejected' });
+  })
+);
+
+// ─── DELETE /:userId — remove friend / cancel request (either direction) ──────
 router.delete(
   '/:userId',
   requireAuth,
   validateParams(userIdParams),
   authHandler(async (req, res) => {
-    const { userId: friendId } = parsedParams<{ userId: number }>(res);
-    await prisma.friend.deleteMany({
-      where: { userId: req.user.id, friendId }
+    const { userId: otherId } = parsedParams<{ userId: number }>(res);
+    await prisma.friendRelationship.deleteMany({
+      where: betweenUsers(req.user.id, otherId)
     });
     res.status(204).send();
   })
 );
 
+// ─── PUT /:userId/comment — note on an accepted friendship ────────────────────
 router.put(
   '/:userId/comment',
   requireAuth,
   validateParams(userIdParams),
   validate(commentSchema),
   authHandler(async (req, res) => {
-    const { userId: friendId } = parsedParams<{ userId: number }>(res);
+    const { userId: otherId } = parsedParams<{ userId: number }>(res);
     const { comment } = parsedBody<{ comment: string }>(res);
 
-    const result = await prisma.friend.updateMany({
-      where: { userId: req.user.id, friendId },
+    const result = await prisma.friendRelationship.updateMany({
+      where: {
+        status: FriendStatus.accepted,
+        ...betweenUsers(req.user.id, otherId)
+      },
       data: { comment: sanitizePlain(comment) }
     });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -8454,6 +8454,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /** List accepted friends */
     get: {
       parameters: {
         query?: {
@@ -8466,7 +8467,7 @@ export interface paths {
       };
       requestBody?: never;
       responses: {
-        /** @description Paginated friends list */
+        /** @description Paginated accepted-friends list */
         200: {
           headers: {
             [name: string]: unknown;
@@ -8497,6 +8498,57 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/friends/requests': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List incoming pending friend requests */
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          limit?: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated incoming-requests list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['FriendRequest'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/friends/status/{userId}': {
     parameters: {
       query?: never;
@@ -8504,6 +8556,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /** Relationship status with a user */
     get: {
       parameters: {
         query?: never;
@@ -8522,6 +8575,13 @@ export interface paths {
           };
           content: {
             'application/json': {
+              /** @enum {string} */
+              status:
+                | 'none'
+                | 'pending_sent'
+                | 'pending_received'
+                | 'accepted'
+                | 'rejected';
               isFriend: boolean;
             };
           };
@@ -8554,6 +8614,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /** Send a friend request (or accept a reciprocal pending one) */
     post: {
       parameters: {
         query?: never;
@@ -8565,12 +8626,23 @@ export interface paths {
       };
       requestBody?: never;
       responses: {
-        /** @description Friend added */
+        /** @description A reciprocal pending request existed and was accepted (now friends) */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['FriendEntry'];
+          };
+        };
+        /** @description Friend request sent (pending) */
         201: {
           headers: {
             [name: string]: unknown;
           };
-          content?: never;
+          content: {
+            'application/json': components['schemas']['FriendRequestSent'];
+          };
         };
         /** @description Cannot add self */
         400: {
@@ -8590,7 +8662,7 @@ export interface paths {
             'application/json': components['schemas']['MsgResponse'];
           };
         };
-        /** @description Already friends */
+        /** @description Already friends or a request is already pending */
         409: {
           headers: {
             [name: string]: unknown;
@@ -8601,6 +8673,7 @@ export interface paths {
         };
       };
     };
+    /** Remove a friend or cancel a request */
     delete: {
       parameters: {
         query?: never;
@@ -8612,7 +8685,7 @@ export interface paths {
       };
       requestBody?: never;
       responses: {
-        /** @description Friend removed */
+        /** @description Friendship/request removed */
         204: {
           headers: {
             [name: string]: unknown;
@@ -8635,6 +8708,100 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/friends/{userId}/accept': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Accept a pending request from a user */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Request accepted — now friends */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['FriendEntry'];
+          };
+        };
+        /** @description No pending request from this user */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/friends/{userId}/reject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reject a pending request from a user */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Request rejected */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description No pending request from this user */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/friends/{userId}/comment': {
     parameters: {
       query?: never;
@@ -8643,6 +8810,7 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
+    /** Set a note on an accepted friendship */
     put: {
       parameters: {
         query?: never;
@@ -8665,7 +8833,9 @@ export interface paths {
           headers: {
             [name: string]: unknown;
           };
-          content?: never;
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
         };
         /** @description Validation error */
         400: {
@@ -12458,16 +12628,34 @@ export interface components {
       createdAt: string;
       updatedAt: string;
     };
+    FriendUserSummary: {
+      id: number;
+      username: string;
+      avatar: string | null;
+    };
     FriendEntry: {
       id: number;
-      userId: number;
       friendId: number;
       comment: string;
-      friend: {
-        id: number;
-        username: string;
-        avatar: string | null;
-      };
+      /** @enum {string} */
+      status: 'pending' | 'accepted' | 'rejected';
+      createdAt: string;
+      friend: components['schemas']['FriendUserSummary'];
+    };
+    FriendRequest: {
+      id: number;
+      requesterId: number;
+      createdAt: string;
+      requester: components['schemas']['FriendUserSummary'];
+    };
+    FriendRequestSent: {
+      id: number;
+      requesterId: number;
+      recipientId: number;
+      /** @enum {string} */
+      status: 'pending' | 'accepted' | 'rejected';
+      createdAt: string;
+      recipient: components['schemas']['FriendUserSummary'];
     };
     TagAliasItem: {
       id: number;


### PR DESCRIPTION
Reworks the friend system to the **PRD-01 "Friends System" specification** — a request → accept/reject lifecycle. This **corrects #190** (already merged), which shipped a directional follow + `isMutual` that did not match the PRD's `FriendRelationship { requesterId, recipientId, status: pending|accepted|rejected, createdAt }` model.

### Why
PRD-01 §"Friends System" specifies request/accept semantics with a `status` enum. #190 built a one-directional follow instead. This PR brings the implementation to the spec of record.

### Schema (`migration 20260619130736_friend_request_lifecycle`)
- Replace `Friend` with `FriendRelationship { requesterId, recipientId, status, comment, createdAt }` + a `FriendStatus` enum (`pending|accepted|rejected`).
- Pre-alpha → destructive migration, no backfill (per project data policy).

### Routes (`src/routes/api/friends.ts`)
| Endpoint | Behaviour |
|---|---|
| `POST /:userId` | Send a request (`201`). If a reciprocal pending request exists, accept it instead of duplicating (`200`). |
| `POST /:userId/accept` | Accept a pending request → `200` + friendship |
| `POST /:userId/reject` | Reject a pending request → `200 { msg }` |
| `GET /requests` | Incoming pending requests |
| `GET /` | Accepted friends (either direction; maps to the other party) |
| `GET /status/:userId` | `none \| pending_sent \| pending_received \| accepted \| rejected` |
| `DELETE /:userId` | Remove friend / cancel request (either direction) |
| `PUT /:userId/comment` | Note on an accepted friendship → `200 { msg }` |

### CRS (`reputation.ts`)
Friend count now counts **accepted** relationships in either direction — a one-sided request earns nothing until reciprocated (the dimension comment is updated to drop the old "directed add" note).

### Notes
- `comment` is retained as a relationship-level note (an extension beyond the bare PRD model, preserving #190's existing feature). Single row per friendship ⇒ the note is shared, not per-side.
- OpenAPI registry updated; regenerated `openapi.json`, `src/types/api.ts`, `docs/erd.md`.

### Tests
`src/friends.spec.ts` rewritten for the full lifecycle; `reputation.spec.ts` mock updated. **Unit 1581 passed**, **integration green (exit 0)**; `lint` / `tsc --noEmit` / `typecheck:test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQTJsBVrQij84uRKaCqQq