### PR TITLE
feat(governance): invite-tree Contagion — graded distance-decaying suspicion (#155)

### DIFF
--- a/docs/adr/0004-standing-warnings-bans.md
+++ b/docs/adr/0004-standing-warnings-bans.md
@@ -32,11 +32,17 @@ Tenure distinguishes only the top two rungs (`clean` vs `pristine`); a single wa
 
 The terminal-rung `banEvasion` input means **confirmed self ban-evasion** — binary, the worst standing. The broader signal — an inviter (trunk) that is infected makes their invitees (branches) _suspect_ — is **contagion**, and is deliberately **not** wired to the terminal tier. A clean user must not be auto-condemned because a distant inviter was banned long after the invite; **suspect is not condemned**. Contagion is therefore a _graded_ suspicion — a review flag plus a mild, distance-decaying CRS drag — owned by the InviteTree model ([#61](https://github.com/orphic-inc/stellar-api/issues/61)), not a Standing rung. This ADR names #61 as the source of the confirmed-evasion linkage and scopes contagion-suspicion out of the terminal tier.
 
+**Pinned magnitudes ([#155](https://github.com/orphic-inc/stellar-api/issues/155)).** Implemented as the signed `inviteContagion` CRS dimension (cap 0, negative floor), with the pure `contagion()` scorer (`src/modules/contagion.ts`) over a member's distances to each infected ancestor. "Infected" = `banned` (`User.banDate`) today; the confirmed-evasion trunk stays a dormant seam until that linkage model lands. `disabled`-without-ban does not infect, and there is no recency horizon — distance-decay is the only dampener. The read path walks _up_ the inviter chain (`getInfectedAncestorDistances`, capped at the reach) so the per-member CRS read stays bounded.
+
+- **Decay**: halves per level from the trunk — direct invitee ×1.0, then ×0.5 / ×0.25 / ×0.125 — out of **reach** past level 4.
+- **Drag**: base **−1.0** for a direct invitee; **cumulative** across multiple infected ancestors (a denser bad cluster is stronger evidence), clamped to a **−2.0 floor** so the worst case stays suspect, not condemned.
+- **Review flag**: `suspect` fires at cumulative drag **≤ −0.5** (direct invitee, grandchild, or a stacked genealogy). It is a _moderation_ signal: stripped from non-staff reputation views (including the member's own) so suspicion can't tip off a sockpuppet ring; the drag still counts in the true internal CRS.
+
 ## Deferred (tracked, not part of this decision)
 
 - **Magnitudes** — the ×10 reward, the hammer curve, warning thresholds, and per-rule/SubRule micro-impact weights (PRD-05 open questions).
 - **The fuller Warning/Ban entity model** — suspension/ban entities and an explicit escalation ladder beyond `UserWarning` + `User.banDate`.
-- **Invite-tree contagion** (the graded suspicion above) and the **positive Invite CRS dimension** (a productive sub-tree reflecting well on the inviter) — both owned by [#61](https://github.com/orphic-inc/stellar-api/issues/61); the latter registers as a future `reputation.ts` dimension.
+- **Invite-tree contagion** — _implemented_ as the signed `inviteContagion` dimension ([#155](https://github.com/orphic-inc/stellar-api/issues/155); magnitudes pinned in §3 above). The **positive Invite CRS dimension** (a productive sub-tree reflecting well on the inviter) remains the separate, already-shipped `invite` dimension.
 
 ## Consequences
 

--- a/src/modules/contagion.spec.ts
+++ b/src/modules/contagion.spec.ts
@@ -1,0 +1,49 @@
+import {
+  contagion,
+  CONTAGION_FLOOR,
+  CONTAGION_REVIEW_THRESHOLD
+} from './contagion';
+
+// ADR-0004 §3 / PRD-05 — invite-tree Contagion. Distances are hops UP to each
+// infected (banned) ancestor; 1 = direct inviter. Decay halves per level over a
+// reach of 4; base drag −1.0; cumulative, floored at −2.0; suspect ≤ −0.5.
+describe('contagion', () => {
+  it('scores a clean genealogy as 0 / not suspect', () => {
+    expect(contagion([])).toEqual({ score: 0, suspect: false });
+  });
+
+  it('decays by distance — direct invitee penalised more than a grandchild', () => {
+    expect(contagion([1]).score).toBeCloseTo(-1.0, 10);
+    expect(contagion([2]).score).toBeCloseTo(-0.5, 10);
+    expect(contagion([3]).score).toBeCloseTo(-0.25, 10);
+    expect(contagion([4]).score).toBeCloseTo(-0.125, 10);
+    // Strictly weaker each level down.
+    expect(contagion([1]).score).toBeLessThan(contagion([2]).score);
+    expect(contagion([2]).score).toBeLessThan(contagion([3]).score);
+  });
+
+  it('is out of reach past level 4', () => {
+    expect(contagion([5])).toEqual({ score: 0, suspect: false });
+    expect(contagion([6, 9])).toEqual({ score: 0, suspect: false });
+  });
+
+  it('compounds multiple infected ancestors cumulatively', () => {
+    // direct inviter banned (−1.0) + banned grandparent (−0.5) = −1.5
+    expect(contagion([1, 2]).score).toBeCloseTo(-1.5, 10);
+  });
+
+  it('clamps the worst case to the floor (suspect, not condemned)', () => {
+    // −1.0 −1.0 −0.5 = −2.5 raw → clamped to −2.0
+    expect(contagion([1, 1, 2]).score).toBeCloseTo(CONTAGION_FLOOR, 10);
+    expect(contagion([1, 1, 1, 1]).score).toBe(CONTAGION_FLOOR);
+  });
+
+  it('flags suspect at or below the review threshold', () => {
+    expect(contagion([1]).suspect).toBe(true); // −1.0 ≤ −0.5
+    expect(contagion([2]).suspect).toBe(true); // −0.5 ≤ −0.5 (boundary)
+    expect(contagion([3]).suspect).toBe(false); // −0.25 > −0.5
+    // A lone distant ancestor isn't suspect, but two stack into it.
+    expect(contagion([3, 3]).suspect).toBe(true); // −0.5
+    expect(CONTAGION_REVIEW_THRESHOLD).toBe(-0.5);
+  });
+});

--- a/src/modules/contagion.ts
+++ b/src/modules/contagion.ts
@@ -1,0 +1,51 @@
+/**
+ * ADR-0004 §3 / PRD-05 — invite-tree Contagion.
+ *
+ * Pure function: an infected trunk (a banned — or, when that model lands,
+ * confirmed-evading — inviter) casts graded, distance-decaying suspicion DOWN
+ * over its branches. The negative governance arm of the invite tree, the
+ * counterpart to the positive `invite` CRS dimension.
+ *
+ * Deliberately NOT terminal: a clean member is *suspect*, never condemned,
+ * because a distant inviter was later banned — distance-decay (not recency) is
+ * the dampener. The terminal confirmed-self-evasion rung is a separate seam
+ * (`computeStanding`'s `banEvasion`) and is never reached here.
+ *
+ * No DB and direction-agnostic: it consumes the distances from a member UP to
+ * each infected ancestor (the read path walks the inviter chain, capped at
+ * REACH), mirroring the pure style of `computeStanding` / `ruleImpact`.
+ * Magnitudes are pinned (#155) and tunable here in one place.
+ */
+
+export interface Contagion {
+  /** The CRS drag — ≤ 0, clamped to FLOOR. 0 for a clean genealogy. */
+  score: number;
+  /** True when the drag warrants a moderation review (score ≤ REVIEW_THRESHOLD). */
+  suspect: boolean;
+}
+
+// Suspicion halves each level away from the infected trunk and is out of reach
+// past level 4 (1/8 of base is already near-noise). Steep on purpose — a
+// distant-but-clean member must not be condemned by an ancestor's later ban.
+const REACH = 4;
+const DECAY = 0.5; // per-level multiplier: mult(d) = DECAY^(d-1)
+const BASE = -1.0; // drag from a *direct* invitee of an infected trunk (distance 1)
+const FLOOR = -2.0; // most contagion can ever subtract (dense bad genealogy)
+const REVIEW_THRESHOLD = -0.5; // ≤ this surfaces a moderation review flag
+
+export const CONTAGION_FLOOR = FLOOR;
+export const CONTAGION_REVIEW_THRESHOLD = REVIEW_THRESHOLD;
+/** How far up the inviter chain the read path walks — beyond this, drag is 0. */
+export const CONTAGION_REACH = REACH;
+
+/** Drag contributed by one infected ancestor `distance` hops up (0 past REACH). */
+const dragAt = (distance: number): number =>
+  distance >= 1 && distance <= REACH ? BASE * DECAY ** (distance - 1) : 0;
+
+export const contagion = (infectedAncestorDistances: number[]): Contagion => {
+  // Cumulative: multiple infected ancestors compound (a denser bad cluster is
+  // stronger evidence), then clamp so the worst case stays suspect, not condemned.
+  const raw = infectedAncestorDistances.reduce((sum, d) => sum + dragAt(d), 0);
+  const score = Math.max(FLOOR, raw);
+  return { score, suspect: score <= REVIEW_THRESHOLD };
+};

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -754,7 +754,8 @@ export const buildCommunityStats = (
   friendCount: number | null,
   inviteView: InviteSummaryView | null,
   reputation: CrsResult | null,
-  includeSnatchDerived: boolean
+  includeSnatchDerived: boolean,
+  includeModeration: boolean
 ): {
   friends: number;
   invites: { direct: number; total: number; depth: number };
@@ -770,7 +771,10 @@ export const buildCommunityStats = (
       total: inviteView.summary.entries,
       depth: inviteView.summary.depth
     },
-    reputation: filterReputationView(reputation, { includeSnatchDerived })
+    reputation: filterReputationView(reputation, {
+      includeSnatchDerived,
+      includeModeration
+    })
   };
 };
 
@@ -839,7 +843,8 @@ const buildProfileView = async (
     friendCount,
     inviteView,
     reputation,
-    canSeeDownloaded
+    canSeeDownloaded,
+    viewer.isStaff // contagion drag + suspect flag are staff-only (ADR-0004 §3)
   );
   const percentiles = await getPercentileSummary(user, activitySummary);
   const donorPresentation = buildDonorPresentation(user);

--- a/src/modules/profileCommunity.spec.ts
+++ b/src/modules/profileCommunity.spec.ts
@@ -21,34 +21,80 @@ const reputation = {
     { name: 'longevity', subScore: 6, weighted: 6 },
     { name: 'ratio', subScore: 4, weighted: 4 },
     { name: 'friends', subScore: 2, weighted: 2 }
-  ]
+  ],
+  suspect: false
+};
+
+// A member sitting under a banned trunk: a contagion drag + suspect flag.
+const reputationWithContagion = {
+  score: 11, // 6 + 4 + 2 − 1
+  dimensions: [
+    { name: 'longevity', subScore: 6, weighted: 6 },
+    { name: 'ratio', subScore: 4, weighted: 4 },
+    { name: 'friends', subScore: 2, weighted: 2 },
+    { name: 'inviteContagion', subScore: -1, weighted: -1 }
+  ],
+  suspect: true
 };
 
 describe('buildCommunityStats', () => {
   it('returns null when any input is null (top paranoia tier hides all stats)', () => {
-    expect(buildCommunityStats(null, inviteView, reputation, true)).toBeNull();
-    expect(buildCommunityStats(5, null, reputation, true)).toBeNull();
-    expect(buildCommunityStats(5, inviteView, null, true)).toBeNull();
+    expect(
+      buildCommunityStats(null, inviteView, reputation, true, true)
+    ).toBeNull();
+    expect(buildCommunityStats(5, null, reputation, true, true)).toBeNull();
+    expect(buildCommunityStats(5, inviteView, null, true, true)).toBeNull();
   });
 
   it('maps friends + invite summary (direct/total/depth)', () => {
-    const block = buildCommunityStats(5, inviteView, reputation, true)!;
+    const block = buildCommunityStats(5, inviteView, reputation, true, true)!;
     expect(block.friends).toBe(5);
     expect(block.invites).toEqual({ direct: 3, total: 9, depth: 2 });
   });
 
   it('keeps the full reputation (incl. ratio) when snatch stats are visible', () => {
-    const block = buildCommunityStats(5, inviteView, reputation, true)!;
+    const block = buildCommunityStats(5, inviteView, reputation, true, true)!;
     expect(block.reputation.dimensions.map((d) => d.name)).toContain('ratio');
     expect(block.reputation.score).toBe(12);
   });
 
   it('drops the snatch-derived ratio dimension and recomputes when hidden', () => {
-    const block = buildCommunityStats(5, inviteView, reputation, false)!;
+    const block = buildCommunityStats(5, inviteView, reputation, false, true)!;
     expect(block.reputation.dimensions.map((d) => d.name)).not.toContain(
       'ratio'
     );
     // 6 (longevity) + 2 (friends) = 8
     expect(block.reputation.score).toBe(8);
+  });
+
+  it('shows the contagion drag + suspect flag to staff (includeModeration)', () => {
+    const block = buildCommunityStats(
+      5,
+      inviteView,
+      reputationWithContagion,
+      true,
+      true
+    )!;
+    expect(block.reputation.dimensions.map((d) => d.name)).toContain(
+      'inviteContagion'
+    );
+    expect(block.reputation.suspect).toBe(true);
+    expect(block.reputation.score).toBe(11);
+  });
+
+  it('hides the contagion drag + suspect from non-staff (recomputes score)', () => {
+    const block = buildCommunityStats(
+      5,
+      inviteView,
+      reputationWithContagion,
+      true,
+      false
+    )!;
+    expect(block.reputation.dimensions.map((d) => d.name)).not.toContain(
+      'inviteContagion'
+    );
+    expect(block.reputation.suspect).toBe(false);
+    // Penalty stripped from the displayed total: 6 + 4 + 2 = 12.
+    expect(block.reputation.score).toBe(12);
   });
 });

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -3,7 +3,8 @@
  * computeCrs is pure; getReputation uses a Prisma mock.
  */
 
-const mockPrismaUser = { findUnique: jest.fn() };
+const mockPrismaUser = { findUnique: jest.fn(), findMany: jest.fn() };
+const mockPrismaQueryRaw = jest.fn();
 const mockPrismaFriend = { count: jest.fn() };
 const mockPrismaEconomy = { count: jest.fn() };
 const mockPrismaInviteTree = { findMany: jest.fn() };
@@ -19,7 +20,8 @@ jest.mock('../lib/prisma', () => ({
     inviteTree: mockPrismaInviteTree,
     donation: mockPrismaDonation,
     communityHealthSnapshot: mockPrismaCommunitySnapshot,
-    contribution: mockPrismaContribution
+    contribution: mockPrismaContribution,
+    $queryRaw: mockPrismaQueryRaw
   }
 }));
 
@@ -310,6 +312,46 @@ describe('computeCrs — Invite dimension', () => {
   });
 });
 
+// ─── computeCrs / InviteContagion dimension (#155) ────────────────────────────
+
+describe('computeCrs — InviteContagion dimension', () => {
+  const crsOf = (infectedAncestorDistances: number[]) =>
+    computeCrs({
+      userId: 1,
+      createdAt: NOW,
+      now: NOW,
+      infectedAncestorDistances
+    });
+  const contagionOf = (distances: number[]) =>
+    crsOf(distances).dimensions.find((d) => d.name === 'inviteContagion')!
+      .subScore;
+
+  it('a clean genealogy has no drag and is not suspect', () => {
+    expect(contagionOf([])).toBe(0);
+    expect(crsOf([]).suspect).toBe(false);
+  });
+
+  it('drags negative, decaying with distance from the banned trunk', () => {
+    expect(contagionOf([1])).toBeCloseTo(-1.0, 10);
+    expect(contagionOf([2])).toBeCloseTo(-0.5, 10);
+    expect(contagionOf([1])).toBeLessThan(contagionOf([2]));
+  });
+
+  it('lowers the total CRS by the drag', () => {
+    expect(crsOf([1]).score).toBeLessThan(crsOf([]).score);
+  });
+
+  it('clamps to the dimension floor (−2.0)', () => {
+    expect(contagionOf([1, 1, 1, 1])).toBe(-2);
+  });
+
+  it('sets suspect at/below the review threshold (−0.5)', () => {
+    expect(crsOf([1]).suspect).toBe(true); // −1.0
+    expect(crsOf([2]).suspect).toBe(true); // −0.5 boundary
+    expect(crsOf([3]).suspect).toBe(false); // −0.25
+  });
+});
+
 // ─── computeCrs / Donation dimension ──────────────────────────────────────────
 
 describe('computeCrs — Donation dimension', () => {
@@ -494,6 +536,8 @@ describe('getReputation', () => {
     mockPrismaDonation.aggregate.mockResolvedValue(emptyDonationAgg);
     mockPrismaContribution.findMany.mockResolvedValue([]);
     mockPrismaCommunitySnapshot.findMany.mockResolvedValue([]);
+    mockPrismaQueryRaw.mockResolvedValue([]); // no infected ancestors (#155)
+    mockPrismaUser.findMany.mockResolvedValue([]);
   });
 
   it('computes CRS from the user createdAt + ratio + friends', async () => {
@@ -520,7 +564,7 @@ describe('getReputation', () => {
     mockPrismaUser.findUnique.mockResolvedValue(null);
     mockPrismaFriend.count.mockResolvedValue(0);
     const result = await getReputation(999);
-    expect(result).toEqual({ score: 0, dimensions: [] });
+    expect(result).toEqual({ score: 0, dimensions: [], suspect: false });
   });
 
   it('reflects stylesheet adoptions from the CRS_* ledger count', async () => {
@@ -763,37 +807,77 @@ describe('getReputation', () => {
 
 describe('filterReputationView', () => {
   const crs = {
-    score: 12,
+    score: 11,
     dimensions: [
       { name: 'longevity', subScore: 6, weighted: 6 },
       { name: 'ratio', subScore: 4, weighted: 4 },
-      { name: 'friends', subScore: 2, weighted: 2 }
-    ]
+      { name: 'friends', subScore: 2, weighted: 2 },
+      { name: 'inviteContagion', subScore: -1, weighted: -1 }
+    ],
+    suspect: true
   };
 
-  it('passes through unchanged when snatch-derived dimensions are included', () => {
-    expect(filterReputationView(crs, { includeSnatchDerived: true })).toBe(crs);
+  it('passes through unchanged when both gates are open', () => {
+    expect(
+      filterReputationView(crs, {
+        includeSnatchDerived: true,
+        includeModeration: true
+      })
+    ).toBe(crs);
   });
 
-  it('drops the ratio dimension and recomputes the score when excluded', () => {
-    const view = filterReputationView(crs, { includeSnatchDerived: false });
+  it('drops the ratio dimension and recomputes the score when snatch excluded', () => {
+    const view = filterReputationView(crs, {
+      includeSnatchDerived: false,
+      includeModeration: true
+    });
+    expect(view.dimensions.map((d) => d.name)).toEqual([
+      'longevity',
+      'friends',
+      'inviteContagion'
+    ]);
+    // recomputed from remaining weighted subscores: 6 + 2 − 1 = 7
+    expect(view.score).toBe(7);
+    expect(view.suspect).toBe(true); // moderation gate still open
+  });
+
+  it('hides the contagion drag + clears suspect when moderation excluded', () => {
+    const view = filterReputationView(crs, {
+      includeSnatchDerived: true,
+      includeModeration: false
+    });
+    expect(view.dimensions.map((d) => d.name)).not.toContain('inviteContagion');
+    // penalty stripped from the displayed total: 6 + 4 + 2 = 12
+    expect(view.score).toBe(12);
+    expect(view.suspect).toBe(false);
+  });
+
+  it('applies both gates together (member-facing, no ratio + no contagion)', () => {
+    const view = filterReputationView(crs, {
+      includeSnatchDerived: false,
+      includeModeration: false
+    });
     expect(view.dimensions.map((d) => d.name)).toEqual([
       'longevity',
       'friends'
     ]);
-    // score recomputed from the remaining weighted subscores: 6 + 2 = 8
-    expect(view.score).toBe(8);
+    expect(view.score).toBe(8); // 6 + 2
+    expect(view.suspect).toBe(false);
   });
 
-  it('is a no-op when there is no snatch-derived dimension present', () => {
-    const noRatio = {
+  it('is a no-op on score when neither hidden dimension is present', () => {
+    const plain = {
       score: 8,
       dimensions: [
         { name: 'longevity', subScore: 6, weighted: 6 },
         { name: 'friends', subScore: 2, weighted: 2 }
-      ]
+      ],
+      suspect: false
     };
-    const view = filterReputationView(noRatio, { includeSnatchDerived: false });
+    const view = filterReputationView(plain, {
+      includeSnatchDerived: false,
+      includeModeration: false
+    });
     expect(view.dimensions).toHaveLength(2);
     expect(view.score).toBe(8);
   });

--- a/src/modules/reputation.ts
+++ b/src/modules/reputation.ts
@@ -19,6 +19,12 @@ import { prisma } from '../lib/prisma';
 import { computeRatio } from './ratio';
 import { getIrcScore } from './irc';
 import { scoreStylesheetTier } from './stylesheetScore';
+import {
+  contagion,
+  CONTAGION_FLOOR,
+  CONTAGION_REVIEW_THRESHOLD
+} from './contagion';
+import { getInfectedAncestorDistances } from './user';
 import { communityHealthFor } from './communityHealthHistory';
 import { gradeContribution } from './contributionQuality';
 
@@ -79,6 +85,10 @@ export interface DimensionInput {
    *  healthy-link-years (H) — the volume×duration term of the same dimension.
    *  Defaults to 0. */
   linkHealthYears?: number;
+  /** Hops UP this member's invite chain (1 = direct inviter) to each *infected*
+   *  (banned) ancestor, capped at the contagion reach. Feeds the signed
+   *  `inviteContagion` dimension (#155 / ADR-0004 §3). Defaults to []. */
+  infectedAncestorDistances?: number[];
   /** Injectable for deterministic tests; defaults to now. */
   now?: Date;
 }
@@ -105,6 +115,11 @@ export interface DimensionResult {
 export interface CrsResult {
   score: number;
   dimensions: DimensionResult[];
+  /** ADR-0004 §3 invite-tree Contagion review flag — true when the member sits
+   *  close/dense enough to a banned trunk to warrant a moderator look. A
+   *  *moderation* signal: stripped from non-staff views (see
+   *  `filterReputationView`) so suspicion can't tip off a sockpuppet ring. */
+  suspect: boolean;
 }
 
 const clamp = (value: number, cap: number, floor = 0): number =>
@@ -292,6 +307,22 @@ const inviteScorer: DimensionScorer = {
   }
 };
 
+// ─── InviteContagion ──────────────────────────────────────────────────────────
+// The negative governance arm of the invite tree (ADR-0004 §3 / PRD-05, #155):
+// an infected trunk (a banned inviter) casts graded, distance-decaying suspicion
+// down over its descendants. A *signed* dimension (cap 0, no upside — a healthy
+// genealogy isn't a reward, just the absence of a drag) with a negative floor,
+// like CommunityScore. The magnitude + decay live in `contagion()`; this is the
+// read-time wiring over the per-member distances to banned ancestors.
+const inviteContagionScorer: DimensionScorer = {
+  name: 'inviteContagion',
+  weight: 1.0,
+  cap: 0,
+  floor: CONTAGION_FLOOR,
+  compute: ({ infectedAncestorDistances = [] }) =>
+    contagion(infectedAncestorDistances).score
+};
+
 // ─── DonationScore ──────────────────────────────────────────────────────────
 // Financial support (PRD-01 Donations): "recognition, not pay-to-win" —
 // donation *value must never dominate*. So this is AMOUNT-AGNOSTIC: it never
@@ -429,6 +460,7 @@ const REGISTRY: DimensionScorer[] = [
   ratioScorer,
   friendsScorer,
   inviteScorer,
+  inviteContagionScorer,
   donationScorer,
   communityScorer,
   linkHealthScorer,
@@ -443,7 +475,10 @@ export const computeCrs = (input: DimensionInput): CrsResult => {
     return { name: d.name, subScore, weighted: d.weight * subScore };
   });
   const score = dimensions.reduce((sum, d) => sum + d.weighted, 0);
-  return { score, dimensions };
+  // The contagion review flag is a function of the computed drag (ADR-0004 §3).
+  const contagionDim = dimensions.find((d) => d.name === 'inviteContagion');
+  const suspect = (contagionDim?.subScore ?? 0) <= CONTAGION_REVIEW_THRESHOLD;
+  return { score, dimensions, suspect };
 };
 
 /** Read-time CRS for a user. Assembles the dimension input, then computes. */
@@ -463,7 +498,8 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     stylesheetAdoptionsMade,
     invitees,
     donationAgg,
-    contributedContributions
+    contributedContributions,
+    infectedAncestorDistances
   ] = await Promise.all([
     prisma.user.findUnique({
       where: { id: userId },
@@ -548,9 +584,11 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
           select: { bitrate: true, hasLog: true, hasCue: true }
         }
       }
-    })
+    }),
+    // Distances up the invite chain to each banned ancestor (#155 / ADR-0004 §3).
+    getInfectedAncestorDistances(userId)
   ]);
-  if (!user) return { score: 0, dimensions: [] };
+  if (!user) return { score: 0, dimensions: [], suspect: false };
 
   // Sum each contributed-to community's quality-graded weight (#76).
   const weightByCommunity = new Map<number, number>();
@@ -652,6 +690,7 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
     communityHealth,
     linkHealthReliability,
     linkHealthYears,
+    infectedAncestorDistances,
     now
   });
 };
@@ -662,20 +701,36 @@ export const getReputation = async (userId: number): Promise<CrsResult> => {
 // the only consumed-derived dimension (ratio = contributed / consumed).
 export const SNATCH_DERIVED_DIMENSIONS = ['ratio'];
 
+// Moderation-only dimensions: the invite-tree Contagion drag is a suspicion
+// signal (ADR-0004 §3). Hidden from non-staff views — including the member's own
+// — so the penalty + flag can't tip off a sockpuppet ring. The drag still counts
+// in the true internal CRS (`getReputation`); only the projected VIEW omits it.
+export const MODERATION_DIMENSIONS = ['inviteContagion'];
+
 /**
- * Project a computed CRS into a viewer-safe view. When `includeSnatchDerived`
- * is false, the snatch-derived dimensions are removed and the displayed score is
- * recomputed from the remaining weighted subscores — so a paranoia-gated viewer
- * neither sees the dimension nor can back it out of the total. Pure.
+ * Project a computed CRS into a viewer-safe view by dropping dimensions the
+ * viewer isn't entitled to and recomputing the displayed score from what
+ * remains — so a gated viewer neither sees a hidden dimension nor can back it
+ * out of the total. Two independent gates: `includeSnatchDerived` (paranoia —
+ * hides consumed-derived `ratio`) and `includeModeration` (staff-only — hides
+ * the invite-tree Contagion drag + clears the `suspect` flag). Pure.
  */
 export const filterReputationView = (
   crs: CrsResult,
-  opts: { includeSnatchDerived: boolean }
+  opts: { includeSnatchDerived: boolean; includeModeration: boolean }
 ): CrsResult => {
-  if (opts.includeSnatchDerived) return crs;
-  const dimensions = crs.dimensions.filter(
-    (d) => !SNATCH_DERIVED_DIMENSIONS.includes(d.name)
-  );
+  if (opts.includeSnatchDerived && opts.includeModeration) return crs;
+  const hidden = [
+    ...(opts.includeSnatchDerived ? [] : SNATCH_DERIVED_DIMENSIONS),
+    ...(opts.includeModeration ? [] : MODERATION_DIMENSIONS)
+  ];
+  const dimensions = crs.dimensions.filter((d) => !hidden.includes(d.name));
+  // Recompute from the visible dimensions so a gated viewer can't back a hidden
+  // dimension out of the total.
   const score = dimensions.reduce((sum, d) => sum + d.weighted, 0);
-  return { score, dimensions };
+  return {
+    score,
+    dimensions,
+    suspect: opts.includeModeration ? crs.suspect : false
+  };
 };

--- a/src/modules/user.ts
+++ b/src/modules/user.ts
@@ -5,6 +5,7 @@ import { AppError } from '../lib/errors';
 import { getDefaultStylesheetName } from './stylesheet';
 import { primaryArtist, releaseCreditsSelect } from './releaseCredits';
 import { computeRatio } from './ratio';
+import { CONTAGION_REACH } from './contagion';
 import {
   buildInviteSubtree,
   summarizeInviteTree,
@@ -308,6 +309,46 @@ export const getInviteSubtreeRows = async (
       consumed: u.consumed
     };
   });
+};
+
+/**
+ * Distances (1 = direct inviter) UP a member's invite chain to each *infected*
+ * ancestor, capped at `CONTAGION_REACH`. Feeds the `inviteContagion` CRS
+ * dimension (#155 / ADR-0004 §3): an infected ancestor drags a descendant's
+ * score, decaying by distance. "Infected" today = `banned` (User.banDate set);
+ * the confirmed-evasion trunk stays a dormant seam until that model lands.
+ */
+export const getInfectedAncestorDistances = async (
+  userId: number
+): Promise<number[]> => {
+  const ancestors = await prisma.$queryRaw<
+    { inviterId: number; depth: number }[]
+  >`
+    WITH RECURSIVE chain AS (
+      SELECT "inviterId", 1 AS depth
+      FROM "invite_trees"
+      WHERE "userId" = ${userId} AND "inviterId" IS NOT NULL
+      UNION ALL
+      SELECT it."inviterId", c.depth + 1
+      FROM "invite_trees" it
+      JOIN chain c ON it."userId" = c."inviterId"
+      WHERE c.depth < ${CONTAGION_REACH} AND it."inviterId" IS NOT NULL
+    )
+    SELECT "inviterId", depth FROM chain
+  `;
+  if (!ancestors.length) return [];
+
+  const banned = await prisma.user.findMany({
+    where: {
+      id: { in: ancestors.map((a) => a.inviterId) },
+      banDate: { not: null }
+    },
+    select: { id: true }
+  });
+  const bannedIds = new Set(banned.map((u) => u.id));
+  return ancestors
+    .filter((a) => bannedIds.has(a.inviterId))
+    .map((a) => Number(a.depth));
 };
 
 export interface InviteTreeViewNode {

--- a/src/routes/api/profile.ts
+++ b/src/routes/api/profile.ts
@@ -8,7 +8,7 @@ import {
   createInvite
 } from '../../modules/profile';
 import { getRatioStats } from '../../modules/ratio';
-import { getReputation } from '../../modules/reputation';
+import { getReputation, filterReputationView } from '../../modules/reputation';
 import { getCrsHistory, type CrsHistoryPeriod } from '../../modules/crsHistory';
 import {
   reputationHistoryPeriodQuerySchema,
@@ -105,7 +105,15 @@ router.get(
   '/me/reputation',
   requireAuth,
   authHandler(async (req, res) => {
-    res.json(await getReputation(req.user.id));
+    // Self-view: the member sees their own snatch-derived dimensions but NOT the
+    // moderation-only Contagion drag / suspect flag (ADR-0004 §3).
+    const crs = await getReputation(req.user.id);
+    res.json(
+      filterReputationView(crs, {
+        includeSnatchDerived: true,
+        includeModeration: false
+      })
+    );
   })
 );
 


### PR DESCRIPTION
Closes #155 (ADR-0004 §3 / PRD-05 — the negative governance arm of the invite tree).

> **Stacked on #248 (#121).** This branch builds on the stylesheet-tiering commit, so until #248 merges this PR's diff also shows that commit. Once #248 lands in `main`, this collapses to the contagion changes alone.

## What

An **infected trunk** (a banned inviter) casts **graded, distance-decaying suspicion** down over its descendants — counterpart to the positive `invite` dimension. Deliberately **not terminal**: *suspect is not condemned* (the confirmed-self-evasion hammer rung in `computeStanding` is untouched).

## Pinned magnitudes (design pass with PRD owner)

- **Infected** = `banned` (`User.banDate`) today; confirmed-evasion trunk is a dormant seam. `disabled`-without-ban does not infect; no recency horizon.
- **Decay** halves per level — direct invitee ×1.0, then ×0.5/×0.25/×0.125 — out of **reach** past level 4.
- **Drag** base **−1.0** (direct invitee), **cumulative** across infected ancestors, clamped to a **−2.0 floor**.
- **Review flag** `suspect` fires at cumulative drag **≤ −0.5**.

## Design highlights

- **Pure scorer** `contagion(distances) → { score, suspect }` (`src/modules/contagion.ts`), table-driven, DB-free — mirrors `computeStanding`/`ruleImpact`.
- **Read path** walks *up* the inviter chain (`getInfectedAncestorDistances`, depth-capped at the reach), so per-member CRS reads stay bounded.
- **Signed `inviteContagion` dimension** (cap 0, floor −2.0) drops into the existing `clamp(value, cap, floor)` aggregator like CommunityScore.
- **Staff-only signal:** `filterReputationView` gains an `includeModeration` gate. Non-staff views — *including the member's own* `/me/reputation` — strip the drag + clear `suspect` so suspicion can't tip off a sockpuppet ring. The drag still counts in the true internal CRS (and the service-key `/:id/reputation` korin view).

## Tests

Unit tests pin distance-decay (direct invitee > grandchild; clean tree = 0), the cumulative −2.0 clamp, the `suspect` threshold, and both view gates (snatch + moderation). **Full suite green (1706).**

## Follow-up (not in scope)

Integration coverage for the ascending `getInfectedAncestorDistances` walk (needs `.env.test`), and wiring the confirmed-evasion trunk once that linkage model lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)