### PR TITLE
test(openapi): contract-coverage guard for the stylesheet router (#239)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,9 @@
 module.exports = {
+  // Stop the config cascade here: a checkout nested inside another checkout
+  // (e.g. a git worktree under .claude/worktrees/) otherwise inherits the
+  // outer repo's .eslintrc.cjs too, and ESLint refuses to load the
+  // @typescript-eslint plugin from two node_modules at once.
+  root: true,
   env: {
     es2020: true,
     node: true

--- a/src/lib/openapi.spec.ts
+++ b/src/lib/openapi.spec.ts
@@ -1,0 +1,64 @@
+import type { Router } from 'express';
+// Load first: registers the harness's jest.mock('../modules/config', ...) etc.
+// so the direct route-module import below doesn't hit the real config module's
+// requireEnv() and exit the process for a JWT secret this spec never uses.
+import '../test/apiTestHarness';
+import stylesheetRouter from '../routes/api/stylesheet';
+import { registry } from './openapi';
+
+/**
+ * #198-class guard — a route can ship in routes/api/*.ts without ever being
+ * registered in src/lib/openapi.ts: the manual registry gives no compile-time
+ * or runtime signal that a route is missing, and the CI freshness gate only
+ * re-diffs whatever IS in the registry against the last export. Both #175
+ * (IRC nick-link) and #239 (AuthorStylesheet /css delivery) were exactly this
+ * — the route worked, the contract just didn't know it existed. This walks a
+ * router's mounted routes and fails if any lack a matching
+ * `registry.registerPath()` entry, so the same class of gap can't reopen
+ * silently for the routes covered here.
+ *
+ * Scoped to the stylesheet router (the site of #239) rather than the whole
+ * app: a repo-wide walker would surface any pre-existing unrelated gaps as
+ * failures here, which is a separate cleanup, not this guard's job.
+ */
+interface MountedRoute {
+  method: string;
+  path: string;
+}
+
+function mountedRoutes(router: Router, prefix: string): MountedRoute[] {
+  const routes: MountedRoute[] = [];
+  for (const layer of router.stack) {
+    if (!layer.route) continue;
+    // Express `:id` params → OpenAPI `{id}` path-template syntax; the router's
+    // own root ('/') contributes no suffix, matching how it's registered.
+    const suffix =
+      layer.route.path === '/'
+        ? ''
+        : layer.route.path.replace(/:(\w+)/g, '{$1}');
+    const path = prefix + suffix;
+    const methods = layer.route.methods as Record<string, boolean>;
+    for (const method of Object.keys(methods)) {
+      if (methods[method]) routes.push({ method, path });
+    }
+  }
+  return routes;
+}
+
+describe('OpenAPI contract coverage — stylesheet router (#198-class guard)', () => {
+  it('registers every mounted /stylesheet route in the OpenAPI contract', () => {
+    const registered = new Set(
+      registry.definitions
+        .filter(
+          (d): d is Extract<typeof d, { type: 'route' }> => d.type === 'route'
+        )
+        .map((d) => `${d.route.method} ${d.route.path}`)
+    );
+
+    const missing = mountedRoutes(stylesheetRouter, '/stylesheet').filter(
+      (r) => !registered.has(`${r.method} ${r.path}`)
+    );
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #239.

## Ground truth on #239

The issue's four named routes (`POST /stylesheet/author`, `GET /stylesheet/author/{userId}`, `GET /stylesheet/author-stylesheet/{id}`, `POST .../adopt`) are **already registered** on main — the 0.6.1 CHANGELOG claim is accurate (`src/lib/openapi.ts` ~L1689-1755, present in `openapi.json`). The one real residual gap was the newer ADR-0024 `GET /stylesheet/author-stylesheet/{id}/css` delivery path, and **#257 registers it** — this PR is stacked on #257's branch and should merge after it (the shared commits drop out of this diff once #257 lands).

## What this PR adds

The piece #257 lacks: a #198-class regression guard. `src/lib/openapi.spec.ts` walks the mounted stylesheet router and fails if any route lacks a matching `registry.registerPath()` entry — the manual registry gives no signal for a missing registration, and the CI freshness gate only re-diffs what *is* registered, so this exact gap (#175/#198, then #239) kept reopening silently. Verified red on pre-#257 code (it flags the unregistered `/css` path) and green on #257's branch.

Also includes a one-line `root: true` in `.eslintrc.cjs`: without it, a checkout nested inside another checkout (git worktrees under `.claude/worktrees/`) inherits the outer repo's config and ESLint refuses to load `@typescript-eslint` from two `node_modules`, breaking the pre-commit hook's lint-staged.

## Testing

- `npm run test -- --no-coverage`: 95 suites, 1747 tests, all green
- Guard verified to fail when the `/css` registration is absent (stashed-fix red run)
- `npx tsc --noEmit`, `npm run typecheck:test`, `npm run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtdEr5SpKvpsbi4shjAYAx