### PR TITLE
fix(ratio): getRatioStats throws AppError(404) on missing user

### DIFF
--- a/src/modules/ratio.spec.ts
+++ b/src/modules/ratio.spec.ts
@@ -20,6 +20,7 @@ import {
   getEligibleContributionBytes,
   getRatioStats
 } from './ratio';
+import { AppError } from '../lib/errors';
 
 const GiB = BigInt(1024 ** 3);
 
@@ -204,5 +205,15 @@ describe('getRatioStats', () => {
     expect(typeof stats.contributed).toBe('string');
     expect(typeof stats.consumed).toBe('string');
     expect(typeof stats.eligibleContributionBytes).toBe('string');
+  });
+
+  it('throws AppError(404) when the user is missing (#233)', async () => {
+    mockPrismaUser.findUnique.mockResolvedValue(null);
+
+    await expect(getRatioStats(1)).rejects.toThrow(AppError);
+    await expect(getRatioStats(1)).rejects.toMatchObject({
+      statusCode: 404,
+      message: 'User not found'
+    });
   });
 });

--- a/src/modules/ratio.ts
+++ b/src/modules/ratio.ts
@@ -1,5 +1,6 @@
 import { LinkHealthStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
 
 const GiB = BigInt(1024 ** 3);
 
@@ -100,7 +101,7 @@ export const getRatioStats = async (userId: number): Promise<RatioStats> => {
     where: { id: userId },
     select: { contributed: true, consumed: true }
   });
-  if (!user) throw new Error('User not found');
+  if (!user) throw new AppError(404, 'User not found');
 
   const { contributed, consumed } = user;
   const eligibleBytes = await getEligibleContributionBytes(userId);


### PR DESCRIPTION
## Summary

- `getRatioStats` in `src/modules/ratio.ts` threw a raw `Error('User not found')` on a missing user lookup. The global error handler in `app.ts` maps `err.statusCode ?? 500`, so a native `Error` (no `statusCode`) surfaced as a generic 500 for what is really a 404 domain condition.
- Replaced with `throw new AppError(404, 'User not found')`, matching the codebase-wide convention (`src/lib/errors.ts`).
- Confirmed `bootstrap.ts:427`'s raw throw is out of scope (intentional internal seed-data invariant where 500 is correct) per the issue's stated non-goals — left as-is.

Closes #233

## Test plan

- [x] Added a deterministic unit test in `src/modules/ratio.spec.ts` asserting `getRatioStats` rejects with `AppError` (`statusCode: 404`, `message: 'User not found'`) when the user lookup misses
- [x] Existing `getRatioStats` behavior (stats computation, BigInt serialization) unchanged and still covered
- [x] `npx tsc --noEmit` clean
- [x] `npm run test -- --no-coverage` — 94 suites / 1747 tests passing
- [x] `npm run openapi:export` produces no diff (no response-shape change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtdEr5SpKvpsbi4shjAYAx