### PR TITLE
feat(infra): enforced version-consistency guardrail (#79)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,11 @@ jobs:
         run: npm run openapi:export && git diff --exit-code openapi.json
       - name: ERD freshness
         run: npm run db:erd && git diff --exit-code docs/erd.md
+      - name: Version consistency
+        run: npm run version:check
+      - name: Version consistency (tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: git fetch --tags --force && npm run version:check -- --check-tag
       - name: Integration tests
         run: npm run test:integration
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
+
+# Version-consistency guardrail (#79). Internal axes only — the git-tag axis is
+# enforced in CI on tag pushes so a release bump commit isn't blocked here.
+npm run version:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:watch": "jest --watch --forceExit",
     "test:integration": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ./node_modules/jest/bin/jest.js --runInBand --config jest.integration.cjs",
     "openapi:export": "ts-node src/scripts/export-openapi.ts",
+    "version:check": "ts-node src/scripts/check-version-consistency.ts",
     "db:generate": "prisma generate",
     "db:erd": "prisma generate --generator erd",
     "db:migrate": "prisma migrate dev",

--- a/src/lib/versionConsistency.spec.ts
+++ b/src/lib/versionConsistency.spec.ts
@@ -1,0 +1,89 @@
+import { checkVersionConsistency } from './versionConsistency';
+
+describe('checkVersionConsistency', () => {
+  it('reports no mismatches when every present surface agrees with the manifest', () => {
+    const result = checkVersionConsistency({
+      manifest: '0.5.6',
+      lockfile: '0.5.6',
+      changelogTop: '0.5.6',
+      runtime: '0.5.6'
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('flags a lockfile that lags the manifest (the recurring drift)', () => {
+    const result = checkVersionConsistency({
+      manifest: '0.5.6',
+      lockfile: '0.5.5'
+    });
+    expect(result).toEqual([
+      { surface: 'lockfile', expected: '0.5.6', actual: '0.5.5' }
+    ]);
+  });
+
+  it('flags a CHANGELOG whose top dated section lags the manifest', () => {
+    const result = checkVersionConsistency({
+      manifest: '0.5.6',
+      lockfile: '0.5.6',
+      changelogTop: '0.5.5'
+    });
+    expect(result).toEqual([
+      { surface: 'changelog', expected: '0.5.6', actual: '0.5.5' }
+    ]);
+  });
+
+  it('flags an API runtime version that no longer derives the manifest', () => {
+    const result = checkVersionConsistency({
+      manifest: '0.5.6',
+      lockfile: '0.5.6',
+      runtime: '0.1.0'
+    });
+    expect(result).toEqual([
+      { surface: 'runtime', expected: '0.5.6', actual: '0.1.0' }
+    ]);
+  });
+
+  it('ignores the tag axis by default (a release bump runs ahead of the tag)', () => {
+    const result = checkVersionConsistency({
+      manifest: '0.5.6',
+      lockfile: '0.5.6',
+      latestTag: '0.5.5'
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('flags a tag mismatch only when the tag axis is explicitly enabled', () => {
+    const result = checkVersionConsistency(
+      { manifest: '0.5.6', lockfile: '0.5.6', latestTag: '0.5.5' },
+      { checkTag: true }
+    );
+    expect(result).toEqual([
+      { surface: 'tag', expected: '0.5.6', actual: '0.5.5' }
+    ]);
+  });
+
+  it('skips the tag axis when no tag is available, even with checkTag', () => {
+    const result = checkVersionConsistency(
+      { manifest: '0.5.6', lockfile: '0.5.6', latestTag: null },
+      { checkTag: true }
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('aggregates every disagreeing surface in a single pass', () => {
+    const result = checkVersionConsistency(
+      {
+        manifest: '0.5.6',
+        lockfile: '0.5.5',
+        changelogTop: '0.5.4',
+        latestTag: '0.5.5'
+      },
+      { checkTag: true }
+    );
+    expect(result.map((m) => m.surface)).toEqual([
+      'lockfile',
+      'changelog',
+      'tag'
+    ]);
+  });
+});

--- a/src/lib/versionConsistency.ts
+++ b/src/lib/versionConsistency.ts
@@ -1,0 +1,54 @@
+// Pure version-consistency checker (#79). The manifest (package.json) is the
+// single source of truth; every other version surface present on the project is
+// compared against it. No I/O here — the CLI wrapper
+// (src/scripts/check-version-consistency.ts) gathers the real surfaces and feeds
+// them in, which keeps the comparison logic trivially unit-testable.
+
+export interface VersionSurfaces {
+  /** package.json version — the source of truth all others are compared against. */
+  manifest: string;
+  /** package-lock.json version. */
+  lockfile: string;
+  /** First dated `## [X.Y.Z]` heading in CHANGELOG.md (null when none found). */
+  changelogTop?: string | null;
+  /** API runtime version (src/lib/version.ts appVersion). */
+  runtime?: string;
+  /** Latest `vX.Y.Z` git tag, v-prefix stripped (null when no tags). */
+  latestTag?: string | null;
+}
+
+export interface VersionMismatch {
+  surface: string;
+  expected: string;
+  actual: string;
+}
+
+export interface CheckOptions {
+  /** Enforce the git-tag axis. Off by default — a release bump commit
+   *  legitimately runs ahead of the tag, so the tag is only checked on
+   *  tag/release events in CI, never on every commit. */
+  checkTag?: boolean;
+}
+
+export function checkVersionConsistency(
+  surfaces: VersionSurfaces,
+  opts: CheckOptions = {}
+): VersionMismatch[] {
+  const { manifest, lockfile, changelogTop, runtime, latestTag } = surfaces;
+  const mismatches: VersionMismatch[] = [];
+
+  const compare = (surface: string, actual: string | null | undefined) => {
+    if (actual != null && actual !== manifest) {
+      mismatches.push({ surface, expected: manifest, actual });
+    }
+  };
+
+  compare('lockfile', lockfile);
+  compare('changelog', changelogTop);
+  compare('runtime', runtime);
+  if (opts.checkTag) {
+    compare('tag', latestTag);
+  }
+
+  return mismatches;
+}

--- a/src/scripts/check-version-consistency.ts
+++ b/src/scripts/check-version-consistency.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { execFileSync } from 'child_process';
+import {
+  checkVersionConsistency,
+  VersionSurfaces
+} from '../lib/versionConsistency';
+import { appVersion } from '../lib/version';
+
+// Gathers the real version surfaces and feeds them to the pure checker (#79).
+// Internal axes (lockfile, CHANGELOG, runtime) run on every invocation; the
+// git-tag axis is opt-in via --check-tag so a release bump commit — which
+// legitimately runs ahead of its tag — isn't blocked at pre-commit time.
+
+const root = resolve(__dirname, '../..');
+
+const readVersion = (file: string): string => {
+  const pkg = JSON.parse(readFileSync(resolve(root, file), 'utf8')) as {
+    version?: string;
+  };
+  return pkg.version ?? '0.0.0';
+};
+
+// First dated section heading, e.g. `## [0.5.6] - 2026-06-17`. The `[Unreleased]`
+// section is intentionally skipped (no version to compare).
+const readChangelogTop = (): string | null => {
+  const text = readFileSync(resolve(root, 'CHANGELOG.md'), 'utf8');
+  const match = text.match(/^##\s*\[(\d+\.\d+\.\d+)\]/m);
+  return match ? match[1] : null;
+};
+
+const readLatestTag = (): string | null => {
+  try {
+    const out = execFileSync(
+      'git',
+      ['tag', '--list', 'v[0-9]*', '--sort=-v:refname'],
+      { cwd: root, encoding: 'utf8' }
+    );
+    const latest = out.split('\n').find((l) => l.trim().length > 0);
+    return latest ? latest.trim().replace(/^v/, '') : null;
+  } catch {
+    // Not a git repo, shallow clone, or git unavailable — skip the tag axis.
+    return null;
+  }
+};
+
+const checkTag = process.argv.includes('--check-tag');
+
+const surfaces: VersionSurfaces = {
+  manifest: readVersion('package.json'),
+  lockfile: readVersion('package-lock.json'),
+  changelogTop: readChangelogTop(),
+  runtime: appVersion,
+  latestTag: checkTag ? readLatestTag() : undefined
+};
+
+const mismatches = checkVersionConsistency(surfaces, { checkTag });
+
+if (mismatches.length > 0) {
+  console.error(`Version drift detected (manifest is ${surfaces.manifest}):`);
+  for (const m of mismatches) {
+    console.error(
+      `  ✗ ${m.surface}: expected ${m.expected}, found ${m.actual}`
+    );
+  }
+  console.error(
+    '\nRealign every surface to the manifest version before committing.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Version surfaces consistent at ${surfaces.manifest}${
+    checkTag ? ' (incl. git tag)' : ''
+  }.`
+);


### PR DESCRIPTION
## Summary

Adds the automated guardrail spine #79 asks for. A pure version-consistency checker (built test-first) treats `package.json` as the single source of truth and flags any surface that drifts from it, wired into CI and a re-enabled husky pre-commit so drift can't merge or be committed.

Scope this PR: **guardrail only** (release-please adoption deferred to a separate non-TDD PR). Also re-enables the husky hook tracked in #77.

## What's here

- **`src/lib/versionConsistency.ts`** — pure `checkVersionConsistency(surfaces, { checkTag })`, 8 unit specs built red→green. Axes: lockfile, CHANGELOG top dated section, API runtime (`lib/version.ts`), and — opt-in via `--check-tag` — the latest `vX.Y.Z` tag.
- **`src/scripts/check-version-consistency.ts`** + `npm run version:check` — gathers the real surfaces, prints mismatches, exits 1 on any.
- **`.github/workflows/publish.yml`** — internal `Version consistency` step every run + a tag-scoped `--check-tag` step on tag pushes.
- **`.husky/pre-commit`** — re-enabled (#77; hook tracked `100755`) and runs the internal check.
- **`package-lock.json` 0.5.5 → 0.5.6** — realigns the live drift this guardrail immediately surfaced.

## Why the tag axis is opt-in

A release bump commit legitimately runs ahead of its tag, so the tag check is off by default (won't block local commits / the bump itself) and CI enforces it only on tag pushes. This addresses the exact recurrence noted in #179 (tag left one commit behind the bump).

## Verification

- 8 new specs green; full suite 1633/1633; format/lint/tsc/typecheck:test clean
- `version:check` exits 1 naming the drifted surface, 0 when aligned (both modes)
- `.husky/pre-commit` run directly: passes clean, blocks a drifted manifest (exit 1)

## Out of scope (deferred — keep #79 open)

release-please adoption, and the cross-repo UI-manifest / stellar-compose submodule axes (not resolvable from this repo).

Closes nothing — #79 stays open for the release-please half. Re-enables the hook from #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)