### PR TITLE
chore(docs): erd pk-rename fix, CODE_OF_CONDUCT + SECURITY, OpenAPI/Testing → CONTRIBUTING

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Code of Conduct — Stellar Golden Rules
+
+These are Stellar's site-wide Golden Rules — the canonical behavioral standard for every member. `${...}` placeholders are rendered per-site by the in-app RulesPage (see PRD-05). The rule _model_ lives in `docs/prd/05-rules-and-governance.md`; this file is the prose.
+
+**1.1 Do not create more than one account.** Users are allowed one account per lifetime. If your account is disabled, contact staff in ${disabled_channel} on ${irc}.
+
+**1.2 Do not trade, sell, give away, or offer accounts.** If you no longer wish to use your account, send a ${staffpm} and request that your account be disabled.
+
+**1.3 Do not share accounts.** Accounts are for personal use only. Granting access to your account in any way (e.g., shared login details, external programs) is prohibited. [Invite](wiki.php?action=article&name=invite) friends or direct them to the [IRC Interview](http://www.whatinterviewprep.com/).
+
+---
+
+**2.1 Do not invite bad users.** You are responsible for your invitees. You will not be punished if your invitees fail to maintain required share ratios, but invitees who break golden rules will place your invite privileges and account at risk.
+
+**2.2 Do not trade, sell, publicly give away, or publicly offer invites.** Only invite people you know and trust. Do not offer invites via other trackers, forums, social media, or other public locations. Responding to public invite requests is prohibited. Exception: Staff-designated recruiters may offer invites in approved locations.
+
+**2.3 Do not request invites or accounts.** Requesting invites to—or accounts on—${site_name} or other trackers is prohibited. Invites may be _offered_, but not requested, in the site's Invites forum (restricted to the [Power User class](wiki.php?action=article&name=classes) and above). You may request invites by messaging users only when they have offered them in the Invites Forum. Unsolicited invite requests, even by private message, are prohibited.
+
+---
+
+**3.1 Do not engage in ratio manipulation.** Transferring buffer—or increasing your buffer—through unintended uses of the IRC protocol or site features (e.g., [request abuse](rules.php?p=requests)) constitutes ratio manipulation. When in doubt, send a ${staffpm} asking for more information.
+
+**3.2 Do not report incorrect data to the tracker (i.e., cheating).** Reporting incorrect data to the tracker constitutes cheating, whether it is accomplished through the use of a modified "cheat API call" or through manipulation of an approved interface (stellar-ui).
+
+**3.3 Do not use unapproved interfaces.** Your client must be found on the [Interface Whitelist](rules.php?p=interfaces). You must not use interfaces that have been modified in any way. Developers interested in testing unstable interfaces must first receive staff approval.
+
+**3.4 Do not modify ${site_name} files.** Embedding non-${site_name} announce XML/URLs in ${site_name} releases are prohibited. Doing so causes false data to be reported and will be interpreted as cheating. This applies to standalone URLs, stringified XML (JSON, etc.), and API-based URLs that have been loaded into an interface.
+
+**3.5 Do not share consumed links or your IRC key.** Sharing consumed links is considered cheating. IRC keys enable users to report stats to the tracker.
+
+---
+
+**4.1 Do not blackmail, threaten, or expose fellow users.** Exposing or threatening to expose private information about users for any reason is prohibited. Private information includes but is not limited to personally identifying information (e.g., names, records, biographical details, photos). Information that hasn't been openly volunteered by a user should not be discussed or shared without permission. This includes private information collected via investigations into openly volunteered information (e.g., Google search results).
+
+**4.2 Do not scam or defraud.** Scams (e.g., phishing) of any kind are prohibited.
+
+**4.3 Do not disrespect staff decisions.** Disagreements must be discussed privately with the deciding moderator. If the moderator has retired or is unavailable, you may send a ${staffpm}. Do not contact multiple moderators hoping to find one amenable to your cause; however, you may contact a site administrator if you require a second opinion. Options for contacting staff include private message, Staff PM, and ${disabled_channel} on ${irc}.
+
+**4.4 Do not impersonate staff.** Impersonating staff or official service accounts (e.g., stellar-irc-bridge) on-site, off-site, or on IRC is prohibited. Deceptively misrepresenting staff decisions is also prohibited.
+
+**4.5 Do not backseat moderate.** "Backseat moderation" occurs when users police other users. Confronting, provoking, or chastising users suspected of violating rules—or users suspected of submitting reports—is prohibited. Submit a report if you see a rule violation.
+
+**4.6 Do not request special events.** Special events (e.g., freepass, neutral pass, picks) are launched at the discretion of the staff. They do not adhere to a fixed schedule, and may not be requested by users.
+
+**4.7 Do not harvest user-identifying information.** Using ${site_name}'s services to harvest user-identifying information of any kind (e.g., IP addresses, personal links) through the use of scripts, exploits, or other techniques is prohibited.
+
+**4.8 Do not use ${site_name}'s services (including the tracker, website, and IRC network) for commercial gain.** Commercializing services provided by or code maintained by ${site_name} (e.g., Stellar, korin-pink) is prohibited. Commercializing content provided by ${site_name} users via the aforementioned services (e.g., user community data) is prohibited. Referral schemes, financial solicitations, and money offers are also prohibited.
+
+---
+
+**5.1 Do not browse ${site_name} using proxies (including any VPN) with dynamic or shared IP addresses.** You may browse the site through a private server/proxy only if it has a static IP address unique to you, or through your private or shared VPS. Note that this applies to every kind of proxy, including VPN services, Tor, and public proxies. When in doubt, send a ${staffpm} seeking approval of your proxy or VPN. See our ${vpns_article} and ${ips_article} articles for more information.
+
+**5.2 Do not abuse automated site access.** All automated site access must be done through the [API](https://github.com/orphic-inc/stellar-api/docs/JSON-API-Documentation). API use is limited to x requests within any xx-second window. Scripts and other automated processes must not scrape the site's HTML pages.
+
+**5.3 Do not autosnatch freepass releases.** The automatic snatching of freepass releases using any method involving little or no user-input (e.g., API-based scripts, log or site scraping, etc.) is prohibited. See ${site_name}'s ${autofp_article} article for more information.
+
+---
+
+**6.1 Do not seek or exploit live bugs for any reason.** Seeking or exploiting bugs in the live site (as opposed to a local development environment) is prohibited. If you discover a critical bug or security vulnerability, immediately report it in accordance with ${site_name}'s ${bugs_article}. Non-critical bugs can be reported in the [Bugs Forum](/private/forums/[todo]).
+
+**6.2 Do not publish exploits.** The publication, organization, dissemination, sharing, technical discussion, or technical facilitation of exploits is prohibited at staff discretion. Exploits are defined as unanticipated or unaccepted uses of internal, external, non-profit, or for-profit services. See ${site_name}'s ${exploit_article} article for more information. Exploits are subject to reclassification at any time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,24 @@ const { email, password } = parsedBody<LoginInput>(res);
 - Avoid manual string manipulation or raw SQL unless absolutely necessary.
 - **Soft Deletes**: Always rely on Prisma soft-delete patterns or extensions rather than manually filtering `deletedAt: null` across all queries.
 
+## OpenAPI Synchronization
+
+Stellar relies on an OpenAPI specification to maintain type-safety between the API and the UI. When you make changes to Zod schemas or API routes, you must export the new OpenAPI spec:
+
+```bash
+npm run openapi:export
+```
+
+This generates an `openapi.json` file in the project root. The `stellar-ui` repository reads this file to generate its frontend TypeScript types, so a stale `openapi.json` will silently drift the UI's types away from the live API contract.
+
 ## Testing
 
-We utilize Jest and Supertest.
+We utilize Jest and Supertest. Supertest drives our route-level tests through the harness in `src/test/apiTestHarness.ts`, exercising the real Express app without binding a port.
+
+```bash
+npm run test              # unit/spec suite (mocked DB)
+npm run test:integration  # integration suite (requires a stellar_test database and a .env.test file)
+```
 
 - New endpoints must be accompanied by integration tests in `src/integration`.
 - Utilize the `apiTestHarness` and `dbHelpers` to cleanly stub out the database or test user context during integration tests.

--- a/README.md
+++ b/README.md
@@ -87,27 +87,6 @@ Start the server in development mode (with hot-reloading):
 npm run dev
 ```
 
-## OpenAPI Synchronization
+## Contributing
 
-Stellar relies on an OpenAPI specification to maintain type-safety between the API and the UI.
-When you make changes to Zod schemas or API routes, you must export the new OpenAPI spec:
-
-```bash
-npm run openapi:export
-```
-
-This generates an `openapi.json` file in the project root. The `stellar-ui` repository will read this file to generate its frontend TypeScript types.
-
-## Testing
-
-Run the test suite:
-
-```bash
-npm run test
-```
-
-Run integration tests (requires a `stellar_test` database and `.env.test` file):
-
-```bash
-npm run test:integration
-```
+For the contributor workflow (OpenAPI sync, testing), see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+Stellar takes the safety of its members and its infrastructure seriously. This policy describes how to report a vulnerability responsibly. It mirrors Golden Rule 6 in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md): **do not seek or exploit live bugs** (6.1) and **do not publish exploits** (6.2).
+
+## Reporting a vulnerability
+
+If you discover a critical bug or security vulnerability:
+
+- **Report it privately.** Do **not** open a public GitHub issue, post in a public forum, or discuss the vulnerability in any public channel — doing so exposes other members before a fix can ship.
+- Use the appropriate **staff / security contact channel**: send a Staff PM in-app, or contact a site administrator directly. If you cannot reach staff in-app, use the disabled-account support channel on IRC.
+- Include enough detail to reproduce: affected endpoint or page, steps, and expected vs. actual behavior. A minimal proof of concept is welcome; a weaponized exploit is not.
+
+Non-critical bugs (no security or data-integrity impact) may be reported through the normal Bugs Forum rather than this private channel.
+
+## Rules of engagement
+
+- **Do not test against the live site.** Verify findings against a local development environment, not production. Probing, fuzzing, or exploiting the live site is itself a Golden Rule 6.1 violation.
+- **No data exfiltration or persistence.** Do not access, modify, or retain data that is not yours, and do not pivot beyond the minimum needed to demonstrate the issue.
+- **Do not publish or share exploits.** Publication, dissemination, or technical facilitation of exploits is prohibited (Golden Rule 6.2).
+
+## Coordinated disclosure
+
+We practice coordinated disclosure. Please give us a reasonable window to investigate and ship a fix before any public discussion. Good-faith research conducted within this policy — private reporting, no live-site testing, no exfiltration, no publication — will not be treated as a Golden Rule violation. We will acknowledge valid reports and keep you informed as we remediate.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1568,7 +1568,7 @@ Yearly Yearly
   "dev_seed_records" {
     String id "🗝️"
     String entityType 
-    Json pk 
+    Json primaryKey 
     DateTime createdAt 
     }
   
@@ -1576,7 +1576,7 @@ Yearly Yearly
   "dev_seed_mutations" {
     String id "🗝️"
     String entityType 
-    Json pk 
+    Json primaryKey 
     String mutation 
     Json before "❓"
     Json after "❓"

--- a/docs/home.md
+++ b/docs/home.md
@@ -10,6 +10,7 @@
 | docs/agents/issue-tracker.md | GitHub issue workflow                              |
 | docs/agents/triage-labels.md | Standard label definitions                         |
 | docs/agents/domain.md        | Domain-specific guidance                           |
+| CODE_OF_CONDUCT.md           | Stellar Golden Rules — canonical behavioral prose  |
 
 ## Introduction
 

--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -4,7 +4,7 @@
 **Decisions:** [ADR-0001 granular permissions](../adr/0001-granular-permission-checks.md) (enforcement), [ADR-0002 community-health-pulse](../adr/0002-community-health-pulse.md) (standing trend), [ADR-0004 standing → CRS + warnings/bans](../adr/0004-standing-warnings-bans.md)
 **Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance** · PRD-06 Ratio · PRD-07 Donations · PRD-08 Collages & Cover Art
 
-> The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose (that lives in `RulesPage`).
+> The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose. The canonical prose lives in two mirrors: the in-app `RulesPage` (rendered per-site with `${...}` placeholders) and the repo's [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md) (the prose home). The 7-rule **model** stays here in the PRD.
 
 ## The Golden Rules (7 — canonical, site-wide)
 

--- a/prisma/migrations/20260622023704_rename_devseed_pk_to_primarykey/migration.sql
+++ b/prisma/migrations/20260622023704_rename_devseed_pk_to_primarykey/migration.sql
@@ -1,0 +1,9 @@
+-- Rename `pk` -> `primaryKey` on dev-seed tracking tables. The literal column
+-- name `pk` collides with mermaid's reserved PK attribute keyword, breaking the
+-- generated docs/erd.md render on GitHub. RENAME (not DROP/ADD) preserves data.
+
+-- AlterTable
+ALTER TABLE "dev_seed_records" RENAME COLUMN "pk" TO "primaryKey";
+
+-- AlterTable
+ALTER TABLE "dev_seed_mutations" RENAME COLUMN "pk" TO "primaryKey";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2474,7 +2474,7 @@ model DevSeedRecord {
   runId      String
   run        DevSeedRun @relation(fields: [runId], references: [id], onDelete: Cascade)
   entityType String // e.g. "User", "WikiAlias", "UserSecondaryRank"
-  pk         Json // { id: 7 } or { alias: "foo" } or { userId: 2, userRankId: 5 }
+  primaryKey Json // { id: 7 } or { alias: "foo" } or { userId: 2, userRankId: 5 }
   createdAt  DateTime   @default(now())
 
   @@index([runId])
@@ -2489,7 +2489,7 @@ model DevSeedMutation {
   runId      String
   run        DevSeedRun @relation(fields: [runId], references: [id], onDelete: Cascade)
   entityType String
-  pk         Json
+  primaryKey Json // { id: 7 } or { alias: "foo" } or composite
   mutation   String // e.g. "counter_increment", "field_update", "relation_connect"
   before     Json?
   after      Json?

--- a/src/integration/devTools.integration.ts
+++ b/src/integration/devTools.integration.ts
@@ -128,10 +128,10 @@ describe('runGeneration — minimal isolated', () => {
 
     const records = await testPrisma.devSeedRecord.findMany({
       where: { runId: result.runId, entityType: 'User' },
-      select: { pk: true }
+      select: { primaryKey: true }
     });
-    // pk is JSON: { id: <number> } for User records.
-    const ids = records.map((r) => (r.pk as { id: number }).id);
+    // primaryKey is JSON: { id: <number> } for User records.
+    const ids = records.map((r) => (r.primaryKey as { id: number }).id);
     const users = await testPrisma.user.findMany({
       where: { id: { in: ids } },
       select: { avatar: true }

--- a/src/modules/devTools/cleanup.ts
+++ b/src/modules/devTools/cleanup.ts
@@ -827,7 +827,7 @@ export async function cleanupRun(
     if (!mutation.reversible || mutation.before === null) {
       warnings.push(
         `Non-reversible mutation on ${mutation.entityType} (${JSON.stringify(
-          mutation.pk
+          mutation.primaryKey
         )}) not reverted`
       );
       continue;
@@ -839,7 +839,7 @@ export async function cleanupRun(
       mutation.mutation === 'counter_increment'
     ) {
       try {
-        const pk = mutation.pk as { id: number };
+        const pk = mutation.primaryKey as { id: number };
         const before = mutation.before as Record<string, number>;
         await prisma.forum.update({
           where: { id: pk.id },

--- a/src/modules/devTools/tracking.ts
+++ b/src/modules/devTools/tracking.ts
@@ -25,7 +25,7 @@ export async function trackCreate(
   pk: Record<string, unknown>
 ): Promise<void> {
   await tx.devSeedRecord.create({
-    data: { runId, entityType, pk: pk as Prisma.InputJsonValue }
+    data: { runId, entityType, primaryKey: pk as Prisma.InputJsonValue }
   });
 }
 
@@ -50,7 +50,7 @@ export async function trackMutation(
     data: {
       runId,
       entityType,
-      pk: pk as Prisma.InputJsonValue,
+      primaryKey: pk as Prisma.InputJsonValue,
       before:
         before == null ? Prisma.DbNull : (before as Prisma.InputJsonValue),
       after: after == null ? Prisma.DbNull : (after as Prisma.InputJsonValue),
@@ -100,7 +100,7 @@ export async function trackManyCreated(
 ): Promise<void> {
   if (ids.length === 0) return;
   await tx.devSeedRecord.createMany({
-    data: ids.map((id) => ({ runId, entityType, pk: { id } }))
+    data: ids.map((id) => ({ runId, entityType, primaryKey: { id } }))
   });
 }
 
@@ -115,7 +115,7 @@ export async function getTrackedRecords(
   const map = new Map<string, unknown[]>();
   for (const r of records) {
     const list = map.get(r.entityType) ?? [];
-    list.push(r.pk);
+    list.push(r.primaryKey);
     map.set(r.entityType, list);
   }
   return map;
@@ -130,7 +130,7 @@ export async function getTrackedMutations(
 ): Promise<
   Array<{
     entityType: string;
-    pk: unknown;
+    primaryKey: unknown;
     mutation: string;
     before: unknown;
     reversible: boolean;


### PR DESCRIPTION
## Documentation standards sweep

Four documentation/standards fixes, plus the root-cause schema rename that was breaking the ERD render.

### 1. Fix `docs/erd.md` mermaid render (root cause)
GitHub failed to render `docs/erd.md` because `DevSeedRecord` and `DevSeedMutation` each had a field literally named `pk` (Json), which collides with mermaid's reserved `PK` attribute keyword. Renamed the field `pk` → `primaryKey` on both models with a **data-preserving `RENAME COLUMN` migration** (`20260622023704_rename_devseed_pk_to_primarykey`), then regenerated the Prisma client and `docs/erd.md`. Updated all Prisma-row references in `src/modules/devTools/{tracking,cleanup}.ts` and `src/integration/devTools.integration.ts` (local function params / the internal `CleanupResult.failedItems` type keep their `pk` name — they never touch the model).

### 2. OpenAPI + Testing detail → CONTRIBUTING
Moved the full "OpenAPI Synchronization" and "Testing" sections out of `README.md` (now a single pointer to CONTRIBUTING) into `CONTRIBUTING.md`. Enriched Testing: Supertest drives route-level tests via `src/test/apiTestHarness.ts`; documented `npm run test` (unit) vs `npm run test:integration` (needs `stellar_test` DB + `.env.test`).

### 3. Add `CODE_OF_CONDUCT.md`
The Stellar Golden Rules prose (verbatim, with `${...}` template variables) — the prose mirror of the in-app RulesPage. The 7-rule *model* stays in PRD-05.

### 4. Add `SECURITY.md` + cross-links
Concise responsible-disclosure policy mapping to Golden Rule 6.1/6.2. Linked `CODE_OF_CONDUCT.md` from `docs/prd/05-rules-and-governance.md` and `docs/home.md`.

### Gate
- `npm run format` / `npm run lint` clean
- `npx tsc --noEmit` and `npm run typecheck:test` both clean (catch the `.pk` rename across base + test tsconfigs)
- `npm run test`: **1645 passed / 86 suites**
- `npm run openapi:export`: no diff (no route changes)
- `docs/erd.md` regenerated — `Json pk` gone, `Json primaryKey` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)