### PR TITLE
feat(releases): release-scoped contributions read with rip-quality + edition (#129)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2982,6 +2982,215 @@
           "collaborators"
         ]
       },
+      "ReleaseFileQuality": {
+        "type": "object",
+        "properties": {
+          "bitrate": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "Lossless",
+              "Lossless24",
+              "Kbps320",
+              "Kbps256",
+              "KbpsV0",
+              "Kbps192",
+              "KbpsV2",
+              "Kbps128",
+              "Other",
+              null
+            ]
+          },
+          "hasLog": {
+            "type": "boolean"
+          },
+          "hasCue": {
+            "type": "boolean"
+          },
+          "isScene": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "bitrate",
+          "hasLog",
+          "hasCue",
+          "isScene"
+        ]
+      },
+      "EditionIdentity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "media": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "CD",
+              "WEB",
+              "Vinyl",
+              "SACD",
+              "DVD",
+              "Cassette",
+              "BluRay",
+              "DAT",
+              "Soundboard",
+              "Other",
+              null
+            ]
+          },
+          "year": {
+            "type": "number",
+            "nullable": true
+          },
+          "recordLabel": {
+            "type": "string",
+            "nullable": true
+          },
+          "catalogueNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "isRemaster": {
+            "type": "boolean"
+          },
+          "isUnknownEdition": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "media",
+          "year",
+          "recordLabel",
+          "catalogueNumber",
+          "title",
+          "isRemaster",
+          "isUnknownEdition"
+        ]
+      },
+      "ReleaseContributionDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "number"
+          },
+          "releaseId": {
+            "type": "number"
+          },
+          "contributorId": {
+            "type": "number"
+          },
+          "releaseDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadUrl": {
+            "type": "string"
+          },
+          "sizeInBytes": {
+            "type": "number",
+            "nullable": true
+          },
+          "linkStatus": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "UNKNOWN",
+              "PASS",
+              "WARN",
+              "FAIL",
+              null
+            ]
+          },
+          "linkCheckedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "username"
+            ]
+          },
+          "collaborators": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name"
+              ]
+            }
+          },
+          "releaseFile": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReleaseFileQuality"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "edition": {
+            "$ref": "#/components/schemas/EditionIdentity"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "releaseId",
+          "contributorId",
+          "downloadUrl",
+          "sizeInBytes",
+          "linkStatus",
+          "linkCheckedAt",
+          "type",
+          "createdAt",
+          "updatedAt",
+          "user",
+          "collaborators",
+          "releaseFile",
+          "edition"
+        ]
+      },
       "ReleaseTagEnriched": {
         "type": "object",
         "properties": {
@@ -10417,6 +10626,64 @@
       }
     },
     "/communities/{communityId}/releases/{releaseId}/contributions": {
+      "get": {
+        "tags": [
+          "Communities"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "communityId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "releaseId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Release contributions with rip-quality and edition identity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseContributionDetail"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not a member of this community",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Release not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "Communities"

--- a/src/communityReleases.spec.ts
+++ b/src/communityReleases.spec.ts
@@ -163,6 +163,111 @@ describe('GET /api/communities/:communityId/releases/:releaseId', () => {
   });
 });
 
+describe('GET /api/communities/:communityId/releases/:releaseId/contributions', () => {
+  const makeQualityContribution = (
+    overrides: Record<string, unknown> = {}
+  ) => ({
+    id: 15,
+    userId: 7,
+    releaseId: 3,
+    contributorId: 4,
+    releaseDescription: 'Lossless rip',
+    downloadUrl: 'https://example.com/kob.torrent',
+    // BigInt on the wire proves the number-normalization contract.
+    sizeInBytes: BigInt('5000000000'),
+    linkStatus: 'PASS',
+    linkCheckedAt: null,
+    type: FileType.flac,
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+    user: { id: 7, username: 'user' },
+    collaborators: [{ id: 2, name: 'Miles Davis' }],
+    releaseFile: {
+      bitrate: 'Lossless',
+      hasLog: true,
+      hasCue: true,
+      isScene: false
+    },
+    edition: {
+      id: 8,
+      media: 'CD',
+      year: 1997,
+      recordLabel: 'Columbia',
+      catalogueNumber: 'CL 1355',
+      title: 'Legacy Edition',
+      isRemaster: true,
+      isUnknownEdition: false
+    },
+    ...overrides
+  });
+
+  it('returns contributions with rip-quality and edition identity', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
+    prismaMock.contribution.findMany.mockResolvedValue([
+      makeQualityContribution()
+    ] as never);
+
+    const res = await request(app).get(
+      '/api/communities/1/releases/3/contributions'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    const entry = res.body[0];
+    expect(entry.type).toBe('flac');
+    // BigInt serialized to a JS number, not a string.
+    expect(entry.sizeInBytes).toBe(5000000000);
+    expect(entry.releaseFile).toEqual({
+      bitrate: 'Lossless',
+      hasLog: true,
+      hasCue: true,
+      isScene: false
+    });
+    expect(entry.edition.media).toBe('CD');
+    expect(entry.edition.recordLabel).toBe('Columbia');
+    expect(entry.edition.title).toBe('Legacy Edition');
+  });
+
+  it('returns an empty array when the release has no contributions', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue({ id: 3 } as never);
+    prismaMock.contribution.findMany.mockResolvedValue([] as never);
+
+    const res = await request(app).get(
+      '/api/communities/1/releases/3/contributions'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns 404 when the release is not in the community', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
+    prismaMock.release.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get(
+      '/api/communities/1/releases/999/contributions'
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 for a non-member of a restricted community', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ registrationStatus: RegistrationStatus.invite }) as never
+    );
+    prismaMock.consumer.findFirst.mockResolvedValue(null);
+    prismaMock.contributor.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get(
+      '/api/communities/1/releases/3/contributions'
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
 describe('POST /api/communities/:communityId/releases', () => {
   it('requires communities_manage permission', async () => {
     const res = await request(app)

--- a/src/integration/releaseWorkbench.integration.ts
+++ b/src/integration/releaseWorkbench.integration.ts
@@ -1,0 +1,171 @@
+import {
+  ReleaseType,
+  FileType,
+  CommunityType,
+  RegistrationStatus,
+  Bitrate,
+  ReleaseMedia
+} from '@prisma/client';
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { createContributionSubmission } from '../modules/contribution';
+import { listReleaseContributions } from '../modules/releaseWorkbench/contributions';
+import type { CreateContributionInput } from '../schemas/contribution';
+
+// Suppress the async link-health HTTP check — it fires and forgets after every
+// contribution is created, and the pending outbound request holds a prisma
+// connection that blocks the next test's TRUNCATE.
+jest.mock('../modules/linkHealth', () => ({
+  checkContributionLink: jest.fn().mockResolvedValue(undefined)
+}));
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const createUser = async (tag: string) => {
+  const rank = await testPrisma.userRank.findFirstOrThrow();
+  const settings = await testPrisma.userSettings.create({ data: {} });
+  const profile = await testPrisma.profile.create({ data: {} });
+  return testPrisma.user.create({
+    data: {
+      username: `rw-${tag}-${Date.now()}`,
+      email: `rw-${tag}-${Date.now()}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id
+    }
+  });
+};
+
+const createCommunity = () =>
+  testPrisma.community.create({
+    data: {
+      name: `Community-${Date.now()}`,
+      image: '',
+      registrationStatus: RegistrationStatus.open,
+      type: CommunityType.Music
+    }
+  });
+
+// A lossless CD rip with a log + cue — every quality field set to a distinct,
+// non-default value so the assertions fail if the read drops any of them.
+const losslessInput = (communityId: number): CreateContributionInput => ({
+  communityId,
+  type: ReleaseType.Music,
+  title: 'Kind of Blue',
+  year: 1959,
+  fileType: FileType.flac,
+  downloadUrl: 'https://example.com/kob.torrent',
+  sizeInBytes: 5_000_000_000,
+  tags: 'jazz',
+  releaseDescription: 'Lossless rip',
+  image: undefined,
+  description: undefined,
+  bitrate: Bitrate.Lossless,
+  media: ReleaseMedia.CD,
+  releaseCategory: undefined,
+  recordLabel: 'Columbia',
+  catalogueNumber: 'CL 1355',
+  editionTitle: 'Legacy Edition',
+  editionYear: 1997,
+  isRemaster: true,
+  hasLog: true,
+  hasCue: true,
+  isScene: false,
+  collaborators: [{ artist: 'Miles Davis', importance: 'main' }]
+});
+
+describe('listReleaseContributions', () => {
+  it('returns each contribution with its rip-quality satellite and edition identity', async () => {
+    const user = await createUser('quality');
+    const community = await createCommunity();
+
+    const created = await createContributionSubmission({
+      userId: user.id,
+      input: losslessInput(community.id)
+    });
+    expect(created).not.toBeNull();
+
+    const contributions = await listReleaseContributions({
+      actorId: user.id,
+      communityId: community.id,
+      releaseId: created!.releaseId
+    });
+
+    expect(contributions).toHaveLength(1);
+    const entry = contributions[0];
+
+    // Spine facts — format is the contribution type, size normalized to a number.
+    expect(entry.type).toBe(FileType.flac);
+    expect(entry.sizeInBytes).toBe(5_000_000_000);
+    expect(entry.downloadUrl).toBe('https://example.com/kob.torrent');
+
+    // Rip-quality satellite (ReleaseFile) — the whole point of #129.
+    expect(entry.releaseFile).not.toBeNull();
+    expect(entry.releaseFile?.bitrate).toBe(Bitrate.Lossless);
+    expect(entry.releaseFile?.hasLog).toBe(true);
+    expect(entry.releaseFile?.hasCue).toBe(true);
+    expect(entry.releaseFile?.isScene).toBe(false);
+
+    // Full edition identity — media plus the fields that build the edition string.
+    expect(entry.edition?.media).toBe(ReleaseMedia.CD);
+    expect(entry.edition?.recordLabel).toBe('Columbia');
+    expect(entry.edition?.catalogueNumber).toBe('CL 1355');
+    expect(entry.edition?.title).toBe('Legacy Edition');
+    expect(entry.edition?.year).toBe(1997);
+    expect(entry.edition?.isRemaster).toBe(true);
+  });
+
+  it('returns an empty array for a release with no contributions', async () => {
+    const user = await createUser('empty');
+    const community = await createCommunity();
+    const release = await testPrisma.release.create({
+      data: {
+        title: 'Empty',
+        description: 'no contributions',
+        type: ReleaseType.Music,
+        releaseType: 'Album',
+        year: 2020,
+        communityId: community.id
+      }
+    });
+
+    const contributions = await listReleaseContributions({
+      actorId: user.id,
+      communityId: community.id,
+      releaseId: release.id
+    });
+
+    expect(contributions).toEqual([]);
+  });
+
+  it('rejects a non-member of an invite-only community with 403', async () => {
+    const owner = await createUser('owner');
+    const outsider = await createUser('outsider');
+    const community = await createCommunity();
+
+    const created = await createContributionSubmission({
+      userId: owner.id,
+      input: losslessInput(community.id)
+    });
+    await testPrisma.community.update({
+      where: { id: community.id },
+      data: { registrationStatus: RegistrationStatus.invite }
+    });
+
+    await expect(
+      listReleaseContributions({
+        actorId: outsider.id,
+        communityId: community.id,
+        releaseId: created!.releaseId
+      })
+    ).rejects.toThrow(/member/i);
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2797,6 +2797,83 @@ const Contribution = registry.register(
   })
 );
 
+// The per-file rip-quality satellite (ReleaseFile), nested on a release-scoped
+// contribution read. `bitrate` is null until graded.
+const ReleaseFileQuality = registry.register(
+  'ReleaseFileQuality',
+  z.object({
+    bitrate: z
+      .enum([
+        'Lossless',
+        'Lossless24',
+        'Kbps320',
+        'Kbps256',
+        'KbpsV0',
+        'Kbps192',
+        'KbpsV2',
+        'Kbps128',
+        'Other'
+      ])
+      .nullable(),
+    hasLog: z.boolean(),
+    hasCue: z.boolean(),
+    isScene: z.boolean()
+  })
+);
+
+// The Edition identity (per-pressing) nested on a release-scoped contribution
+// read — media plus the fields that compose the edition string.
+const EditionIdentity = registry.register(
+  'EditionIdentity',
+  z.object({
+    id: z.number(),
+    media: z
+      .enum([
+        'CD',
+        'WEB',
+        'Vinyl',
+        'SACD',
+        'DVD',
+        'Cassette',
+        'BluRay',
+        'DAT',
+        'Soundboard',
+        'Other'
+      ])
+      .nullable(),
+    year: z.number().nullable(),
+    recordLabel: z.string().nullable(),
+    catalogueNumber: z.string().nullable(),
+    title: z.string().nullable(),
+    isRemaster: z.boolean(),
+    isUnknownEdition: z.boolean()
+  })
+);
+
+// A release-scoped contribution carrying the rip-quality satellite + edition
+// identity (issue #129) — the shape the release detail view omits.
+const ReleaseContributionDetail = registry.register(
+  'ReleaseContributionDetail',
+  z.object({
+    id: z.number(),
+    userId: z.number(),
+    releaseId: z.number(),
+    contributorId: z.number(),
+    releaseDescription: z.string().nullable().optional(),
+    downloadUrl: z.string(),
+    sizeInBytes: z.number().nullable(),
+    linkStatus: z.enum(['UNKNOWN', 'PASS', 'WARN', 'FAIL']).nullable(),
+    linkCheckedAt: z.string().nullable(),
+    type: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    user: z.object({ id: z.number(), username: z.string() }).nullable(),
+    collaborators: z.array(z.object({ id: z.number(), name: z.string() })),
+    releaseFile: ReleaseFileQuality.nullable(),
+    edition: EditionIdentity
+  })
+);
+
 const ReleaseTagEnriched = registry.register(
   'ReleaseTagEnriched',
   z.object({
@@ -3239,6 +3316,37 @@ registry.registerPath({
     },
     404: {
       description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/communities/{communityId}/releases/{releaseId}/contributions',
+  tags: ['Communities'],
+  request: {
+    params: z.object({
+      communityId: z.string(),
+      releaseId: z.string()
+    })
+  },
+  responses: {
+    200: {
+      description:
+        'Release contributions with rip-quality and edition identity',
+      content: {
+        'application/json': {
+          schema: z.array(ReleaseContributionDetail)
+        }
+      }
+    },
+    403: {
+      description: 'Not a member of this community',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Release not found',
       content: { 'application/json': { schema: MsgResponse } }
     }
   }

--- a/src/modules/releaseWorkbench/contributions.ts
+++ b/src/modules/releaseWorkbench/contributions.ts
@@ -7,8 +7,76 @@ import { addContributionToRelease } from '../contribution';
 import { getSettings } from '../settings';
 import { loadReleaseWorkbenchAuthority } from './authority';
 import { snapshotRelease } from './snapshot';
-import type { ReleaseContributionView, ReleaseWorkbenchRef } from './types';
+import type {
+  ReleaseContributionDetailView,
+  ReleaseContributionView,
+  ReleaseWorkbenchRef
+} from './types';
 import type { AddContributionToReleaseInput } from '../../schemas/contribution';
+
+// The rip-quality satellite + full edition identity for one release's
+// contributions. Kept off the release detail view (which is growing heavy) and
+// served from its own release-scoped GET so the UI can lazy-load an edition
+// stack (bitrate/media/flags) on demand. Gated identically to the detail read.
+export const listReleaseContributions = async (
+  ref: ReleaseWorkbenchRef
+): Promise<ReleaseContributionDetailView[]> => {
+  await loadReleaseWorkbenchAuthority(ref);
+
+  // 404 rather than an empty 200 when the named release isn't in this community —
+  // matches the sibling detail GET and the attach POST.
+  const release = await prisma.release.findFirst({
+    where: { id: ref.releaseId, communityId: ref.communityId },
+    select: { id: true }
+  });
+  if (!release) {
+    throw new AppError(404, 'Release not found');
+  }
+
+  const contributions = await prisma.contribution.findMany({
+    where: {
+      releaseId: ref.releaseId,
+      release: { communityId: ref.communityId }
+    },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    select: {
+      id: true,
+      userId: true,
+      releaseId: true,
+      contributorId: true,
+      releaseDescription: true,
+      downloadUrl: true,
+      sizeInBytes: true,
+      linkStatus: true,
+      linkCheckedAt: true,
+      type: true,
+      createdAt: true,
+      updatedAt: true,
+      user: { select: { id: true, username: true } },
+      collaborators: { select: { id: true, name: true } },
+      releaseFile: {
+        select: { bitrate: true, hasLog: true, hasCue: true, isScene: true }
+      },
+      edition: {
+        select: {
+          id: true,
+          media: true,
+          year: true,
+          recordLabel: true,
+          catalogueNumber: true,
+          title: true,
+          isRemaster: true,
+          isUnknownEdition: true
+        }
+      }
+    }
+  });
+
+  return contributions.map((contribution) => ({
+    ...contribution,
+    sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes)
+  }));
+};
 
 export const attachReleaseWorkbenchContribution = async (
   ref: ReleaseWorkbenchRef,

--- a/src/modules/releaseWorkbench/index.ts
+++ b/src/modules/releaseWorkbench/index.ts
@@ -18,7 +18,10 @@ import {
   removeReleaseWorkbenchTag,
   voteOnReleaseWorkbenchTag
 } from './tags';
-import { attachReleaseWorkbenchContribution } from './contributions';
+import {
+  attachReleaseWorkbenchContribution,
+  listReleaseContributions
+} from './contributions';
 import { revertReleaseWorkbenchHistory } from './history';
 
 const createSession = (ref: ReleaseWorkbenchRef): ReleaseWorkbenchSession => ({
@@ -41,6 +44,7 @@ const createSession = (ref: ReleaseWorkbenchRef): ReleaseWorkbenchSession => ({
     removeReleaseWorkbenchTag(ref, input),
   attachContribution: (input): Promise<ReleaseContributionView> =>
     attachReleaseWorkbenchContribution(ref, input),
+  listContributions: () => listReleaseContributions(ref),
   revertHistory: (input: {
     historyId: number;
   }): Promise<ReleaseWorkbenchView> => revertReleaseWorkbenchHistory(ref, input)

--- a/src/modules/releaseWorkbench/types.ts
+++ b/src/modules/releaseWorkbench/types.ts
@@ -39,6 +39,42 @@ export type ReleaseContributionView = {
   collaborators: Array<{ id: number; name: string }>;
 };
 
+// A release-scoped contribution read that nests the rip-quality satellite
+// (ReleaseFile) and the full Edition identity alongside the spine — the shape
+// the release detail view deliberately omits (see listReleaseContributions).
+export type ReleaseContributionDetailView = {
+  id: number;
+  userId: number;
+  releaseId: number;
+  contributorId: number;
+  releaseDescription: string | null;
+  downloadUrl: string;
+  sizeInBytes: number | null;
+  linkStatus: string | null;
+  linkCheckedAt: Date | null;
+  type: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user: { id: number; username: string } | null;
+  collaborators: Array<{ id: number; name: string }>;
+  releaseFile: {
+    bitrate: string | null;
+    hasLog: boolean;
+    hasCue: boolean;
+    isScene: boolean;
+  } | null;
+  edition: {
+    id: number;
+    media: string | null;
+    year: number | null;
+    recordLabel: string | null;
+    catalogueNumber: string | null;
+    title: string | null;
+    isRemaster: boolean;
+    isUnknownEdition: boolean;
+  };
+};
+
 export type ReleaseHistoryEntry = Prisma.ReleaseHistoryGetPayload<{
   include: { actor: { select: { id: true; username: true } } };
 }>;
@@ -120,6 +156,7 @@ export type ReleaseWorkbenchSession = {
   attachContribution(
     input: AddContributionToReleaseInput
   ): Promise<ReleaseContributionView>;
+  listContributions(): Promise<ReleaseContributionDetailView[]>;
   revertHistory(input: { historyId: number }): Promise<ReleaseWorkbenchView>;
 };
 

--- a/src/routes/api/communities/release.ts
+++ b/src/routes/api/communities/release.ts
@@ -212,6 +212,27 @@ router.put(
   })
 );
 
+// GET /api/communities/:communityId/releases/:releaseId/contributions — release-scoped
+// read carrying rip-quality (ReleaseFile) + edition identity for the edition stack.
+router.get(
+  '/:releaseId/contributions',
+  requireAuth,
+  validateParams(releaseParamsSchema),
+  authHandler(async (req, res) => {
+    const { communityId, releaseId } = parsedParams<{
+      communityId: number;
+      releaseId: number;
+    }>(res);
+    const session = await releaseWorkbench.open({
+      actorId: req.user.id,
+      communityId,
+      releaseId,
+      permissions: req.user.permissions
+    });
+    res.json(await session.listContributions());
+  })
+);
+
 // POST /api/communities/:communityId/releases/:releaseId/contributions — any authenticated user
 router.post(
   '/:releaseId/contributions',


### PR DESCRIPTION
## Why

stellar-ui #129 (edition-disclosure theming) needs to lazy-load rip-quality per release, but a schema audit found **rip-quality is in no release-scoped GET response** — it exists only as POST inputs and search filters. The release detail view (`getReleaseWorkbenchView`) embeds `contributions` but its select omits the `ReleaseFile` satellite and `Edition`, so quality never came back on a read. This is the API prerequisite that unblocks the UI half of #129.

## What

New **`GET /api/communities/:communityId/releases/:releaseId/contributions`** returning each contribution with:
- **rip-quality** (`releaseFile`: `bitrate`, `hasLog`, `hasCue`, `isScene`) — the `ReleaseFile` satellite per ADR-0008
- **full edition identity** (`edition`: `media` + `year`/`recordLabel`/`catalogueNumber`/`title`/`isRemaster`/`isUnknownEdition`) so the UI can group into edition stacks and render an edition string
- spine facts (`type` = format, `sizeInBytes` normalized to a JS number, `downloadUrl`, `linkStatus`, collaborators, user)

Served from its **own route** rather than fattening the already-heavy release detail view (per design discussion). Gated identically to the detail read (community access) and **404s** on a release outside the community, matching the sibling detail GET / attach POST.

## Changes
- `listReleaseContributions` module fn + `session.listContributions` wiring
- `ReleaseContributionDetail` / `ReleaseFileQuality` / `EditionIdentity` OpenAPI schemas + path registration; `openapi.json` regenerated (verified byte-deterministic)
- **Tests (TDD):** integration test asserts the satellite + edition come back from a real seeded row (fails if the select drops a field — no theater); route-tier tests cover shape/number-serialization, empty array, 404, 403

## Gates
`format`, `lint`, `tsc --noEmit`, `typecheck:test`, `npm test` (1737 passed), integration (3 passed), and a byte-stable `openapi.json` export all green. No `schema.prisma` change → no ERD regeneration.

## Follow-up (the stellar-ui half of #129)
`npm run api:generate` to vendor the new shape, wire `CollageDetail` row-expand to the endpoint + render the `edition-*` stack, update `docs/theming.md` §5.

Refs #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)