### PR TITLE
chore(test): silence per-worker ts-jest isolatedModules deprecation

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,14 +9,16 @@ module.exports = {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        // Transpile-only — do NOT remove. Without this, ts-jest full-type-checks
-        // each suite's entire import graph in every parallel worker; on a busy
-        // CPU the heavy suites (docs/search/rules/communities) get time-sliced
-        // past the default 5s testTimeout and flake. isolatedModules drops the
-        // full run from minutes (with timeouts) to ~50s, clean. Type safety is
-        // still enforced by `npx tsc --noEmit` in the commit gate / CI.
-        isolatedModules: true,
         tsconfig: {
+          // Transpile-only — do NOT remove. Without this, ts-jest full-type-checks
+          // each suite's entire import graph in every parallel worker; on a busy
+          // CPU the heavy suites (docs/search/rules/communities) get time-sliced
+          // past the default 5s testTimeout and flake. isolatedModules drops the
+          // full run from minutes (with timeouts) to ~50s, clean. Type safety is
+          // still enforced by `npx tsc --noEmit` in the commit gate / CI.
+          // (Lives inside `tsconfig` because the transformer-level option is
+          // deprecated in ts-jest and warns once per worker.)
+          isolatedModules: true,
           module: 'commonjs',
           moduleResolution: 'node',
           esModuleInterop: true,


### PR DESCRIPTION
## What

Moves `isolatedModules: true` from the deprecated ts-jest transformer-level option into the inline `tsconfig` block in `jest.config.cjs`.

## Why

ts-jest deprecated the transformer-level option (removal slated for v30) and emits a WARN block **once per worker** — 8 blocks of noise on every full run, drowning the signal in `npm test` output. Behavior is unchanged: still transpile-only (the #116 flakiness fix — do-not-remove rationale comment moved along with the option), type safety still enforced by `tsc --noEmit` in the gate/CI.

## Verification

Full suite before/after: 94 suites / 1746 tests green. After the change the deprecation WARNs are gone; the only remaining notice is the `--forceExit` hint, which is the deliberate worker-teardown guard documented in #64 (not a leak — investigated there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtdEr5SpKvpsbi4shjAYAx