### PR TITLE
feat(profile): expose verified IRC nick on the self settings read (#201)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -373,6 +373,10 @@
           },
           "showRatioStats": {
             "type": "boolean"
+          },
+          "ircNick": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -844,7 +844,8 @@ describe('API auth/profile/user flows', () => {
       showContributedStats: true,
       showConsumedStats: true,
       showRatioStats: true,
-      activeAuthorStylesheetId: null
+      activeAuthorStylesheetId: null,
+      ircNick: 'stargazer'
     });
 
     const res = await request(app).get('/api/users/settings');
@@ -852,6 +853,7 @@ describe('API auth/profile/user flows', () => {
     expect(res.status).toBe(200);
     expect(getUserSettingsMock).toHaveBeenCalledWith(7);
     expect(res.body.siteAppearance).toBe('dark');
+    expect(res.body.ircNick).toBe('stargazer');
   });
 
   it('returns the updated settings payload from /api/users/settings', async () => {

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -353,7 +353,10 @@ const UserSettings = registry.register(
     showLastSeen: z.boolean(),
     showContributedStats: z.boolean(),
     showConsumedStats: z.boolean(),
-    showRatioStats: z.boolean()
+    showRatioStats: z.boolean(),
+    // Verified IRC nick (ADR-0015, #201) — self-only read path for the UI's
+    // "currently linked: X" display. Non-null ⇒ verified; null ⇒ unlinked.
+    ircNick: z.string().nullable().optional()
   })
 );
 

--- a/src/modules/user.ts
+++ b/src/modules/user.ts
@@ -23,10 +23,18 @@ export type SnatchItem = {
 export const getUserSettings = async (userId: number) => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { userSettingsId: true }
+    select: { userSettingsId: true, ircNick: true }
   });
   if (!user) return null;
-  return prisma.userSettings.findUnique({ where: { id: user.userSettingsId } });
+  const settings = await prisma.userSettings.findUnique({
+    where: { id: user.userSettingsId }
+  });
+  if (!settings) return null;
+  // ircNick holds only a *verified* nick (ADR-0015), so non-null ⇒ verified. We
+  // surface it self-only here (this route reads the caller's own settings) so the
+  // UI can render "currently linked: X" — the public profile deliberately omits it
+  // (paranoia) since it's not in PROFILE_BASE_SELECT (#201).
+  return { ...settings, ircNick: user.ircNick };
 };
 
 export const updateUserSettings = async (


### PR DESCRIPTION
Closes #201.

## What

Surfaces a member's current **verified** IRC nick on a self-read path so stellar-ui (#82/#89) can render "currently linked: X". Previously `ircNick` (ADR-0015, #175) was write/lookup-only — present in the `PUT /users/:id/irc-nick` result and the service-gated `by-irc-nick` lookup, but with no read path for the owning member.

## How

- `getUserSettings` now merges the caller's `ircNick` into the `GET /users/settings` payload.
- Stays **self-only**: the route reads `req.user.id`, and `ircNick` is deliberately *not* in the shared `PROFILE_BASE_SELECT`, so the public `/user/:id` profile keeps omitting it (paranoia default per the issue).
- Semantics: non-null ⇒ verified; null ⇒ unlinked (the column only ever holds a verified nick).
- Registered on the `UserSettings` OpenAPI schema and regenerated `openapi.json` so it reaches the UI's generated types (satisfies the contract gate, ADR-0018).

## Test

- Extended the `GET /api/users/settings` spec to assert `ircNick` is returned.
- `format` / `lint` / `tsc --noEmit` / `typecheck:test` clean; full suite 1625 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)