### PR TITLE
feat(profile): paranoia-gated community-stats block (PRD-01 Profile Integration)

### DIFF
--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -601,6 +601,7 @@ describe('API auth/profile/user flows', () => {
         displayStaff: false
       },
       inviteTree: [],
+      community: null,
       email: null,
       dateRegistered: '2026-04-24T00:00:00.000Z',
       lastSeen: null,
@@ -730,7 +731,8 @@ describe('API auth/profile/user flows', () => {
       staffBio: null,
       recentContributions: [],
       recentSnatches: [],
-      inviteTree: []
+      inviteTree: [],
+      community: null
     });
 
     const res = await request(app).get('/api/profile/me');
@@ -801,7 +803,8 @@ describe('API auth/profile/user flows', () => {
       recentContributions: [],
       recentSnatches: [],
       userSettings: undefined,
-      inviteTree: []
+      inviteTree: [],
+      community: null
     });
 
     const res = await request(app).get('/api/profile/user/target-user');

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -528,6 +528,31 @@ const InviteNodeSchema: z.ZodType<any> = z.lazy(() =>
 
 const InviteNode = registry.register('InviteNode', InviteNodeSchema);
 
+// PRD-01 Profile Integration: community-stats block. Null when the target's
+// paranoia hides all stats from this viewer; the reputation `ratio` dimension is
+// omitted (and the score recomputed) when consumed stats are hidden.
+const CommunityStats = registry.register(
+  'CommunityStats',
+  z.object({
+    friends: z.number(),
+    invites: z.object({
+      direct: z.number(),
+      total: z.number(),
+      depth: z.number()
+    }),
+    reputation: z.object({
+      score: z.number(),
+      dimensions: z.array(
+        z.object({
+          name: z.string(),
+          subScore: z.number(),
+          weighted: z.number()
+        })
+      )
+    })
+  })
+);
+
 const PublicProfile = registry.register(
   'PublicProfile',
   z.object({
@@ -556,7 +581,8 @@ const PublicProfile = registry.register(
     staffPmOverview: ProfileStaffPmOverview.nullable(),
     recentContributions: z.array(ProfileContribution),
     recentSnatches: z.array(ProfileSnatch),
-    inviteTree: z.array(InviteNode)
+    inviteTree: z.array(InviteNode),
+    community: CommunityStats.nullable()
   })
 );
 

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -13,7 +13,16 @@ import { getLogger } from './logging';
 import { computeRatio } from './ratio';
 import { parsePerks, type PerksMap } from './donor';
 import { computeStanding } from './standing';
-import { getInviteSubtreeRows, type InviteSubtreeRow } from './user';
+import {
+  getInviteSubtreeRows,
+  getMemberInviteTreeView,
+  type InviteSubtreeRow
+} from './user';
+import {
+  getReputation,
+  filterReputationView,
+  type CrsResult
+} from './reputation';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -727,6 +736,44 @@ const getStaffPmOverview = async (
   };
 };
 
+/** A member's invite-tree summary, as far as the community block needs it. */
+interface InviteSummaryView {
+  summary: { branches: number; entries: number; depth: number };
+}
+
+/**
+ * Shape the PRD-01 Profile Integration community-stats block from already-fetched
+ * inputs. Pure so the paranoia gating is testable without a DB:
+ *  - any input `null` (the caller didn't fetch it because the top paranoia tier
+ *    hides every stat) → the whole block is `null`.
+ *  - `includeSnatchDerived` false (consumed stats hidden, paranoia ≥ 2) → the
+ *    snatch-derived (`ratio`) dimension drops out of the reputation view and its
+ *    score is recomputed (see `filterReputationView`).
+ */
+export const buildCommunityStats = (
+  friendCount: number | null,
+  inviteView: InviteSummaryView | null,
+  reputation: CrsResult | null,
+  includeSnatchDerived: boolean
+): {
+  friends: number;
+  invites: { direct: number; total: number; depth: number };
+  reputation: CrsResult;
+} | null => {
+  if (friendCount === null || inviteView === null || reputation === null) {
+    return null;
+  }
+  return {
+    friends: friendCount,
+    invites: {
+      direct: inviteView.summary.branches,
+      total: inviteView.summary.entries,
+      depth: inviteView.summary.depth
+    },
+    reputation: filterReputationView(reputation, { includeSnatchDerived })
+  };
+};
+
 const buildProfileView = async (
   user: ProfileUserRecord,
   viewer: ViewerContext,
@@ -751,13 +798,20 @@ const buildProfileView = async (
     viewer.isOwner || viewer.isStaff || settings.showRatioStats;
   const canSeeSnatches = viewer.isOwner || viewer.isStaff;
 
+  // PRD-01 Profile Integration: the community-stats block (friends count, invite
+  // summary, reputation) is visible unless the highest paranoia tier hides every
+  // stat — same gate as ratio/buffer (`canSeeRatio`). Compute it only when
+  // visible so non-visible profile loads don't pay for the extra queries.
   const [
     activitySummary,
     recentContributions,
     recentSnatches,
     inviteRows,
     collageShelves,
-    staffPmOverview
+    staffPmOverview,
+    friendCount,
+    inviteView,
+    reputation
   ] = await Promise.all([
     getActivitySummary(user.id),
     getRecentContributions(user.id),
@@ -766,8 +820,27 @@ const buildProfileView = async (
       ? getInviteSubtreeRows(user.id)
       : Promise.resolve([] as InviteSubtreeRow[]),
     getProfileCollages(user.id),
-    viewer.isStaff ? getStaffPmOverview(user.id) : Promise.resolve(null)
+    viewer.isStaff ? getStaffPmOverview(user.id) : Promise.resolve(null),
+    canSeeRatio
+      ? prisma.friendRelationship.count({
+          where: {
+            status: 'accepted',
+            OR: [{ requesterId: user.id }, { recipientId: user.id }]
+          }
+        })
+      : Promise.resolve(null),
+    canSeeRatio
+      ? getMemberInviteTreeView(user.id, viewer.isStaff)
+      : Promise.resolve(null),
+    canSeeRatio ? getReputation(user.id) : Promise.resolve(null)
   ]);
+
+  const community = buildCommunityStats(
+    friendCount,
+    inviteView,
+    reputation,
+    canSeeDownloaded
+  );
   const percentiles = await getPercentileSummary(user, activitySummary);
   const donorPresentation = buildDonorPresentation(user);
   const derivedRatio = computeRatio(user.contributed, user.consumed);
@@ -848,7 +921,8 @@ const buildProfileView = async (
     inviteTree:
       includeInviteTree && inviteRows.length
         ? buildInviteTree(inviteRows, user.id, viewer.isOwner || viewer.isStaff)
-        : []
+        : [],
+    community
   };
 };
 

--- a/src/modules/profileCommunity.spec.ts
+++ b/src/modules/profileCommunity.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the PRD-01 Profile Integration community-stats block —
+ * the pure shaping + paranoia gating in `buildCommunityStats`.
+ */
+
+// Avoid pulling isomorphic-dompurify (jsdom ESM) through profile.ts → sanitize.
+jest.mock('../lib/sanitize', () => ({
+  sanitizeHtml: (v: string) => v,
+  sanitizePlain: (v: string) => v
+}));
+
+import { buildCommunityStats } from './profile';
+
+const inviteView = {
+  summary: { branches: 3, entries: 9, depth: 2 }
+};
+
+const reputation = {
+  score: 12,
+  dimensions: [
+    { name: 'longevity', subScore: 6, weighted: 6 },
+    { name: 'ratio', subScore: 4, weighted: 4 },
+    { name: 'friends', subScore: 2, weighted: 2 }
+  ]
+};
+
+describe('buildCommunityStats', () => {
+  it('returns null when any input is null (top paranoia tier hides all stats)', () => {
+    expect(buildCommunityStats(null, inviteView, reputation, true)).toBeNull();
+    expect(buildCommunityStats(5, null, reputation, true)).toBeNull();
+    expect(buildCommunityStats(5, inviteView, null, true)).toBeNull();
+  });
+
+  it('maps friends + invite summary (direct/total/depth)', () => {
+    const block = buildCommunityStats(5, inviteView, reputation, true)!;
+    expect(block.friends).toBe(5);
+    expect(block.invites).toEqual({ direct: 3, total: 9, depth: 2 });
+  });
+
+  it('keeps the full reputation (incl. ratio) when snatch stats are visible', () => {
+    const block = buildCommunityStats(5, inviteView, reputation, true)!;
+    expect(block.reputation.dimensions.map((d) => d.name)).toContain('ratio');
+    expect(block.reputation.score).toBe(12);
+  });
+
+  it('drops the snatch-derived ratio dimension and recomputes when hidden', () => {
+    const block = buildCommunityStats(5, inviteView, reputation, false)!;
+    expect(block.reputation.dimensions.map((d) => d.name)).not.toContain(
+      'ratio'
+    );
+    // 6 (longevity) + 2 (friends) = 8
+    expect(block.reputation.score).toBe(8);
+  });
+});

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -15,7 +15,7 @@ jest.mock('../lib/prisma', () => ({
   }
 }));
 
-import { computeCrs, getReputation } from './reputation';
+import { computeCrs, getReputation, filterReputationView } from './reputation';
 
 const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
 const NOW = new Date('2026-06-08T00:00:00Z');
@@ -307,5 +307,45 @@ describe('getReputation', () => {
     expect(
       result.dimensions.find((d) => d.name === 'friends')!.subScore
     ).toBeGreaterThan(0);
+  });
+});
+
+// ─── filterReputationView (paranoia-gated projection) ─────────────────────────
+
+describe('filterReputationView', () => {
+  const crs = {
+    score: 12,
+    dimensions: [
+      { name: 'longevity', subScore: 6, weighted: 6 },
+      { name: 'ratio', subScore: 4, weighted: 4 },
+      { name: 'friends', subScore: 2, weighted: 2 }
+    ]
+  };
+
+  it('passes through unchanged when snatch-derived dimensions are included', () => {
+    expect(filterReputationView(crs, { includeSnatchDerived: true })).toBe(crs);
+  });
+
+  it('drops the ratio dimension and recomputes the score when excluded', () => {
+    const view = filterReputationView(crs, { includeSnatchDerived: false });
+    expect(view.dimensions.map((d) => d.name)).toEqual([
+      'longevity',
+      'friends'
+    ]);
+    // score recomputed from the remaining weighted subscores: 6 + 2 = 8
+    expect(view.score).toBe(8);
+  });
+
+  it('is a no-op when there is no snatch-derived dimension present', () => {
+    const noRatio = {
+      score: 8,
+      dimensions: [
+        { name: 'longevity', subScore: 6, weighted: 6 },
+        { name: 'friends', subScore: 2, weighted: 2 }
+      ]
+    };
+    const view = filterReputationView(noRatio, { includeSnatchDerived: false });
+    expect(view.dimensions).toHaveLength(2);
+    expect(view.score).toBe(8);
   });
 });

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -276,3 +276,27 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     stylesheetAdoptionsMade
   });
 };
+
+// Dimensions derived from a member's snatches (downloads/consumed). When a
+// viewer's paranoia hides consumed stats, these are dropped from the reputation
+// VIEW too, so the score they see can't leak the hidden activity. RatioScore is
+// the only consumed-derived dimension (ratio = contributed / consumed).
+export const SNATCH_DERIVED_DIMENSIONS = ['ratio'];
+
+/**
+ * Project a computed CRS into a viewer-safe view. When `includeSnatchDerived`
+ * is false, the snatch-derived dimensions are removed and the displayed score is
+ * recomputed from the remaining weighted subscores — so a paranoia-gated viewer
+ * neither sees the dimension nor can back it out of the total. Pure.
+ */
+export const filterReputationView = (
+  crs: CrsResult,
+  opts: { includeSnatchDerived: boolean }
+): CrsResult => {
+  if (opts.includeSnatchDerived) return crs;
+  const dimensions = crs.dimensions.filter(
+    (d) => !SNATCH_DERIVED_DIMENSIONS.includes(d.name)
+  );
+  const score = dimensions.reduce((sum, d) => sum + d.weighted, 0);
+  return { score, dimensions };
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -11686,6 +11686,22 @@ export interface components {
       ratio?: string;
       children?: components['schemas']['InviteNode'][];
     };
+    CommunityStats: {
+      friends: number;
+      invites: {
+        direct: number;
+        total: number;
+        depth: number;
+      };
+      reputation: {
+        score: number;
+        dimensions: {
+          name: string;
+          subScore: number;
+          weighted: number;
+        }[];
+      };
+    };
     PublicProfile: {
       id: number;
       username: string;
@@ -11716,6 +11732,7 @@ export interface components {
       recentContributions: components['schemas']['ProfileContribution'][];
       recentSnatches: components['schemas']['ProfileSnatch'][];
       inviteTree: components['schemas']['InviteNode'][];
+      community: components['schemas']['CommunityStats'] & unknown;
     };
     MyProfile: {
       id: number;
@@ -11747,6 +11764,7 @@ export interface components {
       recentContributions: components['schemas']['ProfileContribution'][];
       recentSnatches: components['schemas']['ProfileSnatch'][];
       inviteTree: components['schemas']['InviteNode'][];
+      community: components['schemas']['CommunityStats'] & unknown;
       userSettings: components['schemas']['UserSettings'];
     };
     AdminCreatedUser: {


### PR DESCRIPTION
Adds a `community` block to the profile contract (`MyProfile` + `PublicProfile`) carrying the three PRD-01 **Profile Integration** stats not yet surfaced: **Friends count, Invited Users + Invite Tree Depth, and Community Reputation**. No schema change — all substrate already exists (friends model, #154 invite-tree view, CRS).

This gives the stellar-ui profile stats section its API contract; the in-flight InviteTree page (stellar-ui #74) already has #154.

### Visibility — paranoia-tiered (Kai's call)
Reuses the existing `canSee*` flags so it tracks the established privacy model:
| Paranoia | Behaviour |
|---|---|
| 0–1 | Full block, all reputation dimensions |
| 2 ("hide snatch-related CRS") | The snatch-derived **`ratio` dimension drops** out of the reputation view and the score is **recomputed** |
| 3 ("all stats hidden except staff") | `community: null` for non-owner/non-staff |
| owner / staff | Always see everything |

"Snatch-related CRS" is interpreted as the **`ratio` dimension** (ratio = contributed/consumed; consumed = snatches) — the only consumed-derived dimension. Flagged as a product interpretation.

### Changes
- `reputation.ts`: pure `filterReputationView` + `SNATCH_DERIVED_DIMENSIONS = ['ratio']` (drops snatch-derived dims and recomputes the displayed score so a gated viewer can't back it out).
- `profile.ts`: pure exported `buildCommunityStats` (the testable gating/shaping) + `friends.count` / `getMemberInviteTreeView` / `getReputation` folded into the existing `Promise.all`, **only queried when visible**.
- `openapi.ts`: `CommunityStats` schema added to both profile schemas; regenerated `openapi.json` + `src/types/api.ts`.

### Notes
- `invites` surfaces `{ direct, total, depth }` from the #154 summary so the UI picks its "Invited Users" semantics.
- **Donation summary excluded** this slice (per scope); "Community Participation" already approximated by the existing `activitySummary`.
- Friends count uses the current directional `Friend` model — update to accepted-relationship count when #191 lands. `reputation.ts` also overlaps #192. Rebase order: **#191 → #192 → this**.

### Tests
`reputation.spec.ts` (filterReputationView) + new `profileCommunity.spec.ts` (buildCommunityStats gating across tiers). Full unit suite **1580 passed**; `standing` integration (exercises the profile route's new query path) **green**; `lint` / `tsc --noEmit` / `typecheck:test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQTJsBVrQij84uRKaCqQq