### PR TITLE
feat(version): expose running platform version at GET /api/version

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2045,6 +2045,17 @@
           "topicId"
         ]
       },
+      "VersionResponse": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "version"
+        ]
+      },
       "Stylesheet": {
         "type": "object",
         "properties": {
@@ -7221,6 +7232,25 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": [
+          "Meta"
+        ],
+        "responses": {
+          "200": {
+            "description": "The running platform version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
                 }
               }
             }

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ import { startRankProgressionJob } from './modules/rankProgressionJob';
 import installRouter from './routes/api/install';
 import homeRouter from './routes/api/home';
 import { specRouter, uiRouter } from './routes/api/docs';
+import versionRouter from './routes/api/version';
 import toolsRouter from './routes/api/tools';
 import userRouter from './routes/api/user';
 import authRouter from './routes/api/auth';
@@ -118,6 +119,7 @@ export const createApp = () => {
   );
 
   app.use('/api/install', installRouter);
+  app.use('/api/version', versionRouter);
   app.use('/api/docs/json', specRouter);
   app.use('/api/docs', uiRouter);
 

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1412,6 +1412,11 @@ const Subscription = registry.register(
   })
 );
 
+const VersionResponse = registry.register(
+  'VersionResponse',
+  z.object({ version: z.string() })
+);
+
 const Stylesheet = registry.register(
   'Stylesheet',
   z.object({
@@ -1432,6 +1437,18 @@ const StylesheetStat = registry.register(
     userCount: z.number()
   })
 );
+
+registry.registerPath({
+  method: 'get',
+  path: '/version',
+  tags: ['Meta'],
+  responses: {
+    200: {
+      description: 'The running platform version',
+      content: { 'application/json': { schema: VersionResponse } }
+    }
+  }
+});
 
 registry.registerPath({
   method: 'get',

--- a/src/routes/api/version.ts
+++ b/src/routes/api/version.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { appVersion } from '../../lib/version';
+
+// GET /api/version — the running platform version, inside the `/api` boundary so
+// UI clients (which only proxy `/api`) can reach it. Distinct from root `/health`
+// (a liveness probe, unreachable through the UI proxy). Mounted before the
+// install gate: build info is install-independent and never sensitive.
+const router = Router();
+
+router.get('/', (_req: Request, res: Response) => {
+  res.json({ version: appVersion });
+});
+
+export default router;

--- a/src/version.spec.ts
+++ b/src/version.spec.ts
@@ -1,0 +1,23 @@
+import { request, app, resetApiTestState } from './test/apiTestHarness';
+import { appVersion } from './lib/version';
+
+beforeEach(() => resetApiTestState());
+
+// ─── GET /api/version ─────────────────────────────────────────────────────────
+
+describe('GET /api/version', () => {
+  it('returns the running platform version', async () => {
+    const res = await request(app).get('/api/version');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ version: appVersion });
+    expect(res.body.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  // Mounted before the install gate — version is install-independent, so it must
+  // not 503 on a fresh, uninstalled instance (the harness default).
+  it('is reachable without the install gate blocking it', async () => {
+    const res = await request(app).get('/api/version');
+    expect(res.status).not.toBe(503);
+  });
+});


### PR DESCRIPTION
## What

Adds a minimal `GET /api/version` → `{ version }` (sourced from `src/lib/version.ts`, the package manifest), mounted before the install gate, and registers it in the OpenAPI contract.

## Why

The stellar-ui footer ("Powered by Stellar v…") is pinned to the **UI's** build-time manifest, which never bumps with API releases — so it silently drifts (stellar-ui #105). The running version is exposed only at root `GET /health`, which the UI **cannot reach**: its dev/prod proxy forwards only `/api` (a `/health` fetch from the UI origin hits the static server / `historyApiFallback`, not the API). No `/api` route carried the version. This puts the version inside the `/api` boundary the UI already speaks, so it can consume it type-safely after `api:sync`.

`/health` stays the root liveness probe; `/api/version` is the UI-facing surface — two surfaces, two purposes.

## Verification

- `grep -c '"/version"' openapi.json` → 1
- new `src/version.spec.ts`: 200 + `{ version }`, and not 503'd by the install gate
- format / lint / `tsc --noEmit` / `typecheck:test` clean
- full suite: 89 suites, 1684 tests green

## Downstream

Unblocks stellar-ui #105: footer reads `GET /api/version` instead of the stale `__APP_VERSION__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)