### PR TITLE
feat(reputation): CRS time-series snapshots (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ src/
     linkHealth.ts           # HEAD-request link checker + auto-warn on 3+ reports; computePulse + getCommunityHealthPulse
     linkHealthJob.ts        # Background job: recheck stale contribution links every 24h
     communityHealthHistory.ts # Persist/query the community health pulse as a time-series snapshot (#75); captured by statsJob
+    crsHistory.ts           # Capture/query CRS as a time-series snapshot (#94, ADR-0007 trend layer); active-users-only, Monthly+Yearly cadence (no hourly), self-read only — captured by statsJob
     auth.ts                 # Password validation, auth user DB query helpers
     artist.ts               # Artist creation/update with history tracking
     comment.ts              # Comment soft-delete with audit logging

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1540,6 +1540,16 @@ Yearly Yearly
     }
   
 
+  "crs_snapshots" {
+    Int id "🗝️"
+    StatSnapshotPeriod period 
+    DateTime bucketAt 
+    DateTime capturedAt 
+    Float score 
+    Json dimensions 
+    }
+  
+
   "dev_seed_runs" {
     String id "🗝️"
     String label "❓"
@@ -1795,6 +1805,8 @@ Yearly Yearly
     "user_stat_snapshots" }o--|| users : "user"
     "community_health_snapshots" |o--|| "StatSnapshotPeriod" : "enum:period"
     "community_health_snapshots" }o--|| communities : "community"
+    "crs_snapshots" |o--|| "StatSnapshotPeriod" : "enum:period"
+    "crs_snapshots" }o--|| users : "user"
     "dev_seed_records" }o--|| dev_seed_runs : "run"
     "dev_seed_mutations" }o--|| dev_seed_runs : "run"
 ```

--- a/openapi.json
+++ b/openapi.json
@@ -5526,6 +5526,52 @@
           "addedBy"
         ]
       },
+      "CrsSnapshot": {
+        "type": "object",
+        "properties": {
+          "capturedAt": {
+            "type": "string"
+          },
+          "period": {
+            "type": "string",
+            "enum": [
+              "Monthly",
+              "Yearly"
+            ]
+          },
+          "score": {
+            "type": "number"
+          },
+          "dimensions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "subScore": {
+                  "type": "number"
+                },
+                "weighted": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "name",
+                "subScore",
+                "weighted"
+              ]
+            }
+          }
+        },
+        "required": [
+          "capturedAt",
+          "period",
+          "score",
+          "dimensions"
+        ]
+      },
       "CommunityHealthPulse": {
         "type": "object",
         "properties": {
@@ -6681,6 +6727,53 @@
           },
           "404": {
             "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/me/reputation/history": {
+      "get": {
+        "summary": "Community Reputation Score over time (own trend series)",
+        "tags": [
+          "Profile"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Monthly",
+                "Yearly"
+              ]
+            },
+            "required": true,
+            "name": "period",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CRS snapshot history (ascending by capturedAt)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CrsSnapshot"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
             "content": {
               "application/json": {
                 "schema": {

--- a/prisma/migrations/20260621192733_crs_time_series_snapshots/migration.sql
+++ b/prisma/migrations/20260621192733_crs_time_series_snapshots/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "crs_snapshots" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "period" "StatSnapshotPeriod" NOT NULL,
+    "bucketAt" TIMESTAMP(3) NOT NULL,
+    "capturedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "score" DOUBLE PRECISION NOT NULL,
+    "dimensions" JSONB NOT NULL,
+
+    CONSTRAINT "crs_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "crs_snapshots_userId_period_capturedAt_idx" ON "crs_snapshots"("userId", "period", "capturedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "crs_snapshots_userId_period_bucketAt_key" ON "crs_snapshots"("userId", "period", "bucketAt");
+
+-- AddForeignKey
+ALTER TABLE "crs_snapshots" ADD CONSTRAINT "crs_snapshots_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -506,6 +506,7 @@ model User {
   wikiAliasesCreated       WikiAlias[]                      @relation("WikiAliasCreator")
   rulesPagesAuthored       RulesPage[]                      @relation("RulesPageAuthor")
   userStatSnapshots        UserStatSnapshot[]
+  crsSnapshots             CrsSnapshot[]
   tagAliasesCreated        TagAlias[]                       @relation("TagAliasCreator")
   authoredStylesheets      AuthorStylesheet[]
 
@@ -2415,6 +2416,31 @@ model CommunityHealthSnapshot {
   @@unique([communityId, period, bucketAt])
   @@index([communityId, period, capturedAt])
   @@map("community_health_snapshots")
+}
+
+// A captured CRS read for one user at a point in time — the additive trend
+// layer deferred by ADR-0007 (#94). The score itself is always computed on read
+// (`reputation.ts`); this is a read-model for trends only and never feeds back
+// into the scorer, so a snapshot bug can never corrupt a real score. Mirrors
+// CommunityHealthSnapshot's bucket/period/retention shape.
+model CrsSnapshot {
+  id         Int                @id @default(autoincrement())
+  userId     Int
+  period     StatSnapshotPeriod
+  bucketAt   DateTime
+  capturedAt DateTime           @default(now())
+  // The overall CRS at capture time.
+  score      Float
+  // The per-dimension breakdown ([{ name, subScore, weighted }]) as captured.
+  // JSON keeps this flexible while the dimension registry is still growing
+  // (#94); a follow-up migrates to typed columns once the shape settles.
+  dimensions Json
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, period, bucketAt])
+  @@index([userId, period, capturedAt])
+  @@map("crs_snapshots")
 }
 
 // ─── Dev Tools ────────────────────────────────────────────────────────────────

--- a/src/crsHistoryModule.spec.ts
+++ b/src/crsHistoryModule.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the CRS snapshot module (#94) — verifies the capture reads
+ * recently-active users, recomputes each one's CRS via `getReputation`, writes
+ * idempotently in concurrency-bounded chunks, and prunes by retention; and that
+ * the history query reads oldest-first. Prisma and `getReputation` are mocked;
+ * `getBucket` and `getRetentionCutoff` run for real.
+ */
+
+import { mockDeep, mockReset } from 'jest-mock-extended';
+import type { PrismaClient } from '@prisma/client';
+
+const prismaMock = mockDeep<PrismaClient>();
+jest.mock('./lib/prisma', () => ({ prisma: prismaMock }));
+
+jest.mock('./modules/logging', () => ({
+  getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+}));
+
+const getReputation = jest.fn();
+jest.mock('./modules/reputation', () => ({
+  getReputation: (id: number) => getReputation(id)
+}));
+
+import { captureCrsSnapshots, getCrsHistory } from './modules/crsHistory';
+
+beforeEach(() => {
+  mockReset(prismaMock);
+  getReputation.mockReset();
+});
+
+// ─── captureCrsSnapshots ──────────────────────────────────────────────────────
+
+describe('captureCrsSnapshots', () => {
+  it('snapshots each active user, writes with skipDuplicates, prunes by period', async () => {
+    prismaMock.user.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as never);
+    getReputation.mockImplementation((id: number) =>
+      Promise.resolve({
+        score: id * 10,
+        dimensions: [{ name: 'longevity', subScore: id, weighted: id }]
+      })
+    );
+    prismaMock.crsSnapshot.createMany.mockResolvedValue({ count: 2 } as never);
+    prismaMock.crsSnapshot.deleteMany.mockResolvedValue({ count: 0 } as never);
+
+    await captureCrsSnapshots('Monthly');
+
+    // Only recently-active (lastLogin gte) non-disabled users are read.
+    const whereArg = prismaMock.user.findMany.mock.calls[0][0] as {
+      where: { disabled: boolean; lastLogin: { gte: Date } };
+    };
+    expect(whereArg.where.disabled).toBe(false);
+    expect(whereArg.where.lastLogin.gte).toBeInstanceOf(Date);
+
+    expect(getReputation).toHaveBeenCalledTimes(2);
+
+    const createArg = prismaMock.crsSnapshot.createMany.mock.calls[0][0] as {
+      data: Array<Record<string, unknown>>;
+      skipDuplicates: boolean;
+    };
+    expect(createArg.skipDuplicates).toBe(true);
+    expect(createArg.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: 1,
+          period: 'Monthly',
+          score: 10,
+          dimensions: [{ name: 'longevity', subScore: 1, weighted: 1 }]
+        }),
+        expect.objectContaining({ userId: 2, period: 'Monthly', score: 20 })
+      ])
+    );
+
+    expect(prismaMock.crsSnapshot.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ period: 'Monthly' })
+      })
+    );
+  });
+
+  it('skips createMany when no users are active, still prunes', async () => {
+    prismaMock.user.findMany.mockResolvedValue([] as never);
+    prismaMock.crsSnapshot.deleteMany.mockResolvedValue({ count: 0 } as never);
+
+    await captureCrsSnapshots('Monthly');
+
+    expect(getReputation).not.toHaveBeenCalled();
+    expect(prismaMock.crsSnapshot.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.crsSnapshot.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ period: 'Monthly' })
+      })
+    );
+  });
+
+  it('snapshots every active user across chunk boundaries', async () => {
+    // More than one CONCURRENCY chunk (25) to exercise the chunk loop.
+    const users = Array.from({ length: 60 }, (_, i) => ({ id: i + 1 }));
+    prismaMock.user.findMany.mockResolvedValue(users as never);
+    getReputation.mockResolvedValue({ score: 1, dimensions: [] });
+    prismaMock.crsSnapshot.createMany.mockResolvedValue({ count: 60 } as never);
+    prismaMock.crsSnapshot.deleteMany.mockResolvedValue({ count: 0 } as never);
+
+    await captureCrsSnapshots('Yearly');
+
+    expect(getReputation).toHaveBeenCalledTimes(60);
+    const createArg = prismaMock.crsSnapshot.createMany.mock.calls[0][0] as {
+      data: unknown[];
+    };
+    expect(createArg.data).toHaveLength(60);
+  });
+});
+
+// ─── getCrsHistory ────────────────────────────────────────────────────────────
+
+describe('getCrsHistory', () => {
+  it('queries the user + period, oldest-first', async () => {
+    prismaMock.crsSnapshot.findMany.mockResolvedValue([] as never);
+
+    await getCrsHistory(7, 'Yearly');
+
+    expect(prismaMock.crsSnapshot.findMany).toHaveBeenCalledWith({
+      where: { userId: 7, period: 'Yearly' },
+      orderBy: { capturedAt: 'asc' }
+    });
+  });
+
+  it('serializes capturedAt to ISO and passes through score/dimensions', async () => {
+    const capturedAt = new Date('2026-06-21T00:00:00.000Z');
+    prismaMock.crsSnapshot.findMany.mockResolvedValue([
+      {
+        capturedAt,
+        period: 'Monthly',
+        score: 12.5,
+        dimensions: [{ name: 'ratio', subScore: 4, weighted: 4 }]
+      }
+    ] as never);
+
+    const out = await getCrsHistory(1, 'Monthly');
+
+    expect(out).toEqual([
+      {
+        capturedAt: '2026-06-21T00:00:00.000Z',
+        period: 'Monthly',
+        score: 12.5,
+        dimensions: [{ name: 'ratio', subScore: 4, weighted: 4 }]
+      }
+    ]);
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -965,6 +965,47 @@ registry.registerPath({
   }
 });
 
+// A captured CRS read in the trend series (#94). The score stays computed on
+// read; this is the snapshot read-model only. The korin service surface
+// (/users/{id}/reputation/history) is intentionally kept out of the public
+// contract, like its sibling /users/{id}/reputation.
+const CrsSnapshot = z
+  .object({
+    capturedAt: z.string(),
+    period: z.enum(['Monthly', 'Yearly']),
+    score: z.number(),
+    dimensions: z.array(
+      z.object({
+        name: z.string(),
+        subScore: z.number(),
+        weighted: z.number()
+      })
+    )
+  })
+  .openapi('CrsSnapshot');
+
+registry.registerPath({
+  method: 'get',
+  path: '/profile/me/reputation/history',
+  summary: 'Community Reputation Score over time (own trend series)',
+  tags: ['Profile'],
+  request: {
+    // CRS is captured only daily/weekly (it moves on a multi-day scale), so the
+    // series offers Monthly and Yearly periods — Daily is rejected.
+    query: z.object({ period: z.enum(['Monthly', 'Yearly']) })
+  },
+  responses: {
+    200: {
+      description: 'CRS snapshot history (ascending by capturedAt)',
+      content: { 'application/json': { schema: z.array(CrsSnapshot) } }
+    },
+    401: {
+      description: 'Not authenticated',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 registry.registerPath({
   method: 'get',
   path: '/profile/user/{userId}',

--- a/src/modules/crsHistory.ts
+++ b/src/modules/crsHistory.ts
@@ -1,0 +1,102 @@
+import { Prisma, StatSnapshotPeriod } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { getReputation } from './reputation';
+import { getBucket, getRetentionCutoff } from './statsHistory';
+
+// ─── Capture ───────────────────────────────────────────────────────────────
+
+/**
+ * Only recently-active accounts are snapshotted. Unlike `captureUserStats`,
+ * which folds all users in a single cheap SQL `groupBy`, a CRS read recomputes
+ * ~8 queries per user (`getReputation`), so snapshotting every account each
+ * cascade would be a query storm. A dormant account earns no trend line until
+ * it returns — its score is still always available live (ADR-0007). One uniform
+ * window across all periods; the per-period retention cutoff prunes the series.
+ */
+const ACTIVE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** How many users' CRS we recompute concurrently per chunk — bounds the burst
+ *  of parallel `getReputation` reads against the DB. */
+const CONCURRENCY = 25;
+
+/**
+ * Snapshot the CRS (overall score + dimension breakdown) of every recently
+ * active user for the given period (#94) — the additive trend layer ADR-0007
+ * deferred. The value stays computed-on-read; this is a captured read, never
+ * the source of truth. Mirrors `captureCommunityHealth`: bucket, write with
+ * `skipDuplicates`, then prune past the period's retention cutoff.
+ */
+export async function captureCrsSnapshots(
+  period: StatSnapshotPeriod
+): Promise<void> {
+  const bucketAt = getBucket(period);
+
+  const users = await prisma.user.findMany({
+    where: {
+      disabled: false,
+      lastLogin: { gte: new Date(Date.now() - ACTIVE_WINDOW_MS) }
+    },
+    select: { id: true }
+  });
+
+  // Recompute CRS in concurrency-bounded chunks rather than fanning out every
+  // active user's ~8-query read at once.
+  const data: Prisma.CrsSnapshotCreateManyInput[] = [];
+  for (let i = 0; i < users.length; i += CONCURRENCY) {
+    const chunk = users.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      chunk.map(async (u) => {
+        const crs = await getReputation(u.id);
+        return {
+          userId: u.id,
+          period,
+          bucketAt,
+          score: crs.score,
+          dimensions: crs.dimensions as unknown as Prisma.InputJsonValue
+        };
+      })
+    );
+    data.push(...results);
+  }
+
+  if (data.length > 0) {
+    await prisma.crsSnapshot.createMany({ data, skipDuplicates: true });
+  }
+
+  await prisma.crsSnapshot.deleteMany({
+    where: { period, capturedAt: { lt: getRetentionCutoff(period) } }
+  });
+}
+
+// ─── Query ─────────────────────────────────────────────────────────────────
+
+/** Periods the CRS series actually captures — Daily is intentionally skipped
+ *  (see `captureCrsSnapshots`), so the read surface never offers it. */
+export type CrsHistoryPeriod = Exclude<StatSnapshotPeriod, 'Daily'>;
+
+/**
+ * A user's CRS history for the given period, oldest-first — the time-series
+ * behind the single read-time `GET /me/reputation` score. Each row's `score` +
+ * `dimensions` are the FULL, unfiltered CRS as captured (store-raw / gate-on-
+ * read, like `UserStatSnapshot`'s raw bytes).
+ *
+ * This is the self-only view (`GET /profile/me/reputation/history`), so it
+ * returns the breakdown verbatim. When the trend is later surfaced on OTHER
+ * users' profiles (the deferred `/user/:id` gated trend, tracked in #210), that
+ * caller MUST replay the #193 profile gating per row: the `canSeeRatio`
+ * block-gate (`profile.ts`) and the per-row `filterReputationView`
+ * (`reputation.ts`) that drops the snatch-derived `ratio` dimension and
+ * recomputes the score — never expose this raw series cross-account unfiltered.
+ */
+export async function getCrsHistory(userId: number, period: CrsHistoryPeriod) {
+  const rows = await prisma.crsSnapshot.findMany({
+    where: { userId, period },
+    orderBy: { capturedAt: 'asc' }
+  });
+  return rows.map((row) => ({
+    capturedAt: row.capturedAt.toISOString(),
+    period: row.period,
+    score: row.score,
+    dimensions: row.dimensions
+  }));
+}

--- a/src/modules/statsJob.ts
+++ b/src/modules/statsJob.ts
@@ -1,6 +1,7 @@
 import { getLogger } from './logging';
 import { captureUserStats, captureSiteStats } from './statsHistory';
 import { captureCommunityHealth } from './communityHealthHistory';
+import { captureCrsSnapshots } from './crsHistory';
 
 const log = getLogger('statsJob');
 
@@ -15,6 +16,8 @@ export const startStatsJob = (): void => {
       captureUserStats('Daily'),
       captureSiteStats(),
       captureCommunityHealth('Daily')
+      // CRS is intentionally not captured hourly — it moves on a multi-day
+      // scale, so it's snapshotted only on the daily/weekly cascades (#94).
     ]).catch((err) => log.error('Hourly stats capture failed', { err }));
   const hourlyDelay = setTimeout(() => {
     runHourly();
@@ -26,7 +29,8 @@ export const startStatsJob = (): void => {
   const runDaily = () =>
     Promise.all([
       captureUserStats('Monthly'),
-      captureCommunityHealth('Monthly')
+      captureCommunityHealth('Monthly'),
+      captureCrsSnapshots('Monthly')
     ]).catch((err) => log.error('Daily stats capture failed', { err }));
   const dailyDelay = setTimeout(() => {
     runDaily();
@@ -38,7 +42,8 @@ export const startStatsJob = (): void => {
   const runWeekly = () =>
     Promise.all([
       captureUserStats('Yearly'),
-      captureCommunityHealth('Yearly')
+      captureCommunityHealth('Yearly'),
+      captureCrsSnapshots('Yearly')
     ]).catch((err) => log.error('Weekly stats capture failed', { err }));
   const weeklyDelay = setTimeout(() => {
     runWeekly();

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -9,6 +9,11 @@ import {
 } from '../../modules/profile';
 import { getRatioStats } from '../../modules/ratio';
 import { getReputation } from '../../modules/reputation';
+import { getCrsHistory, type CrsHistoryPeriod } from '../../modules/crsHistory';
+import {
+  reputationHistoryPeriodQuerySchema,
+  type ReputationHistoryPeriodQuery
+} from '../../schemas/statsHistory';
 import {
   loadLadder,
   buildProgressionInput
@@ -17,7 +22,12 @@ import { describeGapToNext } from '../../modules/rankProgression';
 import { getPolicyState } from '../../modules/ratioPolicy';
 import { requireAuth } from '../../middleware/auth';
 import { audit } from '../../lib/audit';
-import { validate, parsedBody } from '../../middleware/validate';
+import {
+  validate,
+  validateQuery,
+  parsedBody,
+  parsedQuery
+} from '../../middleware/validate';
 import {
   profileUpdateSchema,
   inviteSchema,
@@ -96,6 +106,19 @@ router.get(
   requireAuth,
   authHandler(async (req, res) => {
     res.json(await getReputation(req.user.id));
+  })
+);
+
+// GET /api/profile/me/reputation/history — CRS over time (#94). The score is
+// still computed-on-read; this reads the captured trend series.
+// ?period=Daily|Monthly|Yearly.
+router.get(
+  '/me/reputation/history',
+  requireAuth,
+  validateQuery(reputationHistoryPeriodQuerySchema),
+  authHandler(async (req, res) => {
+    const { period } = parsedQuery<ReputationHistoryPeriodQuery>(res);
+    res.json(await getCrsHistory(req.user.id, period as CrsHistoryPeriod));
   })
 );
 

--- a/src/schemas/statsHistory.ts
+++ b/src/schemas/statsHistory.ts
@@ -5,3 +5,15 @@ export const statsPeriodQuerySchema = z.object({
 });
 
 export type StatsPeriodQuery = z.infer<typeof statsPeriodQuerySchema>;
+
+// CRS moves on a multi-day scale, so the snapshot job skips the hourly Daily
+// cascade (#94 grill) — only Monthly (daily buckets) and Yearly (weekly
+// buckets) series exist. The reputation-history query rejects Daily rather than
+// return a silently-empty series.
+export const reputationHistoryPeriodQuerySchema = z.object({
+  period: z.enum(['Monthly', 'Yearly'])
+});
+
+export type ReputationHistoryPeriodQuery = z.infer<
+  typeof reputationHistoryPeriodQuerySchema
+>;


### PR DESCRIPTION
Closes #94.

Adds the additive CRS trend layer deferred by ADR-0007 rule 3. The CRS value stays **computed-on-read** (`reputation.ts`); this captures a read into a bucketed time-series and **never feeds back into the scorer**, so a snapshot bug can never corrupt a real score (ADR-0007 rule 1).

## What's here

- **`CrsSnapshot` model** (`score Float` + `dimensions Json`) + migration, mirroring `CommunityHealthSnapshot`'s bucket/period/retention shape. Stores the **full unfiltered** result (store-raw / gate-on-read, like `UserStatSnapshot`).
- **`crsHistory.ts`** — `captureCrsSnapshots` (active-users-only, concurrency-chunked `getReputation`) + `getCrsHistory` (self read, oldest-first).
- **Cadence: Monthly + Yearly only.** CRS moves on a multi-day scale, so the hourly Daily capture is skipped; the history query rejects `Daily`.
- **Read surface: self only** — `GET /api/profile/me/reputation/history?period=Monthly|Yearly`.

## Design — grilled before building

This is a CRS scoring keystone, so per the repo's grill-before-schema rule the teeth were settled in a `/grill-with-docs` session against PRD-01 / ADR-0007 / ADR-0002, not fiat'd:

- **Capture scope** → active-users-only, justified as *correctly scoped to the per-user dashboard consumer* (the only consumer; CVI calculation is PRD-01 Out of Scope).
- **Read surface** → self-only. The current CRS *score* is already surfaced cross-account via the paranoia-gated `community` block (#193); the *trend* is not yet consumed by any UI, so the gated cross-account read is deferred rather than shipped half-private.
- **Cadence** → drop Daily (costliest, least informative for a slow-moving value).
- **Storage** → JSON full-store now; typed columns later.

## Follow-ups

- **#210** — gated CRS trend on `/user/:id` (replays `canSeeRatio` block-gate + per-row `filterReputationView`). Breadcrumb in `getCrsHistory`.
- **#209** — migrate `dimensions` JSON → typed per-dimension columns once the registry stabilizes.

## Verification

- `format` / `lint` / `tsc --noEmit` / `typecheck:test` clean; full suite **1638 passed / 85 suites** (incl. new `crsHistoryModule.spec.ts`).
- ERD + OpenAPI freshness gates regenerated (self route documented with `Monthly|Yearly`; korin service surface intentionally excluded, per convention).
- Live smoke against a dev DB: capture is idempotent within a bucket, `getCrsHistory` returns oldest-first, background job confirmed firing on a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)