### PR TITLE
chore(release): cut v0.6.2 — reconcile the CHANGELOG wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ A 0.6.x increment landing the stylesheet delivery contract (registry CSS serving
 
 - **ADR-0024** — stylesheet delivery contract (URL vs stored-source registry serving); PRD-03 amended (`.css`-only, storage shape closed, "registry spaces" naming); superseded ADR-0003 Arm-1 comments corrected [PR #256].
 - **ADR-0023 (proposed)** — `ReleaseGroup` cross-community identity node + the Contribution package seam.
+- **ADR-0025** — moderation & messaging surface model: Reports (content-anchored), Personal Messages (user↔user), and Staff Inbox (generic member→staff) are three separate systems; Staff Inbox is one role-dispatched entry (no separate "Staff Queue"). Reconciles a stellar-ui surface drift ([stellar-ui #164](https://github.com/orphic-inc/stellar-ui/pull/164)); staff-class tiering deferred.
 
 ## [0.6.1] — 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,35 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-07-03
+
+A 0.6.x increment landing the stylesheet delivery contract (registry CSS serving + a single-source slot), site-wide author-sign propagation, the staff-inbox consolidation, and a self-migrating runtime image.
+
 ### Added
 
 - **Registry stylesheet CSS delivery** — `GET /api/stylesheet/author-stylesheet/:id/css` serves an adopted author sheet's stored, sanitized source as `text/css` (no-cache, nosniff), so the UI injector can link it like an external URL [ADR-0024, PR #256]. OpenAPI path registered [PR #257].
 - **`anorex` built-in theme** — registered in the `stylesheets` registry so the wood-toned theme shipped by stellar-ui is reachable through the theme picker [#255].
+- **Release-scoped contributions read** — `getReleaseWorkbenchView` now embeds the `ReleaseFile` satellite and `Edition`, so rip-quality and edition are readable from a release-scoped GET (was POST/search-only), unblocking the UI edition-disclosure feature [#129].
+- **`PUT /api/users/:id/rank-lock`** — staff can freeze/unfreeze a user from auto class-progression; `rankLocked` also exposed on the staff rank-assignment read [#203].
+- **Self-migrating container** — the runtime image runs `prisma migrate deploy` on boot (fail-fast) before exec'ing the app, so a merged-but-unapplied migration can no longer serve a schema-behind DB; a CI `smoke` job boots the real image against a fresh Postgres and gates publish [#276].
 
 ### Changed
 
 - **Site Stylesheet slot is one explicit source** — Personal (external URL) and Registry (`activeAuthorStylesheetId`) are mutually exclusive; selecting one clears the other, enforced server-side on the profile write. The pointer joins the profile contract; `externalStylesheet` is tightened to `https:`-only [ADR-0024, PR #256].
+- **Author-stylesheet list paginated** — `GET /api/stylesheet/author/:userId` returns the standard `{ data, meta }` envelope, plus a rank-gated cap on stored sheets [#146].
+- **RankPromotionRule CRUD guarded to adjacent ladder steps** — promotion-rule admin writes are constrained to neighbouring class levels [#170].
+- **Staff-inbox ticket engine consolidated** — the duplicated engine (copied into `staffPm.ts`, then drifted) is unified onto `staffInbox.ts`; the duplicate module + schema are deleted [#272].
+- ESLint config marked `root: true` so a checkout nested inside another (a git worktree) lints cleanly instead of cascading into the outer repo's config.
+
+### Fixed
+
+- **Author signs follow the author site-wide** — donor sign and warning sign now ship on every PostBox author payload (forum/comment/PM/staff-inbox) via a shared `AuthorRef` seam, not just the profile page [#231].
+- **`getRatioStats` 404s on a missing user** — throws `AppError(404)` per the codebase convention instead of a raw `Error` the global handler mapped to a generic 500 [#233].
 
 ### Docs
 
 - **ADR-0024** — stylesheet delivery contract (URL vs stored-source registry serving); PRD-03 amended (`.css`-only, storage shape closed, "registry spaces" naming); superseded ADR-0003 Arm-1 comments corrected [PR #256].
+- **ADR-0023 (proposed)** — `ReleaseGroup` cross-community identity node + the Contribution package seam.
 
 ## [0.6.1] — 2026-06-25
 
@@ -456,7 +473,8 @@ _Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a0
 
 ---
 
-[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/orphic-inc/stellar-api/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/orphic-inc/stellar-api/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/orphic-inc/stellar-api/compare/v0.5.6...v0.6.0
 [0.5.6]: https://github.com/orphic-inc/stellar-api/compare/v0.5.5...v0.5.6

--- a/docs/adr/0025-moderation-and-messaging-surface-model.md
+++ b/docs/adr/0025-moderation-and-messaging-surface-model.md
@@ -1,0 +1,43 @@
+# Moderation & messaging surface model: three separate systems; Staff Inbox is one role-dispatched entry
+
+**Status: Accepted.** Records the separation that `/api/messages`, `/api/reports`, and `/api/staff-inbox` already encode, and pins the UI surface to it. Reuses the `staff_inbox_manage` and `reports_manage` gates from [ADR-0001 granular permission checks](0001-granular-permission-checks.md). Resolves a stellar-ui drift in which the staff ticket queue was reachable from two nav entries; captured because the model had never been written down and was re-derived (and mis-derived) more than once.
+
+## Context
+
+Three systems look alike at a glance — each surfaces a list a member or a staffer works through — and had drifted toward each other in the UI even though the API keeps them cleanly apart. They are not the same thing:
+
+| System                     | What it is                                                        | Anchored to                                                   |
+| -------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------- |
+| **Personal Messages**      | user ↔ user correspondence                                       | a conversation between members                                |
+| **Reports**                | a member flags a piece of **content** for staff                   | a target: a release, forum topic/post, comment, request, etc. |
+| **Staff Inbox** (staff PM) | a member asks staff a **generic question** with no content target | a member → staff conversation thread                          |
+
+The API already reflects this: `/api/messages` (PMs), `/api/reports` (content-anchored; `POST /` to file, `/mine`, the staff queue at `/`, `/:id/claim|unclaim|resolve|notes`, `/counts`), and `/api/staff-inbox` (`/tickets` for a member's own vs `/queue` for staff, plus `/responses` canned replies and `/:id/reply|resolve|unresolve|assign`). The staff-PM queue and the reports queue are distinct endpoints over distinct data. There is no data-layer conflation.
+
+The drift lived only in the UI. The staff view of the staff-PM queue had accreted **two** homes: the Staff Inbox entry (which dispatches by permission) and a second, separately-built "Staff Queue" tool — both rendering the identical queue component, which is visually a twin of the reports queue. A staff member opening "Staff Inbox" therefore landed on a moderation queue indistinguishable from Reports, and duplicated by "Staff Queue." The root cause was the absence of a written surface model: each surface was built at a different time against the local code shape, with no single spec to reconcile against.
+
+## Decision
+
+**The three systems are separate surfaces and stay separate.** Reports are content-anchored moderation; Staff Inbox is a generic member→staff channel; Personal Messages are member↔member. They may share a visual queue idiom but never share data, nav, or entry point.
+
+**Staff Inbox is a single, role-dispatched entry** — one nav item for everyone:
+
+- A staffer who can manage the inbox (`staff_inbox_manage`) sees the shared ticket **queue** at Staff Inbox.
+- Everyone else sees their **own** member→staff conversations at the same entry.
+- There is **no separate "Staff Queue" surface.** The queue _is_ what a manager sees under Staff Inbox. A staffer's own tickets and the queue they manage are the two sides of the one entry, chosen by permission.
+- The Staff Inbox unread indicator is role-aware for the same reason: it counts the queue's unanswered tickets for a manager, and the member's own unread otherwise.
+- Canned responses, assignment, and resolve/bulk-resolve are affordances _within_ the staff side of Staff Inbox, not a separate destination.
+
+**Reports keep their own surfaces**: a member files/tracks reports from content and under their own reports view; staff triage them in a reports-specific queue gated by `reports_manage`. Reports are never routed through, or visually merged into, Staff Inbox.
+
+**Personal Messages keep their own surface** ("Inbox"), unchanged.
+
+## Consequences
+
+- The duplicate "Staff Queue" nav item and its standalone route/tool are removed; the staff ticket queue and a single ticket are served under the Staff Inbox namespace. A staffer who lacks `staff_inbox_manage` gets their own tickets at Staff Inbox and no queue access, consistent with the gate — an inconsistency in the old dual-gate wiring is also closed.
+- Future work on any of the three systems has a written model to build against instead of re-deriving it from whichever surface the author happens to read first.
+
+## Explicitly deferred
+
+- **Staff-class visibility tiering for staff PMs.** A staff-PM conversation could carry a tier that bounds which staff class may see/answer it (e.g. first-line support vs. full moderators), so lower-tier staff see only the subset routed to them. `/api/staff-inbox` does not model this today; it is a scoping decision to grill separately. Assignment and resolve already exist.
+- **Visual differentiation of the two queue idioms.** The staff-PM queue and the reports queue remain the same triage-table form. De-twinning them visually (so they never _read_ as the same surface even though they are correctly separate) is a design task, not a structural one.

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Stellar API",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Cuts **v0.6.2**, a 0.6.x increment (per the CI/CD-before-0.7.0 gate — this is not the 0.7.0 cut).

## What
- Folds the rotted `[Unreleased]` section into a dated **0.6.2** heading.
- Adds the **8 shipped-but-unrecorded** features since v0.6.1: #129, #146, #170, #203, #231, #233, #272, #276.
- Bumps the manifest `0.6.1 → 0.6.2` (lockfile + `version:check` green).

## Why
`version:check` only diffs the top dated heading, so the changelog silently rots between cuts — this reconciles it against `git log v0.6.1..main`.

After merge, tag `v0.6.2` on upstream `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)