### PR TITLE
feat(rules): seed & surface the Golden Rules tree; SysOp-led flagship community (#215, #221)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -15,6 +15,14 @@ STELLAR_SMTP_USER=
 STELLAR_SMTP_PASS=
 STELLAR_SMTP_FROM=
 STELLAR_SITE_URL=
+# Site identity + Golden Rules ${...} token resolution (PRD-09 / ADR-0020).
+# All optional — sane defaults apply. STELLAR_PUBLIC_KB_BASE is the Stellar Public
+# KB root (public-facing wiki, peer to IRC) hosting the policy/guidance articles.
+STELLAR_SITE_NAME=Stellar
+STELLAR_IRC_URL=/irc
+STELLAR_DISABLED_CHANNEL=#disabled
+STELLAR_STAFFPM_PATH=/inbox/staff
+STELLAR_PUBLIC_KB_BASE=https://kb.stellargra.ph
 # korin.pink IRC integration (ADR-0013).
 # KORIN_API_URL/KORIN_PULL_KEY: stellar→korin (metrics pull + announce push).
 # STELLAR_SERVICE_KEY: bearer korin→stellar (nick lookup, link, reputation).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,17 +37,22 @@ Run every step before committing. All must pass clean on new/changed files.
 
 Copy `.env.default` → `.env`.
 
-| Variable                   | Purpose                                                                                  |
-| -------------------------- | ---------------------------------------------------------------------------------------- |
-| `STELLAR_PSQL_URI`         | PostgreSQL connection string                                                             |
-| `STELLAR_AUTH_JWT_SECRET`  | JWT signing secret                                                                       |
-| `STELLAR_HTTP_PORT`        | Server port (default 8080)                                                               |
-| `STELLAR_HTTP_CORS_ORIGIN` | Allowed CORS origin                                                                      |
-| `STELLAR_LOG_LEVEL`        | Winston log level (default `info`)                                                       |
-| `KORIN_API_URL`            | korin.pink IRC metrics API base URL (ADR-0013; polling disabled when unset)              |
-| `KORIN_PULL_KEY`           | Key stellar presents to korin (`x-pull-key`) for metrics pull + announce push (ADR-0013) |
-| `KORIN_POLL_INTERVAL_MS`   | IRC metrics poll + announce push interval (default 300000 = 5 min)                       |
-| `STELLAR_SERVICE_KEY`      | Bearer korin presents on inbound calls (by-irc-nick, link, reputation); fails closed     |
+| Variable                   | Purpose                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| `STELLAR_PSQL_URI`         | PostgreSQL connection string                                                                |
+| `STELLAR_AUTH_JWT_SECRET`  | JWT signing secret                                                                          |
+| `STELLAR_HTTP_PORT`        | Server port (default 8080)                                                                  |
+| `STELLAR_HTTP_CORS_ORIGIN` | Allowed CORS origin                                                                         |
+| `STELLAR_LOG_LEVEL`        | Winston log level (default `info`)                                                          |
+| `KORIN_API_URL`            | korin.pink IRC metrics API base URL (ADR-0013; polling disabled when unset)                 |
+| `KORIN_PULL_KEY`           | Key stellar presents to korin (`x-pull-key`) for metrics pull + announce push (ADR-0013)    |
+| `KORIN_POLL_INTERVAL_MS`   | IRC metrics poll + announce push interval (default 300000 = 5 min)                          |
+| `STELLAR_SERVICE_KEY`      | Bearer korin presents on inbound calls (by-irc-nick, link, reputation); fails closed        |
+| `STELLAR_SITE_NAME`        | Site name resolved into Golden Rules `${site_name}` (PRD-09; default `Stellar`)             |
+| `STELLAR_IRC_URL`          | UI route `${irc}` resolves to (PRD-09; default `/irc`)                                      |
+| `STELLAR_DISABLED_CHANNEL` | IRC channel `${disabled_channel}` resolves to (PRD-09; default `#disabled`)                 |
+| `STELLAR_STAFFPM_PATH`     | UI route `${staffpm}` resolves to (PRD-09; default `/inbox/staff`)                          |
+| `STELLAR_PUBLIC_KB_BASE`   | Stellar Public KB root for `${*_article}` guidance links (PRD-09; default kb.stellargra.ph) |
 
 ## Architecture
 
@@ -87,6 +92,8 @@ src/
     ircJob.ts               # Background poll job — fetches korin.pink IRC metrics into the in-process cache (ADR-0013)
     announce.ts             # Release-Announce publisher — builds new-contribution RSS, pushes to korin POST /irc/announce (ADR-0013)
     announceJob.ts          # Background job — cursor over new contributions, pushes each to korin (ADR-0013)
+    goldenRules.ts            # The 6 immutable Golden Rules (PRD-05/09): GOLDEN_RULES table mirroring CODE_OF_CONDUCT.md verbatim + idempotent seedGoldenRules(); drift-guarded by goldenRules.spec.ts
+    siteVariables.ts          # resolveSiteVariables() — read-time token→values map for GET /rules/tree (PRD-09, ADR-0020); config + Bugs-forum lookup, single-sourced for UI substitution
   middleware/
     auth.ts                 # JWT cookie decode → DB lookup → req.user
     permissions.ts          # requirePermission, requireAuth, isModerator

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,12 @@
 # Code of Conduct — Stellar Golden Rules
 
-These are Stellar's site-wide Golden Rules — the canonical behavioral standard for every member. `${...}` placeholders are rendered per-site by the in-app RulesPage (see PRD-05). The rule _model_ lives in `docs/prd/05-rules-and-governance.md`; this file is the prose.
+These are Stellar's six site-wide Golden Rules — the non-negotiable behavioral standard baked into the software. Per-Community rules may only ever be a subset or extension of these six. `${...}` placeholders (including the links below) are resolved at read time: `GET /api/rules/tree` ships a `variables` map the UI substitutes (see PRD-09 / ADR-0020); public guidance articles live in the Stellar Public KB. The rule _model_ lives in `docs/prd/05-rules-and-governance.md`; this file is the canonical prose, mirrored into the seed by a CI drift-guard.
 
 **1.1 Do not create more than one account.** Users are allowed one account per lifetime. If your account is disabled, contact staff in ${disabled_channel} on ${irc}.
 
 **1.2 Do not trade, sell, give away, or offer accounts.** If you no longer wish to use your account, send a ${staffpm} and request that your account be disabled.
 
-**1.3 Do not share accounts.** Accounts are for personal use only. Granting access to your account in any way (e.g., shared login details, external programs) is prohibited. [Invite](wiki.php?action=article&name=invite) friends or direct them to the [IRC Interview](http://www.whatinterviewprep.com/).
+**1.3 Do not share accounts.** Accounts are for personal use only. Granting access to your account in any way (e.g., shared login details, external programs) is prohibited. [Invite](${invite_article}) friends or direct them to the [IRC Interview](${interview_article}).
 
 ---
 
@@ -14,15 +14,15 @@ These are Stellar's site-wide Golden Rules — the canonical behavioral standard
 
 **2.2 Do not trade, sell, publicly give away, or publicly offer invites.** Only invite people you know and trust. Do not offer invites via other trackers, forums, social media, or other public locations. Responding to public invite requests is prohibited. Exception: Staff-designated recruiters may offer invites in approved locations.
 
-**2.3 Do not request invites or accounts.** Requesting invites to—or accounts on—${site_name} or other trackers is prohibited. Invites may be _offered_, but not requested, in the site's Invites forum (restricted to the [Power User class](wiki.php?action=article&name=classes) and above). You may request invites by messaging users only when they have offered them in the Invites Forum. Unsolicited invite requests, even by private message, are prohibited.
+**2.3 Do not request invites or accounts.** Requesting invites to—or accounts on—${site_name} or other trackers is prohibited. Invites may be _offered_, but not requested, in the site's Invites forum (restricted to the [Power User class](${classes_article}) and above). You may request invites by messaging users only when they have offered them in the Invites Forum. Unsolicited invite requests, even by private message, are prohibited.
 
 ---
 
-**3.1 Do not engage in ratio manipulation.** Transferring buffer—or increasing your buffer—through unintended uses of the IRC protocol or site features (e.g., [request abuse](rules.php?p=requests)) constitutes ratio manipulation. When in doubt, send a ${staffpm} asking for more information.
+**3.1 Do not engage in ratio manipulation.** Transferring buffer—or increasing your buffer—through unintended uses of the IRC protocol or site features (e.g., [request abuse](${requests_article})) constitutes ratio manipulation. When in doubt, send a ${staffpm} asking for more information.
 
 **3.2 Do not report incorrect data to the tracker (i.e., cheating).** Reporting incorrect data to the tracker constitutes cheating, whether it is accomplished through the use of a modified "cheat API call" or through manipulation of an approved interface (stellar-ui).
 
-**3.3 Do not use unapproved interfaces.** Your client must be found on the [Interface Whitelist](rules.php?p=interfaces). You must not use interfaces that have been modified in any way. Developers interested in testing unstable interfaces must first receive staff approval.
+**3.3 Do not use unapproved interfaces.** Your client must be found on the [Interface Whitelist](${interfaces_article}). You must not use interfaces that have been modified in any way. Developers interested in testing unstable interfaces must first receive staff approval.
 
 **3.4 Do not modify ${site_name} files.** Embedding non-${site_name} announce XML/URLs in ${site_name} releases are prohibited. Doing so causes false data to be reported and will be interpreted as cheating. This applies to standalone URLs, stringified XML (JSON, etc.), and API-based URLs that have been loaded into an interface.
 
@@ -50,12 +50,12 @@ These are Stellar's site-wide Golden Rules — the canonical behavioral standard
 
 **5.1 Do not browse ${site_name} using proxies (including any VPN) with dynamic or shared IP addresses.** You may browse the site through a private server/proxy only if it has a static IP address unique to you, or through your private or shared VPS. Note that this applies to every kind of proxy, including VPN services, Tor, and public proxies. When in doubt, send a ${staffpm} seeking approval of your proxy or VPN. See our ${vpns_article} and ${ips_article} articles for more information.
 
-**5.2 Do not abuse automated site access.** All automated site access must be done through the [API](https://github.com/orphic-inc/stellar-api/docs/JSON-API-Documentation). API use is limited to x requests within any xx-second window. Scripts and other automated processes must not scrape the site's HTML pages.
+**5.2 Do not abuse automated site access.** All automated site access must be done through the [API](https://github.com/orphic-inc/stellar-api). API use is limited to x requests within any xx-second window. Scripts and other automated processes must not scrape the site's HTML pages.
 
 **5.3 Do not autosnatch freepass releases.** The automatic snatching of freepass releases using any method involving little or no user-input (e.g., API-based scripts, log or site scraping, etc.) is prohibited. See ${site_name}'s ${autofp_article} article for more information.
 
 ---
 
-**6.1 Do not seek or exploit live bugs for any reason.** Seeking or exploiting bugs in the live site (as opposed to a local development environment) is prohibited. If you discover a critical bug or security vulnerability, immediately report it in accordance with ${site_name}'s ${bugs_article}. Non-critical bugs can be reported in the [Bugs Forum](/private/forums/[todo]).
+**6.1 Do not seek or exploit live bugs for any reason.** Seeking or exploiting bugs in the live site (as opposed to a local development environment) is prohibited. If you discover a critical bug or security vulnerability, immediately report it in accordance with ${site_name}'s ${bugs_article}. Non-critical bugs can be reported in the [Bugs Forum](${bugs_forum}).
 
 **6.2 Do not publish exploits.** The publication, organization, dissemination, sharing, technical discussion, or technical facilitation of exploits is prohibited at staff discretion. Exploits are defined as unanticipated or unaccepted uses of internal, external, non-profit, or for-profit services. See ${site_name}'s ${exploit_article} article for more information. Exploits are subject to reclassification at any time.

--- a/docs/adr/0020-rules-tree-variable-resolution.md
+++ b/docs/adr/0020-rules-tree-variable-resolution.md
@@ -1,0 +1,33 @@
+# ADR-0020: Read-time variable resolution for the Golden Rules tree
+
+**Status:** Accepted (2026-06-22)
+**Date:** 2026-06-22
+**Repos:** orphic-inc/stellar-api, orphic-inc/stellar-ui (+ external obrien-k/korin-pink)
+**Relates:** [ADR-0018 — development lifecycle & the API/UI contract gate](0018-development-lifecycle-and-contract-gate.md)
+**Implements:** [PRD-09 — Golden-Rules Surfacing](../prd/09-golden-rules-surfacing.md), extending [PRD-05 — Rules & Governance](../prd/05-rules-and-governance.md)
+
+---
+
+## Context
+
+The six Golden Rules have a canonical prose home (`CODE_OF_CONDUCT.md`) and a data substrate (the `Rule`/`SubRule` tree shipped in #123, read via `GET /api/rules/tree`), but the two were never connected and the prose's `${...}` placeholders resolved nowhere. To surface the rules to end users we had to decide, once, where those placeholders get resolved — because the choice determines whether values get duplicated across repos, which is the exact drift the single-source effort exists to avoid.
+
+The prose carries three kinds of dynamic reference: configuration values (`${site_name}`, `${irc}`, `${disabled_channel}`), UI routes (`${staffpm}`, and `${irc}` rendered as a nav link), and links to seeded or external content (the `${*_article}` guidance pages, the internal feature references, and the Bugs forum). The stored rule bodies must remain **verbatim** so `CODE_OF_CONDUCT.md` stays the single authored source and a CI drift-guard can byte-compare the two; resolution is therefore necessarily a read-time concern layered over the stored tree, not a stored value.
+
+Three options were on the table. (A) The API ships the verbatim tree plus a resolved `variables` map and the UI substitutes. (B) The API fully resolves every token server-side and emits final text/markdown, leaving the UI a dumb renderer. (C) The UI owns both the values and the substitution, with the API returning raw tokens only.
+
+## Decision
+
+Adopt **option A**: `GET /api/rules/tree` returns `{ rules, variables }`, where `rules` is the verbatim tree (tokens intact) and `variables` is a token → value map resolved server-side by `resolveSiteVariables()` (`src/modules/siteVariables.ts`) from `config.site` plus a name lookup for the id-based Bugs forum. The UI performs the mechanical substitution and owns presentation per token.
+
+The API is the **single source of the values** (no cross-repo duplication, which kills the drift in option C), while the **UI keeps presentation control** — it can render `${irc}` as a real nav component and `${*_article}` as an anchor with its own link text, which option B's pre-baked markdown anchors cannot. Token classes: text tokens (`site_name`, `disabled_channel`) substitute in place; route/URL tokens are wrapped by the UI. Public-guidance articles resolve under the **Stellar Public KB** (`STELLAR_PUBLIC_KB_BASE`), a public-facing wiki peer to IRC; app-feature references resolve to internal wiki routes; the rules prose carries **no external third-party links**.
+
+The stored bodies stay verbatim; `src/modules/goldenRules.ts` (`GOLDEN_RULES` + idempotent `seedGoldenRules()`) mirrors the prose and `src/modules/goldenRules.spec.ts` drift-guards it against `CODE_OF_CONDUCT.md`.
+
+## Consequences
+
+- Adding/renaming a token is a two-line change in `siteVariables.ts` + the prose; the contract is the `variables` map shape, registered in `src/lib/openapi.ts` (`{ rules, variables }`) so the API/UI contract gate (ADR-0018) covers it.
+- The UI must implement substitution and per-token presentation; until it does, the rules render with literal `${...}` tokens visible. This is the downstream stellar-ui work.
+- Config values (`STELLAR_SITE_NAME`, `STELLAR_IRC_URL`, `STELLAR_DISABLED_CHANNEL`, `STELLAR_STAFFPM_PATH`, `STELLAR_PUBLIC_KB_BASE`) are all optional with sane defaults — the endpoint never fails closed on a missing variable.
+- `${bugs_forum}` depends on the seeded Bugs forum existing; absent it, the resolver falls back to `/forums`. The `/forums/:id` route shape is assumed against stellar-ui and noted as an open confirmation in PRD-09.
+- CRS micro-impact magnitudes remain PRD-05 TBD; seeded weights are `0`, so resolution and scoring evolve independently.

--- a/docs/prd/05-rules-and-governance.md
+++ b/docs/prd/05-rules-and-governance.md
@@ -2,28 +2,27 @@
 
 **Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-01 Community-Score / CRS](01-Community-Score.md)
 **Decisions:** [ADR-0001 granular permissions](../adr/0001-granular-permission-checks.md) (enforcement), [ADR-0002 community-health-pulse](../adr/0002-community-health-pulse.md) (standing trend), [ADR-0004 standing → CRS + warnings/bans](../adr/0004-standing-warnings-bans.md)
-**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance** · PRD-06 Ratio · PRD-07 Donations · PRD-08 Collages & Cover Art
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · **PRD-05 Rules & Governance** · PRD-06 Ratio · PRD-07 Donations · PRD-08 Collages & Cover Art · PRD-09 Golden-Rules Surfacing
 
 > The wide opus. Governs behavior across the site and Communities, and is a backbone of the CRS. Rules are **composable and CRS-weighted**; this PRD defines the model, not the full rule prose. The canonical prose lives in two mirrors: the in-app `RulesPage` (rendered per-site with `${...}` placeholders) and the repo's [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md) (the prose home). The 7-rule **model** stays here in the PRD.
 
-## The Golden Rules (7 — canonical, site-wide)
+## The Golden Rules (6 — canonical, site-wide, immutable)
 
-Seven canonical rules govern the whole site. They are deliberately kept whole — not consolidated — and are the backbone of CRS standing:
+Six canonical rules govern the whole site. They are **non-negotiable and baked into the software** — the seeded root of the rule tree; any per-Community rule may only ever be a **subset or extension** of these six. They are deliberately kept whole — not consolidated — and are the backbone of CRS standing. The canonical prose lives in [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md) (mirrored into the `seedGoldenRules()` table by a CI drift-guard); the user-facing surfacing and `${...}` token resolution are **[PRD-09](09-golden-rules-surfacing.md)** / **[ADR-0020](../adr/0020-rules-tree-variable-resolution.md)**.
 
 1. **Accounts** — one account per person per lifetime; no sharing/trading/selling; keep it active.
 2. **Invites** — you are responsible for your invitees; no public trading/offering; do not request.
 3. **Contribution Integrity & Accounting** — no manipulating the contribute/consume ledger; Contributions must be honest, with **live links + accurate metadata**; protect your credentials (account / API key). _(Content-tracker cast: a self-hosted host counts as a seedbox-class source; RSS/IRC announcements + idle/activity tracking stand in for a torrent announce.)_
-4. **Conduct** — no blackmail/scams/impersonation; civil discourse; no backseat-moderation.
+4. **Conduct** — no blackmail/scams/impersonation; civil discourse; no backseat-moderation; **respect staff decisions** (staff are volunteers; their interpretation of the rules is final; raise disputes privately). _(Earlier drafts split "Respect Staff" into a 7th rule; it folds into Conduct, matching the prose's own grouping.)_
 5. **Access & Automation** — no free VPN/Tor; automated access via the **API only** (rate-limited); no automated abuse of download credits.
 6. **Bugs & Exploits** — don't seek or exploit live bugs (responsible disclosure); don't publish exploits.
-7. **Respect Staff** — staff are volunteers; their interpretation of the rules is final; raise disputes privately.
 
 ## Composable rule model (the architecture)
 
 Rules form a hierarchy, each node carrying a **CRS micro-impact**:
 
 ```
-GoldenRule (site-wide, 1..7)
+GoldenRule (site-wide, 1..6)
   └─ CommunityRules (per Community)
         ├─ may adopt 0, some, or all GoldenRules
         └─ may add its own rules, each with SubRules
@@ -44,7 +43,7 @@ GoldenRule (site-wide, 1..7)
 
 | Ruleset            | Status                                                                                                                                                                                             |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **GoldenRules**    | the 7 above (canonical)                                                                                                                                                                            |
+| **GoldenRules**    | the 6 above (canonical, immutable — seeded from `CODE_OF_CONDUCT.md`, surfaced via PRD-09)                                                                                                         |
 | **CommunityRules** | composable per-Community tree (above) — leans on `Community`, `UserRank`, `RulesPage`                                                                                                              |
 | **StaffRules**     | staff conduct + the +50 CRS/week-served signal (cross-ref PRD-01) — `StaffGroup`, `UserRank` — [documented as built](../governance/forum-and-staff-rules.md#staffrules-built)                      |
 | **InterviewRules** | recruitment/interview conduct — net-new                                                                                                                                                            |
@@ -71,6 +70,7 @@ GoldenRule (site-wide, 1..7)
 1. ~~**Rule model** — a `Rule`/`SubRule` tree with a CRS-weight field + a pure `ruleImpact(...)` function (table-driven, mirroring the PRD-03 stylesheet slice).~~ **Shipped: [#123](https://github.com/orphic-inc/stellar-api/issues/123).** `Rule`/`SubRule` models (compliance/violation weights, `onDelete: Cascade`), the pure table-driven `ruleImpact()` (`src/modules/ruleImpact.ts` — standing-tier × per-node weights, magnitudes still TBD per the open questions below), and `GET /api/rules/tree`. The standing tier it consumes is computed by descent target #2 (ADR-0004).
 2. ~~**Warning/Ban model** + standing computation (ADR-0004).~~ **Standing computation shipped: [#124](https://github.com/orphic-inc/stellar-api/issues/124).** Pure `computeStanding()` (`src/modules/standing.ts`) rolls active `UserWarning` rows (accrual + expiry) and ban state into the 5-tier `Standing` that `ruleImpact()` (#1) consumes; surfaced on the profile read path (`PublicProfile.standing`). Thresholds are ADR-0004 placeholders (TBD). The fuller Warning/Ban _entity_ model (suspensions, escalation ladder, ban-evasion linkage) remains for ADR-0004 to finalize — this slice computes standing over the existing `UserWarning` + `banDate`.
 3. **Document ForumRules/StaffRules** against the built code; spec IRCRules + InterviewRules as net-new. **Documentation half shipped: [#126](https://github.com/orphic-inc/stellar-api/issues/126)** — ForumRules + StaffRules documented as built in [governance/forum-and-staff-rules.md](../governance/forum-and-staff-rules.md) (sub-rule list, the `ruleImpact()` weights as implemented, and an honest built-vs-stub map: `ForumSpecificRule` is a stub, the staff "+50 CRS/week-served" signal is not yet a CRS dimension). The IRCRules + InterviewRules specs remain net-new (HITL — content + weights need product decisions).
+4. ~~**Seed the GoldenRules + surface them**~~ — the 6-rule tree is seeded from `CODE_OF_CONDUCT.md` (`seedGoldenRules()`, drift-guarded), and `GET /api/rules/tree` ships the resolved `${...}` `variables` map for the UI. Spec: **[PRD-09](09-golden-rules-surfacing.md)** / **[ADR-0020](../adr/0020-rules-tree-variable-resolution.md)**.
 
 ## Open questions
 

--- a/docs/prd/09-golden-rules-surfacing.md
+++ b/docs/prd/09-golden-rules-surfacing.md
@@ -1,0 +1,57 @@
+# PRD-09 — Golden-Rules Surfacing & Variable Resolution
+
+**Status:** Draft · **Owner:** @obrien-k · **Extends:** [PRD-05 Rules & Governance](05-rules-and-governance.md)
+**Decisions:** [ADR-0020 rules-tree variable resolution](../adr/0020-rules-tree-variable-resolution.md)
+**Numbering:** PRD-01 Community-Score · PRD-02 IRC & Announce · PRD-03 Stylesheets · PRD-04 Contribution/Release/Music · PRD-05 Rules & Governance · PRD-06 Ratio · PRD-07 Donations · PRD-08 Collages & Cover Art · **PRD-09 Golden-Rules Surfacing**
+
+> Surfaces the six Golden Rules to **end users**, not just developers, from a single authored source. PRD-05 defines the rule _model_; #123 shipped the substrate (`Rule`/`SubRule`, `ruleImpact()`, `GET /api/rules/tree`); this PRD seeds that tree from the canonical prose and resolves its placeholders so the rules render in-app with no third hand-maintained copy.
+
+## Why
+
+The Golden Rules have a canonical prose home (`CODE_OF_CONDUCT.md`) and a data substrate (the rule tree), but nothing connected them — the tree was empty and the prose's `${...}` placeholders and links resolved nowhere. Re-authoring the rules in the UI would have created a third copy that drifts. Instead: the six rules are **seeded** from the prose into the tree, and a read-time **variable map** resolves the placeholders, so the existing API-driven `RulesPage` renders them for free. One authored source (`CODE_OF_CONDUCT.md`), one rendered surface.
+
+## The six rules are immutable canon
+
+The six Golden Rules are non-negotiable and baked into the software — the seeded **root** of the composable rule tree (PRD-05). A per-Community rule may only ever be a **subset or extension** of these six; it can never weaken or remove one. This is the "path of guidance for communities to follow": the root is fixed, Communities compose on top.
+
+## Single authored source + drift-guard
+
+`CODE_OF_CONDUCT.md` is the canonical prose. `src/modules/goldenRules.ts` holds `GOLDEN_RULES` — a structured mirror (6 `Rule` groups, each `x.y` entry a `SubRule`, bodies copied verbatim) — and the idempotent `seedGoldenRules()` (a no-op once any `Rule` rows exist; wired through `prisma/seed.ts` and the install route, like `seedForums`). Group titles and machine `code`s live only in the seed (the prose numbers its groups but does not name them), so a blind markdown parser was rejected. Instead `goldenRules.spec.ts` parses the prose and asserts every sub-rule's number, title, and verbatim body match the seed — drift fails CI. CRS micro-impact weights seed at the schema default `0` (magnitudes are PRD-05 TBD).
+
+## Variable resolution (the `${...}` tokens)
+
+The prose carries `${...}` tokens and tokenized links that resolve nowhere on their own. `GET /api/rules/tree` returns the **verbatim** tree (tokens intact) **plus** a resolved `variables` map; the UI does the mechanical substitution and owns presentation (e.g. renders `${irc}` as the real nav link, `${vpns_article}` as an anchor to the resolved URL). The API single-sources the values (`src/modules/siteVariables.ts` → `resolveSiteVariables()`); no value is duplicated cross-repo. See [ADR-0020](../adr/0020-rules-tree-variable-resolution.md) for why values-map-over-fully-resolved-text and over UI-owned-values.
+
+### Token registry
+
+| Token                                                                                                                | Class     | Resolves to                                                                          |
+| -------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
+| `${site_name}`                                                                                                       | text      | `config.site.name` (`STELLAR_SITE_NAME`, default `Stellar`)                          |
+| `${disabled_channel}`                                                                                                | text      | `config.site.disabledChannel` (`STELLAR_DISABLED_CHANNEL`, default `#disabled`)      |
+| `${irc}`                                                                                                             | route     | `config.site.ircUrl` (`STELLAR_IRC_URL`, default `/irc`); UI renders as the nav link |
+| `${staffpm}`                                                                                                         | route     | `config.site.staffPmPath` (`STELLAR_STAFFPM_PATH`, default `/inbox/staff`)           |
+| `${public_kb}`                                                                                                       | route     | the **Stellar Public KB** root (`STELLAR_PUBLIC_KB_BASE`)                            |
+| `${interview_article}` `${vpns_article}` `${ips_article}` `${autofp_article}` `${bugs_article}` `${exploit_article}` | Public KB | `${public_kb}/<slug>` — net-new public guidance articles                             |
+| `${invite_article}` `${classes_article}` `${requests_article}` `${interfaces_article}`                               | internal  | internal wiki routes (`/wiki/<slug>`) for app-feature references                     |
+| `${bugs_forum}`                                                                                                      | internal  | the seeded **Bugs** forum (id-based; resolved by name lookup)                        |
+
+**Text** tokens substitute in place as-is; **route/URL** tokens are wrapped by the UI in its own link presentation. Public-guidance articles live in the **Stellar Public KB** — a public-facing wiki peer to IRC — and are authored there (tracked separately). App-feature references resolve to internal wiki routes. There are **no external third-party links** in the rules prose; the only literal external URL is the project's own GitHub repo (rule 5.2's API link).
+
+## Concept → code
+
+| Concept                  | Lives in                                                                   |
+| ------------------------ | -------------------------------------------------------------------------- |
+| Canonical prose          | `CODE_OF_CONDUCT.md`                                                       |
+| Seed table + seeder      | `src/modules/goldenRules.ts` (`GOLDEN_RULES`, `seedGoldenRules()`)         |
+| Drift-guard              | `src/modules/goldenRules.spec.ts`                                          |
+| Variable resolution      | `src/modules/siteVariables.ts`, `src/modules/config.ts` (`site` block)     |
+| Read endpoint            | `GET /api/rules/tree` (`src/routes/api/rules.ts`) — `{ rules, variables }` |
+| Substrate (shipped #123) | `Rule`/`SubRule` models, `src/modules/ruleImpact.ts`                       |
+
+## Open questions
+
+- CRS micro-impact magnitudes per node — PRD-05 TBD; rows seed at `0`.
+- Stellar Public KB article authoring (`interview`, `vpns`, `ips`, `autofp`, `security-disclosure`, `exploits`) — tracked issue.
+- Internal feature-doc wiki stubs (`invite`, `classes`, `requests`, `interfaces`) — author where missing.
+- stellar-ui substitution: `RulesPage`/`rulesApi` consume the `variables` map (downstream PR).
+- `${bugs_forum}` route shape (`/forums/:id`) — confirm against the stellar-ui forum route.

--- a/openapi.json
+++ b/openapi.json
@@ -15913,10 +15913,10 @@
         "tags": [
           "Rules"
         ],
-        "description": "The composable Rule/SubRule tree with CRS weights (PRD-05 #1)",
+        "description": "The composable Rule/SubRule tree with CRS weights (PRD-05 #1), plus the resolved ${...} variables map (PRD-09 / ADR-0020)",
         "responses": {
           "200": {
-            "description": "Rule tree, each rule with its nested sub-rules",
+            "description": "Rule tree (each rule with its nested sub-rules) and the variables map the UI substitutes into the verbatim bodies",
             "content": {
               "application/json": {
                 "schema": {
@@ -15927,10 +15927,17 @@
                       "items": {
                         "$ref": "#/components/schemas/Rule"
                       }
+                    },
+                    "variables": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
-                    "rules"
+                    "rules",
+                    "variables"
                   ]
                 }
               }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,6 +12,7 @@ import {
   seedRankPromotionRules,
   seedForums
 } from '../src/modules/bootstrap';
+import { seedGoldenRules } from '../src/modules/goldenRules';
 
 const prisma = new PrismaClient();
 
@@ -19,6 +20,7 @@ async function main() {
   await seedRanks(prisma);
   await seedRankPromotionRules(prisma);
   await seedForums(prisma);
+  await seedGoldenRules(prisma);
   console.log('→ Complete setup at http://localhost:9000/install');
 }
 

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -27,6 +27,10 @@ function mockPreseededBootstrap() {
 }
 
 function mockSysopTransaction() {
+  // The flagship-community seed runs right after the user transaction commits.
+  prismaMock.community.findFirst.mockResolvedValue(null);
+  prismaMock.community.create.mockResolvedValue({ id: 1 } as never);
+  prismaMock.consumer.upsert.mockResolvedValue({ id: 1 } as never);
   prismaMock.$transaction.mockImplementationOnce(async (cb: unknown) => {
     const tx = prismaMock;
     tx.userSettings.create.mockResolvedValueOnce({ id: 4 } as never);
@@ -354,5 +358,32 @@ describe('POST /api/install', () => {
         })
       })
     );
+  });
+
+  it('seeds the flagship community owned by the SysOp', async () => {
+    prismaMock.user.count.mockResolvedValue(0);
+    prismaMock.user.findFirst.mockResolvedValue(null);
+    mockPreseededBootstrap();
+    mockSysopTransaction();
+
+    const res = await request(app).post('/api/install').send({
+      username: 'sysop',
+      email: 'sysop@example.com',
+      password: 'secure-password-123'
+    });
+
+    expect(res.status).toBe(201);
+    // Named after the site, public, with the SysOp connected as CommunityStaff.
+    expect(prismaMock.community.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Stellar',
+          registrationStatus: 'open',
+          staff: { connect: { id: 1 } }
+        })
+      })
+    );
+    // Owner is also registered as a Consumer (mirrors POST /api/communities).
+    expect(prismaMock.consumer.upsert).toHaveBeenCalled();
   });
 });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -5518,13 +5518,18 @@ registry.registerPath({
   method: 'get',
   path: '/rules/tree',
   tags: ['Rules'],
-  description: 'The composable Rule/SubRule tree with CRS weights (PRD-05 #1)',
+  description:
+    'The composable Rule/SubRule tree with CRS weights (PRD-05 #1), plus the resolved ${...} variables map (PRD-09 / ADR-0020)',
   responses: {
     200: {
-      description: 'Rule tree, each rule with its nested sub-rules',
+      description:
+        'Rule tree (each rule with its nested sub-rules) and the variables map the UI substitutes into the verbatim bodies',
       content: {
         'application/json': {
-          schema: z.object({ rules: z.array(Rule) })
+          schema: z.object({
+            rules: z.array(Rule),
+            variables: z.record(z.string(), z.string())
+          })
         }
       }
     }

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -2,12 +2,17 @@
  * Idempotent bootstrap helpers shared by prisma/seed.ts and the install route.
  * Each function is a no-op when the relevant rows already exist.
  */
-import { PrismaClient } from '@prisma/client';
+import {
+  PrismaClient,
+  CommunityType,
+  RegistrationStatus
+} from '@prisma/client';
 import { ALL_PERMISSIONS } from '../lib/rankPermissions';
 import {
   DEFAULT_RANKS as EVALUATOR_RANKS,
   DEFAULT_RULES
 } from './rankProgression';
+import { site } from './config';
 
 export const DEFAULT_RANKS = [
   {
@@ -483,4 +488,43 @@ export async function seedForums(client: PrismaClient): Promise<void> {
       });
     }
   }
+}
+
+/**
+ * Seed the flagship public community named after the site, led by the first
+ * SysOp. Runs from the install flow (needs the SysOp user), not prisma/seed.ts.
+ * Leadership follows POST /api/communities (ADR-0021): the leader is a superset
+ * of staff, so the SysOp is set as leaderId, folded into staff, and upserted as
+ * a Consumer. Idempotent — skipped once a community with the site name exists.
+ */
+export async function seedDefaultCommunity(
+  client: PrismaClient,
+  ownerUserId: number
+): Promise<void> {
+  const existing = await client.community.findFirst({
+    where: { name: site.name },
+    select: { id: true }
+  });
+  if (existing) return;
+
+  const community = await client.community.create({
+    data: {
+      name: site.name,
+      description: `The official ${site.name} community.`,
+      type: CommunityType.Music,
+      registrationStatus: RegistrationStatus.open,
+      image: '/images/defaults/music.png',
+      leader: { connect: { id: ownerUserId } },
+      staff: { connect: { id: ownerUserId } }
+    }
+  });
+
+  await client.consumer.upsert({
+    where: { userId: ownerUserId },
+    create: {
+      userId: ownerUserId,
+      communities: { connect: { id: community.id } }
+    },
+    update: { communities: { connect: { id: community.id } } }
+  });
 }

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -27,6 +27,19 @@ export const http = {
   corsOrigin: process.env.STELLAR_HTTP_CORS_ORIGIN || 'http://localhost:3000'
 };
 
+// Site identity + the canonical targets the Golden Rules `${...}` tokens resolve
+// to at read time (PRD-09 / ADR-0020). `GET /api/rules/tree` ships these as a
+// `variables` map the UI substitutes; the API single-sources the values here.
+// `publicKbBase` is the Stellar Public KB root — a public-facing wiki peer to IRC
+// that hosts the policy/guidance articles.
+export const site = {
+  name: process.env.STELLAR_SITE_NAME || 'Stellar',
+  ircUrl: process.env.STELLAR_IRC_URL || '/irc',
+  disabledChannel: process.env.STELLAR_DISABLED_CHANNEL || '#disabled',
+  staffPmPath: process.env.STELLAR_STAFFPM_PATH || '/inbox/staff',
+  publicKbBase: process.env.STELLAR_PUBLIC_KB_BASE || 'https://kb.stellargra.ph'
+};
+
 export const economy = {
   minimumBounty: parseInt(process.env.STELLAR_MINIMUM_BOUNTY || '104857600', 10)
 };

--- a/src/modules/goldenRules.spec.ts
+++ b/src/modules/goldenRules.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Drift-guard — proves the structured Golden Rules seed (`GOLDEN_RULES`) is a
+ * faithful mirror of the canonical prose in `CODE_OF_CONDUCT.md`. If an editor
+ * touches one without the other, this fails in CI. Pure (no DB): it parses the
+ * markdown off disk and compares it to the in-memory table.
+ *
+ * Parse contract: every sub-rule is a single line of the form
+ *   **<major>.<minor> <Title>.** <body>
+ * Group titles + machine codes are seed-authored (not present in the prose), so
+ * they are checked for internal consistency, not against the markdown.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { GOLDEN_RULES } from './goldenRules';
+
+interface FlatSubRule {
+  number: string;
+  title: string;
+  description: string;
+}
+
+function parseCodeOfConduct(): FlatSubRule[] {
+  const md = readFileSync(
+    resolve(__dirname, '../../CODE_OF_CONDUCT.md'),
+    'utf8'
+  );
+  const re = /^\*\*(\d+\.\d+) (.+?)\.\*\* (.+)$/gm;
+  const out: FlatSubRule[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(md)) !== null) {
+    out.push({ number: m[1], title: m[2], description: m[3] });
+  }
+  return out;
+}
+
+function flattenSeed(): FlatSubRule[] {
+  const out: FlatSubRule[] = [];
+  GOLDEN_RULES.forEach((rule, i) => {
+    rule.subRules.forEach((sub, j) => {
+      out.push({
+        number: `${i + 1}.${j + 1}`,
+        title: sub.title,
+        description: sub.description
+      });
+    });
+  });
+  return out;
+}
+
+describe('Golden Rules ↔ CODE_OF_CONDUCT.md drift-guard', () => {
+  const prose = parseCodeOfConduct();
+  const seed = flattenSeed();
+
+  it('parses the six numbered groups out of the prose', () => {
+    // 3 + 3 + 5 + 8 + 3 + 2 = 24 sub-rules across 6 groups.
+    expect(prose.length).toBe(24);
+    expect(seed.length).toBe(prose.length);
+  });
+
+  it('keeps the seed table byte-identical to the canonical prose', () => {
+    // number + title + verbatim body, in order — catches any silent drift.
+    expect(seed).toEqual(prose);
+  });
+
+  it('has exactly six immutable Golden Rules', () => {
+    expect(GOLDEN_RULES.length).toBe(6);
+  });
+
+  it('uses unique rule codes and unique sub-rule codes within each rule', () => {
+    const ruleCodes = GOLDEN_RULES.map((r) => r.code);
+    expect(new Set(ruleCodes).size).toBe(ruleCodes.length);
+    for (const rule of GOLDEN_RULES) {
+      const subCodes = rule.subRules.map((s) => s.code);
+      expect(new Set(subCodes).size).toBe(subCodes.length);
+    }
+  });
+});

--- a/src/modules/goldenRules.ts
+++ b/src/modules/goldenRules.ts
@@ -1,0 +1,244 @@
+/**
+ * The six Stellar Golden Rules — the non-negotiable, site-wide behavioral canon
+ * (PRD-05 / PRD-09). This module is the structured MIRROR of the canonical prose
+ * in `CODE_OF_CONDUCT.md`: the 6 numbered groups become `Rule` nodes and each
+ * `x.y` entry a `SubRule`, with bodies copied verbatim. A CI drift-guard
+ * (`goldenRules.spec.ts`) parses the prose and asserts it still matches this
+ * table, so the two can never silently diverge.
+ *
+ * CRS micro-impact weights are PRD-05 TBD — rows seed at the schema default (0).
+ * The `${...}` tokens in titles/descriptions are resolved at read time by
+ * `resolveSiteVariables()` and substituted UI-side (ADR-0020); they are stored
+ * verbatim here so the prose is the single authored source.
+ */
+import { PrismaClient } from '@prisma/client';
+
+export interface GoldenSubRule {
+  /** Stable key, unique within the parent rule. */
+  code: string;
+  /** Display title, sans the leading "x.y " number and trailing period. */
+  title: string;
+  /** Verbatim prose body (may carry `${...}` tokens + markdown links). */
+  description: string;
+}
+
+export interface GoldenRuleDef {
+  /** Machine-stable rule key, e.g. "golden.accounts". */
+  code: string;
+  /** The group's display title (lives only here + PRD — not in the prose). */
+  title: string;
+  subRules: GoldenSubRule[];
+}
+
+export const GOLDEN_RULES: readonly GoldenRuleDef[] = [
+  {
+    code: 'golden.accounts',
+    title: 'Accounts',
+    subRules: [
+      {
+        code: 'single-account',
+        title: 'Do not create more than one account',
+        description:
+          'Users are allowed one account per lifetime. If your account is disabled, contact staff in ${disabled_channel} on ${irc}.'
+      },
+      {
+        code: 'no-trade-accounts',
+        title: 'Do not trade, sell, give away, or offer accounts',
+        description:
+          'If you no longer wish to use your account, send a ${staffpm} and request that your account be disabled.'
+      },
+      {
+        code: 'no-share-accounts',
+        title: 'Do not share accounts',
+        description:
+          'Accounts are for personal use only. Granting access to your account in any way (e.g., shared login details, external programs) is prohibited. [Invite](${invite_article}) friends or direct them to the [IRC Interview](${interview_article}).'
+      }
+    ]
+  },
+  {
+    code: 'golden.invites',
+    title: 'Invites',
+    subRules: [
+      {
+        code: 'no-bad-invitees',
+        title: 'Do not invite bad users',
+        description:
+          'You are responsible for your invitees. You will not be punished if your invitees fail to maintain required share ratios, but invitees who break golden rules will place your invite privileges and account at risk.'
+      },
+      {
+        code: 'no-trade-invites',
+        title:
+          'Do not trade, sell, publicly give away, or publicly offer invites',
+        description:
+          'Only invite people you know and trust. Do not offer invites via other trackers, forums, social media, or other public locations. Responding to public invite requests is prohibited. Exception: Staff-designated recruiters may offer invites in approved locations.'
+      },
+      {
+        code: 'no-request-invites',
+        title: 'Do not request invites or accounts',
+        description:
+          "Requesting invites to—or accounts on—${site_name} or other trackers is prohibited. Invites may be _offered_, but not requested, in the site's Invites forum (restricted to the [Power User class](${classes_article}) and above). You may request invites by messaging users only when they have offered them in the Invites Forum. Unsolicited invite requests, even by private message, are prohibited."
+      }
+    ]
+  },
+  {
+    code: 'golden.contribution-integrity',
+    title: 'Contribution Integrity & Accounting',
+    subRules: [
+      {
+        code: 'no-ratio-manipulation',
+        title: 'Do not engage in ratio manipulation',
+        description:
+          'Transferring buffer—or increasing your buffer—through unintended uses of the IRC protocol or site features (e.g., [request abuse](${requests_article})) constitutes ratio manipulation. When in doubt, send a ${staffpm} asking for more information.'
+      },
+      {
+        code: 'no-false-data',
+        title: 'Do not report incorrect data to the tracker (i.e., cheating)',
+        description:
+          'Reporting incorrect data to the tracker constitutes cheating, whether it is accomplished through the use of a modified "cheat API call" or through manipulation of an approved interface (stellar-ui).'
+      },
+      {
+        code: 'no-unapproved-interfaces',
+        title: 'Do not use unapproved interfaces',
+        description:
+          'Your client must be found on the [Interface Whitelist](${interfaces_article}). You must not use interfaces that have been modified in any way. Developers interested in testing unstable interfaces must first receive staff approval.'
+      },
+      {
+        code: 'no-modify-files',
+        title: 'Do not modify ${site_name} files',
+        description:
+          'Embedding non-${site_name} announce XML/URLs in ${site_name} releases are prohibited. Doing so causes false data to be reported and will be interpreted as cheating. This applies to standalone URLs, stringified XML (JSON, etc.), and API-based URLs that have been loaded into an interface.'
+      },
+      {
+        code: 'protect-credentials',
+        title: 'Do not share consumed links or your IRC key',
+        description:
+          'Sharing consumed links is considered cheating. IRC keys enable users to report stats to the tracker.'
+      }
+    ]
+  },
+  {
+    code: 'golden.conduct',
+    title: 'Conduct',
+    subRules: [
+      {
+        code: 'no-blackmail',
+        title: 'Do not blackmail, threaten, or expose fellow users',
+        description:
+          "Exposing or threatening to expose private information about users for any reason is prohibited. Private information includes but is not limited to personally identifying information (e.g., names, records, biographical details, photos). Information that hasn't been openly volunteered by a user should not be discussed or shared without permission. This includes private information collected via investigations into openly volunteered information (e.g., Google search results)."
+      },
+      {
+        code: 'no-scam',
+        title: 'Do not scam or defraud',
+        description: 'Scams (e.g., phishing) of any kind are prohibited.'
+      },
+      {
+        code: 'respect-staff-decisions',
+        title: 'Do not disrespect staff decisions',
+        description:
+          'Disagreements must be discussed privately with the deciding moderator. If the moderator has retired or is unavailable, you may send a ${staffpm}. Do not contact multiple moderators hoping to find one amenable to your cause; however, you may contact a site administrator if you require a second opinion. Options for contacting staff include private message, Staff PM, and ${disabled_channel} on ${irc}.'
+      },
+      {
+        code: 'no-impersonate-staff',
+        title: 'Do not impersonate staff',
+        description:
+          'Impersonating staff or official service accounts (e.g., stellar-irc-bridge) on-site, off-site, or on IRC is prohibited. Deceptively misrepresenting staff decisions is also prohibited.'
+      },
+      {
+        code: 'no-backseat-moderate',
+        title: 'Do not backseat moderate',
+        description:
+          '"Backseat moderation" occurs when users police other users. Confronting, provoking, or chastising users suspected of violating rules—or users suspected of submitting reports—is prohibited. Submit a report if you see a rule violation.'
+      },
+      {
+        code: 'no-request-events',
+        title: 'Do not request special events',
+        description:
+          'Special events (e.g., freepass, neutral pass, picks) are launched at the discretion of the staff. They do not adhere to a fixed schedule, and may not be requested by users.'
+      },
+      {
+        code: 'no-harvest-info',
+        title: 'Do not harvest user-identifying information',
+        description:
+          "Using ${site_name}'s services to harvest user-identifying information of any kind (e.g., IP addresses, personal links) through the use of scripts, exploits, or other techniques is prohibited."
+      },
+      {
+        code: 'no-commercial-use',
+        title:
+          "Do not use ${site_name}'s services (including the tracker, website, and IRC network) for commercial gain",
+        description:
+          'Commercializing services provided by or code maintained by ${site_name} (e.g., Stellar, korin-pink) is prohibited. Commercializing content provided by ${site_name} users via the aforementioned services (e.g., user community data) is prohibited. Referral schemes, financial solicitations, and money offers are also prohibited.'
+      }
+    ]
+  },
+  {
+    code: 'golden.access-automation',
+    title: 'Access & Automation',
+    subRules: [
+      {
+        code: 'no-dynamic-proxies',
+        title:
+          'Do not browse ${site_name} using proxies (including any VPN) with dynamic or shared IP addresses',
+        description:
+          'You may browse the site through a private server/proxy only if it has a static IP address unique to you, or through your private or shared VPS. Note that this applies to every kind of proxy, including VPN services, Tor, and public proxies. When in doubt, send a ${staffpm} seeking approval of your proxy or VPN. See our ${vpns_article} and ${ips_article} articles for more information.'
+      },
+      {
+        code: 'no-automated-abuse',
+        title: 'Do not abuse automated site access',
+        description:
+          "All automated site access must be done through the [API](https://github.com/orphic-inc/stellar-api). API use is limited to x requests within any xx-second window. Scripts and other automated processes must not scrape the site's HTML pages."
+      },
+      {
+        code: 'no-autosnatch',
+        title: 'Do not autosnatch freepass releases',
+        description:
+          "The automatic snatching of freepass releases using any method involving little or no user-input (e.g., API-based scripts, log or site scraping, etc.) is prohibited. See ${site_name}'s ${autofp_article} article for more information."
+      }
+    ]
+  },
+  {
+    code: 'golden.bugs-exploits',
+    title: 'Bugs & Exploits',
+    subRules: [
+      {
+        code: 'no-exploit-live-bugs',
+        title: 'Do not seek or exploit live bugs for any reason',
+        description:
+          "Seeking or exploiting bugs in the live site (as opposed to a local development environment) is prohibited. If you discover a critical bug or security vulnerability, immediately report it in accordance with ${site_name}'s ${bugs_article}. Non-critical bugs can be reported in the [Bugs Forum](${bugs_forum})."
+      },
+      {
+        code: 'no-publish-exploits',
+        title: 'Do not publish exploits',
+        description:
+          "The publication, organization, dissemination, sharing, technical discussion, or technical facilitation of exploits is prohibited at staff discretion. Exploits are defined as unanticipated or unaccepted uses of internal, external, non-profit, or for-profit services. See ${site_name}'s ${exploit_article} article for more information. Exploits are subject to reclassification at any time."
+      }
+    ]
+  }
+];
+
+/**
+ * Idempotent seed — a no-op once any `Rule` rows exist (mirrors `seedForums`).
+ * Weights are left at the schema default (0); magnitudes are PRD-05 TBD.
+ */
+export async function seedGoldenRules(client: PrismaClient): Promise<void> {
+  const existing = await client.rule.count();
+  if (existing > 0) return;
+
+  for (let i = 0; i < GOLDEN_RULES.length; i++) {
+    const rule = GOLDEN_RULES[i];
+    await client.rule.create({
+      data: {
+        code: rule.code,
+        title: rule.title,
+        sortOrder: (i + 1) * 10,
+        subRules: {
+          create: rule.subRules.map((sub, j) => ({
+            code: sub.code,
+            title: sub.title,
+            description: sub.description,
+            sortOrder: (j + 1) * 10
+          }))
+        }
+      }
+    });
+  }
+}

--- a/src/modules/siteVariables.ts
+++ b/src/modules/siteVariables.ts
@@ -1,0 +1,56 @@
+/**
+ * Read-time resolution of the Golden Rules `${...}` tokens (PRD-09 / ADR-0020).
+ *
+ * The canonical prose (`CODE_OF_CONDUCT.md`) and its seeded mirror store tokens
+ * verbatim; this assembles the `variables` map that `GET /api/rules/tree` ships
+ * alongside the verbatim tree. The API single-sources the VALUES; the UI does the
+ * mechanical substitution and owns presentation (e.g. renders `${irc}` as the nav
+ * link, `${vpns_article}` as an anchor to the resolved URL). No value is ever
+ * duplicated cross-repo.
+ *
+ * Token classes:
+ *   - text     : `site_name`, `disabled_channel` — substituted in place as-is.
+ *   - route/URL: everything else — the UI wraps these in its own link presentation.
+ *     Public-guidance articles resolve under the Stellar Public KB (`publicKbBase`);
+ *     app-feature references resolve to internal wiki routes; `bugs_forum` resolves
+ *     to the seeded Bugs forum (looked up by name — forums are id-based).
+ */
+import { PrismaClient } from '@prisma/client';
+import { site } from './config';
+
+export type SiteVariables = Record<string, string>;
+
+export async function resolveSiteVariables(
+  client: PrismaClient
+): Promise<SiteVariables> {
+  const kb = site.publicKbBase.replace(/\/+$/, '');
+
+  const bugsForum = await client.forum.findFirst({
+    where: { name: 'Bugs' },
+    select: { id: true }
+  });
+
+  return {
+    // text tokens
+    site_name: site.name,
+    disabled_channel: site.disabledChannel,
+    // config-backed routes
+    irc: site.ircUrl,
+    staffpm: site.staffPmPath,
+    public_kb: kb,
+    // Stellar Public KB articles (public-facing; authored under the KB)
+    interview_article: `${kb}/interview`,
+    vpns_article: `${kb}/vpns`,
+    ips_article: `${kb}/ips`,
+    autofp_article: `${kb}/autosnatch`,
+    bugs_article: `${kb}/security-disclosure`,
+    exploit_article: `${kb}/exploits`,
+    // internal app-feature references (existing docs / UI routes)
+    invite_article: '/wiki/invite',
+    classes_article: '/wiki/classes',
+    requests_article: '/wiki/requests',
+    interfaces_article: '/wiki/interfaces',
+    // the seeded Bugs forum (id-based; resolved by name)
+    bugs_forum: bugsForum ? `/forums/${bugsForum.id}` : '/forums'
+  };
+}

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -18,6 +18,7 @@ import {
   seedRankPromotionRules,
   seedForums
 } from '../../modules/bootstrap';
+import { seedGoldenRules } from '../../modules/goldenRules';
 import { AppError } from '../../lib/errors';
 import { authUserSelect, toAuthUser } from '../../modules/auth';
 import { getDefaultStylesheetName } from '../../modules/stylesheet';
@@ -171,6 +172,7 @@ router.post(
     await seedRanks(prisma);
     await seedRankPromotionRules(prisma);
     await seedForums(prisma);
+    await seedGoldenRules(prisma);
 
     const sysopRank = await prisma.userRank.findFirst({
       where: { level: 1000 }

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -16,7 +16,8 @@ import { getSettings, markInstalled } from '../../modules/settings';
 import {
   seedRanks,
   seedRankPromotionRules,
-  seedForums
+  seedForums,
+  seedDefaultCommunity
 } from '../../modules/bootstrap';
 import { seedGoldenRules } from '../../modules/goldenRules';
 import { AppError } from '../../lib/errors';
@@ -213,6 +214,10 @@ router.post(
       await markInstalled(tx);
       return user;
     });
+
+    // Flagship community (named after the site) owned by the SysOp — needs the
+    // user to exist, so it runs after the user transaction commits.
+    await seedDefaultCommunity(prisma, rawUser.id);
 
     const token = await issueToken(rawUser.id);
     res.cookie('token', token, {

--- a/src/routes/api/rules.ts
+++ b/src/routes/api/rules.ts
@@ -21,6 +21,7 @@ import {
   type CreateRulesPageInput,
   type UpdateRulesPageInput
 } from '../../schemas/rules';
+import { resolveSiteVariables } from '../../modules/siteVariables';
 
 const router = Router();
 
@@ -57,21 +58,25 @@ router.get(
   })
 );
 
-// GET /tree — the composable Rule/SubRule tree with CRS weights (PRD-05 #1).
-// Static segment — MUST be before /:slug or it'd be read as a rules-page slug.
-// Read-only substrate for ruleImpact(); login-gated only (rules are site-wide
-// and visible to every member).
+// GET /tree — the composable Rule/SubRule tree with CRS weights (PRD-05 #1),
+// plus the resolved `variables` map for the `${...}` tokens carried verbatim in
+// the rule bodies (PRD-09 / ADR-0020 — the API single-sources the values, the UI
+// substitutes). Static segment — MUST be before /:slug or it'd be read as a
+// rules-page slug. Login-gated only (rules are site-wide, visible to every member).
 router.get(
   '/tree',
   requireAuth,
   authHandler(async (_req, res) => {
-    const rules = await prisma.rule.findMany({
-      orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
-      include: {
-        subRules: { orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }] }
-      }
-    });
-    res.json({ rules });
+    const [rules, variables] = await Promise.all([
+      prisma.rule.findMany({
+        orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+        include: {
+          subRules: { orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }] }
+        }
+      }),
+      resolveSiteVariables(prisma)
+    ]);
+    res.json({ rules, variables });
   })
 );
 

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -168,6 +168,13 @@ jest.mock('../modules/config', () => ({
     pullKey: '',
     pollIntervalMs: 300000,
     serviceKey: 'test-service-key'
+  },
+  site: {
+    name: 'Stellar',
+    ircUrl: '/irc',
+    disabledChannel: '#disabled',
+    staffPmPath: '/inbox/staff',
+    publicKbBase: 'https://kb.stellargra.ph'
   }
 }));
 


### PR DESCRIPTION
## What

Two stacked commits, both gated on now-merged work:

1. **`feat(rules): seed Golden Rules tree + read-time variable resolution (#215)`** — seeds the 6-rule canonical GoldenRules tree from `CODE_OF_CONDUCT.md` (`seedGoldenRules()`, drift-guarded), and `GET /api/rules/tree` ships the resolved `${...}` `variables` map for the UI. Spec: **PRD-09** / **ADR-0020**.
2. **`feat(install): seed flagship community led by the SysOp`** — the install flow seeds a public community named after the site with the first SysOp as its leader.

## Closes the #221 merge seam

#216/#217 (ADR-0021) added `CommunityLeader` (`leaderId`) and explicitly noted the seam: *"seedDefaultCommunity (incoming via feat/golden-rules-surfacing) must also set leaderId = ownerUserId when it lands."* This PR wires it — `seedDefaultCommunity` now sets `leader` alongside `staff` + `Consumer` upsert, mirroring `POST /api/communities`. The stale "no separate owner/leader field" docstring is corrected.

## Validation

- `prettier --check`, `eslint`, `tsc --noEmit`, `typecheck:test` — all clean
- full suite: **1682 tests / 88 suites pass**
- `openapi:export` + erd — no diff (fresh)

Rebased onto current `main` (post #214, #217, #223, #224); stale `docs-standards-sweep` base dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)