### PR TITLE
feat(install): record install state as a fact, not inferred from rows (ADR-0022)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ src/**/*.js
 src/**/*.js.map
 .DS_Store
 .playwright-mcp/
+
+# Local recovery / scratch notes — never committed
+/update.md

--- a/docs/adr/0022-install-state-recorded-fact.md
+++ b/docs/adr/0022-install-state-recorded-fact.md
@@ -1,0 +1,37 @@
+# Install state is a recorded fact, not inferred from rows
+
+**Status: Accepted (2026-06-22).** Reverses the original install-barrier implementation. Relates to [ADR-0001 granular permission checks](0001-granular-permission-checks.md) (the barrier is a lifecycle gate, deliberately kept _out_ of the permission graph). Numbering note: lands alongside the unmerged ADR-0021 (community-leader); 0021 is claimed by that branch, this is the next free number.
+
+## Context
+
+The API gates every `/api/*` route behind an install barrier (503 until setup is complete). The original `isInstalled()` answered "are we installed?" by counting rows — `userRank.count() > 0 && user.count() > 0` — and latching the positive in memory. That is the legacy-installer failure mode: a **lifecycle phase reconstructed from incidental domain data**. It needed the dual-table check only to dodge a false-positive (ranks are seeded automatically, so ranks-alone read installed before any owner existed), and that defensive accretion is the tell — every inference grows special cases.
+
+Install is irreducibly a **data-creating transition**: it mints the first SysOp. So the truth has to live in the database, because only the data can answer "does the owner exist?" — but it must be _recorded_ at the moment it becomes true, not _inferred_ afterward from rows that exist for other reasons. An environment variable cannot own this truth: it asserts a phase the deployment _declares_, which can disagree with the data the moment an operator sets it wrong — reintroducing the same two-sources-disagree bug. Env belongs as a future read-time _override_ (CI, ephemeral test DBs), never as the source of truth.
+
+## Decision
+
+Record one fact, expose it through one typed read-port, decide the barrier as a pure function.
+
+1. **One stored truth: `SiteSettings.installedAt DateTime?`.** `null` = awaiting setup; a timestamp = installed (and carries _when_). It lives on the existing settings singleton (`id: 1`). There is no `phase` enum column and no second flag — a single nullable timestamp is the minimal honest record.
+
+2. **Derived representation, never stored.** `getInstallState()` (`installState.ts`) reads that column and parses it into a Zod discriminated union — `{ phase: 'awaiting_setup' }` | `{ phase: 'installed'; installedAt }`. The `phase` is computed at read time; persisting it would re-create the disagreement we are escaping. "Both" a column and a union is two _layers_ of one truth, not two truths — that distinction is the whole rule: derive, don't store.
+
+3. **The barrier is a pure function.** `gate(state): 'pass' | 'block'` takes the union and returns a decision — no Express, no Prisma — so it is exhaustively table-tested over the variants. The route middleware is a thin adapter; `isInstalled()` is a one-line boolean convenience over `gate(getInstallState())` that keeps the test mock surface a single export.
+
+4. **Positive-only latch.** The read caches only the `installed` result and never the negative. Install is irreversible in normal operation, so the positive is permanent; the pre-install window is transient and re-reads each request until the stamp lands. This means **no explicit cache invalidation is needed** when the transition fires — the absence of a cached negative _is_ the invalidation.
+
+5. **The transition lives where the data is owned.** Stamping `installedAt` is a `SiteSettings` write, so `markInstalled(tx)` is a `settings.ts` helper, called as the final step **inside POST /install's existing SysOp transaction**. `installedAt` therefore commits if and only if the owner does — the barrier can never report installed without an owner. `installState.ts` (the read side) and the install route stay decoupled: neither imports the other, so the lifecycle read and the lifecycle write share only the column.
+
+6. **Env override is a seam, not built.** A future `STELLAR_ASSUME_INSTALLED` would resolve inside `getInstallState()`, derived at read time and never persisted alongside `installedAt`. The single read chokepoint makes it a one-line addition; it is deferred until a real CI/headless need exists.
+
+## Consequences
+
+- The barrier reads one explicit column instead of two `count()` queries, and the dual-table defensive check disappears with the false-positive it guarded against.
+- `GET /api/install` reports `installed` from the stamp; its response shape is unchanged (no OpenAPI contract change).
+- The barrier stays a pure lifecycle gate, explicitly _not_ a permission — honoring ADR-0001's "no role bleed" by keeping setup-state out of the authz graph entirely.
+- A migration adds one nullable column. No backfill: pre-existing installs would read `awaiting_setup` until re-stamped, which is correct for a pre-alpha instance (data is disposable) and avoids fabricating a record nothing confirmed.
+
+## Deferred / out of scope
+
+- **Env `STELLAR_ASSUME_INSTALLED` override** — seam left in `getInstallState()`, unbuilt.
+- **User-model tracker-field split** (`ratioWatchDownload`, `UserSettings.paranoia` → a 1:1 satellite) — a separate legacy-shape cleanup, its own ADR/PR.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1294,6 +1294,7 @@ Yearly Yearly
     RegistrationStatus registrationStatus 
     Int maxUsers 
     String dismissedLaunchChecklist 
+    DateTime installedAt "❓"
     DateTime updatedAt 
     }
   

--- a/prisma/migrations/20260622202131_site_settings_installed_at/migration.sql
+++ b/prisma/migrations/20260622202131_site_settings_installed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "site_settings" ADD COLUMN     "installedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2012,6 +2012,10 @@ model SiteSettings {
   registrationStatus       RegistrationStatus @default(open)
   maxUsers                 Int                @default(7000)
   dismissedLaunchChecklist String[]
+  // The one recorded fact for "is this instance installed?" — stamped once by
+  // POST /install. null = awaiting setup. Install state is read from this, never
+  // inferred from row counts (see installState.ts).
+  installedAt              DateTime?
   updatedAt                DateTime           @updatedAt
 
   @@map("site_settings")

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -363,6 +363,7 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
       registrationStatus: 'open',
       maxUsers: 7000,
       dismissedLaunchChecklist: [],
+      installedAt: null,
       updatedAt: new Date()
     });
 
@@ -380,6 +381,7 @@ describe('POST /api/communities/:communityId/releases/:releaseId/contributions',
       registrationStatus: 'open',
       maxUsers: 7000,
       dismissedLaunchChecklist: [],
+      installedAt: null,
       updatedAt: new Date()
     });
 

--- a/src/content.spec.ts
+++ b/src/content.spec.ts
@@ -188,6 +188,7 @@ describe('API content and shared flows', () => {
       registrationStatus: 'open',
       maxUsers: 7000,
       dismissedLaunchChecklist: [],
+      installedAt: null,
       updatedAt: new Date()
     });
 
@@ -215,6 +216,7 @@ describe('API content and shared flows', () => {
       registrationStatus: 'open',
       maxUsers: 7000,
       dismissedLaunchChecklist: [],
+      installedAt: null,
       updatedAt: new Date()
     });
 

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -57,6 +57,7 @@ describe('API auth/profile/user flows', () => {
       registrationStatus: 'closed',
       maxUsers: 7000,
       dismissedLaunchChecklist: [],
+      installedAt: null,
       updatedAt: new Date()
     });
 
@@ -77,6 +78,7 @@ describe('API auth/profile/user flows', () => {
       registrationStatus: 'invite',
       maxUsers: 7000,
       dismissedLaunchChecklist: [],
+      installedAt: null,
       updatedAt: new Date()
     });
 

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -63,9 +63,16 @@ function mockSysopTransaction() {
 // ─── GET /api/install ─────────────────────────────────────────────────────────
 
 describe('GET /api/install', () => {
-  it('reports installed when ranks and users exist', async () => {
-    prismaMock.userRank.count.mockResolvedValue(4);
-    prismaMock.user.count.mockResolvedValue(1);
+  it('reports installed when installedAt is stamped', async () => {
+    prismaMock.siteSettings.upsert.mockResolvedValue({
+      id: 1,
+      approvedDomains: [],
+      registrationStatus: 'open',
+      maxUsers: 7000,
+      dismissedLaunchChecklist: [],
+      installedAt: new Date(),
+      updatedAt: new Date()
+    } as never);
 
     const res = await request(app).get('/api/install');
 
@@ -74,9 +81,16 @@ describe('GET /api/install', () => {
     expect(res.body.registrationStatus).toBe('open');
   });
 
-  it('reports not installed when no users exist', async () => {
-    prismaMock.userRank.count.mockResolvedValue(0);
-    prismaMock.user.count.mockResolvedValue(0);
+  it('reports not installed when installedAt is null', async () => {
+    prismaMock.siteSettings.upsert.mockResolvedValue({
+      id: 1,
+      approvedDomains: [],
+      registrationStatus: 'open',
+      maxUsers: 7000,
+      dismissedLaunchChecklist: [],
+      installedAt: null,
+      updatedAt: new Date()
+    } as never);
 
     const res = await request(app).get('/api/install');
 
@@ -178,7 +192,15 @@ describe('POST /api/install/checklist/:id/dismiss', () => {
 
 describe('POST /api/install', () => {
   it('returns 409 when already installed', async () => {
-    prismaMock.user.count.mockResolvedValue(1);
+    prismaMock.siteSettings.upsert.mockResolvedValue({
+      id: 1,
+      approvedDomains: [],
+      registrationStatus: 'open',
+      maxUsers: 7000,
+      dismissedLaunchChecklist: [],
+      installedAt: new Date(),
+      updatedAt: new Date()
+    } as never);
 
     const res = await request(app).post('/api/install').send({
       username: 'sysop',
@@ -291,6 +313,26 @@ describe('POST /api/install', () => {
 
     expect(prismaMock.userRank.create).not.toHaveBeenCalled();
     expect(prismaMock.forumCategory.create).not.toHaveBeenCalled();
+  });
+
+  it('stamps installedAt as the install transition', async () => {
+    prismaMock.user.count.mockResolvedValue(0);
+    prismaMock.user.findFirst.mockResolvedValue(null);
+    mockPreseededBootstrap();
+    mockSysopTransaction();
+
+    await request(app).post('/api/install').send({
+      username: 'sysop',
+      email: 'sysop@example.com',
+      password: 'secure-password-123'
+    });
+
+    // markInstalled() upserts SiteSettings with a stamped installedAt.
+    expect(prismaMock.siteSettings.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ installedAt: expect.any(Date) })
+      })
+    );
   });
 
   it('assigns the 5 GiB startup buffer to the SysOp user', async () => {

--- a/src/modules/installState.spec.ts
+++ b/src/modules/installState.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for install state: the pure barrier decision (`gate`) and the
+ * read-port that maps the recorded `SiteSettings.installedAt` fact into the
+ * typed `InstallState` union. DB is mocked.
+ */
+
+const mockSiteSettings = {
+  findUnique: jest.fn()
+};
+
+jest.mock('../lib/prisma', () => ({
+  prisma: { siteSettings: mockSiteSettings }
+}));
+
+import {
+  gate,
+  getInstallState,
+  isInstalled,
+  __resetInstallStateCache,
+  type InstallState
+} from './installState';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetInstallStateCache();
+});
+
+describe('gate (pure barrier decision)', () => {
+  it('blocks while awaiting setup', () => {
+    expect(gate({ phase: 'awaiting_setup' })).toBe('block');
+  });
+
+  it('passes once installed', () => {
+    const state: InstallState = {
+      phase: 'installed',
+      installedAt: new Date('2026-06-22T00:00:00Z')
+    };
+    expect(gate(state)).toBe('pass');
+  });
+});
+
+describe('getInstallState (recorded fact → typed union)', () => {
+  it('maps a null installedAt to awaiting_setup', async () => {
+    mockSiteSettings.findUnique.mockResolvedValue({ id: 1, installedAt: null });
+
+    const state = await getInstallState();
+
+    expect(state).toEqual({ phase: 'awaiting_setup' });
+  });
+
+  it('maps a missing settings row to awaiting_setup', async () => {
+    mockSiteSettings.findUnique.mockResolvedValue(null);
+
+    const state = await getInstallState();
+
+    expect(state).toEqual({ phase: 'awaiting_setup' });
+  });
+
+  it('maps a stamped installedAt to installed, carrying the date', async () => {
+    const installedAt = new Date('2026-06-22T12:00:00Z');
+    mockSiteSettings.findUnique.mockResolvedValue({ id: 1, installedAt });
+
+    const state = await getInstallState();
+
+    expect(state).toEqual({ phase: 'installed', installedAt });
+  });
+
+  it('caches the installed result — never re-queries once installed', async () => {
+    mockSiteSettings.findUnique.mockResolvedValue({
+      id: 1,
+      installedAt: new Date()
+    });
+
+    await getInstallState();
+    await getInstallState();
+
+    expect(mockSiteSettings.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache the negative — re-queries while awaiting setup', async () => {
+    mockSiteSettings.findUnique.mockResolvedValue({ id: 1, installedAt: null });
+
+    await getInstallState();
+    await getInstallState();
+
+    expect(mockSiteSettings.findUnique).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isInstalled (boolean adapter over the gate)', () => {
+  it('is false while awaiting setup', async () => {
+    mockSiteSettings.findUnique.mockResolvedValue({ id: 1, installedAt: null });
+    expect(await isInstalled()).toBe(false);
+  });
+
+  it('is true once installedAt is stamped', async () => {
+    mockSiteSettings.findUnique.mockResolvedValue({
+      id: 1,
+      installedAt: new Date()
+    });
+    expect(await isInstalled()).toBe(true);
+  });
+});

--- a/src/modules/installState.ts
+++ b/src/modules/installState.ts
@@ -1,13 +1,50 @@
+import { z } from 'zod';
 import { prisma } from '../lib/prisma';
 
-let cached: boolean | null = null;
+/**
+ * Install state is a recorded fact, not an inference. The single stored truth is
+ * `SiteSettings.installedAt` (stamped once by POST /install). Everything here is
+ * a *derived representation* of that one column — the `phase` is computed at read
+ * time and never persisted, which is what keeps the legacy "two facts disagree"
+ * failure mode from returning.
+ */
+export const InstallState = z.discriminatedUnion('phase', [
+  z.object({ phase: z.literal('awaiting_setup') }),
+  z.object({ phase: z.literal('installed'), installedAt: z.coerce.date() })
+]);
+export type InstallState = z.infer<typeof InstallState>;
 
-export const isInstalled = async (): Promise<boolean> => {
-  if (cached === true) return true;
-  // Requires both ranks (seeded automatically) AND at least one user (created
-  // via /install). Checking only ranks caused false-positives after DB resets.
-  const installed =
-    (await prisma.userRank.count()) > 0 && (await prisma.user.count()) > 0;
-  if (installed) cached = true;
-  return installed;
+/** Pure barrier decision — exhaustive over the union, no I/O. */
+export const gate = (state: InstallState): 'pass' | 'block' =>
+  state.phase === 'installed' ? 'pass' : 'block';
+
+// Cache only the positive: install is irreversible in normal operation, so once
+// installed we latch and skip the DB. The negative is never cached — pre-install
+// is a transient setup window where each check must re-read until the stamp lands
+// (this is also why no explicit invalidation is needed when POST /install stamps).
+let cached: InstallState | null = null;
+
+export const getInstallState = async (): Promise<InstallState> => {
+  if (cached?.phase === 'installed') return cached;
+
+  const settings = await prisma.siteSettings.findUnique({ where: { id: 1 } });
+  // Env-override seam: a future STELLAR_ASSUME_INSTALLED would resolve here,
+  // derived at read time — never stored alongside installedAt.
+  const state = InstallState.parse(
+    settings?.installedAt
+      ? { phase: 'installed', installedAt: settings.installedAt }
+      : { phase: 'awaiting_setup' }
+  );
+
+  if (state.phase === 'installed') cached = state;
+  return state;
+};
+
+/** Boolean convenience for the route barrier; keeps the mock surface small. */
+export const isInstalled = async (): Promise<boolean> =>
+  gate(await getInstallState()) === 'pass';
+
+/** Test-only: drop the latched positive so a fresh DB state can be observed. */
+export const __resetInstallStateCache = (): void => {
+  cached = null;
 };

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -1,5 +1,8 @@
+import { PrismaClient } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import type { UpdateSettingsInput } from '../schemas/settings';
+
+type Tx = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0];
 
 const DEFAULTS = {
   id: 1,
@@ -25,5 +28,19 @@ export async function updateSettings(input: UpdateSettingsInput) {
       ...input
     },
     update: input
+  });
+}
+
+/**
+ * Stamp the install transition. The single write that flips install state from
+ * awaiting_setup → installed; runs inside POST /install's transaction so it
+ * commits atomically with the SysOp it records. Idempotent on `id: 1`.
+ */
+export async function markInstalled(tx: Tx = prisma) {
+  const installedAt = new Date();
+  return tx.siteSettings.upsert({
+    where: { id: 1 },
+    create: { ...DEFAULTS, installedAt },
+    update: { installedAt }
   });
 }

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -12,7 +12,7 @@ import { installLimiter } from '../../middleware/rateLimiter';
 import { requirePermission } from '../../middleware/permissions';
 import { validate, parsedBody } from '../../middleware/validate';
 import { installSchema, type InstallInput } from '../../schemas/install';
-import { getSettings } from '../../modules/settings';
+import { getSettings, markInstalled } from '../../modules/settings';
 import {
   seedRanks,
   seedRankPromotionRules,
@@ -115,13 +115,9 @@ const router = express.Router();
 router.get(
   '/',
   asyncHandler(async (_req: Request, res: Response) => {
-    const [rankCount, userCount, settings] = await Promise.all([
-      prisma.userRank.count(),
-      prisma.user.count(),
-      getSettings()
-    ]);
+    const settings = await getSettings();
     res.json({
-      installed: rankCount > 0 && userCount > 0,
+      installed: settings.installedAt != null,
       registrationStatus: settings.registrationStatus,
       configWarnings: getConfigWarnings().map((item) => item.message),
       setupChecklist: getSetupChecklist(settings as SettingsWithDismissals)
@@ -159,8 +155,8 @@ router.post(
   installLimiter,
   validate(installSchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const userCount = await prisma.user.count();
-    if (userCount > 0)
+    const settings = await getSettings();
+    if (settings.installedAt != null)
       return res.status(409).json({ msg: 'Application already installed' });
 
     const { username, email, password } = parsedBody<InstallInput>(res);
@@ -192,24 +188,28 @@ router.post(
 
     const rawUser = await prisma.$transaction(async (tx) => {
       const defaultTheme = await getDefaultStylesheetName(tx);
-      const settings = await tx.userSettings.create({
+      const userSettings = await tx.userSettings.create({
         data: { siteAppearance: defaultTheme }
       });
       const profile = await tx.profile.create({ data: {} });
-      return tx.user.create({
+      const user = await tx.user.create({
         data: {
           username,
           email: email.toLowerCase(),
           password: hashedPassword,
           // avatar left null — UI falls back to the bundled default avatar.
           userRankId: sysopRank.id,
-          userSettingsId: settings.id,
+          userSettingsId: userSettings.id,
           profileId: profile.id,
           inviteCount: 100,
           contributed: STARTUP_BUFFER
         },
         select: authUserSelect
       });
+      // Stamp install state in the same transaction: installedAt commits iff the
+      // SysOp does, so the barrier can never report installed without an owner.
+      await markInstalled(tx);
+      return user;
     });
 
     const token = await issueToken(rawUser.id);

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -495,6 +495,7 @@ export const resetApiTestState = (): void => {
     registrationStatus: 'open',
     maxUsers: 7000,
     dismissedLaunchChecklist: [],
+    installedAt: null,
     updatedAt: new Date()
   });
   prismaMock.$transaction.mockImplementation(async (arg: unknown) => {


### PR DESCRIPTION
## What

The install barrier gated `/api/*` behind `isInstalled()`, which **inferred a lifecycle phase from domain row counts** (`userRank.count() > 0 && user.count() > 0`) — the legacy-installer pattern that needed a defensive dual-table check to dodge a seed-time false-positive. This replaces the inference with one recorded fact, a typed read-port, and a pure barrier decision. Full rationale (grilled E2E before any schema): **ADR-0022**.

## Decisions (all in ADR-0022)

| Axis | Call |
|---|---|
| Stored truth | `SiteSettings.installedAt DateTime?` — one nullable column, no `phase` enum, no second flag |
| Representation | `getInstallState()` parses it into a Zod discriminated union (`awaiting_setup` \| `installed`); `phase` is **derived, never stored** |
| Barrier | pure `gate(state): 'pass' \| 'block'` — no Express/Prisma, exhaustively table-tested |
| Cache | positive-only latch (caches `installed`, never the negative) → no explicit invalidation needed |
| Transition | `settings.markInstalled(tx)`, stamped **inside POST /install's SysOp transaction** — `installedAt` commits iff the owner does |
| Coupling | read side (`installState.ts`) and the install route never import each other; they share only the column |
| Env override | `STELLAR_ASSUME_INSTALLED` left as a read-time seam, **unbuilt** |

## Changes

- `prisma/schema.prisma` + migration `20260622202131_site_settings_installed_at`: one `ADD COLUMN "installedAt"`
- `src/modules/installState.ts` (rewrite): union + `gate` + read-only `getInstallState` + `isInstalled` adapter
- `src/modules/settings.ts`: `markInstalled(tx)` transition
- `src/routes/api/install.ts`: `GET` derives `installed` from the stamp (response shape unchanged — no OpenAPI change); `POST` guards 409 on it and stamps in-transaction
- Tests: new `installState.spec.ts` (gate variants, null/missing/stamped mapping, latch, adapter) + `install.spec.ts` refactored onto the signal with a stamp assertion; `installedAt` added to `siteSettings` mocks across specs (typecheck:test gate)
- `docs/adr/0022-install-state-recorded-fact.md`; `docs/erd.md` regenerated

## Verification

`format` · `lint` · `tsc --noEmit` · `typecheck:test` clean; full suite **1673 tests / 87 suites pass**. Migration applied to a clean local DB.

## Deferred (out of scope)

- Env `STELLAR_ASSUME_INSTALLED` override — seam only
- `[Medium]` User-model tracker-field split (`ratioWatchDownload`, `UserSettings.paranoia` → 1:1 satellite) — its own ADR/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)