### PR TITLE
feat(reputation): tiering escalation curve for stylesheet CRS (#121)

### DIFF
--- a/docs/prd/03-stylesheet-themes-and-scoring.md
+++ b/docs/prd/03-stylesheet-themes-and-scoring.md
@@ -52,7 +52,17 @@ Stylesheet activity accrues into the **CRS** along three recipients:
 - **×5** when it's the user's **own** authored stylesheet
 - A user on a modified stylesheet: a **+1** engagement bonus → to Site (or admin), and to the **Author** if a custom InjectedStylesheet.
 
-**Tiering (decided).** The +1 is **both** additive **and** folds into the multipliers as a user **tiers up** — engagement escalates like the [`/verbiagating`](../../../skills) tier ladder: each step of customization/sharing compounds the base rather than paying a flat one-off. The flat multipliers above are **tier 0**; the escalation schedule (the curve as a user climbs tiers) is the **next scoring slice** — curve TBD.
+**Tiering (decided — pinned #121).** The +1 is **both** additive **and** folds into the multipliers as a user **tiers up**: each step of sharing compounds the base rather than paying a flat one-off. The flat multipliers above are **tier 0**. The escalation schedule tiers the **author/popularity axis** — the count of distinct members who have adopted a member's AuthorStylesheets (the deduped `(adopter, author)` ledger from #120) — leaving the user-customization rewards above flat. It is a **discrete tier table** applied **marginally** (tax-bracket: each adoption scores at the rate of the band it falls in, summed — monotonic and cliff-free, so an author's score eases down read-time when a sheet loses adoptions rather than re-rating every past adoption). The curve is **back-loaded within the existing cap (6)**: early adoptions score below the base rate `b` (the non-self author delta ≈ 0.708), the marginal rate climbs each band, and the cap is reached only by sustained popularity (~16 distinct adoptions). Rates are fractions of `b`, so retuning the base rescales the whole curve.
+
+| Tier | Distinct adoptions (band) | Marginal rate / adoption | Cumulative CRS at band end |
+| ---- | ------------------------- | ------------------------ | -------------------------- |
+| 0    | 0                         | —                        | 0.00                       |
+| 1    | 1–3                       | 0.30 × b                 | 0.64                       |
+| 2    | 4–8                       | 0.45 × b                 | 2.23                       |
+| 3    | 9–15                      | 0.65 × b                 | 5.45                       |
+| 4    | 16+                       | 0.85 × b                 | cap 6 reached ~adoption 16 |
+
+Lives in `scoreStylesheetTier` (`stylesheetScore.ts`), wired into the `stylesheet` dimension in `reputation.ts`.
 
 **External disposition (decided, #84).** A `profile.externalStylesheet` that resolves to an author is scored as an **AuthorStylesheet** (credit the author). An **authorless** external `.css/.scss` earns the _user_ the customization reward but **nothing to the site** — it's a **prune/investigate** candidate, or, if multiple users share it, a hidden **Community stylesheet**, both handled at the **permission / link-health layer**, not scored here.
 
@@ -119,7 +129,7 @@ The `/private/`, invite-only model is the primary control: a sock-puppeteer must
 First testable slices (much of the substrate already exists):
 
 1. ✅ **Stylesheet selection → CRS accrual** — pure `scoreStylesheetSelection` (no DB), table-driven over each multiplier. **Shipped: [#84](https://github.com/orphic-inc/stellar-api/pull/84)** (tier-0 multipliers; external/self decisions applied).
-2. **Tiering escalation** — the curve that compounds the base multipliers as a user climbs tiers (the `/verbiagating`-style ladder). Next slice; curve TBD.
+2. ✅ **Tiering escalation** — the back-loaded marginal curve that compounds the base author reward as a member accrues distinct adoptions. **Shipped: [#121](https://github.com/orphic-inc/stellar-api/issues/121)** (`scoreStylesheetTier`; table + cap-6 calibration in the Tiering decision above).
 3. **Dead-external penalty** — link-health-driven negative CRS for a dead `externalStylesheet`; red-green once the penalty magnitude is set.
 4. **AuthorStylesheet save → adopt → score** (the keystone — wires shipped `scoreStylesheetSelection` #84 to a real event). Three slices:
 
@@ -136,7 +146,7 @@ First testable slices (much of the substrate already exists):
 ## Open questions
 
 - AuthorStylesheetUrl storage shape (URL vs stored file) — pending ExternalStylesheet + global-reset findings.
-- **Tiering curve** + **dead-external penalty magnitude** — values TBD.
+- **Dead-external penalty magnitude** — value TBD (#122).
 - IRC scoring belongs to PRD-02 — confirm it's not duplicated here.
 
-**Resolved:** external disposition (authorless → permission/link-health, not site) · self-use pays no author bonus · per-author cap not needed for the stylesheet-dimension author bonus (the `/private` invite+report model covers it) · **accrual model = computed-on-read, with adoption events logged to a `CRS_*` ledger** ([ADR-0007](../adr/0007-crs-read-time-and-event-ledger.md)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1, once-per-pair + per-user cap).
+**Resolved:** external disposition (authorless → permission/link-health, not site) · self-use pays no author bonus · per-author cap not needed for the stylesheet-dimension author bonus (the `/private` invite+report model covers it) · **accrual model = computed-on-read, with adoption events logged to a `CRS_*` ledger** ([ADR-0007](../adr/0007-crs-read-time-and-event-ledger.md)) · **Friends×Stylesheet controlled vector** (adopter +0.2 / author +0.1, once-per-pair + per-user cap) · **tiering curve** (#121: back-loaded marginal table over distinct adoptions, cap 6 — table above).

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -230,16 +230,25 @@ describe('computeCrs — Stylesheet dimension', () => {
       stylesheetAdoptions
     }).dimensions.find((d) => d.name === 'stylesheet')!.subScore;
 
+  const b = 0.1415926535 * 5; // SITE_BASE x5 — base author delta of the curve
+
   it('an author with no adoptions scores 0', () => {
     expect(styleOf(0)).toBeCloseTo(0, 10);
   });
 
-  it('rises with each distinct adoption', () => {
+  it('rises with each distinct adoption (back-loaded marginal curve, #121)', () => {
     expect(styleOf(3)).toBeGreaterThan(styleOf(1));
     expect(styleOf(1)).toBeGreaterThan(0);
   });
 
-  it('is bounded: mass adoption cannot dominate (STYLESHEET_CAP = 6)', () => {
+  it('tracks the tiering curve below the cap (15 adoptions ≈ 5.45)', () => {
+    expect(styleOf(15)).toBeCloseTo((3 * 0.3 + 5 * 0.45 + 7 * 0.65) * b, 10);
+  });
+
+  it('clamps to STYLESHEET_CAP = 6 once the curve runs past it', () => {
+    // Raw curve at 16 ≈ 6.05 and keeps climbing; the dimension cap holds it at 6.
+    expect(styleOf(16)).toBeCloseTo(6, 10);
+    expect(styleOf(30)).toBeCloseTo(6, 10);
     expect(styleOf(1000)).toBeLessThanOrEqual(6);
   });
 });

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -18,7 +18,7 @@
 import { prisma } from '../lib/prisma';
 import { computeRatio } from './ratio';
 import { getIrcScore } from './irc';
-import { scoreStylesheetSelection } from './stylesheetScore';
+import { scoreStylesheetTier } from './stylesheetScore';
 import { communityHealthFor } from './communityHealthHistory';
 import { gradeContribution } from './contributionQuality';
 
@@ -227,24 +227,20 @@ const ircScorer: DimensionScorer = {
 };
 
 // ─── StylesheetScore ──────────────────────────────────────────────────────────
-// An author's reward for others adopting their stylesheets (PRD-03). The CRS
-// magnitude is sourced from the shared pure scorer `scoreStylesheetSelection`
-// (the per-adoption author delta of a non-self `author` selection) so the value
-// has a single home; this dimension only multiplies it by the durable count of
-// distinct (adopter, author) adoptions read from the ledger. Computed on read
-// (ADR-0007): nothing stores a denormalized stylesheet score. Anti-farm is the
-// `/private` invite + report model's job (PRD-03), not a bespoke cap — the cap
-// here is the module's standard "no single dimension dominates" guardrail.
+// An author's reward for others adopting their stylesheets (PRD-03). The score
+// is `scoreStylesheetTier` over the durable count of distinct (adopter, author)
+// adoptions read from the ledger — a back-loaded marginal curve, not a flat
+// per-adoption rate. Computed on read (ADR-0007): nothing stores a denormalized
+// stylesheet score. Anti-farm is the `/private` invite + report model's job
+// (PRD-03), not a bespoke cap.
 //
-// PROVISIONAL (tier-0): the per-adoption magnitude and cap are interim. The
-// real reward shape is PRD-03 target #2 (BonusPoints tiering, TBD), which will
-// swap these constants without touching the ledger — the ledger row stays a
-// pure (adopter, author) event marker.
-const STYLESHEET_AUTHOR_PER_ADOPTION =
-  scoreStylesheetSelection({
-    userId: 0,
-    origin: { kind: 'author', authorId: 1 }
-  }).author?.delta ?? 0;
+// The reward shape is PRD-03 target #2 (#121): a back-loaded marginal tiering
+// curve over the distinct-adoption count — `scoreStylesheetTier` owns the
+// magnitude (and the base anchor) so this dimension is just the read-time wiring.
+// The cap is the module's standard "no single dimension dominates" guardrail;
+// the curve is calibrated to reach it (~adoption 16) only by sustained adoption.
+// The ledger row stays a pure (adopter, author) event marker — the curve swaps
+// without touching it.
 const STYLESHEET_CAP = 6;
 const STYLESHEET_WEIGHT = 1.0;
 
@@ -253,7 +249,7 @@ const stylesheetScorer: DimensionScorer = {
   weight: STYLESHEET_WEIGHT,
   cap: STYLESHEET_CAP,
   compute: ({ stylesheetAdoptions = 0 }) =>
-    STYLESHEET_AUTHOR_PER_ADOPTION * Math.max(0, stylesheetAdoptions)
+    scoreStylesheetTier(stylesheetAdoptions)
 };
 
 // ─── InviteScore ──────────────────────────────────────────────────────────

--- a/src/modules/stylesheetScore.spec.ts
+++ b/src/modules/stylesheetScore.spec.ts
@@ -1,4 +1,7 @@
-import { scoreStylesheetSelection } from './stylesheetScore';
+import {
+  scoreStylesheetSelection,
+  scoreStylesheetTier
+} from './stylesheetScore';
 
 // PRD-03 stylesheet scoring (docs/prd/03-stylesheet-themes-and-scoring.md).
 // Pure: CRS deltas for {user, site, author} from a selection event.
@@ -67,5 +70,57 @@ describe('scoreStylesheetSelection', () => {
     expect(a.user).toBeCloseTo(0.5, 10); // USER_BASE x5
     expect(a.site).toBe(0);
     expect(a.author).toBeNull();
+  });
+});
+
+// PRD-03 target #2 (#121) tiering escalation curve. Back-loaded marginal
+// (tax-bracket) schedule over distinct adoptions, rates as fractions of the base
+// author delta b = SITE_BASE x5. The cap (6) lives in reputation.ts, NOT here —
+// this scorer returns the raw bracket sum, so band 4 runs past 6 unclamped.
+describe('scoreStylesheetTier', () => {
+  const b = SITE_BASE * 5; // base author delta ≈ 0.708
+
+  it('scores zero adoptions as zero', () => {
+    expect(scoreStylesheetTier(0)).toBe(0);
+  });
+
+  it('pins each band-end cumulative', () => {
+    expect(scoreStylesheetTier(3)).toBeCloseTo(3 * 0.3 * b, 10); // 0.64
+    expect(scoreStylesheetTier(8)).toBeCloseTo((3 * 0.3 + 5 * 0.45) * b, 10); // 2.23
+    expect(scoreStylesheetTier(15)).toBeCloseTo(
+      (3 * 0.3 + 5 * 0.45 + 7 * 0.65) * b,
+      10
+    ); // 5.45
+  });
+
+  it('scores a mid-band count at the prior bands plus the partial band', () => {
+    // 5 adoptions: full band 1 (3) + 2 into band 2.
+    expect(scoreStylesheetTier(5)).toBeCloseTo((3 * 0.3 + 2 * 0.45) * b, 10);
+  });
+
+  it('keeps climbing past the cap unclamped (band 4 is open-ended)', () => {
+    // The dimension cap is reputation.ts's job; the curve itself is monotone up.
+    expect(scoreStylesheetTier(30)).toBeGreaterThan(scoreStylesheetTier(16));
+    expect(scoreStylesheetTier(16)).toBeCloseTo(
+      (3 * 0.3 + 5 * 0.45 + 7 * 0.65 + 1 * 0.85) * b,
+      10
+    ); // 6.05, pre-clamp
+  });
+
+  it('is strictly monotonic and back-loaded (later adoptions worth more)', () => {
+    for (let n = 1; n <= 25; n++) {
+      expect(scoreStylesheetTier(n)).toBeGreaterThan(
+        scoreStylesheetTier(n - 1)
+      );
+    }
+    // Back-loaded: the marginal value of the 16th adoption exceeds the 1st.
+    const marginal = (n: number) =>
+      scoreStylesheetTier(n) - scoreStylesheetTier(n - 1);
+    expect(marginal(16)).toBeGreaterThan(marginal(1));
+  });
+
+  it('floors and clamps non-integer / negative inputs', () => {
+    expect(scoreStylesheetTier(-4)).toBe(0);
+    expect(scoreStylesheetTier(3.9)).toBeCloseTo(scoreStylesheetTier(3), 10);
   });
 });

--- a/src/modules/stylesheetScore.ts
+++ b/src/modules/stylesheetScore.ts
@@ -78,3 +78,46 @@ export const scoreStylesheetSelection = (
     }
   }
 };
+
+// ─── Tiering escalation curve (PRD-03 target #2, #121) ───────────────────────
+// An author's stylesheet-dimension CRS as a function of how many distinct
+// members have adopted their sheets. Replaces the old flat per-adoption reward
+// with a back-loaded marginal schedule: early adoptions score BELOW the base
+// rate, the marginal rate climbs each band, and the dimension cap (held in
+// reputation.ts) is reached only by sustained popularity (~16 adoptions). We
+// shape the climb, not the ceiling — a celebrated theme author should have to
+// earn the cap, but a cosmetic signal must not dominate global CRS.
+//
+// Marginal (tax-bracket), not a whole-count multiplier, so the score is
+// monotonic and cliff-free: it's read-time over the live adoption count
+// (ADR-0007), so when a sheet loses adoptions the score eases down instead of
+// re-rating every past adoption across a tier boundary. Rates are fractions of
+// the base author delta `TIER_BASE`, so retuning the base rescales the curve.
+const TIER_BASE = scoreStylesheetSelection({
+  userId: 0,
+  origin: { kind: 'author', authorId: 1 }
+}).author!.delta;
+
+// Each band scores adoptions up to (and including) `upTo` at `rate × TIER_BASE`;
+// `upTo: null` is the open-ended top band. Cumulative band-end CRS: 0.64 / 2.23
+// / 5.45 — the cap (6, in reputation.ts) lands at ~adoption 16 inside band 4.
+const TIER_BANDS: ReadonlyArray<{ upTo: number | null; rate: number }> = [
+  { upTo: 3, rate: 0.3 },
+  { upTo: 8, rate: 0.45 },
+  { upTo: 15, rate: 0.65 },
+  { upTo: null, rate: 0.85 }
+];
+
+export const scoreStylesheetTier = (adoptions: number): number => {
+  const n = Math.max(0, Math.floor(adoptions));
+  let scored = 0; // adoptions already credited in lower bands
+  let total = 0;
+  for (const band of TIER_BANDS) {
+    if (scored >= n) break;
+    const bandTop = band.upTo ?? n;
+    const inBand = Math.min(n, bandTop) - scored;
+    total += inBand * band.rate * TIER_BASE;
+    scored += inBand;
+  }
+  return total;
+};


### PR DESCRIPTION
Closes #121 (PRD-03 target #2).

## What

Replaces the flat per-adoption stylesheet author reward with a **back-loaded marginal (tax-bracket) tiering curve** over a member's distinct-adoption count.

- Early adoptions score *below* the base rate; the marginal rate climbs each band; the existing dimension cap (6) is reached only by sustained popularity (~16 distinct adoptions).
- **Marginal**, not whole-count — so the score stays monotonic and cliff-free when a sheet loses adoptions under read-time recompute (ADR-0007).

| Tier | Distinct adoptions | Marginal rate / adoption | Cumulative at band end |
|------|--------------------|--------------------------|------------------------|
| 1 | 1–3 | 0.30 × b | 0.64 |
| 2 | 4–8 | 0.45 × b | 2.23 |
| 3 | 9–15 | 0.65 × b | 5.45 |
| 4 | 16+ | 0.85 × b | cap 6 ~adoption 16 |

`b` = the existing base author delta (≈0.708); rates are fractions of it, so retuning `b` rescales the curve.

## Design rationale

Stylesheet is a cosmetic/soft signal and must not dominate global CRS, so escalation shapes the *climb* to a fixed ceiling rather than raising the ceiling. (Settled in a design pass with the PRD owner.)

## Changes

- `scoreStylesheetTier` — new pure, table-driven curve in `stylesheetScore.ts`.
- `reputation.ts` `stylesheetScorer.compute` now calls it; cap/weight unchanged (registry clamp owns the ceiling).
- PRD-03 target #2 pinned (table + calibration); moved Open → Resolved; scrubbed stale `/verbiagating` references.
- Unit specs pin each band-end cumulative, monotonicity/back-loading, and the cap-6 clamp.

## Verification

`tsc --noEmit` clean · `stylesheetScore` + `reputation` suites green (71 tests) · format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)