### PR TITLE
docs(openapi): register the author-stylesheet /css delivery path (ADR-0024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Registry stylesheet CSS delivery** — `GET /api/stylesheet/author-stylesheet/:id/css` serves an adopted author sheet's stored, sanitized source as `text/css` (no-cache, nosniff), so the UI injector can link it like an external URL [ADR-0024, PR #256]. OpenAPI path registered [PR #257].
+
+### Changed
+
+- **Site Stylesheet slot is one explicit source** — Personal (external URL) and Registry (`activeAuthorStylesheetId`) are mutually exclusive; selecting one clears the other, enforced server-side on the profile write. The pointer joins the profile contract; `externalStylesheet` is tightened to `https:`-only [ADR-0024, PR #256].
+
+### Docs
+
+- **ADR-0024** — stylesheet delivery contract (URL vs stored-source registry serving); PRD-03 amended (`.css`-only, storage shape closed, "registry spaces" naming); superseded ADR-0003 Arm-1 comments corrected [PR #256].
+
 ## [0.6.1] — 2026-06-25
 
 A 0.6.x increment consolidating the post-0.6.0 work: a new rip-log scorer, the running-version endpoint, and the latest CRS dimension tuning.

--- a/openapi.json
+++ b/openapi.json
@@ -8105,6 +8105,45 @@
         }
       }
     },
+    "/stylesheet/author-stylesheet/{id}/css": {
+      "get": {
+        "tags": [
+          "Stylesheets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The stored, sanitized stylesheet source as CSS",
+            "content": {
+              "text/css": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/stylesheet": {
       "get": {
         "tags": [

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1754,6 +1754,25 @@ registry.registerPath({
   }
 });
 
+// The registry sheet's CSS delivery route (ADR-0024 §1) — the injector links
+// this exactly as Personal links an external URL. Body is text/css, not JSON.
+registry.registerPath({
+  method: 'get',
+  path: '/stylesheet/author-stylesheet/{id}/css',
+  tags: ['Stylesheets'],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'The stored, sanitized stylesheet source as CSS',
+      content: { 'text/css': { schema: z.string() } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 registry.registerPath({
   method: 'get',
   path: '/stylesheet',


### PR DESCRIPTION
Follow-up to #256. That PR added the `GET /api/stylesheet/author-stylesheet/:id/css` route handler but not its OpenAPI path registration, so `src/lib/openapi.ts` documented the sibling author routes (`/author`, `/author/{userId}`, `/author-stylesheet/{id}`, `.../adopt`) yet omitted the delivery route.

Registers the `/css` path (`text/css` 200 + 404 `MsgResponse`) and regenerates `openapi.json` so the vendored contract matches the shipped surface — which the stellar-ui `api:sync` consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)