### PR TITLE
feat(classes): RankPromotionRule CRUD + per-user progression endpoint (#170, #171)

### DIFF
--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -917,6 +917,51 @@ registry.registerPath({
   }
 });
 
+const ProgressionGap = registry.register(
+  'ProgressionGap',
+  z.object({
+    toRankName: z.string().nullable(),
+    contributedShortBytes: z.string(),
+    ratioShort: z.number(),
+    contributionsShort: z.number(),
+    ageShortDays: z.number(),
+    extraUnmet: z
+      .enum(['DISTINCT_RELEASES_500', 'QUALITY_CONTRIB_500'])
+      .nullable()
+  })
+);
+
+const ProfileProgression = registry.register(
+  'ProfileProgression',
+  z.object({
+    currentRankId: z.number(),
+    currentRankName: z.string().nullable(),
+    rankLocked: z.boolean(),
+    // null at the top of the auto ladder
+    gap: ProgressionGap.nullable()
+  })
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/profile/me/progression',
+  tags: ['Profile'],
+  responses: {
+    200: {
+      description: 'Gap to the next auto-class rung',
+      content: { 'application/json': { schema: ProfileProgression } }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Profile not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 registry.registerPath({
   method: 'get',
   path: '/profile/user/{userId}',
@@ -3294,6 +3339,147 @@ registry.registerPath({
     },
     409: {
       description: 'Rank still assigned to users',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+// ─── Rank Promotion Rules (#170) ─────────────────────────────────────────────────
+// minContributed is bytes and crosses the wire as a string (past MAX_SAFE_INTEGER).
+
+const RankExtraPredicateEnum = z
+  .enum(['DISTINCT_RELEASES_500', 'QUALITY_CONTRIB_500'])
+  .nullable();
+
+const PromotionRule = registry.register(
+  'PromotionRule',
+  z.object({
+    id: z.number(),
+    fromRankId: z.number(),
+    fromRankName: z.string().nullable(),
+    toRankId: z.number(),
+    toRankName: z.string().nullable(),
+    minContributed: z.string(),
+    minRatio: z.number(),
+    minContributions: z.number(),
+    minAccountAgeDays: z.number(),
+    extra: RankExtraPredicateEnum,
+    enabled: z.boolean(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
+const PromotionRuleCreateBody = z.object({
+  fromRankId: z.number().int().positive(),
+  toRankId: z.number().int().positive(),
+  minContributed: z.string().optional(),
+  minRatio: z.number().min(0).optional(),
+  minContributions: z.number().int().min(0).optional(),
+  minAccountAgeDays: z.number().int().min(0).optional(),
+  extra: RankExtraPredicateEnum.optional(),
+  enabled: z.boolean().optional()
+});
+
+const PromotionRuleUpdateBody = PromotionRuleCreateBody.partial();
+
+registry.registerPath({
+  method: 'get',
+  path: '/tools/promotion-rules',
+  tags: ['Tools'],
+  responses: {
+    200: {
+      description: 'Promotion rules',
+      content: { 'application/json': { schema: z.array(PromotionRule) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/tools/promotion-rules/{id}',
+  tags: ['Tools'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Promotion rule',
+      content: { 'application/json': { schema: PromotionRule } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/tools/promotion-rules',
+  tags: ['Tools'],
+  request: {
+    body: {
+      content: { 'application/json': { schema: PromotionRuleCreateBody } }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Promotion rule created',
+      content: { 'application/json': { schema: PromotionRule } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    409: {
+      description: 'Duplicate rank pair',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    422: {
+      description: 'fromRank or toRank not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/tools/promotion-rules/{id}',
+  tags: ['Tools'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: { 'application/json': { schema: PromotionRuleUpdateBody } }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Promotion rule updated',
+      content: { 'application/json': { schema: PromotionRule } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    409: {
+      description: 'Duplicate rank pair',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    422: {
+      description: 'fromRank or toRank not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/tools/promotion-rules/{id}',
+  tags: ['Tools'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    204: { description: 'Promotion rule deleted' },
+    404: {
+      description: 'Not found',
       content: { 'application/json': { schema: MsgResponse } }
     }
   }

--- a/src/profile.spec.ts
+++ b/src/profile.spec.ts
@@ -17,14 +17,29 @@ jest.mock('./modules/ratioPolicy', () => ({
   getPolicyState: jest.fn()
 }));
 
+jest.mock('./modules/rankProgressionJob', () => ({
+  // startRankProgressionJob is invoked at app bootstrap — keep it a noop
+  startRankProgressionJob: jest.fn(),
+  loadLadder: jest.fn(),
+  buildProgressionInput: jest.fn()
+}));
+
 import { getRatioStats } from './modules/ratio';
 import { getPolicyState } from './modules/ratioPolicy';
+import {
+  loadLadder,
+  buildProgressionInput
+} from './modules/rankProgressionJob';
 
 const getRatioStatsMock = getRatioStats as jest.MockedFunction<
   typeof getRatioStats
 >;
 const getPolicyStateMock = getPolicyState as jest.MockedFunction<
   typeof getPolicyState
+>;
+const loadLadderMock = loadLadder as jest.MockedFunction<typeof loadLadder>;
+const buildProgressionInputMock = buildProgressionInput as jest.MockedFunction<
+  typeof buildProgressionInput
 >;
 
 const mockProfile = {
@@ -199,5 +214,79 @@ describe('POST /api/profile/referral/create-invite', () => {
       .send({ reason: 'No email provided' });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ─── GET /api/profile/me/progression (#171) ──────────────────────────────────────
+
+describe('GET /api/profile/me/progression', () => {
+  const ladderWithOneRung = {
+    ranks: [{ id: 2, level: 150, name: 'Member', autoManaged: true }],
+    rules: [
+      {
+        fromRankId: 1,
+        toRankId: 2,
+        minContributed: BigInt(10),
+        minRatio: 0.7,
+        minContributions: 0,
+        minAccountAgeDays: 7,
+        extra: null,
+        enabled: true
+      }
+    ]
+  };
+
+  const midLadderInput = {
+    currentRankId: 1,
+    contributed: BigInt(0),
+    consumed: BigInt(0),
+    contributionCount: 0,
+    distinctReleaseCount: 0,
+    qualityContributionCount: 0,
+    accountAgeDays: 0,
+    hasActiveWarning: false,
+    rankLocked: false
+  };
+
+  beforeEach(() => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 7,
+      userRankId: 1,
+      consumed: BigInt(0),
+      dateRegistered: new Date('2026-01-01T00:00:00Z'),
+      rankLocked: false,
+      userRank: { name: 'User' }
+    } as never);
+    buildProgressionInputMock.mockResolvedValue(midLadderInput as never);
+  });
+
+  it('returns a shaped gap with contributedShortBytes as a string', async () => {
+    loadLadderMock.mockResolvedValue(ladderWithOneRung as never);
+
+    const res = await request(app).get('/api/profile/me/progression');
+
+    expect(res.status).toBe(200);
+    expect(res.body.currentRankName).toBe('User');
+    expect(res.body.gap.toRankName).toBe('Member');
+    expect(res.body.gap.contributedShortBytes).toBe('10');
+    expect(typeof res.body.gap.contributedShortBytes).toBe('string');
+  });
+
+  it('returns a null gap at the top of the auto ladder', async () => {
+    loadLadderMock.mockResolvedValue({ ranks: [], rules: [] } as never);
+
+    const res = await request(app).get('/api/profile/me/progression');
+
+    expect(res.status).toBe(200);
+    expect(res.body.gap).toBeNull();
+  });
+
+  it('returns 404 when the user record is missing', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    loadLadderMock.mockResolvedValue(ladderWithOneRung as never);
+
+    const res = await request(app).get('/api/profile/me/progression');
+
+    expect(res.status).toBe(404);
   });
 });

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -9,6 +9,11 @@ import {
 } from '../../modules/profile';
 import { getRatioStats } from '../../modules/ratio';
 import { getReputation } from '../../modules/reputation';
+import {
+  loadLadder,
+  buildProgressionInput
+} from '../../modules/rankProgressionJob';
+import { describeGapToNext } from '../../modules/rankProgression';
 import { getPolicyState } from '../../modules/ratioPolicy';
 import { requireAuth } from '../../middleware/auth';
 import { audit } from '../../lib/audit';
@@ -91,6 +96,45 @@ router.get(
   requireAuth,
   authHandler(async (req, res) => {
     res.json(await getReputation(req.user.id));
+  })
+);
+
+// GET /api/profile/me/progression — gap to the next auto-class rung (#171)
+router.get(
+  '/me/progression',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: {
+        id: true,
+        userRankId: true,
+        consumed: true,
+        dateRegistered: true,
+        rankLocked: true,
+        userRank: { select: { name: true } }
+      }
+    });
+    if (!user) return res.status(404).json({ msg: 'Profile not found' });
+
+    // Reuse the DB-backed ladder + the same per-user input builder the sweep
+    // uses, so the widget never drifts from the actual promotion engine.
+    const { ranks, rules } = await loadLadder();
+    const input = await buildProgressionInput(user);
+    const gap = describeGapToNext(input, rules, ranks);
+
+    res.json({
+      currentRankId: user.userRankId,
+      currentRankName: user.userRank?.name ?? null,
+      rankLocked: user.rankLocked,
+      gap: gap
+        ? {
+            ...gap,
+            // bytes — string-encoded past MAX_SAFE_INTEGER
+            contributedShortBytes: gap.contributedShortBytes.toString()
+          }
+        : null
+    });
   })
 );
 

--- a/src/routes/api/tools.ts
+++ b/src/routes/api/tools.ts
@@ -18,8 +18,12 @@ import {
 import {
   createRankSchema,
   updateRankSchema,
+  createPromotionRuleSchema,
+  updatePromotionRuleSchema,
   type CreateRankInput,
-  type UpdateRankInput
+  type UpdateRankInput,
+  type CreatePromotionRuleInput,
+  type UpdatePromotionRuleInput
 } from '../../schemas/tools';
 import {
   createStaffGroupSchema,
@@ -35,6 +39,33 @@ const userRankIdParamsSchema = z.object({
 });
 const staffGroupIdParamsSchema = z.object({
   id: z.coerce.number().int().positive()
+});
+const promotionRuleIdParamsSchema = z.object({
+  id: z.coerce.number().int().positive()
+});
+
+const formatPromotionRule = (
+  r: Prisma.RankPromotionRuleGetPayload<{
+    include: {
+      fromRank: { select: { name: true } };
+      toRank: { select: { name: true } };
+    };
+  }>
+) => ({
+  id: r.id,
+  fromRankId: r.fromRankId,
+  fromRankName: r.fromRank?.name ?? null,
+  toRankId: r.toRankId,
+  toRankName: r.toRank?.name ?? null,
+  // bytes — serialized as a string to survive values past MAX_SAFE_INTEGER
+  minContributed: r.minContributed.toString(),
+  minRatio: r.minRatio,
+  minContributions: r.minContributions,
+  minAccountAgeDays: r.minAccountAgeDays,
+  extra: r.extra,
+  enabled: r.enabled,
+  createdAt: r.createdAt,
+  updatedAt: r.updatedAt
 });
 
 const formatRank = (
@@ -304,6 +335,206 @@ router.delete(
           actorId: req.user.id,
           action: 'rank.delete',
           targetType: 'UserRank',
+          targetId: id
+        }
+      })
+    ]);
+    res.status(204).send();
+  })
+);
+
+// ─── Rank Promotion Rules (#170) ─────────────────────────────────────────────────
+// CRUD over the auto-class evaluator's rule table. Same gate as the rest of the
+// rank tooling (rank_permissions_manage). The unique [fromRankId, toRankId] pair
+// surfaces as a 409.
+
+const promotionRuleInclude = {
+  fromRank: { select: { name: true } },
+  toRank: { select: { name: true } }
+} as const;
+
+// GET /api/tools/promotion-rules — list all promotion rules
+router.get(
+  '/promotion-rules',
+  ...requirePermission('rank_permissions_manage'),
+  asyncHandler(async (_req: Request, res: Response) => {
+    const rules = await prisma.rankPromotionRule.findMany({
+      orderBy: [{ fromRankId: 'asc' }, { toRankId: 'asc' }],
+      include: promotionRuleInclude
+    });
+    res.json(rules.map(formatPromotionRule));
+  })
+);
+
+// GET /api/tools/promotion-rules/:id — single promotion rule
+router.get(
+  '/promotion-rules/:id',
+  ...requirePermission('rank_permissions_manage'),
+  validateParams(promotionRuleIdParamsSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const rule = await prisma.rankPromotionRule.findUnique({
+      where: { id },
+      include: promotionRuleInclude
+    });
+    if (!rule) return res.status(404).json({ msg: 'Promotion rule not found' });
+    res.json(formatPromotionRule(rule));
+  })
+);
+
+// POST /api/tools/promotion-rules — create a promotion rule
+router.post(
+  '/promotion-rules',
+  ...requirePermission('rank_permissions_manage'),
+  validate(createPromotionRuleSchema),
+  authHandler(async (req, res) => {
+    const data = parsedBody<CreatePromotionRuleInput>(res);
+
+    const rankCount = await prisma.userRank.count({
+      where: { id: { in: [data.fromRankId, data.toRankId] } }
+    });
+    if (rankCount !== 2) {
+      return res.status(422).json({ msg: 'fromRank or toRank does not exist' });
+    }
+
+    try {
+      const rule = await prisma.rankPromotionRule.create({
+        data: {
+          fromRankId: data.fromRankId,
+          toRankId: data.toRankId,
+          minContributed: data.minContributed,
+          minRatio: data.minRatio,
+          minContributions: data.minContributions,
+          minAccountAgeDays: data.minAccountAgeDays,
+          extra: data.extra,
+          enabled: data.enabled
+        },
+        include: promotionRuleInclude
+      });
+
+      await audit(
+        prisma,
+        req.user.id,
+        'promotionRule.create',
+        'RankPromotionRule',
+        rule.id,
+        { fromRankId: rule.fromRankId, toRankId: rule.toRankId }
+      );
+      res.status(201).json(formatPromotionRule(rule));
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        return res
+          .status(409)
+          .json({ msg: 'A rule for this rank pair already exists' });
+      }
+      throw err;
+    }
+  })
+);
+
+// PUT /api/tools/promotion-rules/:id — update a promotion rule
+router.put(
+  '/promotion-rules/:id',
+  ...requirePermission('rank_permissions_manage'),
+  validateParams(promotionRuleIdParamsSchema),
+  validate(updatePromotionRuleSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+
+    const existing = await prisma.rankPromotionRule.findUnique({
+      where: { id }
+    });
+    if (!existing) {
+      return res.status(404).json({ msg: 'Promotion rule not found' });
+    }
+
+    const body = parsedBody<UpdatePromotionRuleInput>(res);
+
+    const rankIds = [body.fromRankId, body.toRankId].filter(
+      (v): v is number => v !== undefined
+    );
+    if (rankIds.length > 0) {
+      const rankCount = await prisma.userRank.count({
+        where: { id: { in: rankIds } }
+      });
+      if (rankCount !== rankIds.length) {
+        return res
+          .status(422)
+          .json({ msg: 'fromRank or toRank does not exist' });
+      }
+    }
+
+    try {
+      const rule = await prisma.rankPromotionRule.update({
+        where: { id },
+        data: {
+          ...(body.fromRankId !== undefined && { fromRankId: body.fromRankId }),
+          ...(body.toRankId !== undefined && { toRankId: body.toRankId }),
+          ...(body.minContributed !== undefined && {
+            minContributed: body.minContributed
+          }),
+          ...(body.minRatio !== undefined && { minRatio: body.minRatio }),
+          ...(body.minContributions !== undefined && {
+            minContributions: body.minContributions
+          }),
+          ...(body.minAccountAgeDays !== undefined && {
+            minAccountAgeDays: body.minAccountAgeDays
+          }),
+          ...(body.extra !== undefined && { extra: body.extra }),
+          ...(body.enabled !== undefined && { enabled: body.enabled })
+        },
+        include: promotionRuleInclude
+      });
+
+      await audit(
+        prisma,
+        req.user.id,
+        'promotionRule.update',
+        'RankPromotionRule',
+        id,
+        { ...body, minContributed: body.minContributed?.toString() }
+      );
+      res.json(formatPromotionRule(rule));
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        return res
+          .status(409)
+          .json({ msg: 'A rule for this rank pair already exists' });
+      }
+      throw err;
+    }
+  })
+);
+
+// DELETE /api/tools/promotion-rules/:id — delete a promotion rule
+router.delete(
+  '/promotion-rules/:id',
+  ...requirePermission('rank_permissions_manage'),
+  validateParams(promotionRuleIdParamsSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+
+    const existing = await prisma.rankPromotionRule.findUnique({
+      where: { id },
+      select: { id: true }
+    });
+    if (!existing) {
+      return res.status(404).json({ msg: 'Promotion rule not found' });
+    }
+
+    await prisma.$transaction([
+      prisma.rankPromotionRule.delete({ where: { id } }),
+      prisma.auditLog.create({
+        data: {
+          actorId: req.user.id,
+          action: 'promotionRule.delete',
+          targetType: 'RankPromotionRule',
           targetId: id
         }
       })

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { RankExtraPredicate } from '@prisma/client';
 import {
   normalizePermissions,
   VALID_PERMISSIONS
@@ -41,3 +42,48 @@ export const updateRankSchema = z
 
 export type CreateRankInput = z.infer<typeof createRankSchema>;
 export type UpdateRankInput = z.infer<typeof updateRankSchema>;
+
+// ─── Rank promotion rules (#170) ────────────────────────────────────────────────
+// One row drives the auto-class evaluator's "from → to" rung (see
+// rankProgression.ts RankPromotionRule). minContributed is bytes, so it crosses
+// the wire as a string to survive values past Number.MAX_SAFE_INTEGER.
+
+export const createPromotionRuleSchema = z
+  .object({
+    fromRankId: z.number().int().positive(),
+    toRankId: z.number().int().positive(),
+    minContributed: z.coerce.bigint().nonnegative().default(BigInt(0)),
+    minRatio: z.number().min(0).default(0),
+    minContributions: z.number().int().min(0).default(0),
+    minAccountAgeDays: z.number().int().min(0).default(0),
+    extra: z.nativeEnum(RankExtraPredicate).nullable().default(null),
+    enabled: z.boolean().default(true)
+  })
+  .refine((v) => v.fromRankId !== v.toRankId, {
+    message: 'fromRankId and toRankId must differ'
+  });
+
+export const updatePromotionRuleSchema = z
+  .object({
+    fromRankId: z.number().int().positive().optional(),
+    toRankId: z.number().int().positive().optional(),
+    minContributed: z.coerce.bigint().nonnegative().optional(),
+    minRatio: z.number().min(0).optional(),
+    minContributions: z.number().int().min(0).optional(),
+    minAccountAgeDays: z.number().int().min(0).optional(),
+    extra: z.nativeEnum(RankExtraPredicate).nullable().optional(),
+    enabled: z.boolean().optional()
+  })
+  .refine((v) => Object.keys(v).length > 0, {
+    message: 'At least one field required'
+  })
+  .refine((v) => v.fromRankId === undefined || v.fromRankId !== v.toRankId, {
+    message: 'fromRankId and toRankId must differ'
+  });
+
+export type CreatePromotionRuleInput = z.infer<
+  typeof createPromotionRuleSchema
+>;
+export type UpdatePromotionRuleInput = z.infer<
+  typeof updatePromotionRuleSchema
+>;

--- a/src/tools.spec.ts
+++ b/src/tools.spec.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import {
   request,
   app,
@@ -347,6 +348,193 @@ describe('DELETE /api/tools/staff-groups/:id', () => {
     prismaMock.staffGroup.findUnique.mockResolvedValue(null);
 
     const res = await request(app).delete('/api/tools/staff-groups/999');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Promotion rules (#170) ─────────────────────────────────────────────────────
+
+const makePromotionRule = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  fromRankId: 1,
+  toRankId: 2,
+  fromRank: { name: 'User' },
+  toRank: { name: 'Member' },
+  minContributed: BigInt('536870912000'),
+  minRatio: 1.05,
+  minContributions: 5,
+  minAccountAgeDays: 14,
+  extra: null,
+  enabled: true,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides
+});
+
+const dupPairError = () =>
+  new Prisma.PrismaClientKnownRequestError('Unique constraint', {
+    code: 'P2002',
+    clientVersion: 'test'
+  });
+
+describe('GET /api/tools/promotion-rules', () => {
+  beforeEach(() => {
+    setRankPermissionsManager();
+  });
+
+  it('lists rules with minContributed serialized as a string', async () => {
+    prismaMock.rankPromotionRule.findMany.mockResolvedValue([
+      makePromotionRule()
+    ] as never);
+
+    const res = await request(app).get('/api/tools/promotion-rules');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].minContributed).toBe('536870912000');
+    expect(res.body[0].fromRankName).toBe('User');
+    expect(res.body[0].toRankName).toBe('Member');
+  });
+
+  it('returns 403 without rank_permissions_manage permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
+
+    const res = await request(app).get('/api/tools/promotion-rules');
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/tools/promotion-rules/:id', () => {
+  beforeEach(() => {
+    setRankPermissionsManager();
+  });
+
+  it('returns a single rule', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(
+      makePromotionRule() as never
+    );
+
+    const res = await request(app).get('/api/tools/promotion-rules/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.minContributed).toBe('536870912000');
+  });
+
+  it('returns 404 when the rule does not exist', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/tools/promotion-rules/999');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/tools/promotion-rules', () => {
+  beforeEach(() => {
+    setRankPermissionsManager();
+  });
+
+  it('creates a rule and returns 201 with string minContributed', async () => {
+    prismaMock.userRank.count.mockResolvedValue(2);
+    prismaMock.rankPromotionRule.create.mockResolvedValue(
+      makePromotionRule() as never
+    );
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .post('/api/tools/promotion-rules')
+      .send({ fromRankId: 1, toRankId: 2, minContributed: '536870912000' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.minContributed).toBe('536870912000');
+  });
+
+  it('returns 422 when a referenced rank does not exist', async () => {
+    prismaMock.userRank.count.mockResolvedValue(1);
+
+    const res = await request(app)
+      .post('/api/tools/promotion-rules')
+      .send({ fromRankId: 1, toRankId: 99 });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 400 when fromRankId equals toRankId', async () => {
+    const res = await request(app)
+      .post('/api/tools/promotion-rules')
+      .send({ fromRankId: 1, toRankId: 1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 on a duplicate rank pair', async () => {
+    prismaMock.userRank.count.mockResolvedValue(2);
+    prismaMock.rankPromotionRule.create.mockRejectedValue(dupPairError());
+
+    const res = await request(app)
+      .post('/api/tools/promotion-rules')
+      .send({ fromRankId: 1, toRankId: 2 });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('PUT /api/tools/promotion-rules/:id', () => {
+  beforeEach(() => {
+    setRankPermissionsManager();
+  });
+
+  it('updates a rule and returns 200', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(
+      makePromotionRule() as never
+    );
+    prismaMock.rankPromotionRule.update.mockResolvedValue(
+      makePromotionRule({ minRatio: 1.2 }) as never
+    );
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .put('/api/tools/promotion-rules/1')
+      .send({ minRatio: 1.2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.minRatio).toBe(1.2);
+  });
+
+  it('returns 404 when the rule does not exist', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/tools/promotion-rules/999')
+      .send({ enabled: false });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/tools/promotion-rules/:id', () => {
+  beforeEach(() => {
+    setRankPermissionsManager();
+  });
+
+  it('deletes a rule and returns 204', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue({
+      id: 1
+    } as never);
+    prismaMock.$transaction.mockResolvedValue([{}, {}] as never);
+
+    const res = await request(app).delete('/api/tools/promotion-rules/1');
+
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 404 when the rule does not exist', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).delete('/api/tools/promotion-rules/999');
 
     expect(res.status).toBe(404);
   });


### PR DESCRIPTION
Wires the two stellar-api halves of the User-Classes slice the stellar-ui work is blocked on. Schema (`RankPromotionRule`, #185) and the scoring helpers already landed in main — this is pure route + registry work, no schema change.

## #170 — RankPromotionRule CRUD
`/api/tools/promotion-rules` (GET list, GET :id, POST, PUT, DELETE), gated with `rank_permissions_manage` (consistent with the rest of the rank tooling in `tools.ts`).
- Validates both referenced ranks exist → **422**
- Unique `[fromRankId, toRankId]` pair → **409**
- `fromRankId === toRankId` rejected at validation → **400**
- `minContributed` (bytes) serialized as a **string** past `MAX_SAFE_INTEGER`
- Audited (`promotionRule.create/update/delete`)
- Unblocks stellar-ui **#83** (admin promotion-rule editor)

## #171 — per-user progress-to-next-class
`GET /api/profile/me/progression` returns the member's gap to the next auto-class rung. Reuses `loadLadder` + `buildProgressionInput` + `describeGapToNext` verbatim so the widget never drifts from the promotion engine; `gap` is `null` at the top of the ladder.
- Unblocks stellar-ui **#84** (progress-to-next-class widget)

Both surfaces registered in the manual OpenAPI registry (`src/lib/openapi.ts`) so stellar-ui's `api:generate` can consume them.

## Tests
- `src/tools.spec.ts` — CRUD happy paths, 403 gate, 404, 422 (missing rank), 400 (same rank), 409 (duplicate pair via a real `Prisma.PrismaClientKnownRequestError`), bigint-as-string
- `src/profile.spec.ts` — shaped gap + bigint-as-string, null gap at top of ladder, 404 missing user

Gates: `format` · `lint` · `tsc --noEmit` · `typecheck:test` · full suite (1625 passed) all clean.

## Follow-up (post-merge)
Regen stellar-ui `api.ts` (`npm run api:generate` after syncing `../stellar-api` main) so #83/#84 become buildable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)