### PR TITLE
chore(ci): align workflows with trunk-only model; widen format gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,15 +3,11 @@ on:
   push:
     branches:
       - main
-      - staging
-      - develop
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
-      - staging
-      - develop
   workflow_dispatch:
 
 env:
@@ -50,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Format check
-        run: npx prettier --check src
+        run: npx prettier --check src 'prisma/**/*.ts'
       - name: Lint
         run: npm run lint
       - name: Type check
@@ -97,8 +93,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
-            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
       - name: Build and push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -11,8 +11,6 @@ on:
   pull_request:
     branches:
       - main
-      - staging
-      - develop
     paths:
       - 'src/middleware/**'
 


### PR DESCRIPTION
## What

The 2026-06-11 fold to a single `main` trunk ([ADR-0010](../blob/main/docs/adr/0010-trunk-based-single-branch-workflow.md)) retired the `staging` and `develop` branches, but the CI/CD workflows never caught up — both still triggered on those branches and `publish.yml` still minted GHCR image tags for them. Dead config pointing at branches that no longer exist.

## Changes

- **`publish.yml`** + **`security-review-gate.yml`**: drop `staging`/`develop` from `push` and `pull_request` triggers
- **`publish.yml`**: drop the `staging`/`develop` docker-tag rules (kept `latest` on main + `semver` on tags)
- **`publish.yml`**: widen the format gate from `prettier --check src` → `prettier --check src 'prisma/**/*.ts'` to match the commit-workflow format scope — `prisma/**/*.ts` was previously unchecked in CI

## Verification

`npx prettier --check src 'prisma/**/*.ts'` passes clean locally. No `staging`/`develop` references remain under `.github/`. Workflow logic otherwise unchanged.

First slice of the pre-v0.7.0 CI/CD alignment; the CD/deploy-boundary question (GHCR publish vs. an environment deploy step) is deliberately left for a separate scoping pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)