### PR TITLE
ADR-0018: development lifecycle + enforced API/UI contract gate (closes #204)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Something behaves incorrectly, with the fix's Definition of Done
+labels: needs-triage
+---
+
+## Expected vs. actual
+
+<!-- What should happen, and what happens instead. -->
+
+**Expected:**
+
+**Actual:**
+
+## Reproduction
+
+<!-- Steps, request/response, or a failing test that demonstrates it. -->
+
+## Acceptance criteria (Definition of Done)
+
+<!-- What must be true for the fix to be accepted (ADR-0018, step 6). A regression test that fails before and passes after is the strongest form. -->
+
+- [ ] Regression test reproduces the bug (red) and passes after the fix (green).
+- [ ]
+
+## Notes
+
+<!-- Affected routes/modules, related issues, suspected cause. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,27 @@
+---
+name: Feature / enhancement
+about: A new capability or change to existing behavior, with its Definition of Done
+labels: needs-triage
+---
+
+## Context
+
+<!-- What behavior do we want, and why? For parity-driven work, describe the target behavior on its own terms (capabilities, flows) — do not name any prior/legacy system (ADR-0018, step 1). For net-new work, describe the product intent. -->
+
+## Acceptance criteria (Definition of Done)
+
+<!-- The testable checklist that QA verifies (ADR-0018, step 6). Be specific enough that "done" is observable, not a matter of opinion. -->
+
+- [ ]
+- [ ]
+
+## Contract & UI pairing
+
+<!-- Per CONTEXT-MAP "Contract hygiene" and ADR-0018 steps 2/4. Delete the line that doesn't apply. -->
+
+- [ ] This adds/changes a UI-consumable surface → the route is (or will be) registered in `src/lib/openapi.ts`, and a paired stellar-ui tracking issue is linked here.
+- [ ] No UI consumes this surface (internal/CI/infra change).
+
+## Notes
+
+<!-- Links to PRD/ADR, related issues, constraints. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- What this PR changes and why. -->
+
+## Linked issue(s)
+
+<!-- e.g. "Closes #123". Every PR should trace to an issue carrying acceptance criteria. -->
+
+Closes #
+
+## Acceptance criteria
+
+<!-- Copy the issue's Definition of Done and check each item as QA confirms it (ADR-0018, step 6). -->
+
+- [ ]
+
+## QA — agent-run (ADR-0018, step 6)
+
+- [ ] Unit + integration tests pass.
+- [ ] E2E / regression verified for the affected flows (`/verify`, Playwright / Chrome DevTools where applicable).
+- [ ] OpenAPI gate green — any new/changed route is registered in `src/lib/openapi.ts` and `openapi.json` is regenerated.
+- [ ] ERD gate green — `docs/erd.md` regenerated if the schema changed.
+
+## UAT — human (ADR-0018, step 6)
+
+- [ ] Stakeholder acceptance over the green checklist above. (This is the one step that is not delegable.)
+
+## Security review (ADR-0018, step 7)
+
+<!-- The "Security review gate" workflow enforces this for changes under src/middleware/**. Tick exactly one. -->
+
+- [ ] `/security-review` completed — required for changes to `src/middleware/**` (auth, permissions, `serviceAuth`, rate limiting, validation) or any new route.
+- [ ] N/A — no auth-sensitive paths touched.
+
+## Contract & UI pairing (CONTEXT-MAP "Contract hygiene")
+
+- [ ] Paired stellar-ui tracking issue linked, or "no UI consumes this surface" noted.

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -1,0 +1,38 @@
+name: Security review gate
+
+# ADR-0018, step 7: changes to auth-sensitive middleware must not merge without a
+# /security-review. The gate is deliberately scoped to src/middleware/** (auth,
+# permissions, serviceAuth, rate limiting, validation) — the genuinely security-
+# critical surface — rather than every route change, so it stays high-signal and
+# does not erode into reflexive rubber-stamping. New-route coverage is author-
+# attested via the PR template checklist.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+      - develop
+    paths:
+      - 'src/middleware/**'
+
+permissions:
+  pull-requests: read
+
+jobs:
+  require-security-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a completed security review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          body="$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json body --jq '.body // ""')"
+          if printf '%s' "$body" | grep -qiE '^\s*-\s*\[x\].*security[ -]review'; then
+            echo "Security review confirmed in the PR description."
+          else
+            echo "::error::This PR changes auth-sensitive middleware (src/middleware/**)." \
+                 "Run /security-review and tick the 'security-review completed' box in the PR description."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ node_modules/
 dist/
 src/**/*.js
 src/**/*.js.map
-openapi.json
 .DS_Store
 .playwright-mcp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 # Generated artifacts — leave byte-identical to their generators so the
 # committed file never drifts from a fresh `prisma generate` / export.
 docs/erd.md
+openapi.json

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -8,7 +8,7 @@ Stellar's domain spans multiple repositories; one of them (`korin.pink`) is **ex
 | **Frontend**                 | `orphic-inc/stellar-ui`              | [stellar-ui `CONTEXT.md`](https://github.com/orphic-inc/stellar-ui/blob/main/CONTEXT.md)    | stellar-ui `docs/adr/`     | React/TS client; the theming subsystem glossary                               |
 | **IRC + accounting sidecar** | `obrien-k/korin-pink` _(external)_   | [korin `docs/CONTEXT.md`](https://github.com/obrien-k/korin-pink/blob/main/docs/CONTEXT.md) | korin `docs/adr/`          | IRC substrate (Ergo + bridge + wiki) and the Go `ledger` accounting authority |
 
-**Cross-repo / system-wide decisions live in this repo's `docs/adr/`** — notably [ADR-0013](./docs/adr/0013-korin-pink-irc-integration.md) (the korin↔stellar integration boundary) and [ADR-0016](./docs/adr/0016-ledger-accounting-contract.md) (the consumption-accounting & ratio-gate contract). Each other repo carries its own context-scoped ADRs.
+**Cross-repo / system-wide decisions live in this repo's `docs/adr/`** — notably [ADR-0013](./docs/adr/0013-korin-pink-irc-integration.md) (the korin↔stellar integration boundary), [ADR-0016](./docs/adr/0016-ledger-accounting-contract.md) (the consumption-accounting & ratio-gate contract), and [ADR-0018](./docs/adr/0018-development-lifecycle-and-contract-gate.md) (the development lifecycle and the enforced API/UI contract gate). Each other repo carries its own context-scoped ADRs.
 
 ## Contract hygiene — pairing API surfaces with UI tracking
 

--- a/docs/adr/0018-development-lifecycle-and-contract-gate.md
+++ b/docs/adr/0018-development-lifecycle-and-contract-gate.md
@@ -1,6 +1,6 @@
 # ADR-0018: Development lifecycle and the API/UI contract gate
 
-**Status:** Proposed
+**Status:** Accepted (2026-06-20)
 **Date:** 2026-06-20
 **Repos:** orphic-inc/stellar-api, orphic-inc/stellar-ui (+ external obrien-k/korin-pink)
 **Relates:** [ADR-0009 — fork workflow & dependency discipline](0009-fork-workflow-and-dependency-discipline.md), [ADR-0010 — trunk-based single-branch workflow](0010-trunk-based-single-branch-workflow.md), [ADR-0013 — korin.pink IRC integration](0013-korin-pink-irc-integration.md), [ADR-0016 — consumption accounting & ratio-gate contract](0016-ledger-accounting-contract.md)

--- a/docs/adr/0018-development-lifecycle-and-contract-gate.md
+++ b/docs/adr/0018-development-lifecycle-and-contract-gate.md
@@ -1,0 +1,72 @@
+# ADR-0018: Development lifecycle and the API/UI contract gate
+
+**Status:** Proposed
+**Date:** 2026-06-20
+**Repos:** orphic-inc/stellar-api, orphic-inc/stellar-ui (+ external obrien-k/korin-pink)
+**Relates:** [ADR-0009 — fork workflow & dependency discipline](0009-fork-workflow-and-dependency-discipline.md), [ADR-0010 — trunk-based single-branch workflow](0010-trunk-based-single-branch-workflow.md), [ADR-0013 — korin.pink IRC integration](0013-korin-pink-irc-integration.md), [ADR-0016 — consumption accounting & ratio-gate contract](0016-ledger-accounting-contract.md)
+**Tracks:** the OpenAPI freshness gate fix ([#204](https://github.com/orphic-inc/stellar-api/issues/204))
+
+---
+
+## Context
+
+The constellation already has a working delivery loop: establish target behavior, write a PRD/ADR with `/grill-with-docs`, build the API test-first with `/tdd`, file the matching stellar-ui work, build the UI test-first, verify, integrate via Stellar Compose, and sweep stale branches with `/mr-robot`. The loop is sound in skeleton. A QA review of it surfaced three defects that are worth settling as a decision rather than carrying as tribal knowledge, because each is a recurring failure mode rather than a one-off.
+
+First, the API→UI handoff is an unguarded seam. The OpenAPI contract (`src/lib/openapi.ts`, exported to `openapi.json`) is what stellar-ui consumes to generate its `src/types/api.ts`; the CONTEXT-MAP contract-hygiene rule already names an unregistered route as a silent contract gap (the IRC nick-link routes that shipped in #175 without registration, tracked by #198, are the worked example). The drift between the two repos' view of the contract is a known, repeating problem — a process defect, not an isolated bug.
+
+Second, the guard that is supposed to catch that drift is inert. The CI step `npm run openapi:export && git diff --exit-code openapi.json` cannot fail, because `openapi.json` is gitignored and untracked, so the diff compares against nothing. Its sibling ERD freshness step (`npm run db:erd && git diff --exit-code docs/erd.md`) is real only because `docs/erd.md` is committed. We have the right gate shape and the wrong tracking state.
+
+Third, the lifecycle conflates QA with UAT. Verification against a spec (QA) is largely delegable to an agent; stakeholder acceptance (UAT) is, by definition, not. Treating them as one manual step both over-burdens the human and under-uses the automation available.
+
+This ADR codifies the revised lifecycle, splits QA from UAT, and makes the contract seam an enforced gate rather than a convention.
+
+## Decision
+
+Adopt the following lifecycle. Steps 1–8 below supersede the prior informal sequence; the substantive changes are reference-neutral framing of step 1, a contract-first split between steps 2–4, per-issue acceptance criteria as a Definition of Done, an explicit rework loop, the QA/UAT split at step 6, and a security + cross-repo integration gate at step 7.
+
+| #   | Step                                                   | What it produces                                                  | Notes                                                                                                                                                                                                                                                                                                                                                                           |
+| --- | ------------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Reference-implementation parity (gap analysis)**     | A parity gap list                                                 | Establish target behavior by gap analysis against a known-good reference implementation, described on its own terms — capabilities and flows, never by identity. No prior/legacy system is named in the docs (per the repo's no-legacy-references discipline). Net-new features that have no reference enter here too, sourced from product intent rather than a gap.           |
+| 2   | **PRD/ADR via `/grill-with-docs`**                     | A PRD/ADR + a **frozen OpenAPI surface**                          | Standardize the pattern _and_ freeze the contract surface the UI will consume. The route registration in `src/lib/openapi.ts` is part of "spec done," not an afterthought at PR time.                                                                                                                                                                                           |
+| 3   | **API implementation via `/tdd`**                      | API + tests + registered routes                                   | Red-green-refactor. The frozen surface from step 2 is the contract; every public route binds a `zod-to-openapi` registry mapping.                                                                                                                                                                                                                                               |
+| 4   | **File paired stellar-ui issue(s)**                    | A linked UI tracking issue (or an explicit "no UI consumes this") | Authored against the **frozen contract**, so it can begin **in parallel with step 3** — UI work stubs against generated types rather than waiting on a fully-built API. This is the CONTEXT-MAP pairing obligation, promoted into the lifecycle.                                                                                                                                |
+| 5   | **UI implementation via `/tdd`**                       | UI + tests                                                        | Consumes the regenerated `src/types/api.ts`; type drift here is caught by the gate (below), not by review.                                                                                                                                                                                                                                                                      |
+| 6   | **QA, then UAT**                                       | A pass/fail QA report, then human acceptance                      | **QA** (verification against the issue's acceptance criteria) is run by Claude Code — automated E2E + regression via the Playwright / Chrome DevTools MCP servers, plus `/verify` and `/run` — and emits a pass/fail report. **UAT** is the thin human layer on top: the stakeholder judges acceptance over an already-green checklist, rather than hunting for what is broken. |
+| 7   | **Security review + cross-repo integration → Compose** | Integrated, deployed change                                       | Run `/security-review` before integration for anything touching `middleware/`, `serviceAuth`, or new routes. Exercise the cross-repo seams (UI-against-real-API; api-against-external-korin, ADR-0013/0016) before handing to Stellar Compose.                                                                                                                                  |
+| 8   | **Post-deploy smoke + `/mr-robot` sweep**              | A verified deploy + a clean branch set                            | Deploying is not verifying: run a post-deploy smoke check (Sentry is wired) before considering the change live. Then sweep stale branches, tags, and CHANGELOG with `/mr-robot`.                                                                                                                                                                                                |
+
+Cross-cutting decisions that the table assumes:
+
+- **Reference-implementation parity (step 1).** The reference is a behavioral oracle described on its own terms; step 1's output is a parity gap list that feeds the PRD/ADR step. The docs never name the system the reference happens to be.
+- **Contract-first / parallelize API & UI.** Freezing the OpenAPI surface in step 2 lets the UI issue (step 4) and UI build (step 5) proceed against the contract in parallel with the API build (step 3), instead of strictly behind it.
+- **Enforce the contract seam.** The OpenAPI freshness gate must be a real gate, mirroring the working ERD gate — an unregistered or drifted route fails CI rather than shipping as a silent gap. The mechanical fix (track `openapi.json` so `git diff --exit-code` means something) is filed as a separate, separately-reviewed change.
+- **Per-issue acceptance criteria as Definition of Done.** PRDs/ADRs standardize patterns; they are not per-issue test plans. Each issue additionally carries a testable acceptance checklist, and that checklist _is_ the input to step 6's QA.
+- **Explicit rework loop.** A failed QA or UAT reopens the issue back to step 3 (API) or step 5 (UI). The arrow is named rather than implied, so a failure has a defined destination.
+- **QA vs UAT are different steps with different owners.** Claude Code owns QA + E2E + regression and reports; the human owns acceptance. Acceptance cannot be delegated; QA largely can.
+
+## Rationale
+
+- **The seam that drifts is the seam that ships half-built.** Making the contract a step-2 deliverable and a real CI gate moves drift detection left, from human review (where it is missed) to CI (where it is mechanical). This is the same move that makes the ERD gate trustworthy.
+- **Parallelism is the agile lever at this scale**, not ceremony. A small agent-plus-human team gains far more from small batch size and a frozen contract than from sprint ritual. Contract-first is what unlocks API/UI parallelism without integration surprises.
+- **Delegate verification, reserve acceptance.** Splitting step 6 lets the agent absorb the laborious, repeatable part (regression, E2E, a11y) and shrinks the human surface to the judgment that only the stakeholder can make. Conflating them wastes the automation and tires the human.
+- **Deploying is not verifying.** A post-deploy smoke check closes the loop that integration alone leaves open, and it is cheap given Sentry is already wired.
+
+## Consequences
+
+- Step 2 grows a contract-freeze obligation; step 4 can start earlier; step 6 becomes two sub-steps with distinct owners and artifacts (a QA report and an acceptance sign-off). Issues grow an acceptance-criteria section that becomes the test plan.
+- CI gains a _real_ OpenAPI freshness gate once `openapi.json` is tracked. Until that lands, the gate remains inert and the seam is guarded only by convention — so the tracked fix is the load-bearing follow-on, not optional polish.
+- A security-review gate at step 7 adds a checkpoint for auth/permission/service-key surfaces, which are the highest-risk changes in this codebase.
+- This ADR is process, not product: it introduces no schema, no route, and no glossary term, and it is purely additive — teams already following the informal loop are mostly formalizing what they do, plus the contract gate and the QA/UAT split.
+
+## Alternatives rejected
+
+- **Heavyweight Scrum ceremony (sprints, estimation, standups).** Wrong shape for an effectively solo-human-plus-agent team; the cost is ritual and the benefit (coordination across many people) does not apply. Kanban-style flow with small batches fits better.
+- **Keep API and UI strictly sequential.** Simpler to describe, but it serializes work that the contract lets us parallelize and pushes all integration risk to the end. Contract-first costs a little discipline in step 2 to buy parallelism and earlier drift detection.
+- **Keep relying on review to catch contract drift.** This is the status quo, and the #175/#198 episode plus the recorded stellar-ui type drift show it does not hold. A mechanical gate is cheaper and does not forget.
+- **Codify step 1 as parity against the named prior system.** Rejected: it would write a legacy system's identity into our docs, against the repo's no-legacy-references discipline. "Reference-implementation parity, described on its own terms" keeps the practice without the identity.
+
+## Cross-references
+
+- **stellar-api:** ADR-0009 / ADR-0010 (the workflow ADRs this lifecycle sits on top of) · ADR-0013 & ADR-0016 (the cross-repo seams step 7 must exercise) · `CONTEXT-MAP.md` "Contract hygiene" (the pairing obligation promoted into steps 2 and 4) · [#204](https://github.com/orphic-inc/stellar-api/issues/204) (de-inert the OpenAPI freshness gate — the load-bearing follow-on).
+- **stellar-ui:** the generated `src/types/api.ts` consumer of the frozen contract; paired tracking issues per step 4.
+- **korin.pink:** the external integration boundary (ADR-0013/0016) that step 7's cross-repo integration covers.

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,20771 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Stellar API",
+    "version": "0.5.6",
+    "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
+  },
+  "servers": [
+    {
+      "url": "/api",
+      "description": "API server"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "MsgResponse": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "msg"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "ValidationError": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "msg",
+          "errors"
+        ]
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "page": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "totalPages": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
+      "LoginBody": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ]
+      },
+      "RegisterBody": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 6
+          },
+          "inviteKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "email",
+          "password"
+        ]
+      },
+      "AuthUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "inviteCount": {
+            "type": "number"
+          },
+          "dateRegistered": {
+            "type": "string"
+          },
+          "lastLogin": {
+            "type": "string",
+            "nullable": true
+          },
+          "isArtist": {
+            "type": "boolean"
+          },
+          "isDonor": {
+            "type": "boolean"
+          },
+          "canDownload": {
+            "type": "boolean"
+          },
+          "contributed": {
+            "type": "string"
+          },
+          "consumed": {
+            "type": "string"
+          },
+          "ratio": {
+            "type": "number"
+          },
+          "userRank": {
+            "type": "object",
+            "properties": {
+              "level": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "badge": {
+                "type": "string"
+              },
+              "permissions": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "boolean"
+                }
+              },
+              "personalCollageLimit": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "level",
+              "name",
+              "color"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "avatar",
+          "userRank"
+        ]
+      },
+      "PublicUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "dateRegistered": {
+            "type": "string"
+          },
+          "isArtist": {
+            "type": "boolean"
+          },
+          "isDonor": {
+            "type": "boolean"
+          },
+          "userRank": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "color"
+            ]
+          },
+          "profile": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              },
+              "avatarMouseoverText": {
+                "type": "string",
+                "nullable": true
+              },
+              "profileTitle": {
+                "type": "string",
+                "nullable": true
+              },
+              "profileInfo": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "avatar",
+          "dateRegistered",
+          "isArtist",
+          "isDonor",
+          "userRank",
+          "profile"
+        ]
+      },
+      "ProfileDetails": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarMouseoverText": {
+            "type": "string",
+            "nullable": true
+          },
+          "profileTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "profileInfo": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "UserRankSummary": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "badge": {
+            "type": "string"
+          },
+          "displayStaff": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "color"
+        ]
+      },
+      "UserSettings": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "siteAppearance": {
+            "type": "string"
+          },
+          "externalStylesheet": {
+            "type": "string",
+            "nullable": true
+          },
+          "styledTooltips": {
+            "type": "boolean"
+          },
+          "paranoia": {
+            "type": "number"
+          },
+          "notificationMethod": {
+            "type": "string",
+            "enum": [
+              "Disabled",
+              "Popup",
+              "Traditional",
+              "Push",
+              "Combined"
+            ]
+          },
+          "showEmail": {
+            "type": "boolean"
+          },
+          "showLastSeen": {
+            "type": "boolean"
+          },
+          "showContributedStats": {
+            "type": "boolean"
+          },
+          "showConsumedStats": {
+            "type": "boolean"
+          },
+          "showRatioStats": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "siteAppearance",
+          "styledTooltips",
+          "paranoia",
+          "notificationMethod",
+          "showEmail",
+          "showLastSeen",
+          "showContributedStats",
+          "showConsumedStats",
+          "showRatioStats"
+        ]
+      },
+      "ProfileStats": {
+        "type": "object",
+        "properties": {
+          "contributed": {
+            "type": "string",
+            "nullable": true
+          },
+          "consumed": {
+            "type": "string",
+            "nullable": true
+          },
+          "ratio": {
+            "type": "string",
+            "nullable": true
+          },
+          "buffer": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "contributed",
+          "consumed",
+          "ratio",
+          "buffer"
+        ]
+      },
+      "ProfileActivitySummary": {
+        "type": "object",
+        "properties": {
+          "contributions": {
+            "type": "number"
+          },
+          "requestsCreated": {
+            "type": "number"
+          },
+          "requestsFilled": {
+            "type": "number"
+          },
+          "forumTopics": {
+            "type": "number"
+          },
+          "forumPosts": {
+            "type": "number"
+          },
+          "comments": {
+            "type": "number"
+          },
+          "collagesStarted": {
+            "type": "number"
+          },
+          "collageEntries": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "contributions",
+          "requestsCreated",
+          "requestsFilled",
+          "forumTopics",
+          "forumPosts",
+          "comments",
+          "collagesStarted",
+          "collageEntries"
+        ]
+      },
+      "ProfileContribution": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "release": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "title": {
+                "type": "string"
+              },
+              "communityId": {
+                "type": "number",
+                "nullable": true
+              },
+              "image": {
+                "type": "string",
+                "nullable": true
+              },
+              "artist": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "communityId",
+              "image",
+              "artist"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "release"
+        ]
+      },
+      "ProfilePercentile": {
+        "type": "object",
+        "properties": {
+          "percentile": {
+            "type": "number"
+          },
+          "rank": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "percentile",
+          "rank",
+          "total"
+        ]
+      },
+      "ProfilePercentiles": {
+        "type": "object",
+        "properties": {
+          "contributed": {
+            "$ref": "#/components/schemas/ProfilePercentile"
+          },
+          "consumed": {
+            "$ref": "#/components/schemas/ProfilePercentile"
+          },
+          "contributions": {
+            "$ref": "#/components/schemas/ProfilePercentile"
+          },
+          "forumPosts": {
+            "$ref": "#/components/schemas/ProfilePercentile"
+          },
+          "requestsFilled": {
+            "$ref": "#/components/schemas/ProfilePercentile"
+          }
+        },
+        "required": [
+          "contributed",
+          "consumed",
+          "contributions",
+          "forumPosts",
+          "requestsFilled"
+        ]
+      },
+      "ProfileCollageShelf": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "categoryId": {
+            "type": "number"
+          },
+          "isFeatured": {
+            "type": "boolean"
+          },
+          "numEntries": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "coverImages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "categoryId",
+          "isFeatured",
+          "numEntries",
+          "createdAt",
+          "updatedAt",
+          "coverImages"
+        ]
+      },
+      "ProfileCollageShelves": {
+        "type": "object",
+        "properties": {
+          "featuredPersonalCollages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileCollageShelf"
+            }
+          },
+          "publicCollages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileCollageShelf"
+            }
+          }
+        },
+        "required": [
+          "featuredPersonalCollages",
+          "publicCollages"
+        ]
+      },
+      "DonorPresentation": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "badge": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "grantedAt": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "name",
+              "badge",
+              "color",
+              "grantedAt",
+              "expiresAt"
+            ]
+          },
+          "customIcon": {
+            "type": "string",
+            "nullable": true
+          },
+          "customIconLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "secondAvatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconMouseOverText": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarMouseOverText": {
+            "type": "string",
+            "nullable": true
+          },
+          "profileBlocks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "body"
+              ]
+            }
+          }
+        },
+        "required": [
+          "rank",
+          "customIcon",
+          "customIconLink",
+          "secondAvatar",
+          "iconMouseOverText",
+          "avatarMouseOverText",
+          "profileBlocks"
+        ]
+      },
+      "ProfileStaffPmSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Unanswered",
+              "Open",
+              "Resolved"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "assignedStaff": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "viewerCanOpen": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "subject",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "assignedStaff",
+          "replyCount",
+          "viewerCanOpen"
+        ]
+      },
+      "ProfileStaffPmOverview": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "unresolved": {
+            "type": "number"
+          },
+          "recentConversations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileStaffPmSummary"
+            }
+          }
+        },
+        "required": [
+          "total",
+          "unresolved",
+          "recentConversations"
+        ]
+      },
+      "ProfileSnatch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "downloadedAt": {
+            "type": "string"
+          },
+          "release": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "title": {
+                "type": "string"
+              },
+              "communityId": {
+                "type": "number",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "communityId"
+            ]
+          },
+          "artist": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "downloadedAt",
+          "release",
+          "artist"
+        ]
+      },
+      "InviteNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "joinedAt": {
+            "type": "string"
+          },
+          "lastSeen": {
+            "type": "string",
+            "nullable": true
+          },
+          "contributed": {
+            "type": "string"
+          },
+          "consumed": {
+            "type": "string"
+          },
+          "ratio": {
+            "type": "string"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InviteNode"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "joinedAt"
+        ]
+      },
+      "CommunityStats": {
+        "type": "object",
+        "properties": {
+          "friends": {
+            "type": "number"
+          },
+          "invites": {
+            "type": "object",
+            "properties": {
+              "direct": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "depth": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "direct",
+              "total",
+              "depth"
+            ]
+          },
+          "reputation": {
+            "type": "object",
+            "properties": {
+              "score": {
+                "type": "number"
+              },
+              "dimensions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "subScore": {
+                      "type": "number"
+                    },
+                    "weighted": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "subScore",
+                    "weighted"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "score",
+              "dimensions"
+            ]
+          }
+        },
+        "required": [
+          "friends",
+          "invites",
+          "reputation"
+        ]
+      },
+      "PublicProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true,
+            "format": "email"
+          },
+          "dateRegistered": {
+            "type": "string"
+          },
+          "lastSeen": {
+            "type": "string",
+            "nullable": true
+          },
+          "isArtist": {
+            "type": "boolean"
+          },
+          "isDonor": {
+            "type": "boolean"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "warned": {
+            "type": "string",
+            "nullable": true
+          },
+          "standing": {
+            "type": "string",
+            "enum": [
+              "pristine",
+              "clean",
+              "neutral",
+              "poor",
+              "hammer"
+            ]
+          },
+          "inviteCount": {
+            "type": "number",
+            "nullable": true
+          },
+          "staffBio": {
+            "type": "string",
+            "nullable": true
+          },
+          "stats": {
+            "$ref": "#/components/schemas/ProfileStats"
+          },
+          "userRank": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserRankSummary"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            ]
+          },
+          "profile": {
+            "$ref": "#/components/schemas/ProfileDetails"
+          },
+          "activitySummary": {
+            "$ref": "#/components/schemas/ProfileActivitySummary"
+          },
+          "percentiles": {
+            "$ref": "#/components/schemas/ProfilePercentiles"
+          },
+          "donorPresentation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DonorPresentation"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "collageShelves": {
+            "$ref": "#/components/schemas/ProfileCollageShelves"
+          },
+          "staffPmOverview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProfileStaffPmOverview"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "recentContributions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileContribution"
+            }
+          },
+          "recentSnatches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileSnatch"
+            }
+          },
+          "inviteTree": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InviteNode"
+            }
+          },
+          "community": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommunityStats"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "avatar",
+          "email",
+          "dateRegistered",
+          "lastSeen",
+          "isArtist",
+          "isDonor",
+          "disabled",
+          "warned",
+          "standing",
+          "inviteCount",
+          "staffBio",
+          "stats",
+          "userRank",
+          "profile",
+          "activitySummary",
+          "percentiles",
+          "donorPresentation",
+          "collageShelves",
+          "staffPmOverview",
+          "recentContributions",
+          "recentSnatches",
+          "inviteTree",
+          "community"
+        ]
+      },
+      "MyProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true,
+            "format": "email"
+          },
+          "dateRegistered": {
+            "type": "string"
+          },
+          "lastSeen": {
+            "type": "string",
+            "nullable": true
+          },
+          "isArtist": {
+            "type": "boolean"
+          },
+          "isDonor": {
+            "type": "boolean"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "warned": {
+            "type": "string",
+            "nullable": true
+          },
+          "standing": {
+            "type": "string",
+            "enum": [
+              "pristine",
+              "clean",
+              "neutral",
+              "poor",
+              "hammer"
+            ]
+          },
+          "inviteCount": {
+            "type": "number",
+            "nullable": true
+          },
+          "staffBio": {
+            "type": "string",
+            "nullable": true
+          },
+          "stats": {
+            "$ref": "#/components/schemas/ProfileStats"
+          },
+          "userRank": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserRankSummary"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            ]
+          },
+          "profile": {
+            "$ref": "#/components/schemas/ProfileDetails"
+          },
+          "activitySummary": {
+            "$ref": "#/components/schemas/ProfileActivitySummary"
+          },
+          "percentiles": {
+            "$ref": "#/components/schemas/ProfilePercentiles"
+          },
+          "donorPresentation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DonorPresentation"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "collageShelves": {
+            "$ref": "#/components/schemas/ProfileCollageShelves"
+          },
+          "staffPmOverview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProfileStaffPmOverview"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "recentContributions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileContribution"
+            }
+          },
+          "recentSnatches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileSnatch"
+            }
+          },
+          "inviteTree": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InviteNode"
+            }
+          },
+          "community": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommunityStats"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "userSettings": {
+            "$ref": "#/components/schemas/UserSettings"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "avatar",
+          "email",
+          "dateRegistered",
+          "lastSeen",
+          "isArtist",
+          "isDonor",
+          "disabled",
+          "warned",
+          "standing",
+          "inviteCount",
+          "staffBio",
+          "stats",
+          "userRank",
+          "profile",
+          "activitySummary",
+          "percentiles",
+          "donorPresentation",
+          "collageShelves",
+          "staffPmOverview",
+          "recentContributions",
+          "recentSnatches",
+          "inviteTree",
+          "community",
+          "userSettings"
+        ]
+      },
+      "AdminCreatedUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "email"
+        ]
+      },
+      "IrcNickLinkResult": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string"
+          },
+          "ircNick": {
+            "type": "string",
+            "nullable": true
+          },
+          "code": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "instructions": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "msg"
+        ]
+      },
+      "RecoveryRequestItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "used",
+              "expired"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "usedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "username",
+          "email",
+          "status",
+          "createdAt",
+          "expiresAt",
+          "usedAt"
+        ]
+      },
+      "UserWarningItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "warnedBy": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "user",
+          "reason",
+          "expiresAt",
+          "createdAt",
+          "warnedBy"
+        ]
+      },
+      "ProgressionGap": {
+        "type": "object",
+        "properties": {
+          "toRankName": {
+            "type": "string",
+            "nullable": true
+          },
+          "contributedShortBytes": {
+            "type": "string"
+          },
+          "ratioShort": {
+            "type": "number"
+          },
+          "contributionsShort": {
+            "type": "number"
+          },
+          "ageShortDays": {
+            "type": "number"
+          },
+          "extraUnmet": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "DISTINCT_RELEASES_500",
+              "QUALITY_CONTRIB_500",
+              null
+            ]
+          }
+        },
+        "required": [
+          "toRankName",
+          "contributedShortBytes",
+          "ratioShort",
+          "contributionsShort",
+          "ageShortDays",
+          "extraUnmet"
+        ]
+      },
+      "ProfileProgression": {
+        "type": "object",
+        "properties": {
+          "currentRankId": {
+            "type": "number"
+          },
+          "currentRankName": {
+            "type": "string",
+            "nullable": true
+          },
+          "rankLocked": {
+            "type": "boolean"
+          },
+          "gap": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProgressionGap"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        },
+        "required": [
+          "currentRankId",
+          "currentRankName",
+          "rankLocked",
+          "gap"
+        ]
+      },
+      "DonorRewards": {
+        "type": "object",
+        "properties": {
+          "rewards": {
+            "type": "object",
+            "properties": {
+              "iconMouseOverText": {
+                "type": "string"
+              },
+              "avatarMouseOverText": {
+                "type": "string"
+              },
+              "customIcon": {
+                "type": "string"
+              },
+              "customIconLink": {
+                "type": "string"
+              },
+              "secondAvatar": {
+                "type": "string"
+              },
+              "profileInfoTitle1": {
+                "type": "string"
+              },
+              "profileInfo1": {
+                "type": "string"
+              },
+              "profileInfoTitle2": {
+                "type": "string"
+              },
+              "profileInfo2": {
+                "type": "string"
+              },
+              "profileInfoTitle3": {
+                "type": "string"
+              },
+              "profileInfo3": {
+                "type": "string"
+              },
+              "profileInfoTitle4": {
+                "type": "string"
+              },
+              "profileInfo4": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "iconMouseOverText",
+              "avatarMouseOverText",
+              "customIcon",
+              "customIconLink",
+              "secondAvatar",
+              "profileInfoTitle1",
+              "profileInfo1",
+              "profileInfoTitle2",
+              "profileInfo2",
+              "profileInfoTitle3",
+              "profileInfo3",
+              "profileInfoTitle4",
+              "profileInfo4"
+            ]
+          },
+          "perks": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "forumTitle": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "prefix": {
+                "type": "string"
+              },
+              "suffix": {
+                "type": "string"
+              },
+              "useComma": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "prefix",
+              "suffix",
+              "useComma"
+            ]
+          }
+        },
+        "required": [
+          "rewards",
+          "perks",
+          "forumTitle"
+        ]
+      },
+      "DonorForumTitle": {
+        "type": "object",
+        "properties": {
+          "prefix": {
+            "type": "string"
+          },
+          "suffix": {
+            "type": "string"
+          },
+          "useComma": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "prefix",
+          "suffix",
+          "useComma"
+        ]
+      },
+      "HomepageFeaturedRelease": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "year": {
+            "type": "number",
+            "nullable": true
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "communityId": {
+            "type": "number"
+          },
+          "artist": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "communityId"
+        ]
+      },
+      "HomepageFeaturedAlbum": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "started": {
+            "type": "string"
+          },
+          "ended": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "number",
+            "nullable": true
+          },
+          "release": {
+            "$ref": "#/components/schemas/HomepageFeaturedRelease"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "started",
+          "ended",
+          "release"
+        ]
+      },
+      "Announcement": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "body",
+          "createdAt"
+        ]
+      },
+      "BlogPost": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "createdAt"
+        ]
+      },
+      "AnnouncementsResponse": {
+        "type": "object",
+        "properties": {
+          "announcements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Announcement"
+            }
+          },
+          "blogPosts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlogPost"
+            }
+          }
+        },
+        "required": [
+          "announcements",
+          "blogPosts"
+        ]
+      },
+      "SiteStats": {
+        "type": "object",
+        "properties": {
+          "totalUsers": {
+            "type": "number"
+          },
+          "enabledUsers": {
+            "type": "number"
+          },
+          "activeToday": {
+            "type": "number"
+          },
+          "activeThisWeek": {
+            "type": "number"
+          },
+          "activeThisMonth": {
+            "type": "number"
+          },
+          "communities": {
+            "type": "number"
+          },
+          "releases": {
+            "type": "number"
+          },
+          "artists": {
+            "type": "number"
+          },
+          "blogPosts": {
+            "type": "number"
+          },
+          "announcements": {
+            "type": "number"
+          },
+          "comments": {
+            "type": "number"
+          },
+          "contributedLinks": {
+            "type": "number"
+          },
+          "contributedLinkDownloads": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "totalUsers",
+          "enabledUsers",
+          "activeToday",
+          "activeThisWeek",
+          "activeThisMonth",
+          "communities",
+          "releases",
+          "artists",
+          "blogPosts",
+          "announcements",
+          "comments",
+          "contributedLinks",
+          "contributedLinkDownloads"
+        ]
+      },
+      "SiteStatSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "capturedAt": {
+            "type": "string"
+          },
+          "maxUsers": {
+            "type": "number"
+          },
+          "totalUsers": {
+            "type": "number"
+          },
+          "enabledUsers": {
+            "type": "number"
+          },
+          "activeToday": {
+            "type": "number"
+          },
+          "activeThisWeek": {
+            "type": "number"
+          },
+          "activeThisMonth": {
+            "type": "number"
+          },
+          "communities": {
+            "type": "number"
+          },
+          "releases": {
+            "type": "number"
+          },
+          "artists": {
+            "type": "number"
+          },
+          "blogPosts": {
+            "type": "number"
+          },
+          "announcements": {
+            "type": "number"
+          },
+          "comments": {
+            "type": "number"
+          },
+          "contributedLinks": {
+            "type": "number"
+          },
+          "contributedLinkDownloads": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "capturedAt",
+          "maxUsers",
+          "totalUsers",
+          "enabledUsers",
+          "activeToday",
+          "activeThisWeek",
+          "activeThisMonth",
+          "communities",
+          "releases",
+          "artists",
+          "blogPosts",
+          "announcements",
+          "comments",
+          "contributedLinks",
+          "contributedLinkDownloads"
+        ]
+      },
+      "UserStatSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "period": {
+            "type": "string",
+            "enum": [
+              "Daily",
+              "Monthly",
+              "Yearly"
+            ]
+          },
+          "capturedAt": {
+            "type": "string"
+          },
+          "contributed": {
+            "type": "string",
+            "nullable": true
+          },
+          "consumed": {
+            "type": "string",
+            "nullable": true
+          },
+          "contributionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "period",
+          "capturedAt",
+          "contributed",
+          "consumed",
+          "contributionCount"
+        ]
+      },
+      "Notification": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "forum_quote",
+              "forum_sub",
+              "request_filled",
+              "collage_updated",
+              "comment_sub",
+              "artist_release"
+            ]
+          },
+          "actorId": {
+            "type": "number",
+            "nullable": true
+          },
+          "actor": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "page": {
+            "type": "string"
+          },
+          "pageId": {
+            "type": "number"
+          },
+          "postId": {
+            "type": "number",
+            "nullable": true
+          },
+          "readAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "forumId": {
+                "type": "number"
+              },
+              "releaseId": {
+                "type": "number"
+              },
+              "communityId": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "page",
+          "pageId",
+          "createdAt"
+        ]
+      },
+      "Subscription": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "topicId": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "topicId"
+        ]
+      },
+      "Stylesheet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "cssUrl": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "cssUrl",
+          "isDefault",
+          "createdAt"
+        ]
+      },
+      "StylesheetStat": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "userCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "userCount"
+        ]
+      },
+      "GlobalNotice": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "message",
+          "url",
+          "expiresAt",
+          "createdAt",
+          "createdBy"
+        ]
+      },
+      "Forum": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "sort": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "minClassRead": {
+            "type": "number"
+          },
+          "minClassWrite": {
+            "type": "number"
+          },
+          "minClassCreate": {
+            "type": "number"
+          },
+          "numTopics": {
+            "type": "number"
+          },
+          "numPosts": {
+            "type": "number"
+          },
+          "forumCategory": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          },
+          "lastTopic": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "sort",
+          "name",
+          "description",
+          "numTopics",
+          "numPosts"
+        ]
+      },
+      "ForumCategory": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "number"
+          },
+          "forums": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Forum"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sort"
+        ]
+      },
+      "ForumTopic": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "forumId": {
+            "type": "number"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "isLocked": {
+            "type": "boolean"
+          },
+          "isSticky": {
+            "type": "boolean"
+          },
+          "numPosts": {
+            "type": "number"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "lastPost": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "author": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "username"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "createdAt"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "forumId",
+          "authorId",
+          "isLocked",
+          "isSticky",
+          "numPosts",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ForumPostEdit": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "forumPostId": {
+            "type": "number"
+          },
+          "editorId": {
+            "type": "number"
+          },
+          "previousBody": {
+            "type": "string"
+          },
+          "editedAt": {
+            "type": "string"
+          },
+          "editor": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "forumPostId",
+          "editorId",
+          "previousBody",
+          "editedAt"
+        ]
+      },
+      "ForumPostLastEdit": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "forumPostId": {
+            "type": "number"
+          },
+          "editorId": {
+            "type": "number"
+          },
+          "editedAt": {
+            "type": "string"
+          },
+          "editor": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "forumPostId",
+          "editorId",
+          "editedAt"
+        ]
+      },
+      "ForumPost": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "forumTopicId": {
+            "type": "number"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "body": {
+            "type": "string"
+          },
+          "lastEdit": {
+            "$ref": "#/components/schemas/ForumPostLastEdit"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "forumTopicId",
+          "authorId",
+          "body",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ForumPollVote": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "forumPollId": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "vote": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "forumPollId",
+          "userId",
+          "vote"
+        ]
+      },
+      "ForumPoll": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "forumTopicId": {
+            "type": "number"
+          },
+          "question": {
+            "type": "string"
+          },
+          "answers": {
+            "type": "string"
+          },
+          "featured": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "votes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ForumPollVote"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "forumTopicId",
+          "question",
+          "answers",
+          "closed",
+          "votes"
+        ]
+      },
+      "ForumLastReadTopic": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "forumTopicId": {
+            "type": "number"
+          },
+          "forumPostId": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "forumTopicId",
+          "forumPostId"
+        ]
+      },
+      "PaginatedForumTopics": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ForumTopic"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "ForumTopicSession": {
+        "type": "object",
+        "properties": {
+          "forum": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              },
+              "forumCategoryId": {
+                "type": "number"
+              },
+              "forumCategory": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "forumCategoryId"
+            ]
+          },
+          "topic": {
+            "$ref": "#/components/schemas/ForumTopic"
+          },
+          "posts": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ForumPost"
+                }
+              },
+              "meta": {
+                "$ref": "#/components/schemas/PaginationMeta"
+              }
+            },
+            "required": [
+              "data",
+              "meta"
+            ]
+          },
+          "poll": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ForumPoll"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "subscription": {
+            "type": "object",
+            "properties": {
+              "isSubscribed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "isSubscribed"
+            ]
+          },
+          "affordances": {
+            "type": "object",
+            "properties": {
+              "canReply": {
+                "type": "boolean"
+              },
+              "canModerate": {
+                "type": "boolean"
+              },
+              "canVoteInPoll": {
+                "type": "boolean"
+              },
+              "canSubscribe": {
+                "type": "boolean"
+              },
+              "canCatchUp": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "canReply",
+              "canModerate",
+              "canVoteInPoll",
+              "canSubscribe",
+              "canCatchUp"
+            ]
+          },
+          "readState": {
+            "type": "object",
+            "properties": {
+              "lastVisiblePostId": {
+                "type": "number",
+                "nullable": true
+              }
+            },
+            "required": [
+              "lastVisiblePostId"
+            ]
+          }
+        },
+        "required": [
+          "forum",
+          "topic",
+          "posts",
+          "subscription",
+          "affordances",
+          "readState"
+        ]
+      },
+      "CommunityStaffMember": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "username"
+        ]
+      },
+      "CommunityConsumer": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "user"
+        ]
+      },
+      "Community": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "registrationStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "allowDuplicateFormats": {
+            "type": "boolean"
+          },
+          "staff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommunityStaffMember"
+            }
+          },
+          "consumers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommunityConsumer"
+            }
+          },
+          "_count": {
+            "type": "object",
+            "properties": {
+              "releases": {
+                "type": "number"
+              },
+              "contributors": {
+                "type": "number"
+              },
+              "consumers": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "releases",
+              "contributors",
+              "consumers"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "allowDuplicateFormats"
+        ]
+      },
+      "ReleaseTag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "ReleaseArtist": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "ReleaseContribution": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "type": {
+            "type": "string"
+          },
+          "downloadUrl": {
+            "type": "string"
+          },
+          "sizeInBytes": {
+            "type": "number",
+            "nullable": true
+          },
+          "collaborators": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "vanityHouse": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "name"
+              ]
+            }
+          },
+          "releaseDescription": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "user",
+          "type",
+          "downloadUrl",
+          "collaborators"
+        ]
+      },
+      "Contribution": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "release": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "title": {
+                "type": "string"
+              },
+              "communityId": {
+                "type": "number",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "title"
+            ]
+          },
+          "type": {
+            "type": "string"
+          },
+          "downloadUrl": {
+            "type": "string"
+          },
+          "sizeInBytes": {
+            "type": "number",
+            "nullable": true
+          },
+          "linkStatus": {
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "PASS",
+              "WARN",
+              "FAIL"
+            ]
+          },
+          "linkCheckedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "collaborators": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name"
+              ]
+            }
+          },
+          "releaseDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "user",
+          "release",
+          "type",
+          "downloadUrl",
+          "linkStatus",
+          "collaborators"
+        ]
+      },
+      "ReleaseTagEnriched": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "tagId": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "occurrences": {
+            "type": "number"
+          },
+          "score": {
+            "type": "number"
+          },
+          "positiveVotes": {
+            "type": "number"
+          },
+          "negativeVotes": {
+            "type": "number"
+          },
+          "addedBy": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "myVotes": {
+            "type": "object",
+            "properties": {
+              "up": {
+                "type": "boolean"
+              },
+              "down": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "up",
+              "down"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "tagId",
+          "name",
+          "occurrences",
+          "score",
+          "positiveVotes",
+          "negativeVotes"
+        ]
+      },
+      "ReleaseSnapshot": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "number"
+          },
+          "tagIds": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "tagNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "title",
+          "description",
+          "image",
+          "year",
+          "tagIds",
+          "tagNames"
+        ]
+      },
+      "ReleaseHistoryEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "created",
+              "edit",
+              "tag_added",
+              "tag_removed",
+              "contribution_added"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "changedFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "before": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "after": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "snapshot": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReleaseSnapshot"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "actor": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "action",
+          "summary",
+          "changedFields",
+          "createdAt",
+          "actor"
+        ]
+      },
+      "Release": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "number",
+            "nullable": true
+          },
+          "year": {
+            "type": "number",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseType": {
+            "type": "string",
+            "nullable": true
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "artist": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReleaseArtist"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReleaseTag"
+            }
+          },
+          "releaseTags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReleaseTagEnriched"
+            }
+          },
+          "myVote": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "up",
+              "down",
+              null
+            ]
+          },
+          "voteAggregate": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "ups": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "score": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "ups",
+              "total",
+              "score"
+            ]
+          },
+          "contributions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReleaseContribution"
+            }
+          },
+          "isContributor": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "communityId"
+        ]
+      },
+      "PermissionKey": {
+        "type": "string",
+        "enum": [
+          "advanced_search",
+          "users_search",
+          "forums_read",
+          "forums_post",
+          "forums_moderate",
+          "forums_manage",
+          "communities_manage",
+          "contributions_manage",
+          "dnc_manage",
+          "collages_create",
+          "collages_manage",
+          "collages_moderate",
+          "requests_create",
+          "requests_moderate",
+          "wiki_edit",
+          "wiki_manage",
+          "news_manage",
+          "rules_manage",
+          "tags_manage",
+          "reports_manage",
+          "staff_inbox_manage",
+          "users_edit",
+          "users_warn",
+          "users_disable",
+          "users_view_ips",
+          "users_view_email",
+          "recovery_manage",
+          "invites_manage",
+          "ratio_policy_manage",
+          "site_history_manage",
+          "ip_bans_manage",
+          "email_blacklist_manage",
+          "donor_ranks_manage",
+          "donation_log_view",
+          "messages_mass_pm",
+          "login_watch_view",
+          "duplicate_ips_view",
+          "registration_log_view",
+          "staff",
+          "rank_permissions_manage",
+          "staff_groups_manage",
+          "admin"
+        ]
+      },
+      "PermissionEntry": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/PermissionKey"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "description"
+        ]
+      },
+      "PermissionGroup": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionEntry"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "permissions"
+        ]
+      },
+      "UserRank": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "level": {
+            "type": "number"
+          },
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "color": {
+            "type": "string"
+          },
+          "badge": {
+            "type": "string"
+          },
+          "personalCollageLimit": {
+            "type": "integer"
+          },
+          "displayStaff": {
+            "type": "boolean"
+          },
+          "staffGroupId": {
+            "type": "integer",
+            "nullable": true
+          },
+          "userCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "level"
+        ]
+      },
+      "StaffGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "rankCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sortOrder"
+        ]
+      },
+      "StaffMember": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "rankName": {
+            "type": "string"
+          },
+          "rankColor": {
+            "type": "string"
+          },
+          "lastSeen": {
+            "type": "string",
+            "nullable": true
+          },
+          "staffBio": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "userId",
+          "username",
+          "rankName",
+          "rankColor",
+          "lastSeen",
+          "staffBio"
+        ]
+      },
+      "StaffGroupWithMembers": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaffMember"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sortOrder",
+          "members"
+        ]
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "page": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "page",
+          "body",
+          "authorId",
+          "createdAt"
+        ]
+      },
+      "PaginatedComments": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Comment"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "PromotionRule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "fromRankId": {
+            "type": "number"
+          },
+          "fromRankName": {
+            "type": "string",
+            "nullable": true
+          },
+          "toRankId": {
+            "type": "number"
+          },
+          "toRankName": {
+            "type": "string",
+            "nullable": true
+          },
+          "minContributed": {
+            "type": "string"
+          },
+          "minRatio": {
+            "type": "number"
+          },
+          "minContributions": {
+            "type": "number"
+          },
+          "minAccountAgeDays": {
+            "type": "number"
+          },
+          "extra": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "DISTINCT_RELEASES_500",
+              "QUALITY_CONTRIB_500",
+              null
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "fromRankId",
+          "fromRankName",
+          "toRankId",
+          "toRankName",
+          "minContributed",
+          "minRatio",
+          "minContributions",
+          "minAccountAgeDays",
+          "extra",
+          "enabled",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "Artist": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "vanityHouse": {
+            "type": "boolean"
+          },
+          "_count": {
+            "type": "object",
+            "properties": {
+              "releases": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "releases"
+            ]
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "redirect": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              },
+              "required": [
+                "redirect"
+              ]
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              },
+              "required": [
+                "tag"
+              ]
+            }
+          },
+          "similarTo": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "similarArtist": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              },
+              "required": [
+                "similarArtist"
+              ]
+            }
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "releases": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "year": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "type": {
+                  "type": "string"
+                },
+                "releaseType": {
+                  "type": "string"
+                },
+                "communityId": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "community": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "title"
+              ]
+            }
+          },
+          "isSubscribed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "vanityHouse"
+        ]
+      },
+      "ArtistHistory": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "artistId": {
+            "type": "number"
+          },
+          "editedAt": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "editedUser": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "artistId",
+          "editedAt"
+        ]
+      },
+      "SimilarArtist": {
+        "type": "object",
+        "properties": {
+          "similarArtist": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "similarArtist"
+        ]
+      },
+      "PostComment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "postId": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "text": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "postId",
+          "userId",
+          "text",
+          "createdAt"
+        ]
+      },
+      "Post": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostComment"
+            }
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "title",
+          "text",
+          "category",
+          "tags",
+          "comments",
+          "createdAt"
+        ]
+      },
+      "ForumTopicNote": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "forumTopicId": {
+            "type": "number"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "body": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "forumTopicId",
+          "authorId",
+          "body",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "MessageUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username"
+        ]
+      },
+      "PrivateMessage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "conversationId": {
+            "type": "number"
+          },
+          "body": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "sender": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageUser"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "conversationId",
+          "body",
+          "createdAt"
+        ]
+      },
+      "PrivateConversationParticipant": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "conversationId": {
+            "type": "number"
+          },
+          "inInbox": {
+            "type": "boolean"
+          },
+          "inSentbox": {
+            "type": "boolean"
+          },
+          "isRead": {
+            "type": "boolean"
+          },
+          "isSticky": {
+            "type": "boolean"
+          },
+          "sentAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "receivedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/MessageUser"
+          }
+        },
+        "required": [
+          "userId",
+          "conversationId",
+          "inInbox",
+          "inSentbox",
+          "isRead",
+          "isSticky"
+        ]
+      },
+      "PrivateConversation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "participants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateConversationParticipant"
+            }
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateMessage"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "subject",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PaginatedConversations": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "page": {
+            "type": "number"
+          },
+          "pageSize": {
+            "type": "number"
+          },
+          "conversations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateConversation"
+            }
+          }
+        },
+        "required": [
+          "total",
+          "page",
+          "pageSize",
+          "conversations"
+        ]
+      },
+      "StaffInboxTicket": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Unanswered",
+              "Open",
+              "Resolved"
+            ]
+          },
+          "isReadByUser": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/MessageUser"
+          },
+          "assignedUser": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageUser"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "resolver": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageUser"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number"
+                },
+                "body": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "sender": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageUser"
+                    },
+                    {
+                      "nullable": true
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "body",
+                "createdAt",
+                "sender"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "subject",
+          "status",
+          "isReadByUser",
+          "createdAt",
+          "updatedAt",
+          "user"
+        ]
+      },
+      "PaginatedTickets": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "page": {
+            "type": "number"
+          },
+          "pageSize": {
+            "type": "number"
+          },
+          "conversations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaffInboxTicket"
+            }
+          }
+        },
+        "required": [
+          "total",
+          "page",
+          "pageSize",
+          "conversations"
+        ]
+      },
+      "StaffInboxResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "body",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "RatioPolicyState": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "OK",
+              "WATCH",
+              "LEECH_DISABLED"
+            ]
+          },
+          "watchStartedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "watchExpiresAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "leechDisabledAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastEvaluatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "watchStartedAt",
+          "watchExpiresAt",
+          "leechDisabledAt",
+          "lastEvaluatedAt"
+        ]
+      },
+      "SiteSettings": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "approvedDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "registrationStatus": {
+            "type": "string",
+            "enum": [
+              "open",
+              "invite",
+              "closed"
+            ]
+          },
+          "maxUsers": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "approvedDomains",
+          "registrationStatus",
+          "maxUsers",
+          "updatedAt"
+        ]
+      },
+      "Top10Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "Top10ReleaseItem": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "number"
+          },
+          "releaseId": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "year": {
+            "type": "number"
+          },
+          "artistId": {
+            "type": "number"
+          },
+          "artistName": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "releaseType": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Top10Tag"
+            }
+          },
+          "consumerCount": {
+            "type": "number"
+          },
+          "totalBytesConsumed": {
+            "type": "string"
+          },
+          "contributionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "rank",
+          "releaseId",
+          "title",
+          "year",
+          "artistId",
+          "artistName",
+          "type",
+          "releaseType",
+          "tags",
+          "consumerCount",
+          "totalBytesConsumed",
+          "contributionCount"
+        ]
+      },
+      "Top10UserItem": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "contributed": {
+            "type": "string"
+          },
+          "consumed": {
+            "type": "string"
+          },
+          "ratio": {
+            "type": "number"
+          },
+          "numContributions": {
+            "type": "number"
+          },
+          "contributionSpeed": {
+            "type": "number"
+          },
+          "consumeSpeed": {
+            "type": "number"
+          },
+          "joinedAt": {
+            "type": "string"
+          },
+          "rankName": {
+            "type": "string"
+          },
+          "rankLevel": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "rank",
+          "userId",
+          "username",
+          "avatar",
+          "contributed",
+          "consumed",
+          "ratio",
+          "numContributions",
+          "contributionSpeed",
+          "consumeSpeed",
+          "joinedAt",
+          "rankName",
+          "rankLevel"
+        ]
+      },
+      "Top10TagItem": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "number"
+          },
+          "tagId": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uses": {
+            "type": "number"
+          },
+          "positiveVotes": {
+            "type": "number"
+          },
+          "negativeVotes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "rank",
+          "tagId",
+          "name",
+          "uses",
+          "positiveVotes",
+          "negativeVotes"
+        ]
+      },
+      "Top10VoteItem": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "number"
+          },
+          "releaseId": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "year": {
+            "type": "number"
+          },
+          "artistName": {
+            "type": "string"
+          },
+          "ups": {
+            "type": "number"
+          },
+          "downs": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          },
+          "score": {
+            "type": "number"
+          },
+          "positivePercent": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "rank",
+          "releaseId",
+          "title",
+          "year",
+          "artistName",
+          "ups",
+          "downs",
+          "total",
+          "score",
+          "positivePercent"
+        ]
+      },
+      "Top10SnapshotEntry": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "number"
+          },
+          "releaseId": {
+            "type": "number",
+            "nullable": true
+          },
+          "releaseTitle": {
+            "type": "string"
+          },
+          "tagString": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "rank",
+          "releaseId",
+          "releaseTitle",
+          "tagString",
+          "deleted"
+        ]
+      },
+      "Top10Snapshot": {
+        "type": "object",
+        "properties": {
+          "snapshotId": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Daily",
+              "Weekly"
+            ]
+          },
+          "date": {
+            "type": "string"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Top10SnapshotEntry"
+            }
+          }
+        },
+        "required": [
+          "snapshotId",
+          "type",
+          "date",
+          "entries"
+        ]
+      },
+      "RulesPage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "isMain": {
+            "type": "boolean"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "title",
+          "body",
+          "isMain",
+          "sortOrder",
+          "authorId",
+          "author",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "SubRule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "ruleId": {
+            "type": "number"
+          },
+          "code": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "complianceWeight": {
+            "type": "number"
+          },
+          "violationWeight": {
+            "type": "number"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "ruleId",
+          "code",
+          "title",
+          "description",
+          "complianceWeight",
+          "violationWeight",
+          "sortOrder",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "Rule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "code": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "complianceWeight": {
+            "type": "number"
+          },
+          "violationWeight": {
+            "type": "number"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "subRules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubRule"
+            }
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "code",
+          "title",
+          "description",
+          "complianceWeight",
+          "violationWeight",
+          "sortOrder",
+          "subRules",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "FriendUserSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "avatar"
+        ]
+      },
+      "FriendEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "friendId": {
+            "type": "number"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "friend": {
+            "$ref": "#/components/schemas/FriendUserSummary"
+          }
+        },
+        "required": [
+          "id",
+          "friendId",
+          "comment",
+          "status",
+          "createdAt",
+          "friend"
+        ]
+      },
+      "FriendRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "requesterId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "requester": {
+            "$ref": "#/components/schemas/FriendUserSummary"
+          }
+        },
+        "required": [
+          "id",
+          "requesterId",
+          "createdAt",
+          "requester"
+        ]
+      },
+      "FriendRequestSent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "requesterId": {
+            "type": "number"
+          },
+          "recipientId": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "recipient": {
+            "$ref": "#/components/schemas/FriendUserSummary"
+          }
+        },
+        "required": [
+          "id",
+          "requesterId",
+          "recipientId",
+          "status",
+          "createdAt",
+          "recipient"
+        ]
+      },
+      "TagAliasItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "badTag": {
+            "type": "string"
+          },
+          "goodTag": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          },
+          "createdBy": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "badTag",
+          "goodTag",
+          "createdBy",
+          "createdAt"
+        ]
+      },
+      "SessionItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "ipAddress": {
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "lastActiveAt": {
+            "type": "string"
+          },
+          "revokedAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "user",
+          "ipAddress",
+          "userAgent",
+          "createdAt",
+          "lastActiveAt",
+          "revokedAt"
+        ]
+      },
+      "InviteItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "inviter": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "email": {
+            "type": "string"
+          },
+          "expires": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "inviter",
+          "email",
+          "expires",
+          "reason",
+          "status"
+        ]
+      },
+      "InviteTreeItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "inviterId": {
+            "type": "number",
+            "nullable": true
+          },
+          "inviter": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "user",
+          "inviterId",
+          "inviter"
+        ]
+      },
+      "MemberInviteTreeNode": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "rankName": {
+            "type": "string"
+          },
+          "isDonor": {
+            "type": "boolean"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "depth": {
+            "type": "number"
+          },
+          "stats": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "contributed": {
+                "type": "string"
+              },
+              "consumed": {
+                "type": "string"
+              },
+              "ratio": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "contributed",
+              "consumed",
+              "ratio"
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemberInviteTreeNode"
+            }
+          }
+        },
+        "required": [
+          "userId",
+          "username",
+          "rankName",
+          "isDonor",
+          "disabled",
+          "depth",
+          "stats",
+          "children"
+        ]
+      },
+      "InviteTreeSummary": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "type": "number"
+          },
+          "branches": {
+            "type": "number"
+          },
+          "depth": {
+            "type": "number"
+          },
+          "disabledCount": {
+            "type": "number"
+          },
+          "donorCount": {
+            "type": "number"
+          },
+          "hiddenCount": {
+            "type": "number"
+          },
+          "byRank": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "rankName": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "rankName",
+                "count"
+              ]
+            }
+          },
+          "total": {
+            "type": "object",
+            "properties": {
+              "contributed": {
+                "type": "string"
+              },
+              "consumed": {
+                "type": "string"
+              },
+              "ratio": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "contributed",
+              "consumed",
+              "ratio"
+            ]
+          },
+          "topLevel": {
+            "type": "object",
+            "properties": {
+              "contributed": {
+                "type": "string"
+              },
+              "consumed": {
+                "type": "string"
+              },
+              "ratio": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "contributed",
+              "consumed",
+              "ratio"
+            ]
+          }
+        },
+        "required": [
+          "entries",
+          "branches",
+          "depth",
+          "disabledCount",
+          "donorCount",
+          "hiddenCount",
+          "byRank",
+          "total",
+          "topLevel"
+        ]
+      },
+      "RatioWatchItem": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "watchStartedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "watchExpiresAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "leechDisabledAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastEvaluatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "userId",
+          "user",
+          "status",
+          "watchStartedAt",
+          "watchExpiresAt",
+          "leechDisabledAt",
+          "lastEvaluatedAt"
+        ]
+      },
+      "VanityHouseArtist": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "vanityHouse": {
+            "type": "boolean"
+          },
+          "_count": {
+            "type": "object",
+            "properties": {
+              "releases": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "releases"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "vanityHouse",
+          "_count"
+        ]
+      },
+      "FeaturedAlbumItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "groupId": {
+            "type": "number"
+          },
+          "threadId": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "started": {
+            "type": "string"
+          },
+          "ended": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "groupId",
+          "threadId",
+          "title",
+          "started",
+          "ended"
+        ]
+      },
+      "DeletedCollageItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "deletedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "user",
+          "deletedAt",
+          "createdAt"
+        ]
+      },
+      "EconomyGroupedItem": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "_sum": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "amount"
+            ]
+          },
+          "_count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "reason",
+          "_sum",
+          "_count"
+        ]
+      },
+      "EconomyTransactionItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "amount": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "user",
+          "amount",
+          "reason",
+          "createdAt"
+        ]
+      },
+      "DncEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "addedBy": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "comment",
+          "communityId",
+          "userId",
+          "createdAt",
+          "addedBy"
+        ]
+      },
+      "CommunityHealthPulse": {
+        "type": "object",
+        "properties": {
+          "pass": {
+            "type": "number"
+          },
+          "warn": {
+            "type": "number"
+          },
+          "fail": {
+            "type": "number"
+          },
+          "unknown": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          },
+          "checked": {
+            "type": "number"
+          },
+          "coverage": {
+            "type": "number",
+            "nullable": true
+          },
+          "pulse": {
+            "type": "number",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Healthy",
+              "Ailing",
+              "Critical",
+              "Unknown"
+            ]
+          }
+        },
+        "required": [
+          "pass",
+          "warn",
+          "fail",
+          "unknown",
+          "total",
+          "checked",
+          "coverage",
+          "pulse",
+          "status"
+        ]
+      },
+      "CommunityHealthSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "communityId": {
+            "type": "number"
+          },
+          "period": {
+            "type": "string",
+            "enum": [
+              "Daily",
+              "Monthly",
+              "Yearly"
+            ]
+          },
+          "bucketAt": {
+            "type": "string"
+          },
+          "capturedAt": {
+            "type": "string"
+          },
+          "pass": {
+            "type": "number"
+          },
+          "warn": {
+            "type": "number"
+          },
+          "fail": {
+            "type": "number"
+          },
+          "unknown": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          },
+          "checked": {
+            "type": "number"
+          },
+          "coverage": {
+            "type": "number",
+            "nullable": true
+          },
+          "pulse": {
+            "type": "number",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "communityId",
+          "period",
+          "bucketAt",
+          "capturedAt",
+          "pass",
+          "warn",
+          "fail",
+          "unknown",
+          "total",
+          "checked",
+          "coverage",
+          "pulse",
+          "status"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/auth": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JWT issued, user returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/AuthUser"
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Account disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthUser"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Registered and logged in",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/AuthUser"
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "User already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "204": {
+            "description": "Logged out"
+          }
+        }
+      }
+    },
+    "/install": {
+      "get": {
+        "tags": [
+          "Install"
+        ],
+        "responses": {
+          "200": {
+            "description": "Install status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "installed": {
+                      "type": "boolean"
+                    },
+                    "registrationStatus": {
+                      "type": "string",
+                      "enum": [
+                        "open",
+                        "invite",
+                        "closed"
+                      ]
+                    },
+                    "configWarnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "setupChecklist": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "installed",
+                    "registrationStatus",
+                    "configWarnings",
+                    "setupChecklist"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Install"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 30
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 8
+                  }
+                },
+                "required": [
+                  "username",
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Installation complete",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/AuthUser"
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Already installed or validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicUser"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/irc-nick": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ircNick": {
+                    "type": "string",
+                    "nullable": true,
+                    "maxLength": 30,
+                    "pattern": "^[a-zA-Z_\\-[\\]\\\\^{}|`][a-zA-Z0-9_\\-[\\]\\\\^{}|`]*$"
+                  }
+                },
+                "required": [
+                  "ircNick"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Nick claim opened (returns the verification code + instructions), nick cleared, or already verified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IrcNickLinkResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not self or admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Nick already verified by another account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/settings": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "siteAppearance": {
+                    "type": "string"
+                  },
+                  "externalStylesheet": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "styledTooltips": {
+                    "type": "boolean"
+                  },
+                  "paranoia": {
+                    "type": "integer",
+                    "nullable": true,
+                    "minimum": 0,
+                    "maximum": 3
+                  },
+                  "avatar": {
+                    "type": "string"
+                  },
+                  "notificationMethod": {
+                    "type": "string",
+                    "enum": [
+                      "Disabled",
+                      "Popup",
+                      "Traditional",
+                      "Push",
+                      "Combined"
+                    ]
+                  },
+                  "showEmail": {
+                    "type": "boolean"
+                  },
+                  "showLastSeen": {
+                    "type": "boolean"
+                  },
+                  "showContributedStats": {
+                    "type": "boolean"
+                  },
+                  "showConsumedStats": {
+                    "type": "boolean"
+                  },
+                  "showRatioStats": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated current user settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/UserSettings"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "avatar": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 32
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 6
+                  },
+                  "userRankId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "username",
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminCreatedUser"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "User already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/recovery-requests": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "used",
+                "expired"
+              ]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of account recovery requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RecoveryRequestItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/recovery-requests/{reqId}": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "reqId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recovery request revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Token already used",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/warnings": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated staff warning log",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserWarningItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/recovery": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recovery email sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Email delivery not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/me": {
+      "get": {
+        "tags": [
+          "Profile"
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyProfile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Profile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "avatar": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "avatarMouseoverText": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "profileTitle": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "profileInfo": {
+                    "type": "string",
+                    "maxLength": 10000
+                  },
+                  "siteAppearance": {
+                    "type": "string"
+                  },
+                  "externalStylesheet": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "styledTooltips": {
+                    "type": "boolean"
+                  },
+                  "paranoia": {
+                    "type": "integer",
+                    "nullable": true,
+                    "minimum": 0,
+                    "maximum": 3
+                  },
+                  "notificationMethod": {
+                    "type": "string",
+                    "enum": [
+                      "Disabled",
+                      "Popup",
+                      "Traditional",
+                      "Push",
+                      "Combined"
+                    ]
+                  },
+                  "showEmail": {
+                    "type": "boolean"
+                  },
+                  "showLastSeen": {
+                    "type": "boolean"
+                  },
+                  "showContributedStats": {
+                    "type": "boolean"
+                  },
+                  "showConsumedStats": {
+                    "type": "boolean"
+                  },
+                  "showRatioStats": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated current user profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyProfile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/me/progression": {
+      "get": {
+        "tags": [
+          "Profile"
+        ],
+        "responses": {
+          "200": {
+            "description": "Gap to the next auto-class rung",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileProgression"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/user/{userId}": {
+      "get": {
+        "tags": [
+          "Profile"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicProfile"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile": {
+      "delete": {
+        "tags": [
+          "Profile"
+        ],
+        "responses": {
+          "204": {
+            "description": "Account disabled"
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/referral/create-invite": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "maxLength": 1000
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Invite created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "inviteKey": {
+                      "type": "string"
+                    },
+                    "emailSent": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "inviteKey",
+                    "emailSent"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "No invites remaining",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invite already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/me/donor-rewards": {
+      "get": {
+        "tags": [
+          "Profile"
+        ],
+        "responses": {
+          "200": {
+            "description": "Donor reward settings and active perks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonorRewards"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No active donor rank",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Profile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "iconMouseOverText": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "avatarMouseOverText": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "customIcon": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "customIconLink": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "secondAvatar": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "profileInfoTitle1": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "profileInfo1": {
+                    "type": "string",
+                    "maxLength": 5000
+                  },
+                  "profileInfoTitle2": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "profileInfo2": {
+                    "type": "string",
+                    "maxLength": 5000
+                  },
+                  "profileInfoTitle3": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "profileInfo3": {
+                    "type": "string",
+                    "maxLength": 5000
+                  },
+                  "profileInfoTitle4": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "profileInfo4": {
+                    "type": "string",
+                    "maxLength": 5000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated donor reward settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonorRewards"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "No active donor rank",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/me/donor-title": {
+      "put": {
+        "tags": [
+          "Profile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "type": "string",
+                    "maxLength": 64
+                  },
+                  "suffix": {
+                    "type": "string",
+                    "maxLength": 64
+                  },
+                  "useComma": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated forum title",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonorForumTitle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Perk not enabled for this rank",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/home/featured": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "responses": {
+          "200": {
+            "description": "Homepage featured content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "albumOfTheMonth": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/HomepageFeaturedAlbum"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "vanityHouse": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/HomepageFeaturedRelease"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "albumOfTheMonth",
+                    "vanityHouse"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements": {
+      "get": {
+        "tags": [
+          "Announcements"
+        ],
+        "responses": {
+          "200": {
+            "description": "News and blog posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnouncementsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Announcement created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Announcement"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/{id}": {
+      "delete": {
+        "tags": [
+          "Announcements"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Announcement deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/blog": {
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Blog post created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlogPost"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/blog/{id}": {
+      "delete": {
+        "tags": [
+          "Announcements"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Blog post deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/global-notices": {
+      "get": {
+        "tags": [
+          "Announcements"
+        ],
+        "responses": {
+          "200": {
+            "description": "All global notices",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GlobalNotice"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/global-notice": {
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Global notice created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalNotice"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/global-notice/{id}": {
+      "delete": {
+        "tags": [
+          "Announcements"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Notice deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Site statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteStats"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/history": {
+      "get": {
+        "summary": "Site-wide historical stat snapshots",
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Historical site stat snapshots (ascending by capturedAt)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SiteStatSnapshot"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/snapshot": {
+      "post": {
+        "summary": "Manually trigger a site stat snapshot (admin only)",
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "204": {
+            "description": "Snapshot captured"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "msg"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/stats/history": {
+      "get": {
+        "summary": "User historical stat snapshots",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Daily",
+                "Monthly",
+                "Yearly"
+              ]
+            },
+            "required": true,
+            "name": "period",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Historical user stat snapshots (ascending by capturedAt)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserStatSnapshot"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Stats are private",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "msg"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "msg"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet": {
+      "get": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "responses": {
+          "200": {
+            "description": "Available stylesheets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Stylesheet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "default": ""
+                  },
+                  "cssUrl": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "isDefault": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "name",
+                  "cssUrl"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Stylesheet created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stylesheet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet/admin/stats": {
+      "get": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "responses": {
+          "200": {
+            "description": "Stylesheet user counts (admin only)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StylesheetStat"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet/{id}": {
+      "get": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stylesheet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stylesheet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "cssUrl": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "isDefault": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Stylesheet updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stylesheet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Stylesheet removed"
+          },
+          "400": {
+            "description": "Cannot delete the default stylesheet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "responses": {
+          "200": {
+            "description": "Notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Notification"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}": {
+      "delete": {
+        "tags": [
+          "Notifications"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Notification removed"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions": {
+      "get": {
+        "tags": [
+          "Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Forum subscriptions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Subscription"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscribe": {
+      "post": {
+        "tags": [
+          "Subscriptions"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "topicId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "subscribe",
+                      "unsubscribe"
+                    ]
+                  }
+                },
+                "required": [
+                  "topicId",
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Subscription updated"
+          }
+        }
+      }
+    },
+    "/subscriptions/subscribe-comments": {
+      "post": {
+        "tags": [
+          "Subscriptions"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "page": {
+                    "type": "string",
+                    "enum": [
+                      "forums",
+                      "artist",
+                      "collages",
+                      "requests",
+                      "communities",
+                      "contributions",
+                      "release",
+                      "news",
+                      "global_notices"
+                    ]
+                  },
+                  "pageId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "subscribe",
+                      "unsubscribe"
+                    ]
+                  }
+                },
+                "required": [
+                  "page",
+                  "pageId",
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Comment subscription updated"
+          }
+        }
+      }
+    },
+    "/subscriptions/comment-status": {
+      "get": {
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "forums",
+                "artist",
+                "collages",
+                "requests",
+                "communities",
+                "contributions",
+                "release",
+                "news",
+                "global_notices"
+              ]
+            },
+            "required": true,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": true,
+            "name": "pageId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Comment subscription status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subscribed": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "subscribed"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/categories": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "responses": {
+          "200": {
+            "description": "All categories with forums",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ForumCategory"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sort": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Category created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumCategory"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/categories/{id}": {
+      "put": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sort": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Category updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumCategory"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Category deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "responses": {
+          "200": {
+            "description": "Forums",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Forum"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "forumCategoryId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "sort": {
+                    "type": "integer",
+                    "default": 0
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 1024
+                  },
+                  "minClassRead": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                  },
+                  "minClassWrite": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                  },
+                  "minClassCreate": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                  },
+                  "autoLock": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "autoLockWeeks": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 4
+                  }
+                },
+                "required": [
+                  "forumCategoryId",
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Forum created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forum"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{id}": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Forum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forum"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 1024
+                  },
+                  "sort": {
+                    "type": "integer"
+                  },
+                  "minClassRead": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "minClassWrite": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "minClassCreate": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "autoLock": {
+                    "type": "boolean"
+                  },
+                  "autoLockWeeks": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Forum updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forum"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Forum deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated topics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedForumTopics"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "question": {
+                    "type": "string",
+                    "maxLength": 512
+                  },
+                  "answers": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Topic created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumTopic"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics/{topicId}/session": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Topic session view model (forum + topic + posts + poll + subscription + affordances)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumTopicSession"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient class",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Forum or topic not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics/{topicId}": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Topic",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumTopic"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "isLocked": {
+                    "type": "boolean"
+                  },
+                  "isSticky": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Topic updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumTopic"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Topic removed"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics/{topicId}/trash": {
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Topic moved to the trash board",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumTopic"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics/{topicId}/posts": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ForumPost"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Post created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPost"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Topic locked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics/{topicId}/posts/{id}": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPost"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Post updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPost"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Post removed"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/{forumId}/topics/{topicId}/posts/{id}/edits": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "forumId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Moderator edit history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ForumPostEdit"
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/polls/{topicId}": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Poll",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPoll"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/polls": {
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "forumTopicId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "question": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "answers": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "forumTopicId",
+                  "question",
+                  "answers"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Poll created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPoll"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/polls/{id}/close": {
+      "put": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Poll closed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPoll"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/poll-votes": {
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "forumPollId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "vote": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "forumPollId",
+                  "vote"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Vote recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumPollVote"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/last-read": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "responses": {
+          "200": {
+            "description": "Last-read markers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ForumLastReadTopic"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "forumTopicId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "forumPostId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "forumTopicId",
+                  "forumPostId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Last-read marker saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumLastReadTopic"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated communities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Community"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{id}": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Community",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Community"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{id}/health": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Community link-health pulse",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityHealthPulse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not a member of this community",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{id}/health/history": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Daily",
+                "Monthly",
+                "Yearly"
+              ]
+            },
+            "required": false,
+            "name": "period",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Community link-health pulse history (time series)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommunityHealthSnapshot"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not a member of this community",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{id}/releases": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Releases for community",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Release"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Release",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Release"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}/history": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated release history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ReleaseHistoryEntry"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not a community member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}/history/{historyId}/revert": {
+      "post": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "historyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Release after revert",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Release"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Not an edit revision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}/tags": {
+      "post": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Tag added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseTag"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Release already has this tag",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}/tags/{tagId}": {
+      "delete": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "tagId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tag removed"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}/tags/{tagId}/vote": {
+      "post": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "tagId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "direction": {
+                    "type": "string",
+                    "enum": [
+                      "up",
+                      "down"
+                    ]
+                  }
+                },
+                "required": [
+                  "direction"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated tag with vote counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseTagEnriched"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/releases/{releaseId}/contributions": {
+      "post": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fileType": {
+                    "type": "string",
+                    "enum": [
+                      "mp3",
+                      "flac",
+                      "wav",
+                      "ogg",
+                      "aac",
+                      "m4a",
+                      "m4b",
+                      "mp4",
+                      "mkv",
+                      "avi",
+                      "mov",
+                      "zip",
+                      "exe",
+                      "dmg",
+                      "apk",
+                      "pdf",
+                      "epub",
+                      "mobi",
+                      "cbz",
+                      "cbr",
+                      "jpg",
+                      "png",
+                      "gif",
+                      "txt"
+                    ]
+                  },
+                  "downloadUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "sizeInBytes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991
+                  },
+                  "releaseDescription": {
+                    "type": "string"
+                  },
+                  "bitrate": {
+                    "type": "string",
+                    "enum": [
+                      "Lossless",
+                      "Lossless24",
+                      "Kbps320",
+                      "Kbps256",
+                      "KbpsV0",
+                      "Kbps192",
+                      "KbpsV2",
+                      "Kbps128",
+                      "Other"
+                    ]
+                  },
+                  "media": {
+                    "type": "string",
+                    "enum": [
+                      "CD",
+                      "WEB",
+                      "Vinyl",
+                      "SACD",
+                      "DVD",
+                      "Cassette",
+                      "BluRay",
+                      "DAT",
+                      "Soundboard",
+                      "Other"
+                    ]
+                  },
+                  "hasLog": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "hasCue": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "isScene": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "fileType",
+                  "downloadUrl"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Contribution created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Contribution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Release not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contributions": {
+      "get": {
+        "tags": [
+          "Contributions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated contributions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Contribution"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contributions"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "communityId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Music",
+                      "Applications",
+                      "EBooks",
+                      "ELearningVideos",
+                      "Audiobooks",
+                      "Comedy",
+                      "Comics"
+                    ]
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "year": {
+                    "type": "integer",
+                    "minimum": 1900,
+                    "maximum": 2100
+                  },
+                  "fileType": {
+                    "type": "string",
+                    "enum": [
+                      "mp3",
+                      "flac",
+                      "wav",
+                      "ogg",
+                      "aac",
+                      "m4a",
+                      "m4b",
+                      "mp4",
+                      "mkv",
+                      "avi",
+                      "mov",
+                      "zip",
+                      "exe",
+                      "dmg",
+                      "apk",
+                      "pdf",
+                      "epub",
+                      "mobi",
+                      "cbz",
+                      "cbr",
+                      "jpg",
+                      "png",
+                      "gif",
+                      "txt"
+                    ]
+                  },
+                  "downloadUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "sizeInBytes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991
+                  },
+                  "tags": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "releaseDescription": {
+                    "type": "string"
+                  },
+                  "bitrate": {
+                    "type": "string",
+                    "enum": [
+                      "Lossless",
+                      "Lossless24",
+                      "Kbps320",
+                      "Kbps256",
+                      "KbpsV0",
+                      "Kbps192",
+                      "KbpsV2",
+                      "Kbps128",
+                      "Other"
+                    ]
+                  },
+                  "media": {
+                    "type": "string",
+                    "enum": [
+                      "CD",
+                      "WEB",
+                      "Vinyl",
+                      "SACD",
+                      "DVD",
+                      "Cassette",
+                      "BluRay",
+                      "DAT",
+                      "Soundboard",
+                      "Other"
+                    ]
+                  },
+                  "releaseCategory": {
+                    "type": "string",
+                    "enum": [
+                      "Album",
+                      "Single",
+                      "EP",
+                      "Anthology",
+                      "Compilation",
+                      "DJMix",
+                      "Live",
+                      "Remix",
+                      "Bootleg",
+                      "Interview",
+                      "Mixtape",
+                      "Demo",
+                      "ConcertRecording",
+                      "Unknown"
+                    ]
+                  },
+                  "recordLabel": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "catalogueNumber": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "editionTitle": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "editionYear": {
+                    "type": "integer",
+                    "minimum": 1900,
+                    "maximum": 2100
+                  },
+                  "isRemaster": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "hasLog": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "hasCue": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "isScene": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "collaborators": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "artist": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "importance": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "artist",
+                        "importance"
+                      ]
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "communityId",
+                  "type",
+                  "title",
+                  "year",
+                  "fileType",
+                  "downloadUrl",
+                  "collaborators"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Contribution submitted and release created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Contribution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Community not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/user-ranks": {
+      "get": {
+        "tags": [
+          "Tools"
+        ],
+        "responses": {
+          "200": {
+            "description": "User ranks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRank"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tools"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64
+                  },
+                  "level": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "permissions": {
+                    "type": "object",
+                    "properties": {
+                      "advanced_search": {
+                        "type": "boolean"
+                      },
+                      "users_search": {
+                        "type": "boolean"
+                      },
+                      "forums_read": {
+                        "type": "boolean"
+                      },
+                      "forums_post": {
+                        "type": "boolean"
+                      },
+                      "forums_moderate": {
+                        "type": "boolean"
+                      },
+                      "forums_manage": {
+                        "type": "boolean"
+                      },
+                      "communities_manage": {
+                        "type": "boolean"
+                      },
+                      "contributions_manage": {
+                        "type": "boolean"
+                      },
+                      "dnc_manage": {
+                        "type": "boolean"
+                      },
+                      "collages_create": {
+                        "type": "boolean"
+                      },
+                      "collages_manage": {
+                        "type": "boolean"
+                      },
+                      "collages_moderate": {
+                        "type": "boolean"
+                      },
+                      "requests_create": {
+                        "type": "boolean"
+                      },
+                      "requests_moderate": {
+                        "type": "boolean"
+                      },
+                      "wiki_edit": {
+                        "type": "boolean"
+                      },
+                      "wiki_manage": {
+                        "type": "boolean"
+                      },
+                      "news_manage": {
+                        "type": "boolean"
+                      },
+                      "rules_manage": {
+                        "type": "boolean"
+                      },
+                      "tags_manage": {
+                        "type": "boolean"
+                      },
+                      "reports_manage": {
+                        "type": "boolean"
+                      },
+                      "staff_inbox_manage": {
+                        "type": "boolean"
+                      },
+                      "users_edit": {
+                        "type": "boolean"
+                      },
+                      "users_warn": {
+                        "type": "boolean"
+                      },
+                      "users_disable": {
+                        "type": "boolean"
+                      },
+                      "users_view_ips": {
+                        "type": "boolean"
+                      },
+                      "users_view_email": {
+                        "type": "boolean"
+                      },
+                      "recovery_manage": {
+                        "type": "boolean"
+                      },
+                      "invites_manage": {
+                        "type": "boolean"
+                      },
+                      "ratio_policy_manage": {
+                        "type": "boolean"
+                      },
+                      "site_history_manage": {
+                        "type": "boolean"
+                      },
+                      "ip_bans_manage": {
+                        "type": "boolean"
+                      },
+                      "email_blacklist_manage": {
+                        "type": "boolean"
+                      },
+                      "donor_ranks_manage": {
+                        "type": "boolean"
+                      },
+                      "donation_log_view": {
+                        "type": "boolean"
+                      },
+                      "messages_mass_pm": {
+                        "type": "boolean"
+                      },
+                      "login_watch_view": {
+                        "type": "boolean"
+                      },
+                      "duplicate_ips_view": {
+                        "type": "boolean"
+                      },
+                      "registration_log_view": {
+                        "type": "boolean"
+                      },
+                      "staff": {
+                        "type": "boolean"
+                      },
+                      "rank_permissions_manage": {
+                        "type": "boolean"
+                      },
+                      "staff_groups_manage": {
+                        "type": "boolean"
+                      },
+                      "admin": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "secondary": {
+                    "type": "boolean"
+                  },
+                  "permittedForumIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true
+                    },
+                    "default": []
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "badge": {
+                    "type": "string"
+                  },
+                  "personalCollageLimit": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "displayStaff": {
+                    "type": "boolean"
+                  },
+                  "staffGroupId": {
+                    "type": "integer",
+                    "nullable": true,
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "name",
+                  "level"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User rank created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRank"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate rank name or level",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Staff group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/user-ranks/permissions": {
+      "get": {
+        "tags": [
+          "Tools"
+        ],
+        "responses": {
+          "200": {
+            "description": "Permission catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "$ref": "#/components/schemas/PermissionKey"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "label",
+                            "description"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "title",
+                      "permissions"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/user-ranks/{id}": {
+      "get": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User rank",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRank"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64
+                  },
+                  "level": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "permissions": {
+                    "type": "object",
+                    "properties": {
+                      "advanced_search": {
+                        "type": "boolean"
+                      },
+                      "users_search": {
+                        "type": "boolean"
+                      },
+                      "forums_read": {
+                        "type": "boolean"
+                      },
+                      "forums_post": {
+                        "type": "boolean"
+                      },
+                      "forums_moderate": {
+                        "type": "boolean"
+                      },
+                      "forums_manage": {
+                        "type": "boolean"
+                      },
+                      "communities_manage": {
+                        "type": "boolean"
+                      },
+                      "contributions_manage": {
+                        "type": "boolean"
+                      },
+                      "dnc_manage": {
+                        "type": "boolean"
+                      },
+                      "collages_create": {
+                        "type": "boolean"
+                      },
+                      "collages_manage": {
+                        "type": "boolean"
+                      },
+                      "collages_moderate": {
+                        "type": "boolean"
+                      },
+                      "requests_create": {
+                        "type": "boolean"
+                      },
+                      "requests_moderate": {
+                        "type": "boolean"
+                      },
+                      "wiki_edit": {
+                        "type": "boolean"
+                      },
+                      "wiki_manage": {
+                        "type": "boolean"
+                      },
+                      "news_manage": {
+                        "type": "boolean"
+                      },
+                      "rules_manage": {
+                        "type": "boolean"
+                      },
+                      "tags_manage": {
+                        "type": "boolean"
+                      },
+                      "reports_manage": {
+                        "type": "boolean"
+                      },
+                      "staff_inbox_manage": {
+                        "type": "boolean"
+                      },
+                      "users_edit": {
+                        "type": "boolean"
+                      },
+                      "users_warn": {
+                        "type": "boolean"
+                      },
+                      "users_disable": {
+                        "type": "boolean"
+                      },
+                      "users_view_ips": {
+                        "type": "boolean"
+                      },
+                      "users_view_email": {
+                        "type": "boolean"
+                      },
+                      "recovery_manage": {
+                        "type": "boolean"
+                      },
+                      "invites_manage": {
+                        "type": "boolean"
+                      },
+                      "ratio_policy_manage": {
+                        "type": "boolean"
+                      },
+                      "site_history_manage": {
+                        "type": "boolean"
+                      },
+                      "ip_bans_manage": {
+                        "type": "boolean"
+                      },
+                      "email_blacklist_manage": {
+                        "type": "boolean"
+                      },
+                      "donor_ranks_manage": {
+                        "type": "boolean"
+                      },
+                      "donation_log_view": {
+                        "type": "boolean"
+                      },
+                      "messages_mass_pm": {
+                        "type": "boolean"
+                      },
+                      "login_watch_view": {
+                        "type": "boolean"
+                      },
+                      "duplicate_ips_view": {
+                        "type": "boolean"
+                      },
+                      "registration_log_view": {
+                        "type": "boolean"
+                      },
+                      "staff": {
+                        "type": "boolean"
+                      },
+                      "rank_permissions_manage": {
+                        "type": "boolean"
+                      },
+                      "staff_groups_manage": {
+                        "type": "boolean"
+                      },
+                      "admin": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "secondary": {
+                    "type": "boolean"
+                  },
+                  "permittedForumIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true
+                    }
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "badge": {
+                    "type": "string"
+                  },
+                  "personalCollageLimit": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "displayStaff": {
+                    "type": "boolean"
+                  },
+                  "staffGroupId": {
+                    "type": "integer",
+                    "nullable": true,
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User rank updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRank"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate rank name or level",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Staff group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User rank deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Rank still assigned to users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/promotion-rules": {
+      "get": {
+        "tags": [
+          "Tools"
+        ],
+        "responses": {
+          "200": {
+            "description": "Promotion rules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PromotionRule"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tools"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fromRankId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "toRankId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "minContributed": {
+                    "type": "string"
+                  },
+                  "minRatio": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "minContributions": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "minAccountAgeDays": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "extra": {
+                    "type": "string",
+                    "nullable": true,
+                    "enum": [
+                      "DISTINCT_RELEASES_500",
+                      "QUALITY_CONTRIB_500",
+                      null
+                    ]
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "fromRankId",
+                  "toRankId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Promotion rule created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromotionRule"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate rank pair",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "fromRank or toRank not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/promotion-rules/{id}": {
+      "get": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Promotion rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromotionRule"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fromRankId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "toRankId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "minContributed": {
+                    "type": "string"
+                  },
+                  "minRatio": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "minContributions": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "minAccountAgeDays": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "extra": {
+                    "type": "string",
+                    "nullable": true,
+                    "enum": [
+                      "DISTINCT_RELEASES_500",
+                      "QUALITY_CONTRIB_500",
+                      null
+                    ]
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Promotion rule updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromotionRule"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate rank pair",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "fromRank or toRank not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Promotion rule deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/staff-groups": {
+      "get": {
+        "tags": [
+          "Tools"
+        ],
+        "responses": {
+          "200": {
+            "description": "Staff groups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StaffGroup"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tools"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sortOrder": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "name",
+                  "sortOrder"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Staff group created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/staff-groups/{id}": {
+      "put": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sortOrder": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Staff group updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffGroup"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tools"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Staff group deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Ranks still assigned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "responses": {
+          "200": {
+            "description": "Staff listing grouped by staff group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "groups": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/StaffGroupWithMembers"
+                      }
+                    }
+                  },
+                  "required": [
+                    "groups"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/staff-bio": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "staffBio": {
+                    "type": "string",
+                    "nullable": true,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "staffBio"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Staff bio updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/comments": {
+      "get": {
+        "tags": [
+          "Comments"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "artist",
+                "collages",
+                "contributions",
+                "requests",
+                "communities",
+                "release"
+              ]
+            },
+            "required": false,
+            "name": "context",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "pageId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Comments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedComments"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Comments"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "page": {
+                    "type": "string",
+                    "enum": [
+                      "artist",
+                      "collages",
+                      "contributions",
+                      "requests",
+                      "communities",
+                      "release"
+                    ]
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "communityId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "contributionId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "requestId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "artistId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "releaseId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "collageId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "page",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Comment created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Comment"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/comments/{id}": {
+      "put": {
+        "tags": [
+          "Comments"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Comment updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Comment"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Comments"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Comment deleted"
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated artists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Artist"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Artists"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "vanityHouse": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Artist created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Artist"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/{id}": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artist with releases and tags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Artist"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "vanityHouse": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Artist updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Artist"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Artist deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/{id}/subscribe": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subscribed": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "subscribed"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscribed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subscribed": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "subscribed"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Artist not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unsubscribed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subscribed": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "subscribed"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/history/{artistId}": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "artistId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artist history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtistHistory"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/revert/{historyId}": {
+      "post": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "historyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artist reverted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    },
+                    "artist": {
+                      "$ref": "#/components/schemas/Artist"
+                    }
+                  },
+                  "required": [
+                    "msg",
+                    "artist"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/{id}/similar": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Similar artists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SimilarArtist"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/similar": {
+      "post": {
+        "tags": [
+          "Artists"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "artistId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "similarArtistId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "artistId",
+                  "similarArtistId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Similar artist link created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/alias": {
+      "post": {
+        "tags": [
+          "Artists"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "artistId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "redirectId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "artistId",
+                  "redirectId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Artist alias created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/tag": {
+      "post": {
+        "tags": [
+          "Artists"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "artistId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "tagId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "artistId",
+                  "tagId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Artist tagged",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts": {
+      "get": {
+        "tags": [
+          "Posts"
+        ],
+        "responses": {
+          "200": {
+            "description": "All posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Post"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Posts"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "category": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "title",
+                  "text",
+                  "category"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Post created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Post"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}": {
+      "get": {
+        "tags": [
+          "Posts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Posts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Post deleted"
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}/comments": {
+      "post": {
+        "tags": [
+          "Posts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Comment created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostComment"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Post not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}/comments/{commentId}": {
+      "delete": {
+        "tags": [
+          "Posts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "commentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Comment deleted"
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Comment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/topic-notes/{topicId}": {
+      "get": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "topicId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Topic notes (moderators only)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ForumTopicNote"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/topic-notes": {
+      "post": {
+        "tags": [
+          "Forums"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "forumTopicId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "forumTopicId",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Note created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForumTopicNote"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forums/topic-notes/{id}": {
+      "delete": {
+        "tags": [
+          "Forums"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Note deleted"
+          },
+          "403": {
+            "description": "Not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/requests": {
+      "get": {
+        "summary": "List requests",
+        "tags": [
+          "requests"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new request",
+        "tags": [
+          "requests"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "communityId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Music",
+                      "Applications",
+                      "EBooks",
+                      "ELearningVideos",
+                      "Audiobooks",
+                      "Comedy",
+                      "Comics"
+                    ]
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "year": {
+                    "type": "integer",
+                    "minimum": 1900,
+                    "maximum": 2100
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "bounty": {
+                    "type": "string",
+                    "pattern": "^d+$"
+                  },
+                  "artists": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true
+                    }
+                  }
+                },
+                "required": [
+                  "communityId",
+                  "type",
+                  "title",
+                  "description",
+                  "bounty"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/requests/{id}": {
+      "get": {
+        "summary": "Get request details",
+        "tags": [
+          "requests"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/requests/{id}/bounty": {
+      "post": {
+        "summary": "Add bounty to request",
+        "tags": [
+          "requests"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "string",
+                    "pattern": "^d+$"
+                  }
+                },
+                "required": [
+                  "amount"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/requests/{id}/fill": {
+      "post": {
+        "summary": "Fill request",
+        "tags": [
+          "requests"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contributionId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                },
+                "required": [
+                  "contributionId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "tags": [
+          "Messages"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "search",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox conversations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedConversations"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Messages"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "toUserId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "toUsername": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 32
+                  },
+                  "subject": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "subject",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Conversation created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateConversation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messages/unread-count": {
+      "get": {
+        "tags": [
+          "Messages"
+        ],
+        "responses": {
+          "200": {
+            "description": "Unread conversation count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "count"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messages/sent": {
+      "get": {
+        "tags": [
+          "Messages"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sent conversations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedConversations"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messages/bulk": {
+      "post": {
+        "tags": [
+          "Messages"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true
+                    },
+                    "minItems": 1
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "delete",
+                      "markRead",
+                      "markUnread"
+                    ]
+                  }
+                },
+                "required": [
+                  "ids",
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Bulk action applied"
+          }
+        }
+      }
+    },
+    "/messages/{id}": {
+      "get": {
+        "tags": [
+          "Messages"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation with messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateConversation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Messages"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "isSticky": {
+                    "type": "boolean"
+                  },
+                  "isRead": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Flags updated"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Messages"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Conversation soft-deleted"
+          }
+        }
+      }
+    },
+    "/messages/{id}/reply": {
+      "post": {
+        "tags": [
+          "Messages"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Reply sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not a participant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets": {
+      "get": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "responses": {
+          "200": {
+            "description": "My support tickets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedTickets"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "subject",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Ticket created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffInboxTicket"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets/count": {
+      "get": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "responses": {
+          "200": {
+            "description": "Count of tickets with unread staff replies",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "count"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/queue": {
+      "get": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "Unanswered",
+                "Open",
+                "Resolved"
+              ],
+              "default": "all"
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "default": false
+            },
+            "required": false,
+            "name": "assignedToMe",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "default": false
+            },
+            "required": false,
+            "name": "unassigned",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Staff ticket queue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedTickets"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/queue/count": {
+      "get": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "responses": {
+          "200": {
+            "description": "Unresolved ticket count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "count"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/bulk-resolve": {
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tickets bulk resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "resolved": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "resolved"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets/{id}": {
+      "get": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticket with messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffInboxTicket"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets/{id}/reply": {
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Reply sent"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Ticket resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets/{id}/resolve": {
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Resolved"
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets/{id}/unresolve": {
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unresolved"
+          }
+        }
+      }
+    },
+    "/staff-inbox/tickets/{id}/assign": {
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "assignedUserId": {
+                    "type": "integer",
+                    "nullable": true,
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "assignedUsername": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 32
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Assigned"
+          }
+        }
+      }
+    },
+    "/staff-inbox/responses": {
+      "get": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "responses": {
+          "200": {
+            "description": "Canned responses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StaffInboxResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "name",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Response created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffInboxResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staff-inbox/responses/{id}": {
+      "put": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffInboxResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "StaffInbox"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response deleted"
+          }
+        }
+      }
+    },
+    "/reports/stats": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "responses": {
+          "200": {
+            "description": "Report resolution statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "last24h": {
+                      "type": "number"
+                    },
+                    "lastWeek": {
+                      "type": "number"
+                    },
+                    "lastMonth": {
+                      "type": "number"
+                    },
+                    "allTime": {
+                      "type": "number"
+                    },
+                    "byStaff": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "number"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "userId",
+                          "username",
+                          "count"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "last24h",
+                    "lastWeek",
+                    "lastMonth",
+                    "allTime",
+                    "byStaff"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/counts": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "responses": {
+          "200": {
+            "description": "Open and claimed report counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "open": {
+                      "type": "number"
+                    },
+                    "claimed": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "open",
+                    "claimed"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/mine": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "responses": {
+          "200": {
+            "description": "User's submitted reports",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "number"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "pageSize": {
+                      "type": "number"
+                    },
+                    "reports": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "targetType": {
+                            "type": "string"
+                          },
+                          "targetId": {
+                            "type": "number"
+                          },
+                          "category": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "resolvedAt": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "resolution": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "sourceUrl": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "targetType",
+                          "targetId",
+                          "category",
+                          "status",
+                          "createdAt",
+                          "resolvedAt",
+                          "resolution",
+                          "sourceUrl"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "page",
+                    "pageSize",
+                    "reports"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated staff report queue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "number"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "pageSize": {
+                      "type": "number"
+                    },
+                    "reports": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "reporterId": {
+                            "type": "number"
+                          },
+                          "reporter": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "avatar"
+                            ]
+                          },
+                          "targetType": {
+                            "type": "string",
+                            "enum": [
+                              "User",
+                              "Release",
+                              "Artist",
+                              "Contribution",
+                              "ForumTopic",
+                              "ForumPost",
+                              "Comment",
+                              "Collage",
+                              "Post"
+                            ]
+                          },
+                          "targetId": {
+                            "type": "number"
+                          },
+                          "category": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "evidence": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "Open",
+                              "Claimed",
+                              "Resolved"
+                            ]
+                          },
+                          "claimedById": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "claimedBy": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "avatar"
+                            ]
+                          },
+                          "claimedAt": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "resolvedById": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "resolvedBy": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "avatar"
+                            ]
+                          },
+                          "resolvedAt": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "resolution": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "resolutionAction": {
+                            "type": "string",
+                            "nullable": true,
+                            "enum": [
+                              "Dismissed",
+                              "ContentRemoved",
+                              "UserWarned",
+                              "UserDisabled",
+                              "MetadataFixed",
+                              "MarkedDuplicate",
+                              "Other",
+                              null
+                            ]
+                          },
+                          "notes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "reportId": {
+                                  "type": "number"
+                                },
+                                "authorId": {
+                                  "type": "number"
+                                },
+                                "author": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    },
+                                    "avatar": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "username",
+                                    "avatar"
+                                  ]
+                                },
+                                "body": {
+                                  "type": "string"
+                                },
+                                "createdAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "reportId",
+                                "authorId",
+                                "author",
+                                "body",
+                                "createdAt"
+                              ]
+                            }
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "sourceUrl": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "reporterId",
+                          "reporter",
+                          "targetType",
+                          "targetId",
+                          "category",
+                          "reason",
+                          "evidence",
+                          "status",
+                          "claimedById",
+                          "claimedBy",
+                          "claimedAt",
+                          "resolvedById",
+                          "resolvedBy",
+                          "resolvedAt",
+                          "resolution",
+                          "resolutionAction",
+                          "notes",
+                          "createdAt",
+                          "updatedAt",
+                          "sourceUrl"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "page",
+                    "pageSize",
+                    "reports"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Reports"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "targetType": {
+                    "type": "string"
+                  },
+                  "targetId": {
+                    "type": "number"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "releaseCategory": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "evidence": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "targetType",
+                  "targetId",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Report created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "reporterId": {
+                      "type": "number"
+                    },
+                    "reporter": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "targetType": {
+                      "type": "string",
+                      "enum": [
+                        "User",
+                        "Release",
+                        "Artist",
+                        "Contribution",
+                        "ForumTopic",
+                        "ForumPost",
+                        "Comment",
+                        "Collage",
+                        "Post"
+                      ]
+                    },
+                    "targetId": {
+                      "type": "number"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "evidence": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "Open",
+                        "Claimed",
+                        "Resolved"
+                      ]
+                    },
+                    "claimedById": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "claimedBy": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "claimedAt": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolvedById": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "resolvedBy": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "resolvedAt": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolution": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolutionAction": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "Dismissed",
+                        "ContentRemoved",
+                        "UserWarned",
+                        "UserDisabled",
+                        "MetadataFixed",
+                        "MarkedDuplicate",
+                        "Other",
+                        null
+                      ]
+                    },
+                    "notes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "reportId": {
+                            "type": "number"
+                          },
+                          "authorId": {
+                            "type": "number"
+                          },
+                          "author": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "avatar"
+                            ]
+                          },
+                          "body": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "reportId",
+                          "authorId",
+                          "author",
+                          "body",
+                          "createdAt"
+                        ]
+                      }
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "sourceUrl": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "reporterId",
+                    "reporter",
+                    "targetType",
+                    "targetId",
+                    "category",
+                    "reason",
+                    "evidence",
+                    "status",
+                    "claimedById",
+                    "claimedBy",
+                    "claimedAt",
+                    "resolvedById",
+                    "resolvedBy",
+                    "resolvedAt",
+                    "resolution",
+                    "resolutionAction",
+                    "notes",
+                    "createdAt",
+                    "updatedAt",
+                    "sourceUrl"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{id}": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Report detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "reporterId": {
+                      "type": "number"
+                    },
+                    "reporter": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "targetType": {
+                      "type": "string",
+                      "enum": [
+                        "User",
+                        "Release",
+                        "Artist",
+                        "Contribution",
+                        "ForumTopic",
+                        "ForumPost",
+                        "Comment",
+                        "Collage",
+                        "Post"
+                      ]
+                    },
+                    "targetId": {
+                      "type": "number"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "evidence": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "Open",
+                        "Claimed",
+                        "Resolved"
+                      ]
+                    },
+                    "claimedById": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "claimedBy": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "claimedAt": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolvedById": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "resolvedBy": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "resolvedAt": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolution": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolutionAction": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "Dismissed",
+                        "ContentRemoved",
+                        "UserWarned",
+                        "UserDisabled",
+                        "MetadataFixed",
+                        "MarkedDuplicate",
+                        "Other",
+                        null
+                      ]
+                    },
+                    "notes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "reportId": {
+                            "type": "number"
+                          },
+                          "authorId": {
+                            "type": "number"
+                          },
+                          "author": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "avatar"
+                            ]
+                          },
+                          "body": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "reportId",
+                          "authorId",
+                          "author",
+                          "body",
+                          "createdAt"
+                        ]
+                      }
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "sourceUrl": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "reporterId",
+                    "reporter",
+                    "targetType",
+                    "targetId",
+                    "category",
+                    "reason",
+                    "evidence",
+                    "status",
+                    "claimedById",
+                    "claimedBy",
+                    "claimedAt",
+                    "resolvedById",
+                    "resolvedBy",
+                    "resolvedAt",
+                    "resolution",
+                    "resolutionAction",
+                    "notes",
+                    "createdAt",
+                    "updatedAt",
+                    "sourceUrl"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{id}/claim": {
+      "post": {
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Claimed"
+          }
+        }
+      }
+    },
+    "/reports/{id}/unclaim": {
+      "post": {
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unclaimed"
+          }
+        }
+      }
+    },
+    "/reports/{id}/resolve": {
+      "post": {
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "resolution": {
+                    "type": "string"
+                  },
+                  "resolutionAction": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "resolution",
+                  "resolutionAction"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Resolved"
+          }
+        }
+      }
+    },
+    "/reports/{id}/notes": {
+      "post": {
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Note added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "reportId": {
+                      "type": "number"
+                    },
+                    "authorId": {
+                      "type": "number"
+                    },
+                    "author": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username",
+                        "avatar"
+                      ]
+                    },
+                    "body": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "reportId",
+                    "authorId",
+                    "author",
+                    "body",
+                    "createdAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ratio-policy/{userId}": {
+      "get": {
+        "tags": [
+          "RatioPolicy"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User's ratio policy state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RatioPolicyState"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ratio-policy/{userId}/override": {
+      "post": {
+        "tags": [
+          "RatioPolicy"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OK",
+                      "WATCH",
+                      "LEECH_DISABLED"
+                    ]
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Override applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RatioPolicyState"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Site settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "approvedDomains": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "registrationStatus": {
+                    "type": "string",
+                    "enum": [
+                      "open",
+                      "invite",
+                      "closed"
+                    ]
+                  },
+                  "maxUsers": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated site settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/top10/releases": {
+      "get": {
+        "summary": "Top releases",
+        "tags": [
+          "Top10"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "day",
+                "week",
+                "month",
+                "year",
+                "overall",
+                "consumed",
+                "contributed"
+              ]
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "excludeTags",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "format",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top releases list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Top10ReleaseItem"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/top10/users": {
+      "get": {
+        "summary": "Top users",
+        "tags": [
+          "Top10"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "contributed",
+                "consumed",
+                "numContributions",
+                "contributionSpeed",
+                "consumeSpeed"
+              ]
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top users list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Top10UserItem"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/top10/tags": {
+      "get": {
+        "summary": "Top tags",
+        "tags": [
+          "Top10"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "used",
+                "voted"
+              ]
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top tags list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Top10TagItem"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/top10/votes": {
+      "get": {
+        "summary": "Top voted releases (BPCI ranked)",
+        "tags": [
+          "Top10"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "number",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "tags",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "nullable": true
+            },
+            "required": false,
+            "name": "year",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top voted releases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Top10VoteItem"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/top10/history": {
+      "get": {
+        "summary": "Top 10 history snapshot (staff)",
+        "tags": [
+          "Top10"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Daily",
+                "Weekly"
+              ]
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "date",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "History snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Top10Snapshot"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No snapshot found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "msg"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/top10/snapshot": {
+      "post": {
+        "summary": "Trigger a history snapshot (admin/cron)",
+        "tags": [
+          "Top10"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Daily",
+                      "Weekly"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Snapshot created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "msg"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rules/tree": {
+      "get": {
+        "tags": [
+          "Rules"
+        ],
+        "description": "The composable Rule/SubRule tree with CRS weights (PRD-05 #1)",
+        "responses": {
+          "200": {
+            "description": "Rule tree, each rule with its nested sub-rules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Rule"
+                      }
+                    }
+                  },
+                  "required": [
+                    "rules"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rules": {
+      "get": {
+        "tags": [
+          "Rules"
+        ],
+        "responses": {
+          "200": {
+            "description": "Main rules page and sub-pages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "main": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RulesPage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "pages": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RulesPage"
+                      }
+                    }
+                  },
+                  "required": [
+                    "main",
+                    "pages"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Rules"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "slug": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "pattern": "^[a-z0-9-]+$"
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "isMain": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "sortOrder": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Page created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RulesPage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rules/{slug}": {
+      "get": {
+        "tags": [
+          "Rules"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "slug",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Single rules page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RulesPage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rules/{id}": {
+      "put": {
+        "tags": [
+          "Rules"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "isMain": {
+                    "type": "boolean"
+                  },
+                  "sortOrder": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Page updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RulesPage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Rules"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Page deleted"
+          },
+          "400": {
+            "description": "Cannot delete main page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends": {
+      "get": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "List accepted friends",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated accepted-friends list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FriendEntry"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends/requests": {
+      "get": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "List incoming pending friend requests",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated incoming-requests list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FriendRequest"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends/status/{userId}": {
+      "get": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "Relationship status with a user",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Friend status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "pending_sent",
+                        "pending_received",
+                        "accepted",
+                        "rejected"
+                      ]
+                    },
+                    "isFriend": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "isFriend"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends/{userId}": {
+      "post": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "Send a friend request (or accept a reciprocal pending one)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A reciprocal pending request existed and was accepted (now friends)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FriendEntry"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Friend request sent (pending)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FriendRequestSent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Cannot add self",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Already friends or a request is already pending",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "Remove a friend or cancel a request",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Friendship/request removed"
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends/{userId}/accept": {
+      "post": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "Accept a pending request from a user",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request accepted — now friends",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FriendEntry"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No pending request from this user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends/{userId}/reject": {
+      "post": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "Reject a pending request from a user",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No pending request from this user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/friends/{userId}/comment": {
+      "put": {
+        "tags": [
+          "Friends"
+        ],
+        "summary": "Set a note on an accepted friendship",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "comment"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Comment updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Friend not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tag-aliases": {
+      "get": {
+        "tags": [
+          "TagAliases"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated tag alias list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TagAliasItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "TagAliases"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "badTag": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "goodTag": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  }
+                },
+                "required": [
+                  "badTag",
+                  "goodTag"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Tag alias created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagAliasItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Canonical tag not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tag-aliases/{id}": {
+      "put": {
+        "tags": [
+          "TagAliases"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "badTag": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "goodTag": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  }
+                },
+                "required": [
+                  "badTag",
+                  "goodTag"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tag alias updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagAliasItem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TagAliases"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tag alias deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/sessions": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated session list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SessionItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/invites": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated invite list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/InviteItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/invite-tree": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated invite tree",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/InviteTreeItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/invite-tree": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A member's invite subtree + summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tree": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MemberInviteTreeNode"
+                      }
+                    },
+                    "summary": {
+                      "$ref": "#/components/schemas/InviteTreeSummary"
+                    }
+                  },
+                  "required": [
+                    "tree",
+                    "summary"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/ratio-watch": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated ratio watch list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RatioWatchItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/vanity-house": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated vanity house artists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/VanityHouseArtist"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artists/{id}/vanity-house": {
+      "put": {
+        "tags": [
+          "Staff"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "vanityHouse": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "vanityHouse"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Artist updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VanityHouseArtist"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/album-of-month": {
+      "get": {
+        "tags": [
+          "Announcements"
+        ],
+        "responses": {
+          "200": {
+            "description": "Featured album list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeaturedAlbumItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "groupId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "threadId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "maxLength": 1000,
+                        "format": "uri"
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  "started": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "ended": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "groupId",
+                  "threadId",
+                  "title",
+                  "started",
+                  "ended"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturedAlbumItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/announcements/album-of-month/{albumId}": {
+      "delete": {
+        "tags": [
+          "Announcements"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "albumId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collages/deleted": {
+      "get": {
+        "tags": [
+          "Collages"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated deleted collages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DeletedCollageItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/economy": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Economy stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "grouped": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/EconomyGroupedItem"
+                      }
+                    },
+                    "recent": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/EconomyTransactionItem"
+                      }
+                    }
+                  },
+                  "required": [
+                    "grouped",
+                    "recent"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/releases": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Release and contribution counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "releases": {
+                      "type": "number"
+                    },
+                    "contributions": {
+                      "type": "number"
+                    },
+                    "artists": {
+                      "type": "number"
+                    },
+                    "byType": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "_count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "_count"
+                        ]
+                      }
+                    },
+                    "byLinkStatus": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "linkStatus": {
+                            "type": "string"
+                          },
+                          "_count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "linkStatus",
+                          "_count"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "releases",
+                    "contributions",
+                    "artists",
+                    "byType",
+                    "byLinkStatus"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/clients": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Top user agent strings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "userAgent": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "count": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "userAgent",
+                      "count"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/user-flow": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Invite funnel and snapshot trend",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "inviteFunnel": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string"
+                          },
+                          "_count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "_count"
+                        ]
+                      }
+                    },
+                    "snapshots": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "bucketAt": {
+                            "type": "string"
+                          },
+                          "totalUsers": {
+                            "type": "number"
+                          },
+                          "activeThisMonth": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "bucketAt",
+                          "totalUsers",
+                          "activeThisMonth"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "inviteFunnel",
+                    "snapshots"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/site-info": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregate DB counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalUsers": {
+                      "type": "number"
+                    },
+                    "enabledUsers": {
+                      "type": "number"
+                    },
+                    "disabledUsers": {
+                      "type": "number"
+                    },
+                    "releases": {
+                      "type": "number"
+                    },
+                    "artists": {
+                      "type": "number"
+                    },
+                    "contributions": {
+                      "type": "number"
+                    },
+                    "communities": {
+                      "type": "number"
+                    },
+                    "forumTopics": {
+                      "type": "number"
+                    },
+                    "forumPosts": {
+                      "type": "number"
+                    },
+                    "collages": {
+                      "type": "number"
+                    },
+                    "wikiPages": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "totalUsers",
+                    "enabledUsers",
+                    "disabledUsers",
+                    "releases",
+                    "artists",
+                    "contributions",
+                    "communities",
+                    "forumTopics",
+                    "forumPosts",
+                    "collages",
+                    "wikiPages"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/dnc": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "communityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DNC list for the community",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DncEntry"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Communities"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "communityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "comment": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "comment"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created DNC entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DncEntry"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/communities/{communityId}/dnc/{dncId}": {
+      "delete": {
+        "tags": [
+          "Communities"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "communityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "dncId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        }
+      }
+    },
+    "/bookmarks/artists": {
+      "get": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "userId": {
+                        "type": "number"
+                      },
+                      "artistId": {
+                        "type": "number"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "artist": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "userId",
+                      "artistId",
+                      "createdAt",
+                      "artist"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bookmarks/artists/{artistId}": {
+      "post": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "artistId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Toggled bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bookmarked": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "bookmarked"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "artistId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed"
+          }
+        }
+      }
+    },
+    "/bookmarks/releases": {
+      "get": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "userId": {
+                        "type": "number"
+                      },
+                      "releaseId": {
+                        "type": "number"
+                      },
+                      "sort": {
+                        "type": "number"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "release": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "communityId": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "artist": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "communityId",
+                          "title",
+                          "artist"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "userId",
+                      "releaseId",
+                      "sort",
+                      "createdAt",
+                      "release"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bookmarks/releases/{releaseId}": {
+      "post": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Toggled bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bookmarked": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "bookmarked"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed"
+          }
+        }
+      }
+    },
+    "/bookmarks/communities": {
+      "get": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "userId": {
+                        "type": "number"
+                      },
+                      "communityId": {
+                        "type": "number"
+                      },
+                      "sort": {
+                        "type": "number"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "community": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "userId",
+                      "communityId",
+                      "sort",
+                      "createdAt",
+                      "community"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bookmarks/communities/{communityId}": {
+      "post": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Toggled bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bookmarked": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "bookmarked"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed"
+          }
+        }
+      }
+    },
+    "/bookmarks/requests": {
+      "get": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "userId": {
+                        "type": "number"
+                      },
+                      "requestId": {
+                        "type": "number"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "request": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "userId",
+                      "requestId",
+                      "createdAt",
+                      "request"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bookmarks/requests/{requestId}": {
+      "post": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "requestId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Toggled bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bookmarked": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "bookmarked"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "requestId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed"
+          }
+        }
+      }
+    },
+    "/random/release": {
+      "get": {
+        "tags": [
+          "Random"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A random release",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "communityId": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "year": {
+                      "type": "number"
+                    },
+                    "artist": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "communityId",
+                    "title",
+                    "year",
+                    "artist"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No releases found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/random/artist": {
+      "get": {
+        "tags": [
+          "Random"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A random artist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No artists found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/releases": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 500
+            },
+            "required": false,
+            "name": "tags",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "any",
+                "all"
+              ],
+              "default": "any"
+            },
+            "required": false,
+            "name": "tagMode",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "createdAt",
+                "year",
+                "consumers",
+                "contributors",
+                "random"
+              ],
+              "default": "createdAt"
+            },
+            "required": false,
+            "name": "orderBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            },
+            "required": false,
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0,
+                  "exclusiveMinimum": true
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                }
+              ]
+            },
+            "required": false,
+            "name": "communityId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "artist",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "title",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "recordLabel",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "required": false,
+            "name": "catalogueNumber",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1900,
+              "maximum": 2100
+            },
+            "required": false,
+            "name": "year",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1900,
+              "maximum": 2100
+            },
+            "required": false,
+            "name": "yearTo",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 500
+            },
+            "required": false,
+            "name": "description",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Music",
+                "Applications",
+                "EBooks",
+                "ELearningVideos",
+                "Audiobooks",
+                "Comedy",
+                "Comics"
+              ]
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Album",
+                "Single",
+                "EP",
+                "Anthology",
+                "Compilation",
+                "DJMix",
+                "Live",
+                "Remix",
+                "Bootleg",
+                "Interview",
+                "Mixtape",
+                "Demo",
+                "ConcertRecording",
+                "Unknown"
+              ]
+            },
+            "required": false,
+            "name": "releaseType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "mp3",
+                "flac",
+                "wav",
+                "ogg",
+                "aac",
+                "m4a",
+                "m4b",
+                "mp4",
+                "mkv",
+                "avi",
+                "mov",
+                "zip",
+                "exe",
+                "dmg",
+                "apk",
+                "pdf",
+                "epub",
+                "mobi",
+                "cbz",
+                "cbr",
+                "jpg",
+                "png",
+                "gif",
+                "txt"
+              ]
+            },
+            "required": false,
+            "name": "format",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Lossless",
+                "Lossless24",
+                "Kbps320",
+                "Kbps256",
+                "KbpsV0",
+                "Kbps192",
+                "KbpsV2",
+                "Kbps128",
+                "Other"
+              ]
+            },
+            "required": false,
+            "name": "bitrate",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CD",
+                "WEB",
+                "Vinyl",
+                "SACD",
+                "DVD",
+                "Cassette",
+                "BluRay",
+                "DAT",
+                "Soundboard",
+                "Other"
+              ]
+            },
+            "required": false,
+            "name": "media",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "hasLog",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "hasCue",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "isScene",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "vanityHouse",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Release search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "year": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "releaseType": {
+                            "type": "string"
+                          },
+                          "communityId": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "artist": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ]
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "name"
+                              ]
+                            }
+                          },
+                          "_count": {
+                            "type": "object",
+                            "properties": {
+                              "consumers": {
+                                "type": "number"
+                              },
+                              "contributors": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "consumers",
+                              "contributors"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "year",
+                          "type",
+                          "releaseType",
+                          "communityId",
+                          "description",
+                          "createdAt",
+                          "artist",
+                          "tags",
+                          "_count"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/artists": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 500
+            },
+            "required": false,
+            "name": "tags",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "any",
+                "all"
+              ],
+              "default": "any"
+            },
+            "required": false,
+            "name": "tagMode",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "vanityHouse",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "random"
+              ],
+              "default": "name"
+            },
+            "required": false,
+            "name": "orderBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            },
+            "required": false,
+            "name": "order",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artist search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "vanityHouse": {
+                            "type": "boolean"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "tag": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "name"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "tag"
+                              ]
+                            }
+                          },
+                          "_count": {
+                            "type": "object",
+                            "properties": {
+                              "releases": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "releases"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "vanityHouse",
+                          "tags",
+                          "_count"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/requests": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "artist",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Music",
+                "Applications",
+                "EBooks",
+                "ELearningVideos",
+                "Audiobooks",
+                "Comedy",
+                "Comics"
+              ]
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1900,
+              "maximum": 2100
+            },
+            "required": false,
+            "name": "year",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "filled",
+                "deleted"
+              ]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "communityId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "createdAt",
+                "voteCount",
+                "random"
+              ],
+              "default": "createdAt"
+            },
+            "required": false,
+            "name": "orderBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            },
+            "required": false,
+            "name": "order",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "year": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "voteCount": {
+                            "type": "number"
+                          },
+                          "communityId": {
+                            "type": "number"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username"
+                            ]
+                          },
+                          "community": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ]
+                          },
+                          "artists": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "artist": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "name"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "artist"
+                              ]
+                            }
+                          },
+                          "totalBounty": {
+                            "type": "string"
+                          },
+                          "_count": {
+                            "type": "object",
+                            "properties": {
+                              "bounties": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "bounties"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "description",
+                          "type",
+                          "year",
+                          "status",
+                          "voteCount",
+                          "communityId",
+                          "createdAt",
+                          "user",
+                          "artists",
+                          "totalBounty",
+                          "_count"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/log": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "topic",
+                "post",
+                "all"
+              ],
+              "default": "all"
+            },
+            "required": false,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "authorId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "createdAt"
+              ],
+              "default": "createdAt"
+            },
+            "required": false,
+            "name": "orderBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            },
+            "required": false,
+            "name": "order",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Forum log search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "isLocked": {
+                                "type": "boolean"
+                              },
+                              "isSticky": {
+                                "type": "boolean"
+                              },
+                              "numPosts": {
+                                "type": "number"
+                              },
+                              "forumId": {
+                                "type": "number"
+                              },
+                              "author": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "username": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "username"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "title",
+                              "createdAt",
+                              "isLocked",
+                              "isSticky",
+                              "numPosts",
+                              "forumId",
+                              "author"
+                            ]
+                          }
+                        },
+                        "meta": {
+                          "$ref": "#/components/schemas/PaginationMeta"
+                        }
+                      },
+                      "required": [
+                        "data",
+                        "meta"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "body": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "forumTopicId": {
+                                "type": "number"
+                              },
+                              "author": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "username": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "username"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "body",
+                              "createdAt",
+                              "forumTopicId",
+                              "author"
+                            ]
+                          }
+                        },
+                        "meta": {
+                          "$ref": "#/components/schemas/PaginationMeta"
+                        }
+                      },
+                      "required": [
+                        "data",
+                        "meta"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "topics": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "createdAt": {
+                                    "type": "string"
+                                  },
+                                  "isLocked": {
+                                    "type": "boolean"
+                                  },
+                                  "isSticky": {
+                                    "type": "boolean"
+                                  },
+                                  "numPosts": {
+                                    "type": "number"
+                                  },
+                                  "forumId": {
+                                    "type": "number"
+                                  },
+                                  "author": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "number"
+                                      },
+                                      "username": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "username"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "title",
+                                  "createdAt",
+                                  "isLocked",
+                                  "isSticky",
+                                  "numPosts",
+                                  "forumId",
+                                  "author"
+                                ]
+                              }
+                            },
+                            "meta": {
+                              "$ref": "#/components/schemas/PaginationMeta"
+                            }
+                          },
+                          "required": [
+                            "data",
+                            "meta"
+                          ]
+                        },
+                        "posts": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "body": {
+                                    "type": "string"
+                                  },
+                                  "createdAt": {
+                                    "type": "string"
+                                  },
+                                  "forumTopicId": {
+                                    "type": "number"
+                                  },
+                                  "author": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "number"
+                                      },
+                                      "username": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "username"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "body",
+                                  "createdAt",
+                                  "forumTopicId",
+                                  "author"
+                                ]
+                              }
+                            },
+                            "meta": {
+                              "$ref": "#/components/schemas/PaginationMeta"
+                            }
+                          },
+                          "required": [
+                            "data",
+                            "meta"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "topics",
+                        "posts"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/users": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "username",
+                "createdAt",
+                "lastLogin"
+              ],
+              "default": "username"
+            },
+            "required": false,
+            "name": "orderBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            },
+            "required": false,
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "disabled",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "userRank": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "color"
+                            ]
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "lastLogin": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "ratio": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "contributed": {
+                            "type": "string"
+                          },
+                          "consumed": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "username",
+                          "createdAt",
+                          "userRank"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/site-history": {
+      "get": {
+        "tags": [
+          "Site history"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Site history entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "authorId": {
+                        "type": "number"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "body": {
+                        "type": "string"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "updatedAt": {
+                        "type": "string"
+                      },
+                      "author": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "username": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "username"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "authorId",
+                      "title",
+                      "body",
+                      "createdAt",
+                      "updatedAt",
+                      "author"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Site history"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "authorId": {
+                      "type": "number"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "authorId",
+                    "title",
+                    "body",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/site-history/{id}": {
+      "put": {
+        "tags": [
+          "Site history"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "authorId": {
+                      "type": "number"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "authorId",
+                    "title",
+                    "body",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Site history"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contributions/{id}/access": {
+      "post": {
+        "tags": [
+          "Downloads"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idempotencyKey": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Download access granted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "grantId": {
+                      "type": "number"
+                    },
+                    "downloadUrl": {
+                      "type": "string"
+                    },
+                    "amountBytes": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "grantId",
+                    "downloadUrl",
+                    "amountBytes",
+                    "status",
+                    "createdAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contributions/{id}/access/latest": {
+      "get": {
+        "tags": [
+          "Downloads"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Most recent grant within the idempotency window",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "grantId": {
+                      "type": "number"
+                    },
+                    "downloadUrl": {
+                      "type": "string"
+                    },
+                    "amountBytes": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "grantId",
+                    "downloadUrl",
+                    "amountBytes",
+                    "status",
+                    "createdAt"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No recent grant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/downloads/{grantId}/reverse": {
+      "post": {
+        "tags": [
+          "Downloads"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "grantId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Grant reversed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "grantId": {
+                      "type": "number"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "grantId",
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/donations": {
+      "get": {
+        "tags": [
+          "Donations"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Donation log",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "userId": {
+                            "type": "number"
+                          },
+                          "amount": {
+                            "type": "number"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "donatedAt": {
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "username": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "userId",
+                          "amount",
+                          "email",
+                          "donatedAt",
+                          "currency",
+                          "source",
+                          "reason",
+                          "user"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Donations"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "number"
+                  },
+                  "amount": {
+                    "type": "number"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "donatedAt": {
+                    "type": "string"
+                  },
+                  "currency": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userId",
+                  "amount",
+                  "email",
+                  "donatedAt",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Donation recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "userId": {
+                      "type": "number"
+                    },
+                    "amount": {
+                      "type": "number"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "donatedAt": {
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "username"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "userId",
+                    "amount",
+                    "email",
+                    "donatedAt",
+                    "currency",
+                    "source",
+                    "reason",
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/donations/{id}": {
+      "delete": {
+        "tags": [
+          "Donations"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email-blacklist": {
+      "get": {
+        "tags": [
+          "Email blacklist"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Blacklisted emails",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "userId": {
+                        "type": "number"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "addedAt": {
+                        "type": "string"
+                      },
+                      "comment": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "userId",
+                      "email",
+                      "addedAt",
+                      "comment"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Email blacklist"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "comment": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email",
+                  "comment"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "userId": {
+                      "type": "number"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "addedAt": {
+                      "type": "string"
+                    },
+                    "comment": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "userId",
+                    "email",
+                    "addedAt",
+                    "comment"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email-blacklist/{id}": {
+      "delete": {
+        "tags": [
+          "Email blacklist"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ip-bans": {
+      "get": {
+        "tags": [
+          "IP bans"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "IP bans",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "fromIp": {
+                        "type": "string"
+                      },
+                      "toIp": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "fromIp",
+                      "toIp"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "IP bans"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fromIp": {
+                    "type": "string"
+                  },
+                  "toIp": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "fromIp"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created ban",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "fromIp": {
+                      "type": "string"
+                    },
+                    "toIp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "fromIp",
+                    "toIp"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ip-bans/{id}": {
+      "delete": {
+        "tags": [
+          "IP bans"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Tries on ADR-0018 by making the repo compatible with the proposal. The ADR is landed **Accepted** and three of its gates are now real repo tooling.

## What's in here

1. **ADR-0018** (`docs/adr/0018-development-lifecycle-and-contract-gate.md`) + a `CONTEXT-MAP.md` entry. Codifies the revised lifecycle: reference-implementation parity (step 1, named on its own terms — no legacy identity), contract-first API/UI parallelization, per-issue acceptance criteria as DoD, an explicit rework loop, the QA-vs-UAT split, and a security + cross-repo integration gate plus post-deploy smoke.
2. **De-inert the OpenAPI freshness gate** (closes #204). `openapi.json` was gitignored/untracked, so `git diff --exit-code openapi.json` compared against nothing and always passed. Now tracked with a deterministic baseline, mirroring the ERD gate (real only because `docs/erd.md` is committed). Added to `.prettierignore` so `prettier --write .` can't reformat it out from under the byte-exact gate. No workflow YAML change — the existing step is simply live now.
3. **Issue + PR templates and a security-review gate** (the repo had no templates). Issue templates carry an Acceptance criteria / DoD section; the PR template separates agent-run QA from human UAT and carries the OpenAPI/ERD + security checkboxes; `security-review-gate.yml` fails a PR touching `src/middleware/**` unless the security-review box is ticked.

## Verification

- OpenAPI gate proven: committed baseline byte-identical to a fresh `npm run openapi:export`; `git diff --exit-code openapi.json` now **fails on drift** (verified with the file tracked, not the prior vacuous pass).
- Security gate: YAML parses; matcher passes a ticked review box and blocks both unticked and ticked-N/A-only bodies.

## Deliberate scope calls (flag for review)

- Security gate scoped to `src/middleware/**`, not `src/routes/**`, to stay high-signal rather than firing on every PR and eroding into rubber-stamping. New-route coverage is author-attested in the PR template. Widen `paths:` if you'd prefer stricter.
- The security gate is an honesty checkbox, not a cryptographic attestation — appropriate for a small team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)