### PR TITLE
chore(husky): type-check in pre-commit; sync docs to current patterns

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,12 @@
 
 npx lint-staged
 
+# Type-check the whole project (and test files, which the base tsconfig excludes)
+# — catches type errors before push instead of waiting on CI. Whole-project, not
+# staged-only: a staged edit can break types in files it doesn't touch.
+npx tsc --noEmit
+npm run typecheck:test
+
 # Version-consistency guardrail (#79). Internal axes only — the git-tag axis is
 # enforced in CI on tag pushes so a release bump commit isn't blocked here.
 npm run version:check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,15 @@ npm run db:studio        # prisma studio
 
 ## Commit workflow
 
-Run every step before committing. All must pass clean on new/changed files.
+The `.husky/pre-commit` hook runs on every commit and gates: lint-staged (`eslint --fix` + `prettier --write` on staged files), `npx tsc --noEmit`, `npm run typecheck:test`, and `npm run version:check`. So format/lint/type-check are enforced automatically — don't re-run them by hand as a separate pre-commit ritual.
 
-1. `npm run format` — format **all** of `src/` and `prisma/**/*.ts` (not just changed files — confirms nothing else drifted)
-2. `npm run lint` — must be clean on new/changed files; pre-existing errors in untouched files are acceptable
-3. `npx tsc --noEmit` — must be clean
-4. `npm run test --no-coverage` — full suite must pass
-5. Commit with descriptive message following existing log style
+What the hook does **not** cover, run yourself before committing:
 
-> Order matters: format before lint (Prettier violations surface as ESLint errors), and lint before type-check.
+1. `npm run format` — only when you've changed files the hook didn't stage (it formats **all** of `src/` and `prisma/**/*.ts`, confirming nothing else drifted)
+2. `npm run test --no-coverage` — full suite (too slow for the hook; CI is the authority, but run it locally before pushing)
+3. Commit with a descriptive message following existing log style
+
+> If you do run the checks manually (e.g. before staging, or committing with `--no-verify`): order matters — format before lint (Prettier violations surface as ESLint errors), and lint before type-check.
 
 ## Environment
 
@@ -195,13 +195,15 @@ Route handlers delegate to domain modules in `src/modules/`. Modules own DB quer
 
 ### Body validation
 
-Always run `validate(schema)` before the handler. Destructure using the Zod-inferred type:
+Always run `validate(schema)` before the handler. Read the parsed body with the `parsedBody<T>` helper, typed with the Zod-inferred type:
 
 ```ts
 validate(loginSchema),
 asyncHandler(async (req, res) => {
-  const { email, password } = req.body as LoginInput;
+  const { email, password } = parsedBody<LoginInput>(res);
 ```
+
+Use `parsedQuery<T>(res)` / `parsedParams<T>(res)` for `validateQuery` / `validateParams`.
 
 ### Param validation
 


### PR DESCRIPTION
## What

Adds whole-project type-checking to the husky pre-commit hook — `npx tsc --noEmit` plus `npm run typecheck:test` (the latter covers test files the base tsconfig excludes) — and syncs `CLAUDE.md` to current patterns.

## Why

Catches type errors at commit time instead of waiting on CI. Whole-project rather than staged-only because a staged edit can break types in files it doesn't touch (e.g. factories drifting after a schema change). This was committed on a local branch in a prior session but never PR'd — surfaced as stranded WIP during a janitor sweep; the codebase was already passing both checks, so the gate lands green.

## Verification

- `tsc --noEmit` + `typecheck:test` both clean on current main
- lint clean

Co-Authored-By: Mr. Robot <mr.robot@fsociety.dat>

🤖 Generated with [Claude Code](https://claude.com/claude-code)