### PR TITLE
feat(openapi): register AuthorStylesheet author/adopt routes in the contract

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2095,6 +2095,52 @@
           "userCount"
         ]
       },
+      "AuthorStylesheet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "authorId",
+          "name",
+          "source",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "AdoptionResult": {
+        "type": "object",
+        "properties": {
+          "authorStylesheet": {
+            "$ref": "#/components/schemas/AuthorStylesheet"
+          },
+          "scored": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "authorStylesheet",
+          "scored"
+        ]
+      },
       "GlobalNotice": {
         "type": "object",
         "properties": {
@@ -7671,6 +7717,170 @@
                   "required": [
                     "msg"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet/author": {
+      "post": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "source": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100000
+                  }
+                },
+                "required": [
+                  "name",
+                  "source"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Author stylesheet created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorStylesheet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet/author/{userId}": {
+      "get": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An author's stylesheets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AuthorStylesheet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet/author-stylesheet/{id}": {
+      "get": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Author stylesheet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorStylesheet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stylesheet/author-stylesheet/{id}/adopt": {
+      "post": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stylesheet adopted into the Site Stylesheet slot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdoptionResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
                 }
               }
             }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -39,7 +39,8 @@ import {
 } from '../schemas/artist';
 import {
   stylesheetSchema,
-  stylesheetUpdateSchema
+  stylesheetUpdateSchema,
+  authorStylesheetSchema
 } from '../schemas/stylesheet';
 import {
   subscribeSchema,
@@ -1433,6 +1434,30 @@ const StylesheetStat = registry.register(
   })
 );
 
+// PRD-03 #118/#119/#120 — a user-authored stylesheet. `source` is the raw
+// CSS/SCSS (sanitized at store-time, ADR-0003), not a URL.
+const AuthorStylesheet = registry.register(
+  'AuthorStylesheet',
+  z.object({
+    id: z.number(),
+    authorId: z.number(),
+    name: z.string(),
+    source: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
+// Result of adopting an author stylesheet into the Site Stylesheet slot (#119):
+// the adopted sheet plus whether this adoption recorded a new CRS event (#120).
+const AdoptionResult = registry.register(
+  'AdoptionResult',
+  z.object({
+    authorStylesheet: AuthorStylesheet,
+    scored: z.boolean()
+  })
+);
+
 registry.registerPath({
   method: 'get',
   path: '/announcements',
@@ -1642,6 +1667,74 @@ registry.registerPath({
     404: {
       description: 'User not found',
       content: { 'application/json': { schema: z.object({ msg: z.string() }) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/stylesheet/author',
+  tags: ['Stylesheets'],
+  request: {
+    body: {
+      content: { 'application/json': { schema: authorStylesheetSchema } }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Author stylesheet created',
+      content: { 'application/json': { schema: AuthorStylesheet } }
+    },
+    400: {
+      description: 'Validation error',
+      content: { 'application/json': { schema: ValidationError } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/stylesheet/author/{userId}',
+  tags: ['Stylesheets'],
+  request: { params: z.object({ userId: z.string() }) },
+  responses: {
+    200: {
+      description: "An author's stylesheets",
+      content: { 'application/json': { schema: z.array(AuthorStylesheet) } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/stylesheet/author-stylesheet/{id}',
+  tags: ['Stylesheets'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Author stylesheet',
+      content: { 'application/json': { schema: AuthorStylesheet } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/stylesheet/author-stylesheet/{id}/adopt',
+  tags: ['Stylesheets'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Stylesheet adopted into the Site Stylesheet slot',
+      content: { 'application/json': { schema: AdoptionResult } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
     }
   }
 });

--- a/src/schemas/stylesheet.ts
+++ b/src/schemas/stylesheet.ts
@@ -23,9 +23,11 @@ export const stylesheetUpdateSchema = z
 export type StylesheetInput = z.infer<typeof stylesheetSchema>;
 export type StylesheetUpdateInput = z.infer<typeof stylesheetUpdateSchema>;
 
-// PRD-03 #118 — a user-authored stylesheet (one per author) saved for others to
-// adopt. `source` is the raw CSS/SCSS; injection isolation is the UI injector's
-// job (ADR-0003), so it is stored verbatim, not sanitized here.
+// PRD-03 #118 — a user-authored stylesheet (many per author) saved for others to
+// adopt. `source` is raw CSS in transit; the ingestion path sanitizes it at
+// store-time via lib/cssSanitize.ts before persisting (ADR-0003 Arm 2), so the
+// stored artifact is already safe. The UI injector's protected-chrome layer
+// (ADR-0003 Arm 1) is the other half of the boundary.
 export const authorStylesheetSchema = z.object({
   name: z.string().min(1).max(100),
   source: z.string().min(1).max(100_000)


### PR DESCRIPTION
## What

Registers the AuthorStylesheet author/adopt subsystem (PRD-03 #118/#119/#120) in the OpenAPI contract. The routes shipped in `src/routes/api/stylesheet.ts` but were never registered in `src/lib/openapi.ts`, so the generated `openapi.json` — and therefore stellar-ui's vendored types — couldn't see them. This is the same unregistered-route defect class as #175/#198, and the **root cause** of the dangling stylesheet seam on the UI.

## Changes

- Register 4 paths under tag `Stylesheets`:
  - `POST /stylesheet/author`
  - `GET /stylesheet/author/{userId}`
  - `GET /stylesheet/author-stylesheet/{id}`
  - `POST /stylesheet/author-stylesheet/{id}/adopt`
- Add `AuthorStylesheet` and `AdoptionResult` response schemas (mirroring the existing `Stylesheet` registration pattern; `AdoptionResult` shape per `src/modules/authorStylesheet.ts`).
- Reuse `authorStylesheetSchema` for the POST body.
- Regenerate `openapi.json` — the de-inerted publish.yml freshness gate now enforces it on CI.
- Correct a stale "stored verbatim, not sanitized" comment on `authorStylesheetSchema` (ingestion now sanitizes at store-time via `lib/cssSanitize.ts`, ADR-0003 Arm 2).

## Unblocks

- stellar-ui #108 (author/adopt UX) can now `api:sync` + consume type-safe endpoints.
- Render of an adopted author sheet (PRD-03 #5 / ADR-0003 Arm 1 chrome layer) still gated behind stellar-ui #73 — see comment there.

## Verification

- `grep -c author-stylesheet openapi.json` > 0 ✓
- format / lint / `tsc --noEmit` clean ✓
- full suite: 88 suites, 1682 tests green ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)