### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-06-25
+
+A 0.6.x increment consolidating the post-0.6.0 work: a new rip-log scorer, the running-version endpoint, and the latest CRS dimension tuning.
+
+### Added
+
+- **EAC/XLD rip-log scoring module** — `POST /log-check` grades a submitted rip log.
+- **`GET /api/version`** — exposes the running platform version, derived from the manifest so it can't drift [PR #243].
+- **`db:seed-e2e`** — deterministic users + invite tree for E2E runs.
+
+### Changed
+
+- **Invite-tree Contagion** — graded, distance-decaying suspicion across the invite tree [#155, PR #249].
+- **Stylesheet CRS** — tiering escalation curve [#121, PR #248].
+- IRCScore cap pinned to 2; PRD + CONTEXT-MAP drift reconciled.
+- AuthorStylesheet author/adopt routes registered in the OpenAPI contract.
+- ADR-0003 — dropped Arm 1 chrome isolation; themes are visually unrestricted.
+- Husky — type-check folded into pre-commit; docs synced to current patterns.
+
+### Fixed
+
+- `docs/erd.md` — high-level map so GitHub renders the ERD.
+
+### Docs
+
+- Corrected the `AuthorStylesheet.source` sanitization note.
+
 ## [0.6.0] — 2026-06-23
 
 One release consolidating the post-0.5.6 work, shown as dated milestones — no intermediate versions were tagged, so this is the genuine history rather than a fabricated 0.5.7–0.5.9 ladder. Entries already credited in 0.5.5/0.5.6 (tags cut ahead of merges) are not repeated.
@@ -416,7 +443,11 @@ _Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a0
 
 ---
 
-[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/orphic-inc/stellar-api/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/orphic-inc/stellar-api/compare/v0.5.6...v0.6.0
+[0.5.6]: https://github.com/orphic-inc/stellar-api/compare/v0.5.5...v0.5.6
+[0.5.5]: https://github.com/orphic-inc/stellar-api/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/orphic-inc/stellar-api/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/orphic-inc/stellar-api/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/orphic-inc/stellar-api/compare/v0.5.1...v0.5.2

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Stellar API",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Cuts **0.6.1**, consolidating the 11 commits merged since `v0.6.0` (none of which had reached the CHANGELOG — `[Unreleased]` was empty).

## What changed
- **CHANGELOG** — new dated `## [0.6.1] — 2026-06-25` section grouped Added / Changed / Fixed / Docs.
- **Version surfaces bumped in lockstep** — `package.json`, `package-lock.json`, regenerated `openapi.json` (`info.version` derives from the manifest). `version:check` green at 0.6.1.
- **Compare-link footer repaired** — was stale: `[Unreleased]` pointed at `v0.5.4` and the `0.5.5` / `0.5.6` / `0.6.0` links were missing.

## Wave contents (since v0.6.0)
**Added:** EAC/XLD rip-log scorer + `POST /log-check`; `GET /api/version` (PR #243); `db:seed-e2e`.
**Changed:** invite-tree Contagion (#155, PR #249); stylesheet CRS tiering curve (#121, PR #248); IRCScore cap pinned to 2; AuthorStylesheet routes in OpenAPI; ADR-0003 chrome-isolation drop; husky type-check.
**Fixed:** `docs/erd.md` GitHub rendering.

## Verification
- `npm run version:check` → consistent at 0.6.1
- `npx tsc --noEmit` + `typecheck:test` clean
- Full suite: 94 suites / 1732 tests pass

**Post-merge:** tag `v0.6.1` on the trunk (not cut on the fork branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)