### PR TITLE
feat(classes): guard RankPromotionRule CRUD to adjacent ladder steps (#170)

### DIFF
--- a/src/modules/rankProgression.spec.ts
+++ b/src/modules/rankProgression.spec.ts
@@ -6,6 +6,7 @@
  */
 import {
   evaluateRankChange,
+  isAdjacentPromotionStep,
   DEFAULT_RANKS,
   RankProgressionInput
 } from './rankProgression';
@@ -187,5 +188,26 @@ describe('evaluateRankChange — guards', () => {
       maxed({ currentRankId: rankId('Staff') })
     );
     expect(result.direction).toBe('none');
+  });
+});
+
+// ─── isAdjacentPromotionStep (#170 admin CRUD guard) ────────────────────────────
+
+describe('isAdjacentPromotionStep', () => {
+  it('accepts a toRank one rung above fromRank with nothing between', () => {
+    expect(isAdjacentPromotionStep(100, 150, [200, 300])).toBe(true);
+  });
+
+  it('rejects a toRank at or below fromRank', () => {
+    expect(isAdjacentPromotionStep(150, 150, [])).toBe(false);
+    expect(isAdjacentPromotionStep(150, 100, [])).toBe(false);
+  });
+
+  it('rejects a step that skips a rung on the ladder', () => {
+    expect(isAdjacentPromotionStep(100, 200, [150])).toBe(false);
+  });
+
+  it('ignores rungs outside the (fromLevel, toLevel) window', () => {
+    expect(isAdjacentPromotionStep(150, 200, [100, 300])).toBe(true);
   });
 });

--- a/src/modules/rankProgression.ts
+++ b/src/modules/rankProgression.ts
@@ -200,3 +200,18 @@ export const evaluateRankChange = (
 
   return stay(outgoing ? 'criteria not yet met' : 'top of the auto ladder');
 };
+
+/**
+ * Guards RankPromotionRule admin CRUD (tools.ts, #170): a rule must step to the
+ * very next rung by level, with nothing else on the ladder in between. Without
+ * this, two rules could both claim the same fromRankId — evaluateRankChange's
+ * `rules.find` takes whichever one Prisma returns first, an unordered query
+ * result — silently dropping coverage instead of erroring.
+ */
+export const isAdjacentPromotionStep = (
+  fromLevel: number,
+  toLevel: number,
+  otherLadderLevels: number[]
+): boolean =>
+  toLevel > fromLevel &&
+  !otherLadderLevels.some((level) => level > fromLevel && level < toLevel);

--- a/src/routes/api/tools.ts
+++ b/src/routes/api/tools.ts
@@ -31,6 +31,7 @@ import {
   type CreateStaffGroupInput,
   type UpdateStaffGroupInput
 } from '../../schemas/staff';
+import { isAdjacentPromotionStep } from '../../modules/rankProgression';
 
 const router = express.Router();
 
@@ -353,6 +354,48 @@ const promotionRuleInclude = {
   toRank: { select: { name: true } }
 } as const;
 
+/**
+ * Existence + adjacency guard shared by create/update. Returns an error
+ * message to surface as a 422, or null when the pair is valid. Adjacency is
+ * scoped to the primary ladder (secondary ranks like Donor/VIP overlay tags
+ * don't participate in auto-progression — see rankProgressionJob.loadLadder).
+ */
+async function validatePromotionRulePair(
+  fromRankId: number,
+  toRankId: number
+): Promise<string | null> {
+  const [fromRank, toRank] = await Promise.all([
+    prisma.userRank.findUnique({
+      where: { id: fromRankId },
+      select: { level: true }
+    }),
+    prisma.userRank.findUnique({
+      where: { id: toRankId },
+      select: { level: true }
+    })
+  ]);
+  if (!fromRank || !toRank) return 'fromRank or toRank does not exist';
+
+  const ladderLevels = await prisma.userRank.findMany({
+    where: {
+      secondary: false,
+      id: { notIn: [fromRankId, toRankId] }
+    },
+    select: { level: true }
+  });
+
+  if (
+    !isAdjacentPromotionStep(
+      fromRank.level,
+      toRank.level,
+      ladderLevels.map((r) => r.level)
+    )
+  ) {
+    return 'fromRank and toRank must be adjacent rungs on the ladder (toRank the very next level up, nothing in between)';
+  }
+  return null;
+}
+
 // GET /api/tools/promotion-rules — list all promotion rules
 router.get(
   '/promotion-rules',
@@ -390,12 +433,11 @@ router.post(
   authHandler(async (req, res) => {
     const data = parsedBody<CreatePromotionRuleInput>(res);
 
-    const rankCount = await prisma.userRank.count({
-      where: { id: { in: [data.fromRankId, data.toRankId] } }
-    });
-    if (rankCount !== 2) {
-      return res.status(422).json({ msg: 'fromRank or toRank does not exist' });
-    }
+    const pairError = await validatePromotionRulePair(
+      data.fromRankId,
+      data.toRankId
+    );
+    if (pairError) return res.status(422).json({ msg: pairError });
 
     try {
       const rule = await prisma.rankPromotionRule.create({
@@ -453,18 +495,12 @@ router.put(
 
     const body = parsedBody<UpdatePromotionRuleInput>(res);
 
-    const rankIds = [body.fromRankId, body.toRankId].filter(
-      (v): v is number => v !== undefined
-    );
-    if (rankIds.length > 0) {
-      const rankCount = await prisma.userRank.count({
-        where: { id: { in: rankIds } }
-      });
-      if (rankCount !== rankIds.length) {
-        return res
-          .status(422)
-          .json({ msg: 'fromRank or toRank does not exist' });
-      }
+    if (body.fromRankId !== undefined || body.toRankId !== undefined) {
+      const pairError = await validatePromotionRulePair(
+        body.fromRankId ?? existing.fromRankId,
+        body.toRankId ?? existing.toRankId
+      );
+      if (pairError) return res.status(422).json({ msg: pairError });
     }
 
     try {

--- a/src/tools.spec.ts
+++ b/src/tools.spec.ts
@@ -378,6 +378,25 @@ const dupPairError = () =>
     clientVersion: 'test'
   });
 
+// Rank #1 → #2 with levels 100 → 150, nothing on the ladder between them —
+// the "valid adjacent pair" fixture most tests build on.
+const mockAdjacentRankPair = (
+  fromLevel = 100,
+  toLevel = 150,
+  betweenLevels: number[] = []
+) => {
+  prismaMock.userRank.findUnique.mockImplementation(((args: {
+    where: { id?: number };
+  }) => {
+    if (args.where.id === 1) return Promise.resolve({ level: fromLevel });
+    if (args.where.id === 2) return Promise.resolve({ level: toLevel });
+    return Promise.resolve(null);
+  }) as never);
+  prismaMock.userRank.findMany.mockResolvedValue(
+    betweenLevels.map((level) => ({ level })) as never
+  );
+};
+
 describe('GET /api/tools/promotion-rules', () => {
   beforeEach(() => {
     setRankPermissionsManager();
@@ -438,7 +457,7 @@ describe('POST /api/tools/promotion-rules', () => {
   });
 
   it('creates a rule and returns 201 with string minContributed', async () => {
-    prismaMock.userRank.count.mockResolvedValue(2);
+    mockAdjacentRankPair();
     prismaMock.rankPromotionRule.create.mockResolvedValue(
       makePromotionRule() as never
     );
@@ -453,7 +472,7 @@ describe('POST /api/tools/promotion-rules', () => {
   });
 
   it('returns 422 when a referenced rank does not exist', async () => {
-    prismaMock.userRank.count.mockResolvedValue(1);
+    prismaMock.userRank.findUnique.mockResolvedValue(null);
 
     const res = await request(app)
       .post('/api/tools/promotion-rules')
@@ -470,8 +489,30 @@ describe('POST /api/tools/promotion-rules', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 422 when toRank is not a higher level than fromRank', async () => {
+    mockAdjacentRankPair(150, 100); // toRank (100) below fromRank (150)
+
+    const res = await request(app)
+      .post('/api/tools/promotion-rules')
+      .send({ fromRankId: 1, toRankId: 2 });
+
+    expect(res.status).toBe(422);
+    expect(res.body.msg).toMatch(/adjacent/);
+  });
+
+  it('returns 422 when a rank sits between fromRank and toRank on the ladder', async () => {
+    mockAdjacentRankPair(100, 200, [150]); // skips the 150 rung
+
+    const res = await request(app)
+      .post('/api/tools/promotion-rules')
+      .send({ fromRankId: 1, toRankId: 2 });
+
+    expect(res.status).toBe(422);
+    expect(res.body.msg).toMatch(/adjacent/);
+  });
+
   it('returns 409 on a duplicate rank pair', async () => {
-    prismaMock.userRank.count.mockResolvedValue(2);
+    mockAdjacentRankPair();
     prismaMock.rankPromotionRule.create.mockRejectedValue(dupPairError());
 
     const res = await request(app)
@@ -512,6 +553,37 @@ describe('PUT /api/tools/promotion-rules/:id', () => {
       .send({ enabled: false });
 
     expect(res.status).toBe(404);
+  });
+
+  it('re-validates adjacency when toRankId changes', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(
+      makePromotionRule() as never
+    );
+    mockAdjacentRankPair(100, 200, [150]); // skips the 150 rung
+
+    const res = await request(app)
+      .put('/api/tools/promotion-rules/1')
+      .send({ toRankId: 2 });
+
+    expect(res.status).toBe(422);
+    expect(res.body.msg).toMatch(/adjacent/);
+  });
+
+  it('skips the adjacency check when fromRankId/toRankId are untouched', async () => {
+    prismaMock.rankPromotionRule.findUnique.mockResolvedValue(
+      makePromotionRule() as never
+    );
+    prismaMock.rankPromotionRule.update.mockResolvedValue(
+      makePromotionRule({ enabled: false }) as never
+    );
+    prismaMock.auditLog.create.mockResolvedValue({} as never);
+
+    const res = await request(app)
+      .put('/api/tools/promotion-rules/1')
+      .send({ enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.userRank.findUnique).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #170.

## What was already shipped vs what this adds

Both halves of #170 turned out to be largely landed already:

- **rankLocked override** — split to #203 per the issue comment; the write route (`PUT /api/user/:id/rank-lock`) and the staff read surface (rank-assignment read exposes `rankLocked`) are both on main. No changes here.
- **RankPromotionRule criteria editor CRUD** — shipped in PR #202 (`/api/tools/promotion-rules` GET/POST/PUT/DELETE, `rank_permissions_manage`-gated, registered in the OpenAPI contract), despite the issue comment marking it deferred — the deferral note was stale by the time it posted.

What was still missing from the issue's pinned decisions: **"rule CRUD guarded to adjacent level-steps."** That's what this PR adds.

## The guard

Without it, `evaluateRankChange`'s `rules.find` takes whichever rule Prisma returns first for a given `fromRankId` — an unordered query result — so two competing "from" rules, or a rule that skips a rung, would silently drop ladder coverage instead of erroring at write time.

- `validatePromotionRulePair` (tools.ts) replaces the existence-only check on POST and PUT: both ranks must exist (422) **and** `toRank` must be the very next rung by level on the primary ladder, with nothing in between (422). Secondary ranks (Donor/VIP overlays) don't participate, consistent with `rankProgressionJob.loadLadder`.
- PUT re-validates only when `fromRankId`/`toRankId` actually change; threshold-only edits skip the rank queries.
- The pure comparison, `isAdjacentPromotionStep`, lives in `rankProgression.ts` alongside the evaluator it protects, with its own unit tests.

## Contract

No schema change. `npm run openapi:export` produces no diff — the route surface and payload shapes were already registered by PR #202; this only tightens write-time validation.

stellar-ui #83 consumes this surface: the editor UI should expect a 422 with `{ msg }` when a rule pair is non-adjacent, in addition to the existing 422 (missing rank) and 409 (duplicate pair) cases.

## Tests

Full suite green locally: 94 suites, 1754 tests. New coverage: adjacency unit tests (`rankProgression.spec.ts`) + route specs for non-adjacent create, skipped-rung create, re-validation on update, and skip-when-untouched (`tools.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtdEr5SpKvpsbi4shjAYAx