### PR TITLE
fix(display): donor sign + warning sign follow the user site-wide via shared AuthorRef

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -79,6 +79,56 @@
           "totalPages"
         ]
       },
+      "AuthorRef": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "isDonor": {
+            "type": "boolean"
+          },
+          "donorRank": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "badge": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "badge",
+              "color"
+            ]
+          },
+          "warned": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "avatar",
+          "isDonor",
+          "donorRank",
+          "warned"
+        ]
+      },
       "LoginBody": {
         "type": "object",
         "properties": {
@@ -2252,26 +2302,11 @@
             "type": "number"
           },
           "author": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              },
-              "username": {
-                "type": "string"
-              },
-              "avatar": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "required": [
-              "id",
-              "username"
-            ]
+            "$ref": "#/components/schemas/AuthorRef"
           },
           "lastPost": {
             "type": "object",
+            "nullable": true,
             "properties": {
               "id": {
                 "type": "number"
@@ -2280,19 +2315,7 @@
                 "type": "string"
               },
               "author": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "number"
-                  },
-                  "username": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "id",
-                  "username"
-                ]
+                "$ref": "#/components/schemas/AuthorRef"
               }
             },
             "required": [
@@ -2418,23 +2441,7 @@
             "$ref": "#/components/schemas/ForumPostLastEdit"
           },
           "author": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              },
-              "username": {
-                "type": "string"
-              },
-              "avatar": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "required": [
-              "id",
-              "username"
-            ]
+            "$ref": "#/components/schemas/AuthorRef"
           },
           "createdAt": {
             "type": "string"
@@ -3716,23 +3723,7 @@
             "type": "string"
           },
           "author": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              },
-              "username": {
-                "type": "string"
-              },
-              "avatar": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "required": [
-              "id",
-              "username"
-            ]
+            "$ref": "#/components/schemas/AuthorRef"
           }
         },
         "required": [
@@ -4071,23 +4062,7 @@
             "type": "string"
           },
           "user": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              },
-              "username": {
-                "type": "string"
-              },
-              "avatar": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "required": [
-              "id",
-              "username"
-            ]
+            "$ref": "#/components/schemas/AuthorRef"
           }
         },
         "required": [
@@ -4132,23 +4107,7 @@
             "type": "string"
           },
           "user": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              },
-              "username": {
-                "type": "string"
-              },
-              "avatar": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "required": [
-              "id",
-              "username"
-            ]
+            "$ref": "#/components/schemas/AuthorRef"
           }
         },
         "required": [
@@ -4208,25 +4167,6 @@
           "updatedAt"
         ]
       },
-      "MessageUser": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "number"
-          },
-          "username": {
-            "type": "string"
-          },
-          "avatar": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "id",
-          "username"
-        ]
-      },
       "PrivateMessage": {
         "type": "object",
         "properties": {
@@ -4245,7 +4185,7 @@
           "sender": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/MessageUser"
+                "$ref": "#/components/schemas/AuthorRef"
               },
               {
                 "nullable": true
@@ -4290,7 +4230,7 @@
             "nullable": true
           },
           "user": {
-            "$ref": "#/components/schemas/MessageUser"
+            "$ref": "#/components/schemas/AuthorRef"
           }
         },
         "required": [
@@ -4390,12 +4330,12 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/MessageUser"
+            "$ref": "#/components/schemas/AuthorRef"
           },
           "assignedUser": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/MessageUser"
+                "$ref": "#/components/schemas/AuthorRef"
               },
               {
                 "nullable": true
@@ -4405,7 +4345,7 @@
           "resolver": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/MessageUser"
+                "$ref": "#/components/schemas/AuthorRef"
               },
               {
                 "nullable": true
@@ -4429,7 +4369,7 @@
                 "sender": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/MessageUser"
+                      "$ref": "#/components/schemas/AuthorRef"
                     },
                     {
                       "nullable": true

--- a/src/comments.spec.ts
+++ b/src/comments.spec.ts
@@ -5,7 +5,11 @@ import {
   prismaMock,
   makeUserRank
 } from './test/apiTestHarness';
-import { makeComment, makeCommentWithAuthor } from './test/factories';
+import {
+  makeAuthorRefRow,
+  makeComment,
+  makeCommentWithAuthor
+} from './test/factories';
 
 jest.mock('./modules/comment', () => ({
   deleteComment: jest.fn()
@@ -31,6 +35,37 @@ describe('GET /api/comments', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.meta.total).toBe(1);
+  });
+
+  // #231 — comment authors must carry the donor sign + warning sign so the
+  // PostBox renders them anywhere comments appear, not just on the profile.
+  it('returns authors as AuthorRef with donor and warning signs', async () => {
+    prismaMock.comment.findMany.mockResolvedValue([
+      makeCommentWithAuthor({
+        id: 12,
+        author: makeAuthorRefRow({
+          isDonor: true,
+          warned: new Date('2026-03-01T00:00:00.000Z'),
+          donorRank: {
+            expiresAt: null,
+            donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' }
+          }
+        })
+      })
+    ] as never);
+    prismaMock.comment.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/comments');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].author).toEqual({
+      id: 7,
+      username: 'testuser',
+      avatar: null,
+      isDonor: true,
+      donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' },
+      warned: '2026-03-01T00:00:00.000Z'
+    });
   });
 
   it('filters by communities page and pageId', async () => {

--- a/src/content.spec.ts
+++ b/src/content.spec.ts
@@ -8,7 +8,9 @@ import {
   recordContributionReportMock,
   resetApiTestState
 } from './test/apiTestHarness';
+import { authorRefSelect } from './modules/authorRef';
 import {
+  makeAuthorRefRow,
   makePost,
   makePostWithIncludes,
   makePostComment,
@@ -43,7 +45,7 @@ describe('API content and shared flows', () => {
         text: 'Some text',
         category: 'news',
         tags: ['launch'],
-        user: { id: 7, username: 'kai', avatar: null }
+        user: makeAuthorRefRow({ username: 'kai' })
       }) as unknown as ReturnType<typeof makePost>
     );
 
@@ -66,11 +68,11 @@ describe('API content and shared flows', () => {
         tags: ['launch']
       },
       include: {
-        user: { select: { id: true, username: true, avatar: true } },
+        user: { select: authorRefSelect },
         comments: {
           orderBy: { createdAt: 'asc' },
           include: {
-            user: { select: { id: true, username: true, avatar: true } }
+            user: { select: authorRefSelect }
           }
         }
       }
@@ -88,7 +90,7 @@ describe('API content and shared flows', () => {
         postId: 14,
         userId: 7,
         text: 'Nice post',
-        user: { id: 7, username: 'kai', avatar: null }
+        user: makeAuthorRefRow({ username: 'kai' })
       }) as unknown as ReturnType<typeof makePostComment>
     );
 
@@ -99,7 +101,7 @@ describe('API content and shared flows', () => {
     expect(res.status).toBe(201);
     expect(prismaMock.postComment.create).toHaveBeenCalledWith({
       data: { postId: 14, userId: 7, text: 'Nice post' },
-      include: { user: { select: { id: true, username: true, avatar: true } } }
+      include: { user: { select: authorRefSelect } }
     });
     expect(res.body.text).toBe('Nice post');
   });
@@ -428,7 +430,7 @@ describe('API content and shared flows', () => {
         body: 'hello',
         communityId: 3,
         authorId: 7,
-        author: { id: 7, username: 'kai', avatar: null }
+        author: makeAuthorRefRow({ username: 'kai' })
       }) as unknown as ReturnType<typeof makeComment>
     );
 
@@ -447,7 +449,7 @@ describe('API content and shared flows', () => {
         communityId: 3
       },
       include: {
-        author: { select: { id: true, username: true, avatar: true } }
+        author: { select: authorRefSelect }
       }
     });
     expect(res.body.communityId).toBe(3);

--- a/src/forum.spec.ts
+++ b/src/forum.spec.ts
@@ -15,6 +15,7 @@ import {
   resetApiTestState
 } from './test/apiTestHarness';
 import {
+  makeAuthorRefRow,
   makeForum,
   makeForumTopic,
   makeForumPost,
@@ -553,6 +554,52 @@ describe('GET /api/forums/:forumId/topics', () => {
     expect(res.body.meta.total).toBe(1);
   });
 
+  // #231 — topic and last-post authors carry the donor sign + warning sign.
+  it('returns topic and lastPost authors as AuthorRef with the signs', async () => {
+    prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
+    prismaMock.forumTopic.findMany.mockResolvedValue([
+      {
+        ...makeForumTopic({ id: 44, title: 'Topic A' }),
+        author: makeAuthorRefRow({
+          isDonor: true,
+          donorRank: {
+            expiresAt: null,
+            donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' }
+          }
+        }),
+        lastPost: {
+          id: 21,
+          createdAt: new Date(),
+          author: makeAuthorRefRow({
+            id: 9,
+            username: 'warneduser',
+            warned: new Date('2026-04-01T00:00:00.000Z')
+          })
+        }
+      } as never
+    ]);
+    prismaMock.forumTopic.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/forums/9/topics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].author).toEqual(
+      expect.objectContaining({
+        isDonor: true,
+        donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' },
+        warned: null
+      })
+    );
+    expect(res.body.data[0].lastPost.author).toEqual(
+      expect.objectContaining({
+        id: 9,
+        isDonor: false,
+        donorRank: null,
+        warned: '2026-04-01T00:00:00.000Z'
+      })
+    );
+  });
+
   it('returns 404 when forum does not exist', async () => {
     prismaMock.forum.findUnique.mockResolvedValue(null);
 
@@ -749,6 +796,38 @@ describe('GET /api/forums/:forumId/topics/:forumTopicId/posts', () => {
       editor: { id: 11, username: 'mod' }
     });
     expect(res.body.meta.total).toBe(1);
+  });
+
+  // #231 — post authors carry the donor sign + warning sign in the list read.
+  it('returns post authors as AuthorRef with the signs', async () => {
+    prismaMock.forum.findUnique.mockResolvedValue(makeForum({ id: 9 }));
+    prismaMock.forumPost.findMany.mockResolvedValue([
+      {
+        ...makeForumPost({ id: 21, body: 'Post body' }),
+        author: makeAuthorRefRow({
+          isDonor: true,
+          warned: new Date('2026-05-01T00:00:00.000Z'),
+          donorRank: {
+            expiresAt: null,
+            donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' }
+          }
+        }),
+        edits: []
+      } as never
+    ]);
+    prismaMock.forumPost.count.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/forums/9/topics/44/posts');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].author).toEqual({
+      id: 7,
+      username: 'testuser',
+      avatar: null,
+      isDonor: true,
+      donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' },
+      warned: '2026-05-01T00:00:00.000Z'
+    });
   });
 
   it('returns 404 when forum does not exist', async () => {

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -118,6 +118,30 @@ const PaginationMeta = registry.register(
 
 const StaffUserRef = z.object({ id: z.number(), username: z.string() });
 
+// #231 — the shared author identity for every PostBox-rendering surface (forum
+// posts/topics, comments, blog-post comments, PMs, staff inbox). Carries the
+// donor sign + warning sign so they follow the user site-wide, mirroring the
+// fields the profile shapes already expose. `donorRank` is null when no active
+// (unexpired) grant exists; `warned` is the ISO timestamp of the active warning
+// or null. Backed by src/modules/authorRef.ts.
+const AuthorRef = registry.register(
+  'AuthorRef',
+  z.object({
+    id: z.number(),
+    username: z.string(),
+    avatar: z.string().nullable(),
+    isDonor: z.boolean(),
+    donorRank: z
+      .object({
+        name: z.string(),
+        badge: z.string(),
+        color: z.string()
+      })
+      .nullable(),
+    warned: z.string().nullable()
+  })
+);
+
 // ─── Auth ─────────────────────────────────────────────────────────────────────
 
 const LoginBody = registry.register(
@@ -2002,24 +2026,14 @@ const ForumTopic = registry.register(
     isLocked: z.boolean(),
     isSticky: z.boolean(),
     numPosts: z.number(),
-    author: z
-      .object({
-        id: z.number(),
-        username: z.string(),
-        avatar: z.string().nullable().optional()
-      })
-      .optional(),
+    author: AuthorRef.optional(),
     lastPost: z
       .object({
         id: z.number(),
         createdAt: z.string(),
-        author: z
-          .object({
-            id: z.number(),
-            username: z.string()
-          })
-          .optional()
+        author: AuthorRef.optional()
       })
+      .nullable()
       .optional(),
     createdAt: z.string(),
     updatedAt: z.string()
@@ -2057,13 +2071,7 @@ const ForumPost = registry.register(
     authorId: z.number(),
     body: z.string(),
     lastEdit: ForumPostLastEdit.optional(),
-    author: z
-      .object({
-        id: z.number(),
-        username: z.string(),
-        avatar: z.string().nullable().optional()
-      })
-      .optional(),
+    author: AuthorRef.optional(),
     createdAt: z.string(),
     updatedAt: z.string()
   })
@@ -3567,13 +3575,7 @@ const Comment = registry.register(
     body: z.string(),
     authorId: z.number(),
     createdAt: z.string(),
-    author: z
-      .object({
-        id: z.number(),
-        username: z.string(),
-        avatar: z.string().nullable().optional()
-      })
-      .optional()
+    author: AuthorRef.optional()
   })
 );
 
@@ -4315,13 +4317,7 @@ const PostComment = registry.register(
     userId: z.number(),
     text: z.string(),
     createdAt: z.string(),
-    user: z
-      .object({
-        id: z.number(),
-        username: z.string(),
-        avatar: z.string().nullable().optional()
-      })
-      .optional()
+    user: AuthorRef.optional()
   })
 );
 
@@ -4336,13 +4332,7 @@ const Post = registry.register(
     tags: z.array(z.string()),
     comments: z.array(PostComment),
     createdAt: z.string(),
-    user: z
-      .object({
-        id: z.number(),
-        username: z.string(),
-        avatar: z.string().nullable().optional()
-      })
-      .optional()
+    user: AuthorRef.optional()
   })
 );
 
@@ -4606,14 +4596,9 @@ registry.registerPath({
 
 // ─── Private Messages ────────────────────────────────────────────────────────
 
-const MessageUser = registry.register(
-  'MessageUser',
-  z.object({
-    id: z.number(),
-    username: z.string(),
-    avatar: z.string().nullable().optional()
-  })
-);
+// PM senders/participants carry the full AuthorRef (#231) so donor/warning
+// signs render in conversations; the old thin MessageUser shape is retired.
+const MessageUser = AuthorRef;
 
 const PrivateMessage = registry.register(
   'PrivateMessage',

--- a/src/messages.spec.ts
+++ b/src/messages.spec.ts
@@ -24,7 +24,15 @@ const makeMessage = () => ({
   senderId: 7,
   body: 'Hey there',
   createdAt: new Date(),
-  sender: { id: 7, username: 'testuser', avatar: null }
+  // AuthorRef sender (#231) — donor/warning signs travel with PM senders.
+  sender: {
+    id: 7,
+    username: 'testuser',
+    avatar: null,
+    isDonor: false,
+    warned: null,
+    donorRank: null
+  }
 });
 
 describe('GET /api/messages', () => {

--- a/src/modules.spec.ts
+++ b/src/modules.spec.ts
@@ -700,7 +700,22 @@ describe('staffPm.listMyTickets', () => {
   it('returns paginated ticket list for a user', async () => {
     prismaMock.staffInboxConversation.count.mockResolvedValue(1);
     prismaMock.staffInboxConversation.findMany.mockResolvedValue([
-      { id: 1, userId: 7, status: 'Unanswered' }
+      {
+        id: 1,
+        userId: 7,
+        status: 'Unanswered',
+        user: {
+          id: 7,
+          username: 'testuser',
+          avatar: null,
+          isDonor: false,
+          warned: null,
+          donorRank: null
+        },
+        assignedUser: null,
+        resolver: null,
+        messages: []
+      }
     ] as never);
 
     const result = await listMyTickets(7, 1);
@@ -1119,6 +1134,16 @@ describe('staffPm.viewTicket', () => {
       id: 1,
       userId: 7,
       isReadByUser: false,
+      user: {
+        id: 7,
+        username: 'testuser',
+        avatar: null,
+        isDonor: false,
+        warned: null,
+        donorRank: null
+      },
+      assignedUser: null,
+      resolver: null,
       messages: []
     } as never);
     prismaMock.staffInboxConversation.update.mockResolvedValueOnce({} as never);

--- a/src/modules/authorRef.spec.ts
+++ b/src/modules/authorRef.spec.ts
@@ -1,0 +1,90 @@
+import { toAuthorRef, toAuthorRefOrNull, type AuthorRefRow } from './authorRef';
+
+const makeRow = (overrides: Partial<AuthorRefRow> = {}): AuthorRefRow => ({
+  id: 7,
+  username: 'testuser',
+  avatar: null,
+  isDonor: false,
+  warned: null,
+  donorRank: null,
+  ...overrides
+});
+
+describe('toAuthorRef', () => {
+  it('carries the donor sign and warning sign (#231)', () => {
+    const ref = toAuthorRef(
+      makeRow({
+        isDonor: true,
+        warned: new Date('2026-01-15T12:00:00.000Z'),
+        donorRank: {
+          expiresAt: null,
+          donorRank: { name: 'Patron', badge: 'patron.png', color: '#ffd700' }
+        }
+      })
+    );
+
+    expect(ref).toEqual({
+      id: 7,
+      username: 'testuser',
+      avatar: null,
+      isDonor: true,
+      donorRank: { name: 'Patron', badge: 'patron.png', color: '#ffd700' },
+      warned: '2026-01-15T12:00:00.000Z'
+    });
+  });
+
+  it('returns null flags for a plain user', () => {
+    const ref = toAuthorRef(makeRow());
+
+    expect(ref).toEqual({
+      id: 7,
+      username: 'testuser',
+      avatar: null,
+      isDonor: false,
+      donorRank: null,
+      warned: null
+    });
+  });
+
+  it('treats an expired donor grant as no rank (sweep-lag guard)', () => {
+    const ref = toAuthorRef(
+      makeRow({
+        isDonor: true,
+        donorRank: {
+          expiresAt: new Date(Date.now() - 60_000),
+          donorRank: { name: 'Patron', badge: 'patron.png', color: '#ffd700' }
+        }
+      })
+    );
+
+    expect(ref.donorRank).toBeNull();
+  });
+
+  it('keeps an unexpired dated grant active', () => {
+    const ref = toAuthorRef(
+      makeRow({
+        donorRank: {
+          expiresAt: new Date(Date.now() + 60_000),
+          donorRank: { name: 'Patron', badge: 'patron.png', color: '#ffd700' }
+        }
+      })
+    );
+
+    expect(ref.donorRank).toEqual({
+      name: 'Patron',
+      badge: 'patron.png',
+      color: '#ffd700'
+    });
+  });
+});
+
+describe('toAuthorRefOrNull', () => {
+  it('passes null and undefined through as null', () => {
+    expect(toAuthorRefOrNull(null)).toBeNull();
+    expect(toAuthorRefOrNull(undefined)).toBeNull();
+  });
+
+  it('maps a present row', () => {
+    expect(toAuthorRefOrNull(makeRow())?.username).toBe('testuser');
+  });
+});

--- a/src/modules/authorRef.ts
+++ b/src/modules/authorRef.ts
@@ -1,0 +1,60 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * The author identity every PostBox-rendering surface needs — forum
+ * posts/topics, comments, blog-post comments, PMs, staff inbox — so the donor
+ * sign and warning sign follow the user site-wide rather than only on the
+ * profile page (#231). Select via `authorRefSelect`; shape the raw row with
+ * `toAuthorRef` (or `toAuthorRefOrNull` for a nullable relation, e.g. a
+ * system PM with no sender) before sending it in a response.
+ */
+export const authorRefSelect = {
+  id: true,
+  username: true,
+  avatar: true,
+  isDonor: true,
+  warned: true,
+  donorRank: {
+    select: {
+      expiresAt: true,
+      donorRank: { select: { name: true, badge: true, color: true } }
+    }
+  }
+} satisfies Prisma.UserSelect;
+
+export type AuthorRefRow = Prisma.UserGetPayload<{
+  select: typeof authorRefSelect;
+}>;
+
+export type AuthorRef = {
+  id: number;
+  username: string;
+  avatar: string | null;
+  isDonor: boolean;
+  donorRank: { name: string; badge: string; color: string } | null;
+  warned: string | null;
+};
+
+// Mirrors the expiry rule in profile.ts's buildDonorPresentation: an expired
+// grant renders as no donor rank, even if the hourly sweep hasn't cleared
+// isDonor/donorRank yet.
+export const toAuthorRef = (user: AuthorRefRow): AuthorRef => {
+  const grant = user.donorRank;
+  const activeRank =
+    grant && (grant.expiresAt === null || grant.expiresAt > new Date())
+      ? grant.donorRank
+      : null;
+
+  return {
+    id: user.id,
+    username: user.username,
+    avatar: user.avatar,
+    isDonor: user.isDonor,
+    donorRank: activeRank,
+    warned: user.warned?.toISOString() ?? null
+  };
+};
+
+export const toAuthorRefOrNull = (
+  user: AuthorRefRow | null | undefined
+): AuthorRef | null => (user ? toAuthorRef(user) : null);

--- a/src/modules/pm.spec.ts
+++ b/src/modules/pm.spec.ts
@@ -74,6 +74,17 @@ const makeConversation = (overrides: Record<string, unknown> = {}) => ({
   ...overrides
 });
 
+// AuthorRef-shaped sender row as returned by authorRefSelect (#231).
+const makeSenderRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 7,
+  username: 'testuser',
+  avatar: null,
+  isDonor: false,
+  warned: null,
+  donorRank: null,
+  ...overrides
+});
+
 beforeEach(() => {
   mockTransaction.mockImplementation(
     (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)
@@ -181,7 +192,7 @@ describe('sendMessage', () => {
         { userId: 9, inInbox: true, inSentbox: false, isRead: false },
         { userId: 7, inInbox: false, inSentbox: true, isRead: true }
       ],
-      messages: [{ id: 10, body: 'Body' }]
+      messages: [{ id: 10, body: 'Body', sender: makeSenderRow() }]
     });
     prismaMock.user.findUnique.mockResolvedValue({
       id: 9,
@@ -192,7 +203,26 @@ describe('sendMessage', () => {
 
     const result = await sendMessage(7, 9, 'Subject', 'Body');
 
-    expect(result).toEqual({ ok: true, conversation: created });
+    expect(result).toEqual({
+      ok: true,
+      conversation: expect.objectContaining({
+        participants: created.participants,
+        messages: [
+          {
+            id: 10,
+            body: 'Body',
+            sender: {
+              id: 7,
+              username: 'testuser',
+              avatar: null,
+              isDonor: false,
+              donorRank: null,
+              warned: null
+            }
+          }
+        ]
+      })
+    });
     expect(mockTx.privateConversation.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -330,6 +360,67 @@ describe('viewConversation', () => {
     await expect(viewConversation(1, 7)).resolves.toEqual({
       ok: false,
       reason: 'not_found'
+    });
+  });
+
+  // #231 — every sender/participant in a conversation read must carry the
+  // donor sign + warning sign so PMs render them like the profile does.
+  it('carries donor and warning signs on message senders and participants', async () => {
+    const warnedAt = new Date('2026-02-01T00:00:00.000Z');
+    prismaMock.privateConversation.findUnique.mockResolvedValue(
+      makeConversation({
+        participants: [
+          {
+            userId: 7,
+            inInbox: true,
+            inSentbox: false,
+            isRead: true,
+            user: makeSenderRow()
+          },
+          {
+            userId: 9,
+            inInbox: false,
+            inSentbox: true,
+            isRead: true,
+            user: makeSenderRow({
+              id: 9,
+              username: 'donorwarned',
+              isDonor: true,
+              warned: warnedAt,
+              donorRank: {
+                expiresAt: null,
+                donorRank: { name: 'Patron', badge: 'p.png', color: '#fff' }
+              }
+            })
+          }
+        ],
+        messages: [
+          {
+            id: 11,
+            body: 'Hi',
+            sender: makeSenderRow({
+              id: 9,
+              username: 'donorwarned',
+              isDonor: true
+            })
+          }
+        ]
+      })
+    );
+
+    const result = await viewConversation(1, 7);
+
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.conversation.messages[0].sender).toEqual(
+      expect.objectContaining({ isDonor: true, warned: null, donorRank: null })
+    );
+    expect(result.conversation.participants[1].user).toEqual({
+      id: 9,
+      username: 'donorwarned',
+      avatar: null,
+      isDonor: true,
+      donorRank: { name: 'Patron', badge: 'p.png', color: '#fff' },
+      warned: '2026-02-01T00:00:00.000Z'
     });
   });
 

--- a/src/modules/pm.ts
+++ b/src/modules/pm.ts
@@ -1,12 +1,42 @@
 import { prisma } from '../lib/prisma';
+import {
+  authorRefSelect,
+  toAuthorRefOrNull,
+  type AuthorRefRow
+} from './authorRef';
 
 const PAGE_SIZE = 25;
 
-const senderSelect = {
-  id: true,
-  username: true,
-  avatar: true
-} as const;
+const senderSelect = authorRefSelect;
+
+// Shapes the sender/participant relations a PM conversation carries so the
+// donor sign + warning sign follow the sender everywhere a message renders
+// (#231), not just on their profile.
+const mapMessage = <T extends { sender: AuthorRefRow | null }>(message: T) => ({
+  ...message,
+  sender: toAuthorRefOrNull(message.sender)
+});
+
+type ParticipantRow = { user?: AuthorRefRow } & Record<string, unknown>;
+
+const mapConversation = <
+  T extends {
+    messages?: Array<{ sender: AuthorRefRow | null } & Record<string, unknown>>;
+    participants?: Array<ParticipantRow>;
+  }
+>(
+  conversation: T
+) => ({
+  ...conversation,
+  ...(conversation.messages && {
+    messages: conversation.messages.map(mapMessage)
+  }),
+  ...(conversation.participants && {
+    participants: conversation.participants.map((p) =>
+      'user' in p ? { ...p, user: toAuthorRefOrNull(p.user) } : p
+    )
+  })
+});
 
 export async function listInbox(userId: number, page: number, search?: string) {
   const where = {
@@ -44,7 +74,12 @@ export async function listInbox(userId: number, page: number, search?: string) {
     })
   ]);
 
-  return { total, page, pageSize: PAGE_SIZE, conversations };
+  return {
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    conversations: conversations.map(mapConversation)
+  };
 }
 
 export async function listSentbox(userId: number, page: number) {
@@ -73,7 +108,12 @@ export async function listSentbox(userId: number, page: number) {
     })
   ]);
 
-  return { total, page, pageSize: PAGE_SIZE, conversations };
+  return {
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    conversations: conversations.map(mapConversation)
+  };
 }
 
 export async function getUnreadCount(userId: number): Promise<number> {
@@ -136,7 +176,7 @@ export async function sendMessage(
     return conv;
   });
 
-  return { ok: true as const, conversation };
+  return { ok: true as const, conversation: mapConversation(conversation) };
 }
 
 /**
@@ -181,7 +221,7 @@ export async function sendSystemMessage(
     }
   });
 
-  return { ok: true as const, conversation };
+  return { ok: true as const, conversation: mapConversation(conversation) };
 }
 
 export async function replyToConversation(
@@ -229,7 +269,7 @@ export async function replyToConversation(
     return msg;
   });
 
-  return { ok: true as const, message };
+  return { ok: true as const, message: mapMessage(message) };
 }
 
 export async function viewConversation(conversationId: number, userId: number) {
@@ -259,7 +299,7 @@ export async function viewConversation(conversationId: number, userId: number) {
     });
   }
 
-  return { ok: true as const, conversation };
+  return { ok: true as const, conversation: mapConversation(conversation) };
 }
 
 export async function updateConversationFlags(

--- a/src/modules/staffPm.spec.ts
+++ b/src/modules/staffPm.spec.ts
@@ -55,6 +55,19 @@ const prismaMock = prisma as unknown as {
   user: { findUnique: jest.Mock };
 };
 
+// Minimal AuthorRef-shaped row (#231): a plain donor/warning-free user unless
+// a test overrides it, so mapTicket's transform is a no-op on the fields it
+// doesn't touch.
+const makeAuthorRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 7,
+  username: 'testuser',
+  avatar: null,
+  isDonor: false,
+  warned: null,
+  donorRank: null,
+  ...overrides
+});
+
 const makeTicket = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
   userId: 7,
@@ -63,6 +76,9 @@ const makeTicket = (overrides: Record<string, unknown> = {}) => ({
   isReadByUser: false,
   assignedUserId: null,
   resolverId: null,
+  user: makeAuthorRow(),
+  assignedUser: null,
+  resolver: null,
   messages: [],
   ...overrides
 });
@@ -76,7 +92,7 @@ beforeEach(() => {
 describe('createTicket', () => {
   it('creates an unanswered ticket with the initial message', async () => {
     const created = makeTicket({
-      messages: [{ id: 10, body: 'Please help', sender: { id: 7 } }]
+      messages: [{ id: 10, body: 'Please help', sender: makeAuthorRow() }]
     });
     prismaMock.staffInboxConversation.create.mockResolvedValue(created);
 
@@ -92,7 +108,45 @@ describe('createTicket', () => {
         })
       })
     );
-    expect(result).toBe(created);
+    expect(result).toEqual(created);
+  });
+
+  // #231 — the ticket owner and each message sender must carry isDonor/warned/
+  // donorRank so the donor sign + warning sign render in the staff inbox, not
+  // just on the profile page.
+  it('carries the donor sign and warning sign on the ticket owner and sender', async () => {
+    const created = makeTicket({
+      user: makeAuthorRow({
+        isDonor: true,
+        warned: new Date('2026-01-01T00:00:00.000Z'),
+        donorRank: {
+          expiresAt: null,
+          donorRank: { name: 'Patron', badge: 'patron.png', color: '#fff' }
+        }
+      }),
+      messages: [
+        {
+          id: 10,
+          body: 'Please help',
+          sender: makeAuthorRow({ isDonor: true })
+        }
+      ]
+    });
+    prismaMock.staffInboxConversation.create.mockResolvedValue(created);
+
+    const result = await createTicket(7, 'Need help', 'Please help');
+
+    expect(result.user).toEqual({
+      id: 7,
+      username: 'testuser',
+      avatar: null,
+      isDonor: true,
+      donorRank: { name: 'Patron', badge: 'patron.png', color: '#fff' },
+      warned: '2026-01-01T00:00:00.000Z'
+    });
+    expect(result.messages[0].sender).toEqual(
+      expect.objectContaining({ isDonor: true })
+    );
   });
 });
 

--- a/src/modules/staffPm.ts
+++ b/src/modules/staffPm.ts
@@ -1,13 +1,15 @@
 import { prisma } from '../lib/prisma';
 import type { StaffInboxStatus } from '@prisma/client';
+import {
+  authorRefSelect,
+  toAuthorRef,
+  toAuthorRefOrNull,
+  type AuthorRefRow
+} from './authorRef';
 
 const PAGE_SIZE = 25;
 
-const senderSelect = {
-  id: true,
-  username: true,
-  avatar: true
-} as const;
+const senderSelect = authorRefSelect;
 
 const ticketInclude = {
   user: { select: senderSelect },
@@ -15,12 +17,37 @@ const ticketInclude = {
   resolver: { select: senderSelect }
 } as const;
 
+// Shapes a ticket's user/assignedUser/resolver/message-sender relations so the
+// donor sign + warning sign follow staff and members alike in the inbox
+// (#231), not just on their profile.
+const mapTicketMessage = <T extends { sender: AuthorRefRow }>(message: T) => ({
+  ...message,
+  sender: toAuthorRef(message.sender)
+});
+
+const mapTicket = <
+  T extends {
+    user: AuthorRefRow;
+    assignedUser: AuthorRefRow | null;
+    resolver: AuthorRefRow | null;
+    messages?: Array<{ sender: AuthorRefRow } & Record<string, unknown>>;
+  }
+>(
+  ticket: T
+) => ({
+  ...ticket,
+  user: toAuthorRef(ticket.user),
+  assignedUser: toAuthorRefOrNull(ticket.assignedUser),
+  resolver: toAuthorRefOrNull(ticket.resolver),
+  ...(ticket.messages && { messages: ticket.messages.map(mapTicketMessage) })
+});
+
 export async function createTicket(
   userId: number,
   subject: string,
   body: string
 ) {
-  return prisma.staffInboxConversation.create({
+  const ticket = await prisma.staffInboxConversation.create({
     data: {
       subject,
       userId,
@@ -32,6 +59,7 @@ export async function createTicket(
       messages: { include: { sender: { select: senderSelect } } }
     }
   });
+  return mapTicket(ticket);
 }
 
 export async function listMyTickets(userId: number, page: number) {
@@ -53,7 +81,12 @@ export async function listMyTickets(userId: number, page: number) {
       }
     })
   ]);
-  return { total, page, pageSize: PAGE_SIZE, conversations };
+  return {
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    conversations: conversations.map(mapTicket)
+  };
 }
 
 export async function listQueue(opts: {
@@ -87,7 +120,12 @@ export async function listQueue(opts: {
       }
     })
   ]);
-  return { total, page, pageSize: PAGE_SIZE, conversations };
+  return {
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    conversations: conversations.map(mapTicket)
+  };
 }
 
 export async function getQueueCount(): Promise<number> {
@@ -120,7 +158,7 @@ export async function viewTicket(id: number, userId: number, isStaff: boolean) {
     });
   }
 
-  return { ok: true as const, ticket };
+  return { ok: true as const, ticket: mapTicket(ticket) };
 }
 
 export async function replyToTicket(
@@ -157,7 +195,7 @@ export async function replyToTicket(
     return msg;
   });
 
-  return { ok: true as const, message };
+  return { ok: true as const, message: mapTicketMessage(message) };
 }
 
 export async function resolveTicket(

--- a/src/modules/topicSession.ts
+++ b/src/modules/topicSession.ts
@@ -8,6 +8,7 @@ import {
   trashTopic as forumTrashTopic,
   castVote
 } from './forum';
+import { authorRefSelect, toAuthorRefOrNull } from './authorRef';
 import type { PageParams } from '../lib/pagination';
 
 // ─── Actor ───────────────────────────────────────────────────────────────────
@@ -36,7 +37,7 @@ type TopicSessionReadState = {
 // ─── Post serialization (mirrors forumPost.ts) ─────────────────────────────
 
 const publicPostInclude = {
-  author: { select: { id: true, username: true, avatar: true } },
+  author: { select: authorRefSelect },
   edits: {
     orderBy: { editedAt: 'desc' as const },
     take: 1,
@@ -58,6 +59,7 @@ type RawPost = Awaited<
 
 const serializePost = (post: RawPost) => ({
   ...post,
+  author: toAuthorRefOrNull(post.author),
   ...(post.edits?.[0] ? { lastEdit: post.edits[0] } : {}),
   edits: undefined
 });
@@ -97,13 +99,14 @@ export const getTopicSession = async (
   const topic = await prisma.forumTopic.findFirst({
     where: { id: topicId, forumId, deletedAt: null },
     include: {
-      author: { select: { id: true, username: true, avatar: true } },
+      author: { select: authorRefSelect },
       notes: {
         include: { author: { select: { id: true, username: true } } }
       }
     }
   });
   if (!topic) throw new AppError(404, 'Topic not found');
+  const topicWithAuthor = { ...topic, author: toAuthorRefOrNull(topic.author) };
 
   // Posts, poll, and subscription — all parallel
   const [posts, total, poll, subscription] = await Promise.all([
@@ -162,7 +165,7 @@ export const getTopicSession = async (
       forumCategoryId: forum.forumCategoryId,
       forumCategory: forum.forumCategory
     },
-    topic,
+    topic: topicWithAuthor,
     posts: {
       data: serializedPosts,
       meta: {

--- a/src/posts.spec.ts
+++ b/src/posts.spec.ts
@@ -4,6 +4,7 @@ import {
   resetApiTestState,
   prismaMock
 } from './test/apiTestHarness';
+import { makeAuthorRefRow } from './test/factories';
 
 const makePost = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
@@ -14,7 +15,7 @@ const makePost = (overrides: Record<string, unknown> = {}) => ({
   tags: ['jazz', 'history'],
   createdAt: new Date('2026-01-01'),
   updatedAt: new Date('2026-01-01'),
-  user: { id: 7, username: 'testuser', avatar: null },
+  user: makeAuthorRefRow(),
   comments: [],
   ...overrides
 });
@@ -25,7 +26,7 @@ const makePostComment = (overrides: Record<string, unknown> = {}) => ({
   userId: 7,
   text: 'Great post!',
   createdAt: new Date('2026-01-01'),
-  user: { id: 7, username: 'testuser', avatar: null },
+  user: makeAuthorRefRow(),
   ...overrides
 });
 
@@ -49,6 +50,49 @@ describe('GET /api/posts', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual([]);
+  });
+
+  // #231 — post and comment authors carry the donor sign + warning sign.
+  it('returns post and comment authors as AuthorRef with the signs', async () => {
+    prismaMock.post.findMany.mockResolvedValue([
+      makePost({
+        user: makeAuthorRefRow({
+          isDonor: true,
+          donorRank: {
+            expiresAt: null,
+            donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' }
+          }
+        }),
+        comments: [
+          makePostComment({
+            user: makeAuthorRefRow({
+              id: 9,
+              username: 'warneduser',
+              warned: new Date('2026-06-01T00:00:00.000Z')
+            })
+          })
+        ]
+      })
+    ] as never);
+
+    const res = await request(app).get('/api/posts');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].user).toEqual(
+      expect.objectContaining({
+        isDonor: true,
+        donorRank: { name: 'Patron', badge: 'p.png', color: '#ffd700' },
+        warned: null
+      })
+    );
+    expect(res.body[0].comments[0].user).toEqual(
+      expect.objectContaining({
+        id: 9,
+        isDonor: false,
+        donorRank: null,
+        warned: '2026-06-01T00:00:00.000Z'
+      })
+    );
   });
 });
 

--- a/src/routes/api/comments.ts
+++ b/src/routes/api/comments.ts
@@ -29,6 +29,7 @@ import {
   type UpdateCommentInput
 } from '../../schemas/comment';
 import { deleteComment } from '../../modules/comment';
+import { authorRefSelect, toAuthorRefOrNull } from '../../modules/authorRef';
 
 const router = express.Router();
 const commentIdParamsSchema = z.object({
@@ -60,13 +61,17 @@ router.get(
         skip: pg.skip,
         take: pg.limit,
         include: {
-          author: { select: { id: true, username: true, avatar: true } },
+          author: { select: authorRefSelect },
           editedUser: { select: { id: true, username: true } }
         }
       }),
       prisma.comment.count({ where: { ...where, deletedAt: null } })
     ]);
-    paginatedResponse(res, comments, total, pg);
+    const mapped = comments.map((comment) => ({
+      ...comment,
+      author: toAuthorRefOrNull(comment.author)
+    }));
+    paginatedResponse(res, mapped, total, pg);
   })
 );
 
@@ -79,11 +84,11 @@ router.get(
     const comment = await prisma.comment.findUnique({
       where: { id },
       include: {
-        author: { select: { id: true, username: true, avatar: true } }
+        author: { select: authorRefSelect }
       }
     });
     if (!comment) return res.status(404).json({ msg: 'Comment not found' });
-    res.json(comment);
+    res.json({ ...comment, author: toAuthorRefOrNull(comment.author) });
   })
 );
 
@@ -134,7 +139,7 @@ router.post(
           ...(collageId && { collageId })
         },
         include: {
-          author: { select: { id: true, username: true, avatar: true } }
+          author: { select: authorRefSelect }
         }
       });
 
@@ -178,7 +183,9 @@ router.post(
       return created;
     });
 
-    res.status(201).json(comment);
+    res
+      .status(201)
+      .json({ ...comment, author: toAuthorRefOrNull(comment.author) });
   })
 );
 

--- a/src/routes/api/communities/contributions.ts
+++ b/src/routes/api/communities/contributions.ts
@@ -25,6 +25,7 @@ import {
   type CreateContributionInput
 } from '../../../schemas/contribution';
 import { getSettings } from '../../../modules/settings';
+import { authorRefSelect, toAuthorRefOrNull } from '../../../modules/authorRef';
 
 const router = express.Router();
 const contributionIdParamsSchema = z.object({
@@ -120,7 +121,7 @@ router.get(
         collaborators: true,
         comments: {
           include: {
-            author: { select: { id: true, username: true, avatar: true } }
+            author: { select: authorRefSelect }
           }
         }
       }
@@ -129,7 +130,11 @@ router.get(
       return res.status(404).json({ msg: 'Contribution not found' });
     res.json({
       ...contribution,
-      sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes)
+      sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes),
+      comments: contribution.comments.map((comment) => ({
+        ...comment,
+        author: toAuthorRefOrNull(comment.author)
+      }))
     });
   })
 );

--- a/src/routes/api/forum/forumPost.ts
+++ b/src/routes/api/forum/forumPost.ts
@@ -32,6 +32,7 @@ import {
   paginationBase
 } from '../../../lib/pagination';
 import { canAccessForumLevel } from '../../../lib/userRankAccess';
+import { authorRefSelect, toAuthorRefOrNull } from '../../../modules/authorRef';
 
 const router = express.Router({ mergeParams: true });
 const forumTopicParamsSchema = z.object({
@@ -47,7 +48,7 @@ const forumPostParamsSchema = z.object({
 const forumPostsQuerySchema = z.object({ ...paginationBase });
 
 const publicPostInclude = {
-  author: { select: { id: true, username: true, avatar: true } },
+  author: { select: authorRefSelect },
   edits: {
     orderBy: { editedAt: 'desc' as const },
     take: 1,
@@ -59,7 +60,13 @@ const publicPostInclude = {
       editor: { select: { id: true, username: true } }
     }
   }
-};
+} as const;
+
+type RawPost = Awaited<
+  ReturnType<
+    typeof prisma.forumPost.findMany<{ include: typeof publicPostInclude }>
+  >
+>[number];
 
 const editHistoryInclude = {
   edits: {
@@ -68,20 +75,9 @@ const editHistoryInclude = {
   }
 };
 
-const serializeForumPost = <
-  T extends {
-    edits?: Array<{
-      id: number;
-      forumPostId: number;
-      editorId: number;
-      editedAt: Date;
-      editor?: { id: number; username: string } | null;
-    }>;
-  }
->(
-  post: T
-) => ({
+const serializeForumPost = (post: RawPost) => ({
   ...post,
+  author: toAuthorRefOrNull(post.author),
   ...(post.edits?.[0] ? { lastEdit: post.edits[0] } : {}),
   edits: undefined
 });

--- a/src/routes/api/forum/forumTopic.ts
+++ b/src/routes/api/forum/forumTopic.ts
@@ -36,6 +36,7 @@ import {
 import { prisma } from '../../../lib/prisma';
 import { sanitizePlain } from '../../../lib/sanitize';
 import { canAccessForumLevel } from '../../../lib/userRankAccess';
+import { authorRefSelect, toAuthorRefOrNull } from '../../../modules/authorRef';
 import forumPostRouter from './forumPost';
 
 const router = express.Router({ mergeParams: true });
@@ -97,15 +98,25 @@ router.get(
         skip: pg.skip,
         take: pg.limit,
         include: {
-          author: { select: { id: true, username: true } },
+          author: { select: authorRefSelect },
           lastPost: {
-            include: { author: { select: { id: true, username: true } } }
+            include: { author: { select: authorRefSelect } }
           }
         }
       }),
       prisma.forumTopic.count({ where: { forumId, deletedAt: null } })
     ]);
-    paginatedResponse(res, topics, total, pg);
+    const mapped = topics.map((topic) => ({
+      ...topic,
+      author: toAuthorRefOrNull(topic.author),
+      lastPost: topic.lastPost
+        ? {
+            ...topic.lastPost,
+            author: toAuthorRefOrNull(topic.lastPost.author)
+          }
+        : null
+    }));
+    paginatedResponse(res, mapped, total, pg);
   })
 );
 
@@ -150,7 +161,7 @@ router.get(
       prisma.forumTopic.findFirst({
         where: { id, forumId, deletedAt: null },
         include: {
-          author: { select: { id: true, username: true, avatar: true } },
+          author: { select: authorRefSelect },
           notes: {
             include: { author: { select: { id: true, username: true } } }
           }
@@ -164,7 +175,7 @@ router.get(
         .json({ msg: 'Insufficient class to read this forum' });
     }
     if (!topic) return res.status(404).json({ msg: 'Topic not found' });
-    res.json(topic);
+    res.json({ ...topic, author: toAuthorRefOrNull(topic.author) });
   })
 );
 

--- a/src/routes/api/posts.ts
+++ b/src/routes/api/posts.ts
@@ -15,6 +15,7 @@ import {
   type PostInput,
   type PostCommentInput
 } from '../../schemas/post';
+import { authorRefSelect, toAuthorRefOrNull } from '../../modules/authorRef';
 
 const router = express.Router();
 const postIdParamsSchema = z.object({
@@ -26,12 +27,25 @@ const postCommentParamsSchema = z.object({
 });
 
 const postInclude = {
-  user: { select: { id: true, username: true, avatar: true } },
+  user: { select: authorRefSelect },
   comments: {
     orderBy: { createdAt: 'asc' as const },
-    include: { user: { select: { id: true, username: true, avatar: true } } }
+    include: { user: { select: authorRefSelect } }
   }
-};
+} as const;
+
+type RawPost = Awaited<
+  ReturnType<typeof prisma.post.findMany<{ include: typeof postInclude }>>
+>[number];
+
+const serializePost = (post: RawPost) => ({
+  ...post,
+  user: toAuthorRefOrNull(post.user),
+  comments: post.comments.map((comment) => ({
+    ...comment,
+    user: toAuthorRefOrNull(comment.user)
+  }))
+});
 
 // GET /api/posts
 router.get(
@@ -42,7 +56,7 @@ router.get(
       orderBy: { createdAt: 'desc' },
       include: postInclude
     });
-    res.json(posts);
+    res.json(posts.map(serializePost));
   })
 );
 
@@ -58,7 +72,7 @@ router.get(
       include: postInclude
     });
     if (!post) return res.status(404).json({ msg: 'Post not found' });
-    res.json(post);
+    res.json(serializePost(post));
   })
 );
 
@@ -73,7 +87,7 @@ router.post(
       data: { userId: req.user.id, title, text, category, tags: tags ?? [] },
       include: postInclude
     });
-    res.status(201).json(post);
+    res.status(201).json(serializePost(post));
   })
 );
 
@@ -106,9 +120,9 @@ router.post(
     if (!post) return res.status(404).json({ msg: 'Post not found' });
     const comment = await prisma.postComment.create({
       data: { postId: id, userId: req.user.id, text },
-      include: { user: { select: { id: true, username: true, avatar: true } } }
+      include: { user: { select: authorRefSelect } }
     });
-    res.status(201).json(comment);
+    res.status(201).json({ ...comment, user: toAuthorRefOrNull(comment.user) });
   })
 );
 

--- a/src/staffInbox.spec.ts
+++ b/src/staffInbox.spec.ts
@@ -288,7 +288,14 @@ describe('POST /api/staff-inbox/tickets/:id/reply', () => {
         senderId: 7,
         body: 'Reply',
         createdAt: new Date(),
-        sender: { id: 7, username: 'regular', avatar: null }
+        sender: {
+          id: 7,
+          username: 'regular',
+          avatar: null,
+          isDonor: false,
+          warned: null,
+          donorRank: null
+        }
       }
     });
 
@@ -341,7 +348,14 @@ describe('POST /api/staff-inbox/tickets/:id/reply', () => {
         senderId: 7,
         body: 'Staff reply',
         createdAt: new Date(),
-        sender: { id: 7, username: 'mod', avatar: null }
+        sender: {
+          id: 7,
+          username: 'mod',
+          avatar: null,
+          isDonor: false,
+          warned: null,
+          donorRank: null
+        }
       }
     });
 

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -109,6 +109,34 @@ export function asUserMock<T extends Record<string, unknown>>(value: T): User {
   return value as unknown as User;
 }
 
+// ─── AuthorRef row (what authorRefSelect returns from Prisma, #231) ──────────
+
+export type AuthorRefRowFactory = {
+  id: number;
+  username: string;
+  avatar: string | null;
+  isDonor: boolean;
+  warned: Date | null;
+  donorRank: {
+    expiresAt: Date | null;
+    donorRank: { name: string; badge: string; color: string };
+  } | null;
+};
+
+export function makeAuthorRefRow(
+  overrides: Partial<AuthorRefRowFactory> = {}
+): AuthorRefRowFactory {
+  return {
+    id: TEST_USER_ID,
+    username: 'testuser',
+    avatar: null,
+    isDonor: false,
+    warned: null,
+    donorRank: null,
+    ...overrides
+  };
+}
+
 // ─── Forum ────────────────────────────────────────────────────────────────────
 
 export function makeForum(overrides: Partial<Forum> = {}): Forum {
@@ -211,7 +239,7 @@ export function makePost(overrides: Partial<Post> = {}): Post {
 }
 
 type PostWithIncludes = Post & {
-  user: { id: number; username: string; avatar: string | null };
+  user: AuthorRefRowFactory;
   comments: Array<PostCommentWithUser>;
 };
 
@@ -220,7 +248,7 @@ export function makePostWithIncludes(
 ): PostWithIncludes {
   return {
     ...makePost(),
-    user: { id: TEST_USER_ID, username: 'testuser', avatar: null },
+    user: makeAuthorRefRow(),
     comments: [],
     ...overrides
   } as PostWithIncludes;
@@ -242,7 +270,7 @@ export function makePostComment(
 }
 
 type PostCommentWithUser = PostComment & {
-  user: { id: number; username: string; avatar: string | null };
+  user: AuthorRefRowFactory;
 };
 
 export function makePostCommentWithUser(
@@ -250,7 +278,7 @@ export function makePostCommentWithUser(
 ): PostCommentWithUser {
   return {
     ...makePostComment(),
-    user: { id: TEST_USER_ID, username: 'testuser', avatar: null },
+    user: makeAuthorRefRow(),
     ...overrides
   } as PostCommentWithUser;
 }
@@ -278,7 +306,7 @@ export function makeComment(overrides: Partial<Comment> = {}): Comment {
 }
 
 type CommentWithAuthor = Comment & {
-  author: { id: number; username: string; avatar: string | null };
+  author: AuthorRefRowFactory;
 };
 
 export function makeCommentWithAuthor(
@@ -286,7 +314,7 @@ export function makeCommentWithAuthor(
 ): CommentWithAuthor {
   return {
     ...makeComment(),
-    author: { id: TEST_USER_ID, username: 'testuser', avatar: null },
+    author: makeAuthorRefRow(),
     ...overrides
   } as CommentWithAuthor;
 }


### PR DESCRIPTION
Closes #231

## Problem

`isDonor`/`warned` existed only on the profile/user-detail shapes, so the donor sign and warning sign rendered on the profile page and nowhere else. Every other PostBox-backed surface (forum posts/topics, comments, PMs, staff inbox, blog posts) projected authors as a thin `{ id, username, avatar }` — the contract never shipped the data, so the UI could not render the badges.

## Fix

Per the sequence decided on the issue, this is the API half; **stellar-ui#103 consumes these fields** and is blocked on this landing.

- **New seam `src/modules/authorRef.ts`** — `authorRefSelect` (shared Prisma select: `id, username, avatar, isDonor, warned` + active donor-rank grant) and `toAuthorRef`/`toAuthorRefOrNull` shapers producing the wire shape `{ id, username, avatar, isDonor, donorRank: { name, badge, color } | null, warned: ISO | null }`. Mirrors the profile's expiry rule: an expired donor grant renders as no rank even before the hourly sweep clears the flag.
- **Adopted at every PostBox-backed read**:
  - forum topics (list incl. `lastPost.author`, detail, session) and forum posts (list, detail, session) — `src/routes/api/forum/forumTopic.ts`, `forumPost.ts`, `src/modules/topicSession.ts`
  - comments (list, detail, create) + contribution-embedded comments — `src/routes/api/comments.ts`, `src/routes/api/communities/contributions.ts`
  - blog posts + blog-post comments — `src/routes/api/posts.ts`
  - private messages: senders and participants across inbox/sentbox/view/send/reply and system messages — `src/modules/pm.ts`
  - staff inbox: ticket owner, assignee, resolver, and message senders — `src/modules/staffPm.ts`
- **Contract**: `src/lib/openapi.ts` registers `AuthorRef` and replaces the hand-rolled thin author objects in the ForumTopic/ForumPost/Comment/Post/PostComment/PM/StaffInboxTicket slots (`MessageUser` now aliases `AuthorRef`). `openapi.json` regenerated via `npm run openapi:export`.

## Tests

`npm run test -- --no-coverage`: **95 suites / 1758 tests green**. New deterministic assertions: `authorRef.spec.ts` (shaping + expiry sweep-lag guard), plus flag-carrying payload assertions in `comments.spec.ts`, `forum.spec.ts` (topics + posts), `posts.spec.ts`, `pm.spec.ts`, `staffPm.spec.ts`. Test factories gained `makeAuthorRefRow`.

## Notes

- `src/types/api.ts` (openapi-typescript output) was already stale repo-wide before this change; regenerating it here would bundle a large unrelated re-baseline, so it is left untouched. The UI generates its own types from the spec.
- **Merge-order heads-up:** PR #270 also regenerates `openapi.json` — whichever of the two merges second must re-run `npm run openapi:export` after updating its branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtdEr5SpKvpsbi4shjAYAx