### PR TITLE
feat(stylesheets): paginate author-stylesheet list + rank-gated count limit (#146)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -240,6 +240,9 @@
               },
               "personalCollageLimit": {
                 "type": "integer"
+              },
+              "authorStylesheetLimit": {
+                "type": "integer"
               }
             },
             "required": [
@@ -2122,6 +2125,33 @@
           "updatedAt"
         ]
       },
+      "AuthorStylesheetListItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "authorId": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "authorId",
+          "name",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
       "AdoptionResult": {
         "type": "object",
         "properties": {
@@ -3603,6 +3633,9 @@
             "type": "string"
           },
           "personalCollageLimit": {
+            "type": "integer"
+          },
+          "authorStylesheetLimit": {
             "type": "integer"
           },
           "displayStaff": {
@@ -7948,18 +7981,50 @@
             "required": true,
             "name": "userId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "An author's stylesheets",
+            "description": "An author's stylesheets, paginated (#146)",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AuthorStylesheet"
-                  }
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AuthorStylesheetListItem"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
                 }
               }
             }
@@ -11302,6 +11367,10 @@
                     "type": "integer",
                     "minimum": 0
                   },
+                  "authorStylesheetLimit": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
                   "displayStaff": {
                     "type": "boolean"
                   },
@@ -11637,6 +11706,10 @@
                     "type": "string"
                   },
                   "personalCollageLimit": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "authorStylesheetLimit": {
                     "type": "integer",
                     "minimum": 0
                   },

--- a/prisma/migrations/20260703000000_add_author_stylesheet_limit/migration.sql
+++ b/prisma/migrations/20260703000000_add_author_stylesheet_limit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_ranks" ADD COLUMN     "authorStylesheetLimit" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -303,23 +303,24 @@ model StaffGroup {
 }
 
 model UserRank {
-  id                   Int                 @id @default(autoincrement())
-  level                Int
-  name                 String
-  permissions          Json
-  secondary            Boolean             @default(false)
-  permittedForumIds    Int[]               @default([])
-  color                String              @default("")
-  badge                String              @default("")
-  uploadRequired       Int                 @default(0)
-  personalCollageLimit Int                 @default(0)
-  displayStaff         Boolean             @default(false)
-  staffGroupId         Int?
-  staffGroup           StaffGroup?         @relation(fields: [staffGroupId], references: [id], onDelete: SetNull)
-  users                User[]
-  secondaryUsers       UserSecondaryRank[]
-  promotionRulesFrom   RankPromotionRule[] @relation("RankPromotionFrom")
-  promotionRulesTo     RankPromotionRule[] @relation("RankPromotionTo")
+  id                    Int                 @id @default(autoincrement())
+  level                 Int
+  name                  String
+  permissions           Json
+  secondary             Boolean             @default(false)
+  permittedForumIds     Int[]               @default([])
+  color                 String              @default("")
+  badge                 String              @default("")
+  uploadRequired        Int                 @default(0)
+  personalCollageLimit  Int                 @default(0)
+  authorStylesheetLimit Int                 @default(0)
+  displayStaff          Boolean             @default(false)
+  staffGroupId          Int?
+  staffGroup            StaffGroup?         @relation(fields: [staffGroupId], references: [id], onDelete: SetNull)
+  users                 User[]
+  secondaryUsers        UserSecondaryRank[]
+  promotionRulesFrom    RankPromotionRule[] @relation("RankPromotionFrom")
+  promotionRulesTo      RankPromotionRule[] @relation("RankPromotionTo")
 
   @@unique([level])
   @@unique([name])

--- a/src/authorStylesheet.spec.ts
+++ b/src/authorStylesheet.spec.ts
@@ -3,13 +3,14 @@ import {
   request,
   app,
   resetApiTestState,
-  prismaMock
+  prismaMock,
+  makeUserRank
 } from './test/apiTestHarness';
 
 beforeEach(() => resetApiTestState());
 
-// The default authed user is id 7 (see apiTestHarness). authorId 5 ≠ 7 → a
-// cross-user (non-self) adoption.
+// The default authed user is id 7 (see apiTestHarness), on userRankId 1.
+// authorId 5 ≠ 7 → a cross-user (non-self) adoption.
 const mockSheet = {
   id: 1,
   authorId: 5,
@@ -51,28 +52,77 @@ describe('POST /api/stylesheet/author', () => {
       .send({ name: 'Midnight' });
     expect(res.status).toBe(400);
   });
+
+  it('allows creation when authorStylesheetLimit is 0 (unlimited, default)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank() as never); // authorStylesheetLimit: 0
+    prismaMock.authorStylesheet.create.mockResolvedValue(mockSheet as never);
+
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'Midnight', source: 'body { background: #000; }' });
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.authorStylesheet.count).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation at the rank-configured limit (400) — registry spaces (#146)', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue({
+      ...makeUserRank(),
+      authorStylesheetLimit: 1
+    } as never);
+    prismaMock.authorStylesheet.count.mockResolvedValue(1);
+
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'Second Sheet', source: 'body { color: red; }' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.msg).toMatch(/Author stylesheet limit reached/);
+    expect(prismaMock.authorStylesheet.create).not.toHaveBeenCalled();
+  });
+
+  it('allows creation below the rank-configured limit', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue({
+      ...makeUserRank(),
+      authorStylesheetLimit: 2
+    } as never);
+    prismaMock.authorStylesheet.count.mockResolvedValue(1);
+    prismaMock.authorStylesheet.create.mockResolvedValue(mockSheet as never);
+
+    const res = await request(app)
+      .post('/api/stylesheet/author')
+      .send({ name: 'Second Sheet', source: 'body { color: red; }' });
+
+    expect(res.status).toBe(201);
+  });
 });
 
 // ─── GET /api/stylesheet/author/:userId ───────────────────────────────────────
 
 describe('GET /api/stylesheet/author/:userId', () => {
-  it("lists an author's stylesheets", async () => {
+  it("lists an author's stylesheets, paginated (#146)", async () => {
     prismaMock.authorStylesheet.findMany.mockResolvedValue([
       mockSheet
     ] as never);
+    prismaMock.authorStylesheet.count.mockResolvedValue(1);
 
     const res = await request(app).get('/api/stylesheet/author/5');
 
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body).toHaveLength(1);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.meta.total).toBe(1);
     expect(prismaMock.authorStylesheet.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { authorId: 5 } })
     );
+    expect(prismaMock.authorStylesheet.count).toHaveBeenCalledWith({
+      where: { authorId: 5 }
+    });
   });
 
   it('lists metadata only — source never rides a list payload (ADR-0024 §1)', async () => {
     prismaMock.authorStylesheet.findMany.mockResolvedValue([] as never);
+    prismaMock.authorStylesheet.count.mockResolvedValue(0);
     await request(app).get('/api/stylesheet/author/5');
     const call = prismaMock.authorStylesheet.findMany.mock.calls[0][0] as {
       select: Record<string, boolean>;
@@ -87,11 +137,33 @@ describe('GET /api/stylesheet/author/:userId', () => {
     expect(call.select.source).toBeUndefined();
   });
 
+  it('respects page/limit query params (skip/take passed to findMany)', async () => {
+    prismaMock.authorStylesheet.findMany.mockResolvedValue([] as never);
+    prismaMock.authorStylesheet.count.mockResolvedValue(45);
+
+    const res = await request(app).get(
+      '/api/stylesheet/author/5?page=2&limit=10'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.meta).toEqual({
+      total: 45,
+      page: 2,
+      limit: 10,
+      totalPages: 5
+    });
+    expect(prismaMock.authorStylesheet.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 10, take: 10 })
+    );
+  });
+
   it('returns an empty list for an author with no stylesheets', async () => {
     prismaMock.authorStylesheet.findMany.mockResolvedValue([] as never);
+    prismaMock.authorStylesheet.count.mockResolvedValue(0);
     const res = await request(app).get('/api/stylesheet/author/999');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([]);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.total).toBe(0);
   });
 
   it('rejects a non-numeric userId (400)', async () => {

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -212,7 +212,8 @@ describe('API auth/profile/user flows', () => {
         color: '',
         badge: '',
         permissions: {},
-        personalCollageLimit: 0
+        personalCollageLimit: 0,
+        authorStylesheetLimit: 0
       },
       secondaryRanks: []
     };

--- a/src/integration/authorStylesheet.integration.ts
+++ b/src/integration/authorStylesheet.integration.ts
@@ -9,6 +9,14 @@ import { getReputation } from '../modules/reputation';
 import { updateProfile } from '../modules/profile';
 import { AppError } from '../lib/errors';
 
+// Route-level pagination defaults (lib/pagination.ts); the module takes the
+// already-derived PageParams, so integration calls build them directly.
+const page = (p = 1, limit = 25) => ({
+  page: p,
+  limit,
+  skip: (p - 1) * limit
+});
+
 beforeEach(async () => {
   await truncateAll();
   await seedDefaults();
@@ -45,18 +53,70 @@ const activeSlotOf = async (userId: number): Promise<number | null> => {
   return user.userSettings.activeAuthorStylesheetId;
 };
 
-describe('AuthorStylesheet save → list (PRD-03 #118, many per author)', () => {
+describe('AuthorStylesheet save → list (PRD-03 #118/#146, many per author)', () => {
   it('an author can save several stylesheets and list them all', async () => {
     const author = await createUser();
-    await createAuthorStylesheet(author.id, { name: 'First', source: 'a {}' });
-    await createAuthorStylesheet(author.id, { name: 'Second', source: 'b {}' });
+    await createAuthorStylesheet(author.id, author.userRankId, {
+      name: 'First',
+      source: 'a {}'
+    });
+    await createAuthorStylesheet(author.id, author.userRankId, {
+      name: 'Second',
+      source: 'b {}'
+    });
 
-    const all = await listAuthorStylesheets(author.id);
+    const [all, total] = await listAuthorStylesheets(author.id, page());
     expect(all).toHaveLength(2);
+    expect(total).toBe(2);
     expect(all.map((s) => s.name)).toEqual(['First', 'Second']);
     // ADR-0024 §1 — a list payload carries metadata only; source stays behind
     // the per-id /css delivery route, never a JSON list.
     expect(all[0]).not.toHaveProperty('source');
+  });
+
+  it('pages through the list with a stable total (#146)', async () => {
+    const author = await createUser();
+    for (const name of ['One', 'Two', 'Three']) {
+      await createAuthorStylesheet(author.id, author.userRankId, {
+        name,
+        source: 'a {}'
+      });
+    }
+
+    const [firstPage, total1] = await listAuthorStylesheets(
+      author.id,
+      page(1, 2)
+    );
+    const [secondPage, total2] = await listAuthorStylesheets(
+      author.id,
+      page(2, 2)
+    );
+    expect(firstPage.map((s) => s.name)).toEqual(['One', 'Two']);
+    expect(secondPage.map((s) => s.name)).toEqual(['Three']);
+    expect(total1).toBe(3);
+    expect(total2).toBe(3);
+  });
+
+  it('rejects creation past the rank-configured registry-space limit (#146)', async () => {
+    const author = await createUser();
+    await testPrisma.userRank.update({
+      where: { id: author.userRankId },
+      data: { authorStylesheetLimit: 1 }
+    });
+
+    await createAuthorStylesheet(author.id, author.userRankId, {
+      name: 'Allowed',
+      source: 'a {}'
+    });
+    await expect(
+      createAuthorStylesheet(author.id, author.userRankId, {
+        name: 'One too many',
+        source: 'b {}'
+      })
+    ).rejects.toMatchObject({ statusCode: 400 });
+
+    const [, total] = await listAuthorStylesheets(author.id, page());
+    expect(total).toBe(1);
   });
 });
 
@@ -65,7 +125,7 @@ describe('AuthorStylesheet CSS delivery (ADR-0024 §1)', () => {
     const author = await createUser();
     // Raw source with an exfiltration vector; store-time cssSanitize neutralizes
     // it, and the /css read hands back the already-safe stored artifact.
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Anorex',
       source: "@import url('http://evil.example/x.css'); body { color: #0f0; }"
     });
@@ -86,7 +146,7 @@ describe('Site Stylesheet radio — Personal ⟷ Registry mutual exclusion (ADR-
   it('selecting Registry (pointer) clears a previously-set Personal URL', async () => {
     const author = await createUser();
     const member = await createUser();
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Reg',
       source: 'a {}'
     });
@@ -109,7 +169,7 @@ describe('Site Stylesheet radio — Personal ⟷ Registry mutual exclusion (ADR-
   it('selecting Personal (URL) clears a previously-set Registry pointer', async () => {
     const author = await createUser();
     const member = await createUser();
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Reg',
       source: 'a {}'
     });
@@ -134,7 +194,7 @@ describe('Site Stylesheet radio — Personal ⟷ Registry mutual exclusion (ADR-
   it('rejects setting both sources in one write (400)', async () => {
     const author = await createUser();
     const member = await createUser();
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Reg',
       source: 'a {}'
     });
@@ -159,7 +219,7 @@ describe('AuthorStylesheet adopt → score (PRD-03 #119/#120)', () => {
   it('adopt points the adopter Site slot at the sheet and credits the author', async () => {
     const author = await createUser();
     const adopter = await createUser();
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Midnight',
       source: 'body { background: #000; }'
     });
@@ -194,11 +254,11 @@ describe('AuthorStylesheet adopt → score (PRD-03 #119/#120)', () => {
   it('re-adopting the same author is idempotent — no second ledger row', async () => {
     const author = await createUser();
     const adopter = await createUser();
-    const sheetA = await createAuthorStylesheet(author.id, {
+    const sheetA = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'A',
       source: 'a {}'
     });
-    const sheetB = await createAuthorStylesheet(author.id, {
+    const sheetB = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'B',
       source: 'b {}'
     });
@@ -219,7 +279,7 @@ describe('AuthorStylesheet adopt → score (PRD-03 #119/#120)', () => {
   it('concurrent double-adopt credits the author exactly once (F1: partial unique index)', async () => {
     const author = await createUser();
     const adopter = await createUser();
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Race',
       source: 'r {}'
     });
@@ -243,7 +303,7 @@ describe('AuthorStylesheet adopt → score (PRD-03 #119/#120)', () => {
 
   it('self-adoption renders the sheet but credits nothing (anti-farm)', async () => {
     const author = await createUser();
-    const sheet = await createAuthorStylesheet(author.id, {
+    const sheet = await createAuthorStylesheet(author.id, author.userRankId, {
       name: 'Mine',
       source: 'c {}'
     });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -184,7 +184,8 @@ const AuthUser = registry.register(
       color: z.string(),
       badge: z.string().optional(),
       permissions: z.record(z.string(), z.boolean()).optional(),
-      personalCollageLimit: z.number().int().optional()
+      personalCollageLimit: z.number().int().optional(),
+      authorStylesheetLimit: z.number().int().optional()
     })
   })
 );
@@ -1475,6 +1476,19 @@ const AuthorStylesheet = registry.register(
   })
 );
 
+// The list projection (#146) never carries `source` (ADR-0024 §1) — the full
+// body is fetched only via the single-sheet read / `/css` delivery route.
+const AuthorStylesheetListItem = registry.register(
+  'AuthorStylesheetListItem',
+  z.object({
+    id: z.number(),
+    authorId: z.number(),
+    name: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+);
+
 // Result of adopting an author stylesheet into the Site Stylesheet slot (#119):
 // the adopted sheet plus whether this adoption recorded a new CRS event (#120).
 const AdoptionResult = registry.register(
@@ -1735,11 +1749,24 @@ registry.registerPath({
   method: 'get',
   path: '/stylesheet/author/{userId}',
   tags: ['Stylesheets'],
-  request: { params: z.object({ userId: z.string() }) },
+  request: {
+    params: z.object({ userId: z.string() }),
+    query: z.object({
+      page: z.coerce.number().int().positive().optional(),
+      limit: z.coerce.number().int().positive().optional()
+    })
+  },
   responses: {
     200: {
-      description: "An author's stylesheets",
-      content: { 'application/json': { schema: z.array(AuthorStylesheet) } }
+      description: "An author's stylesheets, paginated (#146)",
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(AuthorStylesheetListItem),
+            meta: PaginationMeta
+          })
+        }
+      }
     }
   }
 });
@@ -3023,6 +3050,7 @@ const UserRank = registry.register(
     color: z.string().optional(),
     badge: z.string().optional(),
     personalCollageLimit: z.number().int().optional(),
+    authorStylesheetLimit: z.number().int().optional(),
     displayStaff: z.boolean().optional(),
     staffGroupId: z.number().int().nullable().optional(),
     userCount: z.number().optional()

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -34,7 +34,8 @@ export const authUserSelect = {
       color: true,
       badge: true,
       permissions: true,
-      personalCollageLimit: true
+      personalCollageLimit: true,
+      authorStylesheetLimit: true
     }
   },
   secondaryRanks: {
@@ -46,7 +47,8 @@ export const authUserSelect = {
           level: true,
           permissions: true,
           permittedForumIds: true,
-          personalCollageLimit: true
+          personalCollageLimit: true,
+          authorStylesheetLimit: true
         }
       }
     }
@@ -86,6 +88,12 @@ export const toAuthUser = (raw: RawAuthUser): AuthUser => ({
       raw.userRank.personalCollageLimit ?? 0,
       ...raw.secondaryRanks.map(
         (entry) => entry.userRank.personalCollageLimit ?? 0
+      )
+    ),
+    authorStylesheetLimit: Math.max(
+      raw.userRank.authorStylesheetLimit ?? 0,
+      ...raw.secondaryRanks.map(
+        (entry) => entry.userRank.authorStylesheetLimit ?? 0
       )
     )
   },

--- a/src/modules/authorStylesheet.ts
+++ b/src/modules/authorStylesheet.ts
@@ -2,15 +2,15 @@
  * AuthorStylesheet — user-authored stylesheets saved for others to adopt
  * (PRD-03, descent target #4).
  *
- * A member may author MANY stylesheets (cardinality fixed in #119; the
- * rank-gated count limit is deferred). Adoption is the keystone the shipped
- * `scoreStylesheetSelection` (#84) hooks onto:
+ * A member may author MANY stylesheets (cardinality fixed in #119). Adoption
+ * is the keystone the shipped `scoreStylesheetSelection` (#84) hooks onto:
  *   - #118 save:  create / list / read an author's sheets.
  *   - #119 adopt: a viewer points their Site Stylesheet slot
  *     (`UserSettings.activeAuthorStylesheetId`) at a chosen sheet, idempotently.
  *   - #120 score: a non-self adoption records the durable (adopter, author) pair
  *     once in the `CRS_*` event ledger (ADR-0007); the author's read-time
  *     stylesheet CRS dimension counts those pairs.
+ *   - #146 list pagination + rank-gated count limit (registry spaces, PRD-03).
  */
 import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
@@ -18,42 +18,72 @@ import { AppError } from '../lib/errors';
 import { sanitizeStylesheetSource } from '../lib/cssSanitize';
 import { scoreStylesheetSelection } from './stylesheetScore';
 import type { AuthorStylesheetInput } from '../schemas/stylesheet';
+import type { PageParams } from '../lib/pagination';
 
 /**
- * Create a new AuthorStylesheet for the calling author (many per author).
+ * Create a new AuthorStylesheet for the calling author (many per author),
+ * gated by the author's rank-configured registry-space count (#146,
+ * `UserRank.authorStylesheetLimit`, mirroring `personalCollageLimit`'s
+ * 0-means-unlimited shape). `userRankId` is the caller's primary rank —
+ * passed in rather than re-derived here, same scope as the collage-limit
+ * precedent (secondary ranks are not consulted).
  *
  * `source` is sanitized at store-time (ADR-0003): the injected artifact is kept
  * safe in the database, not just at render. See `lib/cssSanitize.ts`.
  */
-export const createAuthorStylesheet = (
+export const createAuthorStylesheet = async (
   authorId: number,
+  userRankId: number,
   input: AuthorStylesheetInput
-) =>
-  prisma.authorStylesheet.create({
+) => {
+  const rank = await prisma.userRank.findUnique({
+    where: { id: userRankId },
+    select: { authorStylesheetLimit: true }
+  });
+  if (rank && rank.authorStylesheetLimit > 0) {
+    const count = await prisma.authorStylesheet.count({
+      where: { authorId }
+    });
+    if (count >= rank.authorStylesheetLimit) {
+      throw new AppError(
+        400,
+        `Author stylesheet limit reached (${rank.authorStylesheetLimit})`
+      );
+    }
+  }
+
+  return prisma.authorStylesheet.create({
     data: {
       authorId,
       name: input.name,
       source: sanitizeStylesheetSource(input.source)
     }
   });
+};
 
 /**
- * List an author's stylesheets, oldest first — **metadata only** (ADR-0024 §1).
- * `source` never rides a list payload; it is delivered as `text/css` through the
- * per-id `/css` route so there is exactly one path a stored sheet leaves by.
+ * List an author's stylesheets, oldest first, paginated (#146) — **metadata
+ * only** (ADR-0024 §1). `source` never rides a list payload; it is delivered
+ * as `text/css` through the per-id `/css` route so there is exactly one path
+ * a stored sheet leaves by.
  */
-export const listAuthorStylesheets = (authorId: number) =>
-  prisma.authorStylesheet.findMany({
-    where: { authorId },
-    orderBy: { createdAt: 'asc' },
-    select: {
-      id: true,
-      authorId: true,
-      name: true,
-      createdAt: true,
-      updatedAt: true
-    }
-  });
+export const listAuthorStylesheets = (authorId: number, pg: PageParams) =>
+  Promise.all([
+    prisma.authorStylesheet.findMany({
+      where: { authorId },
+      orderBy: { createdAt: 'asc' },
+      skip: pg.skip,
+      take: pg.limit,
+      select: {
+        id: true,
+        authorId: true,
+        name: true,
+        createdAt: true,
+        updatedAt: true
+      }
+    }),
+    prisma.authorStylesheet.count({ where: { authorId } })
+  ]);
 
 /**
  * Read a single AuthorStylesheet by its id, or null if it does not exist.

--- a/src/routes/api/stylesheet.ts
+++ b/src/routes/api/stylesheet.ts
@@ -6,9 +6,15 @@ import { requireStrictAdmin } from '../../middleware/permissions';
 import {
   validate,
   validateParams,
+  validateQuery,
   parsedBody,
   parsedParams
 } from '../../middleware/validate';
+import {
+  parsedPage,
+  paginatedResponse,
+  paginationBase
+} from '../../lib/pagination';
 import {
   stylesheetSchema,
   stylesheetUpdateSchema,
@@ -39,29 +45,38 @@ const stylesheetIdParamsSchema = z.object({
 const authorIdParamsSchema = z.object({
   userId: z.coerce.number().int().positive()
 });
+const listAuthorStylesheetsQuerySchema = z.object({ ...paginationBase });
 
-// ─── AuthorStylesheet (PRD-03 #118/#119/#120) — registered before /:id ────────
+// ─── AuthorStylesheet (PRD-03 #118/#119/#120/#146) — registered before /:id ───
 
-// POST /api/stylesheet/author — author a new stylesheet (many per author).
+// POST /api/stylesheet/author — author a new stylesheet (many per author,
+// rank-gated by UserRank.authorStylesheetLimit — #146).
 router.post(
   '/author',
   requireAuth,
   validate(authorStylesheetSchema),
   authHandler(async (req, res) => {
     const data = parsedBody<AuthorStylesheetInput>(res);
-    const sheet = await createAuthorStylesheet(req.user.id, data);
+    const sheet = await createAuthorStylesheet(
+      req.user.id,
+      req.user.userRankId,
+      data
+    );
     res.status(201).json(sheet);
   })
 );
 
-// GET /api/stylesheet/author/:userId — list an author's stylesheets.
+// GET /api/stylesheet/author/:userId — list an author's stylesheets, paginated (#146).
 router.get(
   '/author/:userId',
   requireAuth,
   validateParams(authorIdParamsSchema),
+  validateQuery(listAuthorStylesheetsQuerySchema),
   authHandler(async (_req, res) => {
     const { userId } = parsedParams<{ userId: number }>(res);
-    res.json(await listAuthorStylesheets(userId));
+    const pg = parsedPage(res);
+    const [rows, total] = await listAuthorStylesheets(userId, pg);
+    paginatedResponse(res, rows, total, pg);
   })
 );
 

--- a/src/routes/api/tools.ts
+++ b/src/routes/api/tools.ts
@@ -87,6 +87,7 @@ const formatRank = (
   color: r.color,
   badge: r.badge,
   personalCollageLimit: r.personalCollageLimit,
+  authorStylesheetLimit: r.authorStylesheetLimit,
   displayStaff: r.displayStaff,
   staffGroupId: r.staffGroupId,
   primaryUserCount: r._count.users,
@@ -149,6 +150,7 @@ router.post(
       color,
       badge,
       personalCollageLimit,
+      authorStylesheetLimit,
       displayStaff,
       staffGroupId
     } = parsedBody<CreateRankInput>(res);
@@ -185,6 +187,7 @@ router.post(
           color: color ?? '',
           badge: badge ?? '',
           personalCollageLimit: personalCollageLimit ?? 0,
+          authorStylesheetLimit: authorStylesheetLimit ?? 0,
           displayStaff: displayStaff ?? false,
           staffGroupId: effectiveStaffGroupId
         },
@@ -237,6 +240,7 @@ router.put(
       color,
       badge,
       personalCollageLimit,
+      authorStylesheetLimit,
       displayStaff,
       staffGroupId
     } = parsedBody<UpdateRankInput>(res);
@@ -276,6 +280,9 @@ router.put(
           ...(color !== undefined && { color }),
           ...(badge !== undefined && { badge }),
           ...(personalCollageLimit !== undefined && { personalCollageLimit }),
+          ...(authorStylesheetLimit !== undefined && {
+            authorStylesheetLimit
+          }),
           ...(displayStaff !== undefined && { displayStaff }),
           ...(effectiveStaffGroupId !== undefined && {
             staffGroupId: effectiveStaffGroupId

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -19,6 +19,7 @@ export const createRankSchema = z.object({
   color: z.string().optional(),
   badge: z.string().optional(),
   personalCollageLimit: z.number().int().min(0).optional(),
+  authorStylesheetLimit: z.number().int().min(0).optional(),
   displayStaff: z.boolean().optional(),
   staffGroupId: z.number().int().positive().nullable().optional()
 });
@@ -33,6 +34,7 @@ export const updateRankSchema = z
     color: z.string().optional(),
     badge: z.string().optional(),
     personalCollageLimit: z.number().int().min(0).optional(),
+    authorStylesheetLimit: z.number().int().min(0).optional(),
     displayStaff: z.boolean().optional(),
     staffGroupId: z.number().int().positive().nullable().optional()
   })

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -51,6 +51,7 @@ export function makeUserRank(
     permittedForumIds: [],
     uploadRequired: 0,
     personalCollageLimit: 0,
+    authorStylesheetLimit: 0,
     displayStaff: false,
     staffGroupId: null
   };


### PR DESCRIPTION
Closes #146

PRD-03 follow-up deferred from the #118/#119/#120 keystone (surfaced in PR #145 review). Both halves of the same unbounded-surface decision land together: the rank limit bounds the data, the pagination bounds the response shape.

## What changed

### 1. Paginated list endpoint
`GET /api/stylesheet/author/:userId` now returns the standard paginated envelope (`{ data, meta }`) via the established `parsedPage` + `Promise.all([findMany, count])` + `paginatedResponse` pattern. The list projection stays **metadata-only** (ADR-0024 §1 — `source` never rides a list payload; the full body is served only by the single-sheet read and the `/css` delivery route, which already satisfied the issue's "omit source from the list" consideration).

### 2. Rank-gated stylesheet count limit (registry spaces)
New `UserRank.authorStylesheetLimit` column, mirroring `personalCollageLimit`'s shape: `0` = unlimited (default), `> 0` = cap. Enforcement lives in the module (`createAuthorStylesheet`) per the business-logic-in-modules pattern — `AppError(400, 'Author stylesheet limit reached (N)')` → `{ msg }` envelope. The limit is:

- editable via the rank-tools CRUD (`POST`/`PUT /api/tools/user-ranks`), exposed on `formatRank`
- surfaced on `AuthUser.userRank` (max across primary + secondary ranks, same resolution as the collage limit)
- checked against the caller's primary rank at create time, same scope as the collage-limit precedent

Seeded ranks keep the default `0` (unlimited) — tuning per-rank registry spaces is a product knob, deliberately not pre-filled here.

## Tests

- `src/authorStylesheet.spec.ts`: paginated envelope + `meta` math, `skip`/`take` derived from `?page=&limit=`, metadata-only projection, at-limit create rejected 400 with `{ msg }`, below-limit allowed, limit-0 short-circuits (no count query)
- `src/integration/authorStylesheet.integration.ts`: page-through with stable total, at-limit rejection against a real rank row (integration suite requires `.env.test`; not run here)
- Full unit suite green locally: 94 suites, 1750 tests

## Human verification needed

- **Migration**: `prisma/migrations/20260703000000_add_author_stylesheet_limit/migration.sql` was hand-authored (no local DB/TTY in this environment) following the `add_personal_collage_limits` convention. Please verify with `prisma migrate dev` against a real database.
- `docs/erd.md` is `tableOnly` — the new column produces byte-identical output, so no ERD regen is needed.
- `openapi.json` regenerated and committed (new `AuthorStylesheetListItem` schema, paginated 200 for the list path, `authorStylesheetLimit` on `UserRank`/`AuthUser`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtdEr5SpKvpsbi4shjAYAx