### PR TITLE
feat(reputation): lifetime link-health CRS dimension (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/
     asyncHandler.ts         # Wraps async routes; catches errors, 10s timeout
     installState.ts         # In-memory cache for isInstalled() check
     logging.ts              # Winston logger factory (JSON in prod, pretty in dev)
-    linkHealth.ts           # HEAD-request link checker + auto-warn on 3+ reports; computePulse + getCommunityHealthPulse
+    linkHealth.ts           # HEAD-request link checker + auto-warn on 3+ reports; computePulse + getCommunityHealthPulse; applyHealthAccrual (per-contribution PASS-uptime accumulator, #95/ADR-0019)
     linkHealthJob.ts        # Background job: recheck stale contribution links every 24h
     communityHealthHistory.ts # Persist/query the community health pulse as a time-series snapshot (#75); captured by statsJob
     crsHistory.ts           # Capture/query CRS as a time-series snapshot (#94, ADR-0007 trend layer); active-users-only, Monthly+Yearly cadence (no hourly), self-read only — captured by statsJob
@@ -82,7 +82,7 @@ src/
     stats.ts                # Stats query helpers
     top10.ts                # Ranked list logic: binomial scoring, TTL caching, snapshots
     user.ts                 # User query helpers
-    reputation.ts           # CRS dimension registry (longevity/ratio/friends/irc); pure scorers + read-time assembler
+    reputation.ts           # CRS dimension registry (longevity/ratio/friends/invite/donation/community/linkHealth/irc/stylesheet); pure scorers + read-time assembler. linkHealth = lifetime confirmed-PASS uptime (#95/ADR-0019)
     irc.ts                  # korin.pink metrics poll client + pure IRCScore scorer (getIrcScore); ADR-0013
     ircJob.ts               # Background poll job — fetches korin.pink IRC metrics into the in-process cache (ADR-0013)
     announce.ts             # Release-Announce publisher — builds new-contribution RSS, pushes to korin POST /irc/announce (ADR-0013)

--- a/docs/adr/0019-lifetime-link-health-crs-dimension.md
+++ b/docs/adr/0019-lifetime-link-health-crs-dimension.md
@@ -1,0 +1,55 @@
+# Lifetime link-health CRS dimension
+
+**Status: Accepted.** Serves [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md). Builds the link-health history series deferred by [ADR-0006](0006-linkhealth-gated-ratio-relief.md) (decision #4) and slots into the registry under [ADR-0007](0007-crs-read-time-and-event-ledger.md). Resolves [#95](https://github.com/orphic-inc/stellar-api/issues/95).
+
+## Context
+
+PRD-01 rewards reliability: "users who consistently contribute over time should be rewarded." For contributions — which are hosted links — reliability means _keeping the link alive_. ADR-0006 made current link health a ratio-relief lever (a contribution's bytes count toward relief only while `linkStatus ≠ FAIL`), but decision #4 deliberately read **only the current `linkStatus`** and explicitly did _not_ build a history series: "Cumulative-uptime-over-account-lifetime is a separate, slower CRS dimension (`LinkHealthBonusPoints`) tracked elsewhere." This ADR is that elsewhere. It is the **positive lifetime-reliability reward** — the mirror of the dead-link/flapping/upheld-report penalties that already live in PRD-01/PRD-03 negative scoring and the LinkHealth lifecycle.
+
+#95 hoped to share a single history substrate with #94 (CRS time-series snapshots). That coordination turned out moot: #94 snapshots the _computed CRS output_ over time (`CrsSnapshot`), not per-contribution link health. So this dimension stands up its own uptime substrate. The pleasant consequence is symmetric anyway — once both land, this dimension's _trend_ is captured by #94 for free, because `CrsSnapshot` stores the full per-dimension breakdown and this dimension self-registers (no snapshot code touched).
+
+A naming note: the issue title `LinkHealthBonusPoints` refers to a **post-v1 reward/teeth layer** (the "making CRS bite — privilege-granting" future direction in PRD-01) that will eventually _consume_ this signal. v1 ships only the underlying CRS **dimension**, named `linkHealth`. Bonus Points are out of scope here.
+
+## Decision
+
+Add a self-registered, bounded, pure CRS dimension `linkHealth` measuring a member's **cumulative lifetime confirmed link uptime**, backed by a per-contribution accumulator on the `Contribution` spine.
+
+1. **Scope: cumulative uptime only.** v1 rewards sustained confirmed availability and nothing else. The other signals #95 floated — contribution frequency, fail-resolved-before-reported, report-upheld suspicion — are deferred (see below); the last two are _negative/suspicion_ signals that belong in negative scoring, not this positive dimension (folding them here would re-open ADR-0006's anti-weaponization stance).
+
+2. **Metric: reliability-first, with a bounded volume×duration term.** Per the member, over all their contributions:
+
+   - `R` (reliability) = mean of `clamp(passMs_i / (now − createdAt_i), 0, 1)` — _"are your links rotting?"_, volume-agnostic, in [0,1]. A dead or never-confirmed link drags `R` down; a rotted catalogue lowers lifetime reliability, which is the point.
+   - `H` (banked healthy-link-time) = `Σ passMs_i` in healthy-link-years — _"how much confirmed uptime have you actually accumulated?"_, capturing both volume and duration in one term.
+   - `subScore = CAP × R × (1 − exp(−H / H_TAU))`. Both factors are in [0,1], so the product is bounded by `CAP` by construction (the PRD's "no single axis dominates" guardrail, structural not aspirational). `R` leads as a true multiplier — if links rot, banked `H` cannot save the score; and a fresh account that dumps many links has `R ≈ 1` but `H ≈ 0`, so it cannot farm the dimension instantly. Only _sustained_ uptime banks `H`.
+
+3. **PASS-only accrual.** Only a confirmed-reachable `PASS` accrues healthy time. `UNKNOWN` (never probed — absence of evidence) and `WARN` (suspect) do not accrue, and `FAIL` obviously does not. This is deliberately _stricter_ than ADR-0006's relief rule (which counts everything but `FAIL`): an enforcement gate is lenient to avoid false revocation, but a positive reward must credit only confirmed health so it cannot be inflated by parking links in an unconfirmed state. WARN windows are short (corrected to PASS on recheck, or swept to FAIL in 72h), so lost credit during a genuine transient blip is negligible.
+
+4. **Substrate: an accumulator on the `Contribution` spine.** Two columns beside the existing link-health fields: `healthyMs BigInt @default(0)` (banked confirmed-PASS milliseconds, excluding the currently-open segment) and `healthySince DateTime?` (when the current open PASS segment began; `null` when not currently PASS). Live uptime at read = `healthyMs + (healthySince ? now − healthySince : 0)`. This is the _time_ analog of `User.contributed`/`consumed` — mutable `BigInt` running accumulators already kept on the spine and read by a scorer (RatioScore). ADR-0007 forbids a denormalized _score_ column that can drift; `healthyMs` is a substrate fact (an input), not a score, so it sits with the other link-health spine fields rather than on a satellite — which also keeps it off a join on the hot reputation read path (#195).
+
+5. **Accrual is a pure function of `(new status, current healthySince)`.** A single helper in `linkHealth.ts`:
+
+   - if `isPass && healthySince == null` → open: `healthySince = now` (covers entering PASS _and_ self-healing a backfilled PASS that never opened);
+   - else if `!isPass && healthySince != null` → bank & close: `healthyMs += now − healthySince; healthySince = null`.
+     `healthySince` itself is the accrual-state flag, so the prior status is irrelevant and the block is idempotent/self-healing. It is reused unchanged at both status writers — `checkContributionLink` and the `recordContributionReport` auto-WARN write. The WARN→FAIL `sweepStaleWarnLinks` is a no-op for accrual (WARN never accrued).
+
+6. **Read-time, single widened fetch.** The dimension self-registers in `reputation.ts`; the aggregator is untouched (PRD-01 registry). `getReputation` widens its existing per-user contribution fetch (previously community-only, for CommunityScore) to _all_ the user's contributions plus the uptime fields, then derives both CommunityScore's per-community weight and this dimension's `R`/`H` from one scan — no second pass over the table. The scorer stays pure: the assembler computes `R`/`H` (including the live open segment) and passes `linkHealthReliability`/`linkHealthYears` into `DimensionInput`.
+
+7. **Cold-start migration, no fabricated history.** New rows default `healthyMs = 0`; the migration seeds `healthySince = now` for rows currently at `linkStatus = PASS` so live links start ticking at launch rather than drifting up to a week before the next probe opens their segment. No `healthyMs` is back-filled — nobody is credited uptime nobody confirmed. The dimension reads near-zero at launch and earns its weight as genuine uptime accrues, which is correct for a _lifetime_ signal. (Prod is pre-alpha; data is disposable, so this is the principled choice even under a reset.)
+
+8. **Tier-0 constants:** `CAP = 8` (tied with RatioScore — both derive from the same contribution-availability substrate, at the current vs. lifetime timescale — and second only to Longevity's 10, honoring the PRD owner's "among the highest-weight signals" note without crowning a new dimension the single biggest), `weight = 1.0` (no second lever), `H_TAU = 3` healthy-link-years (mirrors `LONGEVITY_TAU_YEARS`). Tune alongside the PRD like every other dimension constant.
+
+9. **Visibility.** `linkHealth` is **not** snatch-derived — it is computed purely from the member's own contributions' link status, leaking nothing about what they consumed — so it stays visible in the #193 paranoia-gated profile block alongside longevity/friends/invite. It is a vague reliability signal, not informative activity.
+
+## Consequences
+
+- The history series ADR-0006 deferred now exists — for CRS (lifetime uptime), not for ratio (which still reads current `linkStatus` only). The two systems read one availability substrate at two timescales, as ADR-0006 anticipated.
+- A new schema migration adds two `Contribution` columns; the accrual hook is a small, contained addition to the two existing status writers in `linkHealth.ts`.
+- The reputation read gains a CPU-side `R`/`H` reduction but no new query (it rides the widened contribution fetch). The #195 read-path memoization follow-up now covers this reduction too.
+- A member who lets their catalogue rot sees this dimension decay (lower `R`); one who maintains links for years saturates it. A reformed contributor recovers as new healthy contributions lift `R` and `H` grows — the dimension is purely positive (floor 0), so rot bounds the _gain_, never pushing negative.
+
+## Deferred / out of scope for v1
+
+- **Contribution-frequency signal** — a positive enhancement (reward steady contribution cadence, not just uptime). Tracked as [#212](https://github.com/orphic-inc/stellar-api/issues/212); overlaps the eventual ContributionScore/CommunityScore weight, so it needs its own grill-before-schema design pass.
+- **Fail-resolved-before-reported** and **report-upheld / "highly reported user is always suspect"** — these are _negative/suspicion_ signals. They belong in PRD-01/PRD-03 negative scoring and the LinkHealth lifecycle, not in this positive dimension; keeping them out preserves ADR-0006's anti-weaponization stance (reports cannot be turned into a CRS weapon).
+- **`LinkHealthBonusPoints` (the teeth).** The post-v1 reward/privilege layer that consumes this dimension — part of PRD-01's "making CRS bite" future direction. Captured here and in PRD-01; no issue opened yet, as it is far out.
+- **Typed snapshot columns / per-(user) weight memoization** — covered by the existing #195 read-path follow-up.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -745,6 +745,8 @@ Yearly Yearly
     LinkHealthStatus linkStatus 
     DateTime linkCheckedAt "❓"
     DateTime linkStatusChangedAt "❓"
+    BigInt healthyMs 
+    DateTime healthySince "❓"
     FileType type 
     DateTime createdAt 
     DateTime updatedAt 

--- a/prisma/migrations/20260621201500_lifetime_link_health_uptime/migration.sql
+++ b/prisma/migrations/20260621201500_lifetime_link_health_uptime/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "contributions" ADD COLUMN     "healthyMs" BIGINT NOT NULL DEFAULT 0,
+ADD COLUMN     "healthySince" TIMESTAMP(3);
+
+-- Cold start (ADR-0019, #95): seed the open PASS segment for currently-healthy
+-- links so accrual begins at launch rather than drifting up to a week before the
+-- next probe opens their segment. No healthyMs is back-filled — nobody is
+-- credited uptime that was never confirmed.
+UPDATE "contributions" SET "healthySince" = CURRENT_TIMESTAMP WHERE "linkStatus" = 'PASS';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1044,6 +1044,14 @@ model Contribution {
   linkStatus              LinkHealthStatus      @default(UNKNOWN)
   linkCheckedAt           DateTime?
   linkStatusChangedAt     DateTime?
+  // Cumulative confirmed-PASS uptime, the substrate for the lifetime link-health
+  // CRS dimension (ADR-0019, #95). `healthyMs` is banked PASS milliseconds
+  // excluding the currently-open segment; `healthySince` is when the current open
+  // PASS segment began (null when not currently PASS). Live uptime =
+  // healthyMs + (healthySince ? now - healthySince : 0). The time analog of
+  // User.contributed — a substrate accumulator, not a score (ADR-0007).
+  healthyMs               BigInt                @default(0)
+  healthySince            DateTime?
   type                    FileType
   createdAt               DateTime              @default(now())
   updatedAt               DateTime              @updatedAt

--- a/src/integration/linkHealthUptime.integration.ts
+++ b/src/integration/linkHealthUptime.integration.ts
@@ -1,0 +1,137 @@
+import {
+  ReleaseType,
+  FileType,
+  CommunityType,
+  RegistrationStatus,
+  LinkHealthStatus
+} from '@prisma/client';
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { createContributionSubmission } from '../modules/contribution';
+import type { CreateContributionInput } from '../schemas/contribution';
+
+// Stub the fire-and-forget HTTP check that createContributionSubmission triggers
+// (it would hit the network and hold a connection across the next TRUNCATE). We
+// drive the uptime columns directly below to exercise the read path (#95).
+jest.mock('../modules/linkHealth', () => ({
+  ...jest.requireActual('../modules/linkHealth'),
+  checkContributionLink: jest.fn().mockResolvedValue(undefined)
+}));
+import { getReputation } from '../modules/reputation';
+
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+let seq = 0;
+const createUser = async () => {
+  seq += 1;
+  const tag = `lhu-${seq}-${Date.now()}`;
+  const [rank, settings, profile] = await Promise.all([
+    testPrisma.userRank.findFirstOrThrow(),
+    testPrisma.userSettings.create({ data: {} }),
+    testPrisma.profile.create({ data: {} })
+  ]);
+  return testPrisma.user.create({
+    data: {
+      username: tag,
+      email: `${tag}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id
+    }
+  });
+};
+
+const createCommunity = () =>
+  testPrisma.community.create({
+    data: {
+      name: `Community-${Date.now()}-${seq}`,
+      image: '',
+      registrationStatus: RegistrationStatus.open,
+      type: CommunityType.Music
+    }
+  });
+
+const baseInput = (
+  communityId: number,
+  title: string
+): CreateContributionInput => ({
+  communityId,
+  type: ReleaseType.Music,
+  title,
+  year: 2020,
+  fileType: FileType.flac,
+  downloadUrl: 'https://example.com/file.torrent',
+  sizeInBytes: 1_000_000,
+  tags: 'rock',
+  releaseDescription: 'desc',
+  image: undefined,
+  description: undefined,
+  bitrate: undefined,
+  media: undefined,
+  releaseCategory: undefined,
+  recordLabel: undefined,
+  catalogueNumber: undefined,
+  editionTitle: undefined,
+  editionYear: undefined,
+  isRemaster: false,
+  hasLog: false,
+  hasCue: false,
+  isScene: false,
+  collaborators: [{ artist: 'Test Artist', importance: 'main' }]
+});
+
+describe('lifetime link-health dimension (integration, #95)', () => {
+  it('reads banked confirmed-PASS uptime into the linkHealth CRS dimension', async () => {
+    const user = await createUser();
+    const community = await createCommunity();
+    const contribution = await createContributionSubmission({
+      userId: user.id,
+      input: baseInput(community.id, 'Long-Lived Album')
+    });
+    if (!contribution) throw new Error('fixture contribution failed');
+
+    // A 2-year-old contribution that banked the full 2 years of confirmed PASS
+    // (segment closed). Round-trips the BigInt healthyMs column through Postgres.
+    await testPrisma.contribution.update({
+      where: { id: contribution.id },
+      data: {
+        createdAt: new Date(Date.now() - 2 * YEAR_MS),
+        linkStatus: LinkHealthStatus.FAIL,
+        healthyMs: BigInt(Math.round(2 * YEAR_MS)),
+        healthySince: null
+      }
+    });
+
+    const crs = await getReputation(user.id);
+    const linkHealth = crs.dimensions.find((d) => d.name === 'linkHealth');
+    expect(linkHealth).toBeDefined();
+    // R ≈ 1 over a 2y life, H ≈ 2 link-years → cap 8 · (1 − e^(−2/3)) ≈ 3.9.
+    expect(linkHealth!.subScore).toBeGreaterThan(3);
+    expect(linkHealth!.subScore).toBeLessThanOrEqual(8);
+  });
+
+  it('gives a fresh, never-confirmed contribution ~zero link-health', async () => {
+    const user = await createUser();
+    const community = await createCommunity();
+    const contribution = await createContributionSubmission({
+      userId: user.id,
+      input: baseInput(community.id, 'Brand New Album')
+    });
+    if (!contribution) throw new Error('fixture contribution failed');
+
+    // Default columns: healthyMs 0, healthySince null, UNKNOWN — nothing banked.
+    const crs = await getReputation(user.id);
+    const linkHealth = crs.dimensions.find((d) => d.name === 'linkHealth');
+    expect(linkHealth!.subScore).toBe(0);
+  });
+});

--- a/src/modules/linkHealth.spec.ts
+++ b/src/modules/linkHealth.spec.ts
@@ -30,7 +30,8 @@ import {
   sweepStaleWarnLinks,
   checkContributionLink,
   getCommunityHealthPulse,
-  computePulse
+  computePulse,
+  applyHealthAccrual
 } from './linkHealth';
 import { sendSystemMessage } from './pm';
 
@@ -127,38 +128,151 @@ describe('checkContributionLink stamps linkStatusChangedAt on transition', () =>
     mockPrismaContribution.findUnique.mockResolvedValue({
       downloadUrl: 'http://example.test/x',
       linkStatus: 'WARN',
-      linkStatusChangedAt: new Date('2020-01-01')
+      linkStatusChangedAt: new Date('2020-01-01'),
+      healthyMs: 0n,
+      healthySince: null
     });
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     await checkContributionLink(5);
     const { data } = mockPrismaContribution.update.mock.calls[0][0];
     expect(data.linkStatus).toBe('PASS');
     expect(data.linkStatusChangedAt).toBeInstanceOf(Date);
+    // Entering PASS opens the uptime segment (#95 / ADR-0019).
+    expect(data.healthySince).toBeInstanceOf(Date);
   });
 
   it('does not re-stamp when status is unchanged and already stamped', async () => {
     mockPrismaContribution.findUnique.mockResolvedValue({
       downloadUrl: 'http://example.test/x',
       linkStatus: 'PASS',
-      linkStatusChangedAt: new Date('2020-01-01')
+      linkStatusChangedAt: new Date('2020-01-01'),
+      healthyMs: 0n,
+      healthySince: new Date('2020-01-01')
     });
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     await checkContributionLink(5);
     const { data } = mockPrismaContribution.update.mock.calls[0][0];
     expect(data.linkStatus).toBe('PASS');
     expect(data.linkStatusChangedAt).toBeUndefined();
+    // Still accruing: the open segment is left untouched (no re-open, no bank).
+    expect(data.healthySince).toEqual(new Date('2020-01-01'));
   });
 
   it('initializes the clock when it has never been stamped (backfill case)', async () => {
     mockPrismaContribution.findUnique.mockResolvedValue({
       downloadUrl: 'http://example.test/x',
       linkStatus: 'PASS',
-      linkStatusChangedAt: null
+      linkStatusChangedAt: null,
+      healthyMs: 0n,
+      healthySince: null
     });
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     await checkContributionLink(5);
     const { data } = mockPrismaContribution.update.mock.calls[0][0];
     expect(data.linkStatusChangedAt).toBeInstanceOf(Date);
+    // Self-heal: a backfilled PASS that never opened a segment opens one now.
+    expect(data.healthySince).toBeInstanceOf(Date);
+  });
+
+  it('banks the open PASS segment when a link goes PASS → FAIL', async () => {
+    const since = new Date('2020-01-01T00:00:00Z');
+    mockPrismaContribution.findUnique.mockResolvedValue({
+      downloadUrl: 'http://example.test/x',
+      linkStatus: 'PASS',
+      linkStatusChangedAt: since,
+      healthyMs: 1000n,
+      healthySince: since
+    });
+    // 404 → FAIL.
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    await checkContributionLink(5);
+    const { data } = mockPrismaContribution.update.mock.calls[0][0];
+    expect(data.linkStatus).toBe('FAIL');
+    expect(data.healthySince).toBeNull();
+    // Banked = prior 1000ms + the elapsed open segment (> 0).
+    expect(data.healthyMs).toBeGreaterThan(1000n);
+  });
+});
+
+// ─── applyHealthAccrual (pure) ────────────────────────────────────────────────
+
+describe('applyHealthAccrual', () => {
+  const now = new Date('2026-06-21T00:00:00Z');
+  const earlier = new Date('2026-06-20T00:00:00Z'); // 24h before `now`
+  const DAY_MS = 86_400_000n;
+
+  it('opens a segment when entering PASS from a closed state', () => {
+    expect(
+      applyHealthAccrual(
+        LinkHealthStatus.PASS,
+        { healthyMs: 500n, healthySince: null },
+        now
+      )
+    ).toEqual({ healthyMs: 500n, healthySince: now });
+  });
+
+  it('self-heals: opens a segment for a PASS that never opened one', () => {
+    // Same path as "entering PASS" — healthySince is the only flag that matters.
+    expect(
+      applyHealthAccrual(
+        LinkHealthStatus.PASS,
+        { healthyMs: 0n, healthySince: null },
+        now
+      ).healthySince
+    ).toEqual(now);
+  });
+
+  it('is a no-op while already accruing (PASS with an open segment)', () => {
+    const current = { healthyMs: 10n, healthySince: earlier };
+    expect(applyHealthAccrual(LinkHealthStatus.PASS, current, now)).toEqual(
+      current
+    );
+  });
+
+  it('banks and closes the segment when leaving PASS', () => {
+    expect(
+      applyHealthAccrual(
+        LinkHealthStatus.FAIL,
+        { healthyMs: 100n, healthySince: earlier },
+        now
+      )
+    ).toEqual({ healthyMs: 100n + DAY_MS, healthySince: null });
+  });
+
+  it('does the same for WARN (only PASS accrues)', () => {
+    expect(
+      applyHealthAccrual(
+        LinkHealthStatus.WARN,
+        { healthyMs: 0n, healthySince: earlier },
+        now
+      )
+    ).toEqual({ healthyMs: DAY_MS, healthySince: null });
+  });
+
+  it('is a no-op for a non-PASS status with no open segment', () => {
+    const current = { healthyMs: 7n, healthySince: null };
+    expect(applyHealthAccrual(LinkHealthStatus.UNKNOWN, current, now)).toEqual(
+      current
+    );
+    expect(applyHealthAccrual(LinkHealthStatus.FAIL, current, now)).toEqual(
+      current
+    );
+  });
+
+  it('banks exactly the PASS interval across a PASS → WARN → PASS round-trip', () => {
+    const t0 = new Date('2026-06-01T00:00:00Z');
+    const t1 = new Date('2026-06-03T00:00:00Z'); // +2 days PASS → WARN: bank 2d
+    const t2 = new Date('2026-06-05T00:00:00Z'); // WARN → PASS: reopen (no accrual for WARN)
+    const opened = applyHealthAccrual(
+      LinkHealthStatus.PASS,
+      { healthyMs: 0n, healthySince: null },
+      t0
+    );
+    const banked = applyHealthAccrual(LinkHealthStatus.WARN, opened, t1);
+    expect(banked).toEqual({ healthyMs: 2n * DAY_MS, healthySince: null });
+    const reopened = applyHealthAccrual(LinkHealthStatus.PASS, banked, t2);
+    // The 2-day WARN window is NOT credited; only the new open segment carries on.
+    expect(reopened).toEqual({ healthyMs: 2n * DAY_MS, healthySince: t2 });
   });
 });
 

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -40,12 +40,52 @@ export const checkUrl = async (url: string): Promise<LinkHealthStatus> => {
   }
 };
 
+/**
+ * Accrue confirmed-PASS uptime for the lifetime link-health CRS dimension
+ * (ADR-0019, #95). Pure: a function of the NEW status and the current open-
+ * segment clock only. `healthySince` is itself the accrual-state flag, so the
+ * prior status is irrelevant and the result is idempotent / self-healing —
+ * dropping the same block into any status writer converges the columns to
+ * correct even if a transition was once missed. Returns the next
+ * `(healthyMs, healthySince)` to persist alongside the status write. Only PASS
+ * accrues; UNKNOWN/WARN/FAIL do not — stricter than ADR-0006 ratio relief
+ * (which counts everything but FAIL), because a positive reward must credit
+ * confirmed health only and can't be inflated by unconfirmed/suspect links.
+ */
+export const applyHealthAccrual = (
+  status: LinkHealthStatus,
+  current: { healthyMs: bigint; healthySince: Date | null },
+  now: Date
+): { healthyMs: bigint; healthySince: Date | null } => {
+  const isPass = status === LinkHealthStatus.PASS;
+  if (isPass && current.healthySince === null) {
+    // Open (or self-heal) the segment.
+    return { healthyMs: current.healthyMs, healthySince: now };
+  }
+  if (!isPass && current.healthySince !== null) {
+    // Bank the open segment and close it.
+    const elapsed = BigInt(now.getTime() - current.healthySince.getTime());
+    return {
+      healthyMs: current.healthyMs + (elapsed > 0n ? elapsed : 0n),
+      healthySince: null
+    };
+  }
+  // PASS while already accruing, or non-PASS while not accruing: no change.
+  return { healthyMs: current.healthyMs, healthySince: current.healthySince };
+};
+
 export const checkContributionLink = async (
   contributionId: number
 ): Promise<void> => {
   const contribution = await prisma.contribution.findUnique({
     where: { id: contributionId },
-    select: { downloadUrl: true, linkStatus: true, linkStatusChangedAt: true }
+    select: {
+      downloadUrl: true,
+      linkStatus: true,
+      linkStatusChangedAt: true,
+      healthyMs: true,
+      healthySince: true
+    }
   });
   if (!contribution) return;
 
@@ -56,11 +96,21 @@ export const checkContributionLink = async (
   const stampChange =
     status !== contribution.linkStatus ||
     contribution.linkStatusChangedAt === null;
+  const accrual = applyHealthAccrual(
+    status,
+    {
+      healthyMs: contribution.healthyMs,
+      healthySince: contribution.healthySince
+    },
+    now
+  );
   await prisma.contribution.update({
     where: { id: contributionId },
     data: {
       linkStatus: status,
       linkCheckedAt: now,
+      healthyMs: accrual.healthyMs,
+      healthySince: accrual.healthySince,
       ...(stampChange ? { linkStatusChangedAt: now } : {})
     }
   });
@@ -173,7 +223,7 @@ export const recordContributionReport = async (
   if (distinctReporters.length >= REPORT_WARN_THRESHOLD) {
     const current = await prisma.contribution.findUnique({
       where: { id: contributionId },
-      select: { linkStatus: true }
+      select: { linkStatus: true, healthyMs: true, healthySince: true }
     });
     // Only warn from a healthy/unknown state: don't reset the sweep clock on
     // an already-WARN link, and don't downgrade a confirmed FAIL back to WARN.
@@ -182,11 +232,22 @@ export const recordContributionReport = async (
       current.linkStatus !== LinkHealthStatus.WARN &&
       current.linkStatus !== LinkHealthStatus.FAIL
     ) {
+      const now = new Date();
+      // Bank any open PASS segment before flipping to WARN (same accrual block
+      // as checkContributionLink — ADR-0019). Don't rely on the async recheck
+      // below landing to close the segment.
+      const accrual = applyHealthAccrual(
+        LinkHealthStatus.WARN,
+        { healthyMs: current.healthyMs, healthySince: current.healthySince },
+        now
+      );
       await prisma.contribution.update({
         where: { id: contributionId },
         data: {
           linkStatus: LinkHealthStatus.WARN,
-          linkStatusChangedAt: new Date()
+          linkStatusChangedAt: now,
+          healthyMs: accrual.healthyMs,
+          healthySince: accrual.healthySince
         }
       });
       log.info('Contribution auto-warned by reports', {

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -412,6 +412,53 @@ describe('computeCrs — Community dimension', () => {
   });
 });
 
+describe('computeCrs — LinkHealth dimension', () => {
+  const CAP = 8;
+  const linkHealthOf = (
+    linkHealthReliability: number,
+    linkHealthYears: number
+  ) =>
+    computeCrs({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      linkHealthReliability,
+      linkHealthYears
+    }).dimensions.find((d) => d.name === 'linkHealth')!.subScore;
+
+  it('no contributions (R=0, H=0) → 0', () => {
+    expect(linkHealthOf(0, 0)).toBe(0);
+  });
+
+  it('reliability leads: rotted links (R=0) score 0 no matter how much banked H', () => {
+    expect(linkHealthOf(0, 100)).toBe(0);
+  });
+
+  it('volume gates: perfect reliability but ~no banked uptime (H≈0) ≈ 0', () => {
+    // A fresh account that dumped links all PASS today: R≈1, H≈0 → can't farm it.
+    expect(linkHealthOf(1, 0)).toBeCloseTo(0, 10);
+    expect(linkHealthOf(1, 0.001)).toBeLessThan(0.01);
+  });
+
+  it('perfect reliability at H_TAU=3yr → ~63% of cap', () => {
+    expect(linkHealthOf(1, 3)).toBeCloseTo(CAP * (1 - Math.exp(-1)), 6);
+  });
+
+  it('saturates toward cap 8 with sustained reliable uptime', () => {
+    expect(linkHealthOf(1, 30)).toBeGreaterThan(7.9);
+    expect(linkHealthOf(1, 30)).toBeLessThanOrEqual(CAP);
+  });
+
+  it('scales linearly with reliability (R halved → subScore halved)', () => {
+    expect(linkHealthOf(0.5, 6)).toBeCloseTo(linkHealthOf(1, 6) / 2, 10);
+  });
+
+  it('clamps out-of-range reliability to [0,1]', () => {
+    expect(linkHealthOf(2, 3)).toBeCloseTo(linkHealthOf(1, 3), 10);
+    expect(linkHealthOf(-1, 3)).toBe(0);
+  });
+});
+
 // ─── signed dimension floor (aggregator) ──────────────────────────────────────
 
 describe('computeCrs — signed dimension floor', () => {
@@ -541,11 +588,19 @@ describe('getReputation', () => {
     mockPrismaContribution.findMany.mockResolvedValue([
       {
         type: 'flac',
+        createdAt: NOW,
+        linkStatus: 'UNKNOWN',
+        healthyMs: 0n,
+        healthySince: null,
         release: { communityId: 10 },
         releaseFile: { bitrate: null, hasLog: true, hasCue: true }
       },
       {
         type: 'mp3',
+        createdAt: NOW,
+        linkStatus: 'UNKNOWN',
+        healthyMs: 0n,
+        healthySince: null,
         release: { communityId: 10 },
         releaseFile: { bitrate: null, hasLog: false, hasCue: false }
       }
@@ -584,6 +639,90 @@ describe('getReputation', () => {
     expect(
       result.dimensions.find((d) => d.name === 'donation')!.subScore
     ).toBeGreaterThan(0);
+  });
+
+  it('derives link-health R/H from banked contribution uptime (#95)', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({
+      createdAt: NOW,
+      contributed: 0n,
+      consumed: 0n
+    });
+    mockPrismaFriend.count.mockResolvedValue(0);
+    // A 2-year-old contribution that banked the full 2 years of PASS (link now
+    // down, segment closed): R ≈ 1 over its 2y life, H ≈ 2 link-years. Dates are
+    // Date.now()-relative because the assembler reads the real clock (not NOW).
+    mockPrismaContribution.findMany.mockResolvedValue([
+      {
+        type: 'flac',
+        createdAt: new Date(Date.now() - 2 * YEAR_MS),
+        linkStatus: 'FAIL',
+        healthyMs: BigInt(Math.round(2 * YEAR_MS)),
+        healthySince: null,
+        release: { communityId: null },
+        releaseFile: null
+      }
+    ]);
+
+    const result = await getReputation(1);
+
+    // The fetch is widened to all of the user's contributions (no community filter).
+    expect(mockPrismaContribution.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 1 } })
+    );
+    const linkHealth = result.dimensions.find((d) => d.name === 'linkHealth')!;
+    expect(linkHealth.subScore).toBeCloseTo(8 * (1 - Math.exp(-2 / 3)), 1);
+  });
+
+  it('counts the live open PASS segment (healthySince) at read time (#95)', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({
+      createdAt: NOW,
+      contributed: 0n,
+      consumed: 0n
+    });
+    mockPrismaFriend.count.mockResolvedValue(0);
+    // Nothing banked, but PASS continuously since creation 1y ago — the live
+    // segment alone must yield R ≈ 1, H ≈ 1, so the dimension is non-zero.
+    mockPrismaContribution.findMany.mockResolvedValue([
+      {
+        type: 'flac',
+        createdAt: new Date(NOW.getTime() - YEAR_MS),
+        linkStatus: 'PASS',
+        healthyMs: 0n,
+        healthySince: new Date(NOW.getTime() - YEAR_MS),
+        release: { communityId: null },
+        releaseFile: null
+      }
+    ]);
+
+    const result = await getReputation(1);
+    expect(
+      result.dimensions.find((d) => d.name === 'linkHealth')!.subScore
+    ).toBeGreaterThan(0);
+  });
+
+  it('a dead link with no banked uptime drags link-health reliability to 0 (#95)', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue({
+      createdAt: NOW,
+      contributed: 0n,
+      consumed: 0n
+    });
+    mockPrismaFriend.count.mockResolvedValue(0);
+    mockPrismaContribution.findMany.mockResolvedValue([
+      {
+        type: 'flac',
+        createdAt: new Date(NOW.getTime() - 2 * YEAR_MS),
+        linkStatus: 'FAIL',
+        healthyMs: 0n,
+        healthySince: null,
+        release: { communityId: null },
+        releaseFile: null
+      }
+    ]);
+
+    const result = await getReputation(1);
+    expect(
+      result.dimensions.find((d) => d.name === 'linkHealth')!.subScore
+    ).toBe(0);
   });
 
   it('reads the adopter side of the ledger for the Friends controlled vector (#147)', async () => {

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -71,6 +71,14 @@ export interface DimensionInput {
     coverage: number | null;
     weight: number;
   }>;
+  /** Mean per-contribution confirmed-PASS uptime fraction (R), in [0,1] — the
+   *  reliability term of the lifetime link-health dimension (#95 / ADR-0019).
+   *  Defaults to 0. */
+  linkHealthReliability?: number;
+  /** Total banked confirmed-PASS time across this member's contributions, in
+   *  healthy-link-years (H) — the volume×duration term of the same dimension.
+   *  Defaults to 0. */
+  linkHealthYears?: number;
   /** Injectable for deterministic tests; defaults to now. */
   now?: Date;
 }
@@ -377,6 +385,45 @@ const communityScorer: DimensionScorer = {
   }
 };
 
+// ─── LinkHealthScore ──────────────────────────────────────────────────────────
+// Cumulative lifetime link-health (PRD-01 "Reliability Matters"; #95 / ADR-0019).
+// The positive mirror of the dead-link/flapping penalties: rewards a member for
+// keeping THEIR OWN contributions' download links alive over the account's life.
+// Distinct from `community` (the COMMUNITY's pulse weighted by your stake —
+// signed/collective) and from `longevity` (account age, no links needed).
+//
+// Two factors, both derived from the per-contribution confirmed-PASS accumulator
+// (Contribution.healthyMs/healthySince, fed by linkHealth.ts):
+//   R = mean per-contribution PASS fraction (passMs / age), [0,1] — "are your
+//       links rotting?"; volume-agnostic, so dumping links can't farm it, and a
+//       rotted catalogue lowers lifetime reliability (the point).
+//   H = banked confirmed-PASS time in healthy-link-years — "how much uptime have
+//       you actually accumulated?"; captures volume AND duration in one term.
+//   subScore = CAP × R × (1 − exp(−H / H_TAU))
+// Both factors ∈ [0,1] ⇒ bounded by CAP by construction (the PRD "no single axis
+// dominates" guardrail). R leads as a true multiplier (rotted links ⇒ ~0 whatever
+// H is); a fresh account dumping links has R≈1 but H≈0 ⇒ ~0, so the dimension
+// can't be farmed instantly — only sustained uptime banks H. PASS-only accrual
+// lives in the substrate; this scorer is pure.
+//
+// PROVISIONAL (tier-0): CAP tied with RatioScore (both read the contribution-
+// availability substrate — current vs lifetime timescale), H_TAU mirrors
+// LONGEVITY_TAU_YEARS. Tune alongside the PRD.
+const LINK_HEALTH_CAP = 8;
+const LINK_HEALTH_TAU_YEARS = 3; // ~63% of the volume curve at 3 banked link-years
+const LINK_HEALTH_WEIGHT = 1.0;
+
+const linkHealthScorer: DimensionScorer = {
+  name: 'linkHealth',
+  weight: LINK_HEALTH_WEIGHT,
+  cap: LINK_HEALTH_CAP,
+  compute: ({ linkHealthReliability = 0, linkHealthYears = 0 }) => {
+    const r = Math.max(0, Math.min(1, linkHealthReliability));
+    const h = Math.max(0, linkHealthYears);
+    return LINK_HEALTH_CAP * r * (1 - Math.exp(-h / LINK_HEALTH_TAU_YEARS));
+  }
+};
+
 // Registry — add a dimension here (Invite, Donation, …) and the aggregator
 // picks it up unchanged.
 const REGISTRY: DimensionScorer[] = [
@@ -386,6 +433,7 @@ const REGISTRY: DimensionScorer[] = [
   inviteScorer,
   donationScorer,
   communityScorer,
+  linkHealthScorer,
   ircScorer,
   stylesheetScorer
 ];
@@ -476,18 +524,27 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
       _min: { donatedAt: true },
       _max: { donatedAt: true }
     }),
-    // The user's contributions on community releases, with the grade inputs
-    // (`type` off the spine, `bitrate`/`hasLog`/`hasCue` off the ReleaseFile
-    // satellite). Each is graded by `gradeContribution` and summed per community
-    // to form the CommunityScore weight (#76), so quality pulls more than count.
+    // ALL of the user's contributions — one widened fetch feeding two dimensions
+    // (#95 / ADR-0019): the grade inputs (`type` off the spine, `bitrate`/`hasLog`/
+    // `hasCue` off the ReleaseFile satellite) summed per community for the
+    // CommunityScore weight (#76, community contributions only — non-community
+    // ones skip the weight loop below), AND the per-contribution confirmed-PASS
+    // uptime (`createdAt`/`linkStatus`/`healthyMs`/`healthySince`) reduced to the
+    // R/H of the lifetime link-health dimension. Widened from community-only so a
+    // non-community release's link still counts toward link health.
     // NOTE (read-path cost): this fetches every contribution on each reputation
     // read (every profile view, #193) — the grade lives in TS, so it can't move
-    // to a SQL aggregate without duplicating the logic. Memoising the per-(user,
+    // to a SQL aggregate without duplicating the logic, and the R/H reduction now
+    // rides the same scan (extra CPU, no extra query). Memoising the per-(user,
     // community) weight is folded into the substrate follow-up (#195).
     prisma.contribution.findMany({
-      where: { userId, release: { communityId: { not: null } } },
+      where: { userId },
       select: {
         type: true,
+        createdAt: true,
+        linkStatus: true,
+        healthyMs: true,
+        healthySince: true,
         release: { select: { communityId: true } },
         releaseFile: {
           select: { bitrate: true, hasLog: true, hasCue: true }
@@ -529,6 +586,32 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     };
   });
 
+  // Lifetime link-health (#95 / ADR-0019), from the same widened fetch: reliability
+  // R = mean per-contribution confirmed-PASS fraction; H = total banked PASS time
+  // in healthy-link-years. The live open segment (`healthySince`) is folded in at
+  // read time. A contribution with no banked uptime (dead/never-PASS) contributes
+  // a 0 fraction, dragging R down — a rotted catalogue lowers lifetime reliability.
+  let reliabilitySum = 0;
+  let healthyMsTotal = 0n;
+  for (const contribution of contributedContributions) {
+    const liveHealthyMs =
+      contribution.healthyMs +
+      (contribution.healthySince
+        ? BigInt(
+            Math.max(0, now.getTime() - contribution.healthySince.getTime())
+          )
+        : 0n);
+    healthyMsTotal += liveHealthyMs;
+    const ageMs = now.getTime() - contribution.createdAt.getTime();
+    reliabilitySum +=
+      ageMs > 0 ? Math.min(1, Number(liveHealthyMs) / ageMs) : 0;
+  }
+  const linkHealthReliability =
+    contributedContributions.length > 0
+      ? reliabilitySum / contributedContributions.length
+      : 0;
+  const linkHealthYears = Number(healthyMsTotal) / YEAR_MS;
+
   // Classify direct invitees into the four InviteScore signal counts.
   let inviteActiveContributing = 0;
   let inviteLongLived = 0;
@@ -569,6 +652,8 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     donationCount,
     donationSpanYears,
     communityHealth,
+    linkHealthReliability,
+    linkHealthYears,
     now
   });
 };


### PR DESCRIPTION
Closes #95.

Adds the `linkHealth` CRS dimension — the **positive mirror** of the dead-link penalties — rewarding a member for keeping their own contributions' download links alive over the account's lifetime. Builds the per-contribution link-health history substrate that [ADR-0006](../blob/main/docs/adr/0006-linkhealth-gated-ratio-relief.md) decision #4 deliberately deferred (for CRS, not ratio). Settled via a grill-before-schema design session; recorded as **[ADR-0019](../blob/main/docs/adr/0019-lifetime-link-health-crs-dimension.md)**.

## Shape

`subScore = CAP × R × (1 − exp(−H / H_TAU))`
- **R** = mean per-contribution confirmed-PASS fraction (`passMs / age`) — reliability, leads as a multiplier (rotted links ⇒ ~0 whatever H is).
- **H** = banked healthy-link-years — volume×duration; a fresh account dumping links has H≈0 ⇒ can't farm it.
- **Cap 8** (tied with RatioScore — same availability substrate, current vs lifetime timescale), weight 1.0, **H_TAU 3yr**. Bounded by construction; pure-positive (floor 0). All tier-0.

## Substrate & wiring

- Two `Contribution` **spine** columns `healthyMs BigInt`/`healthySince DateTime?` — the time-analog of `User.contributed`. PASS-only accrual (stricter than ADR-0006 relief).
- One pure helper `applyHealthAccrual` (`healthySince` *is* the accrual-state flag → two branches), reused at `checkContributionLink` + the `recordContributionReport` auto-WARN write. The WARN→FAIL sweep is a no-op for accrual.
- Read: **widened** `getReputation`'s contribution fetch (was community-only) so one scan feeds both CommunityScore weight and R/H — no extra query.
- Migration: cold start (`healthyMs 0`), seed `healthySince=now` for currently-PASS links so live links tick from launch; no fabricated history.
- **Not** snatch-derived → stays visible in the #193 paranoia-gated profile block. Self-registers, so #94's `CrsSnapshot` captures its trend for free.

## Deferred (recorded in ADR-0019)

- Contribution-frequency signal → #212 (needs its own grill-before-schema pass).
- *fail-resolved* / *report-upheld* suspicion signals → stay in negative scoring per ADR-0006's anti-weaponization stance (not this positive dimension).
- `LinkHealthBonusPoints` (the issue's title) is the separate **post-v1 teeth/reward** layer that will *consume* this dimension — out of scope here.

## Tests

- `reputation.spec.ts` — scorer cases (reliability-leads, volume-gate, H_TAU knee, cap clamp) + assembler R/H derivation incl. the live open segment and a dead link dragging R down.
- `linkHealth.spec.ts` — `applyHealthAccrual` branches + a PASS→WARN→PASS round-trip banking exactly the PASS interval + a PASS→FAIL bank via `checkContributionLink`.
- `linkHealthUptime.integration.ts` — real-DB BigInt round-trip + widened fetch + scorer end-to-end.

Full gate clean: format, lint, `tsc`, `typecheck:test`, **1663 tests pass**. Rebased onto current `main` (atop #93/#94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)