### PR TITLE
docs(adr-0003): drop Arm 1 chrome isolation — themes are visually unrestricted

### DIFF
--- a/docs/adr/0003-stylesheet-injection-isolation.md
+++ b/docs/adr/0003-stylesheet-injection-isolation.md
@@ -1,6 +1,6 @@
 # Stylesheet injection isolation & sanitization
 
-**Status: Accepted.** Records the isolation + sanitization strategy for user-supplied stylesheets; see [PRD-03](../prd/03-stylesheet-themes-and-scoring.md). Resolves decision [#130](https://github.com/orphic-inc/stellar-api/issues/130). (ADR-0002 is reserved for community-health-pulse, [#75](https://github.com/orphic-inc/stellar-api/issues/75).)
+**Status: Accepted, amended 2026-06-23.** Records the isolation + sanitization strategy for user-supplied stylesheets; see [PRD-03](../prd/03-stylesheet-themes-and-scoring.md). Resolves decision [#130](https://github.com/orphic-inc/stellar-api/issues/130). (ADR-0002 is reserved for community-health-pulse, [#75](https://github.com/orphic-inc/stellar-api/issues/75).) **Arm 1 (protected-chrome isolation) is superseded — see the [Amendment](#amendment-2026-06-23-arm-1-dropped-themes-are-visually-unrestricted) at the bottom; the boundary is now code-injection only (Arm 2).**
 
 ## Context
 
@@ -12,7 +12,9 @@ The product goal is **site-wide** theming — the theme must cascade into the re
 
 A two-arm, defense-in-depth boundary.
 
-### Arm 1 — Isolation: a protected-chrome layer, not a sandbox
+### Arm 1 — Isolation: a protected-chrome layer, not a sandbox — **SUPERSEDED (see Amendment)**
+
+> Superseded 2026-06-23. Retained for the record; **not implemented**. A sandbox (iframe / shadow DOM) remains rejected for the same reason (it can't theme the app's own chrome). Original text follows.
 
 User CSS is injected into the real document so theming works, but **critical app chrome** (primary navigation, staff/admin and moderation controls) is rendered inside a high-priority CSS `@layer` and/or an `all: revert` reset container that user sheets cannot override. Themeable regions accept the cascade; chrome is locked. This is the "Global SCSS/CSS reset flag" PRD-03 anticipates. A sandbox (iframe / shadow DOM) is **rejected**: it can only theme content inside the sandbox and cannot theme the app's own chrome, which defeats the feature.
 
@@ -26,5 +28,20 @@ User CSS is injected into the real document so theming works, but **critical app
 
 - **#145 changes before merge:** the AuthorStylesheet ingestion path gains a store-time CSS sanitizer; it does **not** merge storing raw `source`.
 - `source` is plain CSS at the boundary; the SCSS-vs-stored-file shape question in PRD-03 narrows to CSS-in, with any authoring-time SCSS compilation happening client-side before submission.
-- The injector spec (PRD-03 descent target #5, stellar-ui) asserts the chrome layer + CSP — the UI half of this boundary.
-- Defense-in-depth: a bypass must defeat the store-time sanitizer, the CSP, and the chrome layer together.
+- The injector spec (PRD-03 descent target #5, stellar-ui) asserts the injection path is code-injection-safe + the CSP — the UI half of this boundary. (Originally also asserted a chrome layer; see Amendment.)
+- Defense-in-depth: a bypass must defeat both the store-time sanitizer and the CSP.
+
+## Amendment (2026-06-23): Arm 1 dropped — themes are visually unrestricted
+
+Building the stylesheet boundary in stellar-ui (#73) proved Arm 1 unworkable **and** unwanted, so it is dropped:
+
+- **CSS cannot enforce it.** Cascade layers tame only _normal_ declarations. A theme shipping `display:none !important` defeats every arrangement — a layered lock loses (for `!important` the layer order reverses, so a lower/earlier layer wins), and unlayered `!important` is the _weakest_ important origin. Verified in a real browser: unlayered, earlier-layer, and later-layer locks were all overridden. Any sheet we agree to inject into the real DOM can override chrome; `!important` makes that absolute.
+- **Product call:** themes should be able to do more or less anything visually — maximal theming freedom is the feature. The only thing we defend is **code injection** (XSS, exfiltration), not visual override of chrome. Hiding your own nav is a cosmetic choice, not a security boundary.
+
+The boundary is therefore **Arm 2 only**, realized as:
+
+- **Store-time sanitization** (API, `lib/cssSanitize.ts`): strips `@import` and constrains `url()` / `@font-face src` to `data:` / same-origin, so persisted author CSS can't fetch arbitrary hosts.
+- **Inject-time CSP** (stellar-ui, prod builds, via HtmlWebpackPlugin): permissive on resource axes (`style-src`/`img-src`/`font-src`/`connect-src`) to keep theming freedom, strict on execution (`script-src 'self'`, `object-src 'none'`, `base-uri`/`form-action 'self'`) — the real XSS gate. `frame-ancestors` needs a response header (tracked separately).
+- **Injector** stays a plain `<link href>` for URL themes (no CSS-injection surface; http(s) scheme gated), and future author raw CSS is injected as already-sanitized `<style>`.
+
+No `data-stellar-chrome` markers, no chrome `@layer`. A bypass must defeat the store-time sanitizer and the CSP — there is no chrome layer in the model.


### PR DESCRIPTION
## What

Amends ADR-0003 to drop **Arm 1** (protected-chrome isolation). Marks it superseded inline and adds a dated amendment recording the new model: themes get full visual freedom; the boundary is **code injection only** (Arm 2 — store-time sanitization + inject-time CSP).

## Why

Building the boundary in stellar-ui (#73, PR orphic-inc/stellar-ui#109) proved Arm 1 both unworkable and unwanted:

- **CSS can't enforce it.** Cascade layers tame only *normal* declarations; a theme's `display:none !important` defeats every layer arrangement (for `!important`, layer order reverses and unlayered important is weakest). Verified in a real browser — unlayered, earlier-layer, and later-layer locks were all overridden.
- **Product call:** maximal theming freedom is the feature. Hiding your own nav is cosmetic, not a security boundary.

Recording this keeps the next agent from rebuilding the chrome lock per the stale spec.

## Pairs with

- stellar-ui PR #109 (drops the chrome lock, adds the CSP)
- `lib/cssSanitize.ts` (store-time sanitizer, already in place) is the other half of Arm 2.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)