### PR TITLE
fix(messages): gate mass PM with granular messages_mass_pm permission

### DIFF
--- a/src/messages.spec.ts
+++ b/src/messages.spec.ts
@@ -533,7 +533,7 @@ describe('POST /api/messages/mass', () => {
   beforeEach(() => {
     resetApiTestState();
     prismaMock.userRank.findUnique.mockResolvedValue(
-      makeUserRank({ staff: true })
+      makeUserRank({ messages_mass_pm: true })
     );
   });
 
@@ -589,8 +589,21 @@ describe('POST /api/messages/mass', () => {
     );
   });
 
-  it('returns 403 without staff permission', async () => {
+  it('returns 403 without messages_mass_pm permission', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
+
+    const res = await request(app)
+      .post('/api/messages/mass')
+      .send({ subject: 'S', body: 'B' });
+
+    expect(res.status).toBe(403);
+  });
+
+  // Granular gate (#281) — the coarse 'staff' flag alone must not satisfy it.
+  it('returns 403 for staff without messages_mass_pm permission', async () => {
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ staff: true })
+    );
 
     const res = await request(app)
       .post('/api/messages/mass')

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -180,6 +180,7 @@ export const DEFAULT_RANKS = [
       users_disable: true,
       users_view_ips: true,
       users_view_email: true,
+      messages_mass_pm: true,
       staff: true
     }
   },

--- a/src/routes/api/messages.ts
+++ b/src/routes/api/messages.ts
@@ -218,7 +218,7 @@ router.delete(
 // POST /api/messages/mass — send mass PM
 router.post(
   '/mass',
-  ...requirePermission('staff'),
+  ...requirePermission('messages_mass_pm'),
   validate(massPmSchema),
   authHandler(async (req, res) => {
     const { subject, body, targetRankId } = parsedBody<MassPmInput>(res);


### PR DESCRIPTION
## Problem

The mass-PM route guarded with the coarse `staff` permission instead of a granular key, contradicting ADR-0001 (granular permission checks — no named role checks).

## Fix

Gate mass PM behind a dedicated `messages_mass_pm` permission key.

Closes #281.

## Verification

- Full suite green on the rebased branch: 95 suites / 1761 tests.
- Rebased onto `main` at the v0.6.2 wave head (`c1b570e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gP8CRTHoUrrT1RqHfQQNG