### PR TITLE
feat(users): write route for User.rankLocked (#203)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6131,6 +6131,82 @@
         }
       }
     },
+    "/users/{id}/rank-lock": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "rankLocked": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "rankLocked"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rank lock toggled (freezes/unfreezes auto class-progression)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing users_edit permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users/settings": {
       "get": {
         "tags": [

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -686,6 +686,41 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: 'put',
+  path: '/users/{id}/rank-lock',
+  tags: ['Users'],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({ rankLocked: z.boolean() })
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description:
+        'Rank lock toggled (freezes/unfreezes auto class-progression)',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    400: {
+      description: 'Validation failed',
+      content: { 'application/json': { schema: ValidationError } }
+    },
+    403: {
+      description: 'Missing users_edit permission',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'User not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
   method: 'get',
   path: '/users/settings',
   tags: ['Users'],

--- a/src/moderation.spec.ts
+++ b/src/moderation.spec.ts
@@ -320,6 +320,94 @@ describe('PUT /api/users/:id/rank', () => {
   });
 });
 
+describe('PUT /api/users/:id/rank-lock', () => {
+  beforeEach(() => setStaff());
+
+  it('locks a user and records an audit entry', async () => {
+    mockTargetUser();
+    prismaMock.user.update.mockResolvedValue(
+      makeUser({ id: 9, rankLocked: true }) as never
+    );
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .put('/api/users/9/rank-lock')
+      .send({ rankLocked: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.msg).toBe('Rank locked');
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: { rankLocked: true }
+    });
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'user.rank_lock_changed',
+          targetType: 'User',
+          targetId: 9,
+          metadata: { rankLocked: true }
+        })
+      })
+    );
+  });
+
+  it('unlocks a user', async () => {
+    mockTargetUser();
+    prismaMock.user.update.mockResolvedValue(makeUser({ id: 9 }) as never);
+
+    const res = await request(app)
+      .put('/api/users/9/rank-lock')
+      .send({ rankLocked: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.msg).toBe('Rank unlocked');
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: { rankLocked: false }
+    });
+  });
+
+  it('does not touch the secondary-rank set (avoids the setUserRank wipe)', async () => {
+    mockTargetUser();
+    prismaMock.user.update.mockResolvedValue(makeUser({ id: 9 }) as never);
+
+    await request(app).put('/api/users/9/rank-lock').send({ rankLocked: true });
+
+    // setUserRank clears+rebuilds userSecondaryRank on every call; the lock
+    // toggle must never go through that path or it would strip Donor/VIP.
+    expect(prismaMock.userSecondaryRank.deleteMany).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: { rankLocked: true }
+    });
+  });
+
+  it('returns 403 without users_edit permission', async () => {
+    setCurrentUserPermissions(
+      makeUserRank().permissions as Record<string, boolean>
+    );
+    const res = await request(app)
+      .put('/api/users/9/rank-lock')
+      .send({ rankLocked: true });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    const res = await request(app)
+      .put('/api/users/9/rank-lock')
+      .send({ rankLocked: true });
+    expect(res.status).toBe(404);
+    expect(res.body.msg).toBe('User not found');
+  });
+
+  it('returns 400 when rankLocked is missing or not a boolean', async () => {
+    const res = await request(app).put('/api/users/9/rank-lock').send({});
+    expect(res.status).toBe(400);
+  });
+});
+
 // ─── IP history ───────────────────────────────────────────────────────────────
 
 describe('GET /api/users/:id/ip-history', () => {

--- a/src/routes/api/user.ts
+++ b/src/routes/api/user.ts
@@ -45,6 +45,7 @@ import {
   warnUserSchema,
   moderationNoteSchema,
   setRankSchema,
+  rankLockSchema,
   donorRankSchema,
   grantDonorSchema,
   ircNickVerifySchema,
@@ -53,6 +54,7 @@ import {
   type WarnUserInput,
   type ModerationNoteInput,
   type SetRankInput,
+  type RankLockInput,
   type DonorRankInput,
   type GrantDonorInput,
   type IrcNickVerifyInput
@@ -823,6 +825,32 @@ router.put(
     const { userRankId, secondaryRankIds } = parsedBody<SetRankInput>(res);
     await setUserRank(id, userRankId, secondaryRankIds, req.user.id);
     res.json({ msg: 'Rank updated' });
+  })
+);
+
+// PUT /api/users/:id/rank-lock — freeze/unfreeze a user from auto
+// class-progression (the engine no-ops on locked users). Deliberately its own
+// route, NOT folded into setUserRank: that path replaces the whole
+// secondary-rank set and would strip a Donor/VIP secondary on every toggle.
+// Mirrors the primary-only update in rankProgressionJob.applyRankChange.
+router.put(
+  '/:id/rank-lock',
+  ...requirePermission('users_edit'),
+  validateParams(userIdParamsSchema),
+  validate(rankLockSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { rankLocked } = parsedBody<RankLockInput>(res);
+    const target = await prisma.user.findUnique({
+      where: { id },
+      select: { id: true }
+    });
+    if (!target) return res.status(404).json({ msg: 'User not found' });
+    await prisma.user.update({ where: { id }, data: { rankLocked } });
+    await audit(prisma, req.user.id, 'user.rank_lock_changed', 'User', id, {
+      rankLocked
+    });
+    res.json({ msg: rankLocked ? 'Rank locked' : 'Rank unlocked' });
   })
 );
 

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -37,6 +37,10 @@ export const setRankSchema = z.object({
   secondaryRankIds: z.array(z.number().int().positive()).default([])
 });
 
+export const rankLockSchema = z.object({
+  rankLocked: z.boolean()
+});
+
 export const donorRankSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   minDonation: z.number().positive(),
@@ -86,6 +90,7 @@ export type UserSettingsInput = z.infer<typeof userSettingsSchema>;
 export type WarnUserInput = z.infer<typeof warnUserSchema>;
 export type ModerationNoteInput = z.infer<typeof moderationNoteSchema>;
 export type SetRankInput = z.infer<typeof setRankSchema>;
+export type RankLockInput = z.infer<typeof rankLockSchema>;
 export type DonorRankInput = z.infer<typeof donorRankSchema>;
 export type GrantDonorInput = z.infer<typeof grantDonorSchema>;
 export type IrcNickVerifyInput = z.infer<typeof ircNickVerifySchema>;


### PR DESCRIPTION
Closes #203.

## What

Adds `PUT /api/users/:id/rank-lock` so staff can freeze/unfreeze a user from auto class-progression. `User.rankLocked` was read-only — surfaced on the progression payload and honored by the sweep, but no route wrote it — which blocked stellar-ui #83's per-user toggle.

## Why a standalone route

Deliberately **not** folded into `setUserRank` (`PUT /:id/rank`): that path replaces the whole secondary-rank set and would strip a Donor/VIP secondary on every toggle (the documented secondary-wipe footgun). This mirrors the primary-only update in `rankProgressionJob.applyRankChange` — direct `user.update` + `audit('user.rank_lock_changed')`.

- `users_edit`-gated; 404 on missing user
- Registered in the OpenAPI contract (`src/lib/openapi.ts`) + regenerated `openapi.json`

## Tests (TDD)

Driven test-first in `moderation.spec.ts`: lock, unlock, the **no-secondary-wipe guard** (asserts `userSecondaryRank.deleteMany` is never called), permission gate (403), missing user (404), invalid body (400).

`tsc` clean · lint clean · full suite 1738 passed / 94 suites.

## Follow-up (cross-repo, not in this PR)

Regen stellar-ui `api.ts` from this contract, then finish stellar-ui #83's `rankLocked` toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)