### PR TITLE
feat(communities): model CommunityLeader as a first-class role (#216)

### DIFF
--- a/docs/adr/0021-community-leader-role.md
+++ b/docs/adr/0021-community-leader-role.md
@@ -1,0 +1,57 @@
+# CommunityLeader: a first-class, single-holder community leader pointer
+
+**Status: Accepted.** Serves [PRD-08 collages & cover art](../prd/08-collages-and-cover-art.md) (the sole `CommunityLeader` mention); reuses the `communities_manage` gate from [ADR-0001 granular permission checks](0001-granular-permission-checks.md). Resolves #216. Ships the leader _model_; the Requests → new-community flow that will consume it is deferred (see below).
+
+## Context
+
+PRD-08 names `CommunityLeader`/`CommunityStaff` as the curators of a community, but "CommunityLeader" was never modeled — it appeared exactly once, in PRD-08 prose. The `Community` model had no owner/leader field. The only expression of ownership was a convention in `POST /api/communities`: the owner was connected to the `staff` `User[]` relation **and** upserted as a `Consumer`. That convention cannot distinguish the founding leader from any other staff member — there is no "this specific user leads this community" pointer.
+
+This blocks the intended Requests interaction: a Request that creates/seeds a new community should, on fulfillment, make the requester that community's leader (`requester = CommunityLeader`). With no modeled leader, the relationship can't be represented or enforced on the staff+consumer convention alone.
+
+The design was grilled before any schema. The crux: keep the change minimal and honest (solve the actual "no founder pointer" problem) without speculatively building a role system or coupling a structural migration to unpinned scoring.
+
+## Decision
+
+Add a **scalar, nullable leader pointer** to `Community`, leaving `staff` untouched:
+
+```prisma
+leaderId Int?
+leader   User? @relation("CommunityLeader", fields: [leaderId], references: [id])
+// + @@index([leaderId]); back-relation User.communitiesLed
+```
+
+Settled properties:
+
+- **Scalar FK, single leader.** Not a typed-membership join model (`CommunityMember{role}`) and not a flagged-staff sidecar. There is no existing role-enum membership pattern (`staff` is a plain implicit M:N; `Consumer`/`Contributor` are satellites), so a scalar is the smallest change that solves the stated problem. Single leader; succession is reassignment. If leadership later becomes genuinely multi-holder or role-graded, scalar → join migrates without data loss.
+- **Leader is a superset of staff.** The invariant `leaderId ⟹ user ∈ staff ∧ user is a Consumer` is enforced in every write path, so existing staff-gated checks keep working with zero "is staff OR is leader" special-casing. The pointer is purely _additional_.
+- **Nullable, recoverable.** Disabling a user does **not** auto-null the pointer (users are soft-deleted, never hard-deleted — auto-nulling would lose provenance and a disabled user can be re-enabled). The FK is `ON DELETE SET NULL` only as a backstop for the rare hard delete.
+- **Transfer = reassignment via `PUT /communities/:id`.** The update route accepts `leaderId`; setting it re-runs the superset invariant. Already `communities_manage`-gated — no new permission surface. When `staffIds` is also supplied (it _replaces_ the whole staff set), the new leader is folded back in to preserve the invariant.
+- **Audited.** Every leader set/change emits `audit(..., 'community.leader.set', 'community', id, { leaderId, previousLeaderId? })`, so a future succession policy has history to read.
+- **Naming: `ownerId` → `leaderId`.** The `POST /communities` body param is renamed. "Owner" was always a fiction with no backing field; there is one concept here and it gets one honest name. Pre-alpha + the gated OpenAPI contract means the rename rides along with stellar-ui's `api.ts` resync.
+
+Write paths enforcing the invariant on trunk today: **`POST /communities`** and **`PUT /communities/:id`**.
+
+## Explicitly deferred
+
+- **The Requests → new-community flow is not built here, and #216's "blocks Requests" premise is currently unrepresentable.** A `Request` is a _release_ request inside an existing community: `communityId` is required and points to an existing community, `type` is a `ReleaseType` (no "Community" type), and it's filled by a `Contribution`. There is no new-community request type and no community-creation fulfillment path (the logic lives in `requestLifecycle.ts`, not the `requests.ts` that #216/CLAUDE.md name). The "requester becomes leader on fulfillment" hook is deferred to whenever that flow is actually designed (pairs with stellar-ui #100). This ADR ships the leader model that flow will later consume.
+- **No leadership CRS dimension.** PRD-01/PRD-08 imply leaders carry curation weight, but a CRS dimension is a _scoring_ decision (registry entry + magnitude pinning, HITL) that must be grilled separately. `leaderId` is the substrate a future dimension reads; this is the pipe, not the water.
+- **No succession _policy_.** Auto-promotion on leader disable, leader-initiated handoff with acceptance, etc. are out of scope. The audit trail is the foundation a later policy builds on.
+
+## Merge seam
+
+`seedDefaultCommunity()` does not exist on trunk — it arrives via the unmerged `feat/golden-rules-surfacing` branch (seeds the flagship community as staff+consumer). **When that branch merges, the seed must also set `leaderId = ownerUserId`** to make the SysOp the flagship community's leader and hold the invariant. This is the third write path named in #216; it is documented here rather than built because it isn't on trunk yet.
+
+## Consequences
+
+- Communities gain a representable, settable, transferable leader distinct from staff — closing #216's actual blocker.
+- One small migration (nullable FK + index); no backfill (pre-alpha).
+- The OpenAPI contract changes (`ownerId` → `leaderId`); stellar-ui absorbs it on its next `api.ts` resync.
+- A clean substrate seam for the deferred leadership CRS dimension and succession policy.
+
+## Alternatives rejected
+
+- **Typed membership join model (`CommunityMember{userId, communityId, role}`)** — the right eventual shape if communities grow a real role system, but a speculative rewrite of how `staff` works everywhere. YAGNI; migrate later if needed.
+- **Flagged staff (sidecar marker on a staff join)** — keeps the founder/staff ambiguity #216 set out to kill.
+- **Keep `ownerId` distinct from `leaderId`** — reintroduces the same can't-tell-founder-from-staff ambiguity.
+- **Build the leadership CRS dimension now** — couples a structural migration to an unpinned scoring decision; exactly how scoring gets decided by accident.
+- **Build the new-community-request flow now** — a whole unbuilt feature, not a Phase 0 enabler.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1648,6 +1648,7 @@ Yearly Yearly
     "communities" |o--|| "RegistrationStatus" : "enum:registrationStatus"
     "communities" |o--|| "CommunityType" : "enum:type"
     "communities" o{--}o "consumers" : ""
+    "communities" }o--|o users : "leader"
     "consumers" |o--|| users : "user"
     "consumers" o{--}o "releases" : ""
     "consumers" o{--}o "contributions" : ""

--- a/openapi.json
+++ b/openapi.json
@@ -2758,6 +2758,10 @@
           "allowDuplicateFormats": {
             "type": "boolean"
           },
+          "leaderId": {
+            "type": "number",
+            "nullable": true
+          },
           "staff": {
             "type": "array",
             "items": {

--- a/prisma/migrations/20260622030000_community_leader/migration.sql
+++ b/prisma/migrations/20260622030000_community_leader/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "communities" ADD COLUMN "leaderId" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "communities_leaderId_idx" ON "communities"("leaderId");
+
+-- AddForeignKey
+ALTER TABLE "communities" ADD CONSTRAINT "communities_leaderId_fkey" FOREIGN KEY ("leaderId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -427,6 +427,7 @@ model User {
   friendRequestsSent       FriendRelationship[]             @relation("FriendRequester")
   friendRequestsReceived   FriendRelationship[]             @relation("FriendRecipient")
   communityStaff           Community[]                      @relation("CommunityStaff")
+  communitiesLed           Community[]                      @relation("CommunityLeader")
   consumer                 Consumer?
   contributor              Contributor?
   contributions            Contribution[]
@@ -957,6 +958,12 @@ model Community {
   releases              Release[]
   comments              Comment[]
   staff                 User[]                    @relation("CommunityStaff")
+  // The founding/owning member. A superset of `staff`: setting it always
+  // connects the same user to `staff` + upserts a Consumer (ADR-0021).
+  // Nullable so a disabled/departed leader leaves a recoverable pointer
+  // rather than orphaning the community.
+  leaderId              Int?
+  leader                User?                     @relation("CommunityLeader", fields: [leaderId], references: [id])
   doNotContribute       DoNotContribute[]
   bookmarks             BookmarkCommunity[]
   createdAt             DateTime                  @default(now())
@@ -964,6 +971,7 @@ model Community {
   Request               Request[]
   healthSnapshots       CommunityHealthSnapshot[]
 
+  @@index([leaderId])
   @@map("communities")
 }
 

--- a/src/communities.spec.ts
+++ b/src/communities.spec.ts
@@ -393,7 +393,7 @@ describe('POST /api/communities', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when ownerId does not exist', async () => {
+  it('returns 404 when leaderId does not exist', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
@@ -403,14 +403,14 @@ describe('POST /api/communities', () => {
       name: 'Jazz',
       type: 'Music',
       registrationStatus: 'open',
-      ownerId: 99
+      leaderId: 99
     });
 
     expect(res.status).toBe(404);
-    expect(res.body).toEqual({ msg: 'Owner user not found' });
+    expect(res.body).toEqual({ msg: 'Leader user not found' });
   });
 
-  it('creates a community with default image and owner membership', async () => {
+  it('creates a community, setting the leader as a superset of staff', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
@@ -429,7 +429,7 @@ describe('POST /api/communities', () => {
         name: 'Jazz',
         type: 'Music',
         registrationStatus: 'open',
-        ownerId: 9,
+        leaderId: 9,
         staffIds: [9, 11]
       });
 
@@ -440,6 +440,7 @@ describe('POST /api/communities', () => {
         type: 'Music',
         registrationStatus: 'open',
         image: '/images/defaults/music.png',
+        leaderId: 9,
         staff: {
           connect: [{ id: 9 }, { id: 11 }]
         }
@@ -449,6 +450,47 @@ describe('POST /api/communities', () => {
       where: { userId: 9 },
       create: { userId: 9, communities: { connect: { id: 4 } } },
       update: { communities: { connect: { id: 4 } } }
+    });
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'community.leader.set',
+          targetType: 'community',
+          targetId: 4
+        })
+      })
+    );
+  });
+
+  it('folds the leader into staff even when omitted from staffIds', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.user.findUnique.mockResolvedValue({ id: 9 } as never);
+    prismaMock.community.create.mockResolvedValue(
+      makeCommunity({ id: 4, staff: [] }) as never
+    );
+    prismaMock.consumer.upsert.mockResolvedValue({
+      id: 10,
+      userId: 9
+    } as never);
+
+    const res = await request(app)
+      .post('/api/communities')
+      .send({
+        name: 'Jazz',
+        type: 'Music',
+        registrationStatus: 'open',
+        leaderId: 9,
+        staffIds: [11]
+      });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.community.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        leaderId: 9,
+        staff: { connect: [{ id: 11 }, { id: 9 }] }
+      })
     });
   });
 });
@@ -491,6 +533,85 @@ describe('PUT /api/communities/:id', () => {
         name: 'Updated',
         registrationStatus: 'invite',
         staff: { set: [{ id: 8 }, { id: 9 }] }
+      }
+    });
+  });
+
+  it('returns 404 when the new leaderId does not exist', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/communities/1')
+      .send({ leaderId: 99 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ msg: 'Leader user not found' });
+  });
+
+  it('reassigns the leader and connects them to staff (transfer)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.user.findUnique.mockResolvedValue({ id: 7 } as never);
+    prismaMock.community.update.mockResolvedValue(
+      makeCommunity({ id: 1, leaderId: 7 }) as never
+    );
+    prismaMock.consumer.upsert.mockResolvedValue({ id: 5, userId: 7 } as never);
+
+    const res = await request(app)
+      .put('/api/communities/1')
+      .send({ leaderId: 7 });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.community.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: {
+        leaderId: 7,
+        staff: { connect: { id: 7 } }
+      }
+    });
+    expect(prismaMock.consumer.upsert).toHaveBeenCalledWith({
+      where: { userId: 7 },
+      create: { userId: 7, communities: { connect: { id: 1 } } },
+      update: { communities: { connect: { id: 1 } } }
+    });
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'community.leader.set',
+          targetType: 'community',
+          targetId: 1
+        })
+      })
+    );
+  });
+
+  it('folds the new leader into a replaced staff set', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.user.findUnique.mockResolvedValue({ id: 7 } as never);
+    prismaMock.community.update.mockResolvedValue(
+      makeCommunity({ id: 1, leaderId: 7 }) as never
+    );
+    prismaMock.consumer.upsert.mockResolvedValue({ id: 5, userId: 7 } as never);
+
+    const res = await request(app)
+      .put('/api/communities/1')
+      .send({ leaderId: 7, staffIds: [8, 9] });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.community.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: {
+        leaderId: 7,
+        staff: { set: [{ id: 8 }, { id: 9 }, { id: 7 }] }
       }
     });
   });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2613,6 +2613,7 @@ const Community = registry.register(
     registrationStatus: z.string().nullable().optional(),
     image: z.string().nullable().optional(),
     allowDuplicateFormats: z.boolean(),
+    leaderId: z.number().nullable().optional(),
     staff: z.array(CommunityStaffMember).optional(),
     consumers: z.array(CommunityConsumer).optional(),
     _count: z

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import { z } from 'zod';
 import { RegistrationStatus, StatSnapshotPeriod } from '@prisma/client';
 import { prisma } from '../../../lib/prisma';
+import { audit } from '../../../lib/audit';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
 import { getCommunityHealthPulse } from '../../../modules/linkHealth';
 import { getCommunityHealthHistory } from '../../../modules/communityHealthHistory';
@@ -316,12 +317,13 @@ router.post(
       registrationStatus,
       allowDuplicateFormats,
       staffIds,
-      ownerId
+      leaderId
     } = parsedBody<CreateCommunityInput>(res);
 
-    if (ownerId !== undefined) {
-      const owner = await prisma.user.findUnique({ where: { id: ownerId } });
-      if (!owner) return res.status(404).json({ msg: 'Owner user not found' });
+    if (leaderId !== undefined) {
+      const leader = await prisma.user.findUnique({ where: { id: leaderId } });
+      if (!leader)
+        return res.status(404).json({ msg: 'Leader user not found' });
     }
 
     const defaultImages: Record<string, string> = {
@@ -334,9 +336,10 @@ router.post(
       Comics: '/images/defaults/comics.png'
     };
 
+    // Leader is a superset of staff (ADR-0021): always fold into the staff set.
     const allStaffIds = [
       ...(staffIds ?? []),
-      ...(ownerId !== undefined ? [ownerId] : [])
+      ...(leaderId !== undefined ? [leaderId] : [])
     ];
 
     const community = await prisma.community.create({
@@ -347,6 +350,7 @@ router.post(
         registrationStatus,
         image: image ?? defaultImages[type] ?? '/images/defaults/music.png',
         ...(allowDuplicateFormats !== undefined && { allowDuplicateFormats }),
+        ...(leaderId !== undefined && { leaderId }),
         ...(allStaffIds.length && {
           staff: {
             connect: [...new Set(allStaffIds)].map((sid) => ({ id: sid }))
@@ -355,15 +359,23 @@ router.post(
       }
     });
 
-    if (ownerId !== undefined) {
+    if (leaderId !== undefined) {
       await prisma.consumer.upsert({
-        where: { userId: ownerId },
+        where: { userId: leaderId },
         create: {
-          userId: ownerId,
+          userId: leaderId,
           communities: { connect: { id: community.id } }
         },
         update: { communities: { connect: { id: community.id } } }
       });
+      await audit(
+        prisma,
+        req.user!.id,
+        'community.leader.set',
+        'community',
+        community.id,
+        { leaderId }
+      );
     }
 
     res.status(201).json(community);
@@ -387,8 +399,24 @@ router.put(
       image,
       registrationStatus,
       allowDuplicateFormats,
-      staffIds
+      staffIds,
+      leaderId
     } = parsedBody<UpdateCommunityInput>(res);
+
+    if (leaderId !== undefined) {
+      const leader = await prisma.user.findUnique({ where: { id: leaderId } });
+      if (!leader)
+        return res.status(404).json({ msg: 'Leader user not found' });
+    }
+
+    // `staffIds` (when given) replaces the whole staff set, so the new leader
+    // might not be in it — fold them back in to preserve the leader⊇staff
+    // invariant (ADR-0021).
+    const staffConnect =
+      leaderId !== undefined && staffIds !== undefined
+        ? [...new Set([...staffIds, leaderId])]
+        : staffIds;
+
     const community = await prisma.community.update({
       where: { id },
       data: {
@@ -397,11 +425,38 @@ router.put(
         ...(image !== undefined && { image }),
         ...(registrationStatus !== undefined && { registrationStatus }),
         ...(allowDuplicateFormats !== undefined && { allowDuplicateFormats }),
-        ...(staffIds !== undefined && {
-          staff: { set: staffIds.map((sid: number) => ({ id: sid })) }
-        })
+        ...(leaderId !== undefined && { leaderId }),
+        ...(staffConnect !== undefined && {
+          staff: { set: staffConnect.map((sid: number) => ({ id: sid })) }
+        }),
+        // Leader given but staff set untouched: connect (don't replace) so the
+        // invariant holds without disturbing existing staff.
+        ...(leaderId !== undefined &&
+          staffIds === undefined && {
+            staff: { connect: { id: leaderId } }
+          })
       }
     });
+
+    if (leaderId !== undefined) {
+      await prisma.consumer.upsert({
+        where: { userId: leaderId },
+        create: {
+          userId: leaderId,
+          communities: { connect: { id: community.id } }
+        },
+        update: { communities: { connect: { id: community.id } } }
+      });
+      await audit(
+        prisma,
+        req.user!.id,
+        'community.leader.set',
+        'community',
+        community.id,
+        { leaderId, previousLeaderId: existing.leaderId }
+      );
+    }
+
     res.json(community);
   })
 );

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -36,16 +36,16 @@ export const createCommunitySchema = z
     registrationStatus: registrationStatusEnum,
     allowDuplicateFormats: z.boolean().optional(),
     staffIds: z.array(z.number().int().positive()).optional(),
-    ownerId: z.number().int().positive().optional()
+    leaderId: z.number().int().positive().optional()
   })
   .refine(
     (data) =>
       data.registrationStatus === RegistrationStatus.open ||
-      data.ownerId !== undefined,
+      data.leaderId !== undefined,
     {
       message:
-        'Owner user ID is required for invite-only and closed communities',
-      path: ['ownerId']
+        'Leader user ID is required for invite-only and closed communities',
+      path: ['leaderId']
     }
   );
 
@@ -55,7 +55,8 @@ export const updateCommunitySchema = z.object({
   image: z.string().url().optional(),
   registrationStatus: registrationStatusEnum.optional(),
   allowDuplicateFormats: z.boolean().optional(),
-  staffIds: z.array(z.number().int().positive()).optional()
+  staffIds: z.array(z.number().int().positive()).optional(),
+  leaderId: z.number().int().positive().optional()
 });
 
 export const createGroupSchema = z.object({


### PR DESCRIPTION
Closes #216 (the leader **model**; the new-community Requests flow it will eventually feed is explicitly deferred — see ADR-0021).

## What

Adds a scalar, nullable `leaderId` pointer to `Community`, replacing the owner-as-staff-member convention that couldn't distinguish the founding leader from any other staff member. Full design rationale (grilled before any schema) in **ADR-0021**.

## Decisions (all recorded in ADR-0021)

| Axis | Call |
|---|---|
| Shape | Scalar `leaderId Int?` + `leader User?` relation; `staff` untouched |
| Staff | Leader is a **superset** — invariant `leaderId ⟹ staff + Consumer`, enforced in write paths |
| Single/multi | Single leader; succession = reassignment |
| Transfer | `PUT /communities/:id` accepts `leaderId` (the transfer mechanism), audited |
| Naming | `ownerId` → `leaderId` (one honest name; "owner" had no backing field) |
| CRS | **Deferred** — relation is substrate; no leadership dimension here |
| Requests hook | **Deferred** — the `Request` model can't represent new-community requests today |

## Changes

- `prisma/schema.prisma` + migration: `leaderId Int?` + `leader` relation + `@@index`; `User.communitiesLed` back-relation
- `POST /communities`: `ownerId`→`leaderId`, set the relation, fold leader into staff, upsert Consumer, audit
- `PUT /communities/:id`: accept `leaderId` as transfer; preserve the superset invariant whether or not `staffIds` is replaced; audit `{ leaderId, previousLeaderId }`
- `src/lib/openapi.ts`: expose `leaderId` on the `Community` response schema (`openapi.json` regenerated)
- `src/schemas/community.ts`: rename + add `leaderId` to the update schema
- `src/communities.spec.ts`: leader-set on create (incl. fold-when-omitted), transfer on PUT, invariant preservation, audit assertions, 404s
- `docs/adr/0021-community-leader-role.md`

## ⚠️ Merge seam

`seedDefaultCommunity()` is **not on trunk** — it arrives via the unmerged `feat/golden-rules-surfacing` branch. When that lands, the seed must also set `leaderId = ownerUserId`. Documented in ADR-0021 §Merge seam.

## ⚠️ Migration not applied to the shared dev DB

The local dev DB carries an out-of-history migration from a sibling session (`20260622023704_rename_devseed_pk_to_primarykey`), so `prisma migrate dev` wanted to reset/wipe it. The migration here was **hand-authored to match Prisma's generated SQL** and `prisma generate` was run for the client types; apply it on a clean DB via `migrate reset`/`deploy`.

## Verification

`format` · `lint` · `tsc --noEmit` · `typecheck:test` clean; full suite **1649 tests / 86 suites pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)