### PR TITLE
docs(context-map): codify the paired-UI-issue + openapi-registration convention

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -10,4 +10,13 @@ Stellar's domain spans multiple repositories; one of them (`korin.pink`) is **ex
 
 **Cross-repo / system-wide decisions live in this repo's `docs/adr/`** — notably [ADR-0013](./docs/adr/0013-korin-pink-irc-integration.md) (the korin↔stellar integration boundary) and [ADR-0016](./docs/adr/0016-ledger-accounting-contract.md) (the consumption-accounting & ratio-gate contract). Each other repo carries its own context-scoped ADRs.
 
+## Contract hygiene — pairing API surfaces with UI tracking
+
+When an API PR adds or changes a **UI-consumable surface** — a new route, a response-shape change, or a new OpenAPI schema — it carries a paired obligation on the frontend. Before considering the work done:
+
+1. **Register the route in the OpenAPI contract** (`src/lib/openapi.ts`). The registry is manual: a route that exists but isn't registered is invisible to `openapi.json`, so stellar-ui's generated `src/types/api.ts` can't see it and the UI can't consume it type-safely. An unregistered route is a silent contract gap (e.g. the IRC nick-link routes shipped in #175 without registration — see #198).
+2. **File a paired stellar-ui tracking issue**, linking the API PR — or explicitly note that no UI consumes the surface. A backend feature with no UI issue is how features ship half-built and untracked; the stellar-ui side does not auto-discover API work.
+
+This keeps the API↔UI seam honest in both directions: the contract exposes what the UI needs, and the tracker reflects what's actually left to build.
+
 > stellar-ui's `CONTEXT.md` currently lands via the `wip/theming-corpus` branch (PR pending); the link resolves once merged.


### PR DESCRIPTION
## Context

A large API arc shipped this session (CRS #190–197, User-Classes #167–171, friends lifecycle, profile community block, IRC nick-link #175) — but stellar-ui had only 2 tracking issues and several surfaces shipped UI-requiring work with no UI issue. One route (#175 IRC nick-link) even shipped **outside the OpenAPI registry**, making it invisible to the UI's generated types.

This codifies the convention so the API↔UI seam stays honest.

## What this adds

A "Contract hygiene" section to `CONTEXT-MAP.md`: when an API PR adds/changes a UI-consumable surface, it carries two paired obligations —

1. **Register the route in `src/lib/openapi.ts`** (the registry is manual — an unregistered route is invisible to `openapi.json` and to stellar-ui's generated `api.ts`).
2. **File a paired stellar-ui tracking issue** linking the API PR, or note that no UI consumes it.

## Companion changes (already up)

- stellar-ui #79 — the api.ts resync that closed the immediate type-drift, + a matching CONTRIBUTING.md checklist item.
- stellar-ui #80–#85 — the paired UI tracking issues this convention would have produced.
- stellar-api #198 — register the #175 IRC routes in OpenAPI (the concrete instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)