### PR TITLE
feat(stylesheets): api-canonical built-in theme fixtures + registry guard — 0.6.3 (#285, #286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.6.3] — 2026-07-07
+
+Stylesheet registry integrity: the built-in themes become api-canonical and single-source, and delivery is guarded so a dead theme-picker entry can't ship.
+
+### Added
+
+- **Built-in stylesheet fixtures are api-canonical** — `anorex` and `dark-ambient` are stored as `AuthorStylesheet` rows owned by a reserved System user and delivered via `GET /api/stylesheet/author-stylesheet/:id/css`; each registry row's `cssUrl` points at that route, so the stored source is the single canonical artifact, no silent static-file duplicate [#285, #286, ADR-0024]. `dark-ambient` — previously a registered row with no stylesheet anywhere (a dead theme-picker entry) — now ships as a token-only theme (stellar-ui ADR-0005) [#286].
+- **Reserved System user** — a non-interactive, disabled account (`seedSystemUser`) owning built-in content fixtures; seeded before them in both the dev seed and the install flow.
+- **Registry ↔ delivery consistency guard** — an integration test asserts every `/css`-backed registry row resolves to a real, non-empty `AuthorStylesheet`, and a pure spec pins each built-in theme to the full `--st-*` primitive set, so a dead or half-painted theme fails CI instead of shipping [#286].
+- **ADR-0026** — static-asset storage plan (design) for theme imagery and content assets the `/css` route can't carry [ADR-0026].
+
+### Fixed
+
+- **Mass PM gated by a granular permission** — mass private messaging now requires `messages_mass_pm` rather than a broad role check [#281].
+
+### Docs
+
+- **ADR-0014** — per-user contribution feed (derive the token, don't mint a secret); cross-linked to the live PRD-02 and ADR-0015.
+- **ADR-0025** — moderation & messaging surface model (Reports vs Personal Messages vs Staff Inbox).
+
 ## [0.6.2] — 2026-07-03
 
 A 0.6.x increment landing the stylesheet delivery contract (registry CSS serving + a single-source slot), site-wide author-sign propagation, the staff-inbox consolidation, and a self-migrating runtime image.
@@ -474,7 +494,8 @@ _Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a0
 
 ---
 
-[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/orphic-inc/stellar-api/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/orphic-inc/stellar-api/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/orphic-inc/stellar-api/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/orphic-inc/stellar-api/compare/v0.5.6...v0.6.0

--- a/docs/adr/0026-static-asset-storage.md
+++ b/docs/adr/0026-static-asset-storage.md
@@ -1,0 +1,39 @@
+# ADR-0026: Static asset storage for themes and content imagery
+
+**Status:** Proposed (2026-07-07)
+**Relates:** [ADR-0024](0024-stylesheet-delivery-contract.md) (stylesheet delivery contract — the `/css` route this ADR complements), stellar-ui ADR-0005 / `docs/theming.md` (the token contract that makes recolor themes asset-free), and the built-in stylesheet fixtures shipped in 0.6.3 (#285, #286).
+
+## Context
+
+ADR-0024 made the stored, sanitized `AuthorStylesheet` source the canonical delivery artifact for a registry theme, served by `GET /api/stylesheet/author-stylesheet/:id/css`. That route carries **only CSS bytes** — there is no companion path for a theme's co-located assets (background images, web fonts, sprites). It works for token-only themes (stellar-ui ADR-0005), which are a `:root { --st-* }` block with no `url()` and no bundled files; the two built-in fixtures shipped in 0.6.3 (`anorex`, `dark-ambient`) are asset-free by design for exactly this reason.
+
+But two forces make a real asset story unavoidable:
+
+1. **The asset-bearing themes can't migrate.** The pre-contract themes still shipped as static files under stellar-ui (`postmod`, `proton`) carry `@font-face` and `url('./images/…')` against a co-located `images/` directory served next to their `style.css`. They cannot move to the api-canonical `/css` model until their assets have somewhere to live — so today the registry is split: two themes api-canonical, the rest ui-static. That split is a stopgap, not the end state ADR-0024 describes.
+
+2. **Content imagery will be plentiful.** Cover art, avatars, community/theme logos, and similar user- and staff-supplied images are coming, and each is the same shape of problem: a binary asset that a stored row references but the api has no first-class way to store, serve, or garbage-collect. Wedging each into an ad-hoc route (or leaning indefinitely on the stellar-ui static tree) rebuilds the cross-repo drift that #285/#286 set out to end — a reference in one repo whose target lives, unverified, in another.
+
+This ADR fixes the **decision** to build a general static-asset store; the implementation is deferred to a tracked follow-up (it does not block the 0.6.3 cut, whose themes are asset-free).
+
+## Decision (shape — to be ratified before implementation)
+
+Introduce an api-owned asset store as the single home for binary assets a stored row references, so an asset — like a stylesheet's canonical source — is verifiable from the api that serves it.
+
+The design space to settle in the implementation ADR/PR:
+
+- **Storage backend.** An object store (S3-compatible / MinIO) is the scalable default for "plentiful"; a mounted volume or a DB-blob table are simpler but bounded. Pick one, with the connection surfaced through `config.ts` and degrade-closed when unset (mirroring the korin integration pattern).
+- **Model + serve route.** An `Asset` row (id, content hash, mime, size, owner, kind) plus a content-addressed serve route (`GET /api/asset/:id` or by hash) with correct `Content-Type` and long-lived caching (assets are immutable once stored, unlike the mutable `/css` sheet).
+- **Ingest + safety.** Store-time validation of mime/size, an upload path gated like the existing author-sheet write, and the same fail-closed posture as `sanitizeStylesheetSource` — the store never serves an unvalidated byte.
+- **Theme assets specifically.** Once the store exists, an asset-bearing theme's `url()` targets resolve to `/api/asset/…`, letting `postmod`/`proton` (and any future rich theme) become api-canonical `/css` fixtures — closing the registry split above.
+- **Lifecycle.** Reference counting or an orphan sweep so a deleted row's assets don't leak (the `AuthorStylesheet` → owner cascade is the precedent to extend).
+
+## Consequences
+
+- **0.6.3 is unblocked** — its built-in themes are token-only, so nothing here gates the cut; this ADR only records the plan the `/css` model forces.
+- **The registry split becomes temporary by design** — `postmod`/`proton` stay ui-static with a named path to api-canonical once the store lands, rather than an open question.
+- **A new subsystem to own** — storage, a serve route, ingest safety, and lifecycle are real surface; the follow-up must scope them deliberately rather than growing a route per asset kind.
+- **Cross-repo drift keeps shrinking** — moving binary assets into an api-verifiable store extends the #285/#286 single-source-of-truth move from CSS to imagery.
+
+## Follow-up
+
+Implementation is tracked separately (a `feat` issue on this repo); this ADR is the design gate, not the build.

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Stellar API",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",

--- a/prisma/seed-assets/stylesheets/anorex.css
+++ b/prisma/seed-assets/stylesheets/anorex.css
@@ -1,0 +1,50 @@
+/*
+ * Anorex — brown / wood theme (the classic tracker default), ported to Stellar.
+ * ============================================================================
+ *
+ * A token-only theme (stellar-ui ADR-0005 / docs/theming.md): a whole-app re-skin
+ * is *just* a redefinition of the `--st-*` Role Tokens — NO selectors, NO utility
+ * overrides, NO `!important`. Components read the tokens through their `data-st`
+ * hooks, so repainting the tokens repaints every migrated surface for free. Built
+ * on the Layer Cake template (src/stylesheets/layer-cake/style.css); the derived
+ * tokens in common/global.css (--st-lossy, --st-weight, --st-weight-track) and the
+ * geometry/type tokens (--st-radius, --st-gap, --st-mono) follow automatically.
+ *
+ * Palette is anorex's own — wood browns, cream boxes, oxblood/gold status. The
+ * original skinned via a wood-texture background *image*; that asset is
+ * deliberately NOT carried over (data-scrub gate) — the wood tone lives in
+ * --st-backdrop as a flat colour instead. No url(), no bundled images.
+ * ============================================================================ */
+
+:root {
+  /* Surfaces — wood chrome, cream panels */
+  --st-backdrop: #6b4f2a; /* page backdrop (was the woodbg texture) */
+  --st-base: #b78234; /* header / column-head (the wood nav)     */
+  --st-panel: #dcb881; /* cards, boxes (.box cream)               */
+  --st-raised: #cda369; /* rows, inputs, chips (tr.rowa)           */
+
+  /* Text — dark brown ink */
+  --st-text-strong: #331c01;
+  --st-text: #492802;
+  --st-text-muted: #6b481e;
+  --st-text-faint: #7a5a2e;
+
+  /* Accent / link — anorex browns */
+  --st-accent: #6b481e;
+  --st-accent-hover: #a56a22;
+  --st-accent-ring: #a56a22;
+  --st-link: #6b481e;
+  --st-link-hover: #a56a22;
+
+  /* Borders */
+  --st-border: #65430f;
+  --st-border-subtle: #8a6a3a;
+  --st-border-strong: #65430f;
+
+  /* Status — oxblood alert, gold save, tracker greens */
+  --st-danger: #af2525;
+  --st-success: #418b00;
+  --st-warning: #b8860b;
+  --st-info: #557d9c;
+  --st-lossless: #418b00; /* quality cue = the tracker green */
+}

--- a/prisma/seed-assets/stylesheets/dark-ambient.css
+++ b/prisma/seed-assets/stylesheets/dark-ambient.css
@@ -1,0 +1,51 @@
+/*
+ * Dark Ambient — deep atmospheric theme with muted blue.
+ * ============================================================================
+ *
+ * A token-only theme (stellar-ui ADR-0005 / docs/theming.md): a whole-app re-skin
+ * is *just* a redefinition of the `--st-*` Role Tokens — NO selectors, NO utility
+ * overrides, NO `!important`. Components read the tokens through their `data-st`
+ * hooks, so repainting the tokens repaints every migrated surface for free. Built
+ * on the Layer Cake template; the derived tokens in common/global.css
+ * (--st-lossy, --st-weight, --st-weight-track) and the geometry/type tokens follow
+ * automatically.
+ *
+ * Palette is dark-ambient's own — near-black greys under a cold #007dc6 blue that
+ * lifts to #22b9ff on hover. The original skinned via tiled background *images*
+ * (wrapper/header/footer/button textures); those assets are deliberately NOT
+ * carried over (data-scrub gate) — the atmosphere lives in flat surface tokens
+ * instead. No url(), no bundled images.
+ * ============================================================================ */
+
+:root {
+  /* Surfaces — near-black, faintly stepped */
+  --st-backdrop: #1a1a1a; /* page backdrop            */
+  --st-base: #202020; /* header / column-head bar */
+  --st-panel: #262626; /* cards, boxes             */
+  --st-raised: #2e2e2e; /* rows, inputs, chips      */
+
+  /* Text — muted grey on dark, cold-white for strong */
+  --st-text-strong: #d5efff; /* the cold blue-white accent text */
+  --st-text: #909090;
+  --st-text-muted: #757575;
+  --st-text-faint: #5c5c5c;
+
+  /* Accent / link — the muted blue signature */
+  --st-accent: #007dc6;
+  --st-accent-hover: #22b9ff;
+  --st-accent-ring: #22b9ff;
+  --st-link: #007dc6;
+  --st-link-hover: #22b9ff;
+
+  /* Borders */
+  --st-border: #303030;
+  --st-border-subtle: #242424;
+  --st-border-strong: #3f3f3f;
+
+  /* Status — red alert, muted-blue info, atmospheric greens/gold */
+  --st-danger: #cf3b3b;
+  --st-success: #5a9e5a;
+  --st-warning: #c99a3a;
+  --st-info: #557d9c;
+  --st-lossless: #7ec97e; /* quality cue */
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -10,9 +10,11 @@ import { PrismaClient } from '@prisma/client';
 import {
   seedRanks,
   seedRankPromotionRules,
-  seedForums
+  seedForums,
+  seedSystemUser
 } from '../src/modules/bootstrap';
 import { seedGoldenRules } from '../src/modules/goldenRules';
+import { seedStylesheetFixtures } from '../src/modules/stylesheetFixtures';
 
 const prisma = new PrismaClient();
 
@@ -21,6 +23,9 @@ async function main() {
   await seedRankPromotionRules(prisma);
   await seedForums(prisma);
   await seedGoldenRules(prisma);
+  // System user must precede the stylesheet fixtures it owns (needs ranks first).
+  const systemUserId = await seedSystemUser(prisma);
+  await seedStylesheetFixtures(prisma, systemUserId);
   console.log('→ Complete setup at http://localhost:9000/install');
 }
 

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -27,6 +27,18 @@ function mockPreseededBootstrap() {
 }
 
 function mockSysopTransaction() {
+  // seedSystemUser + seedStylesheetFixtures run just before the SysOp transaction:
+  // the reserved System user is absent (findUnique → null), its UserSettings/Profile/
+  // User rows create as base mocks (the tx's once-mocks below still win for the SysOp),
+  // and the two built-in fixtures create + repoint their registry rows.
+  prismaMock.user.findUnique.mockResolvedValue(null);
+  prismaMock.userSettings.create.mockResolvedValue({ id: 4 } as never);
+  prismaMock.profile.create.mockResolvedValue({ id: 5 } as never);
+  prismaMock.user.create.mockResolvedValue({ id: 2 } as never);
+  prismaMock.authorStylesheet.findFirst.mockResolvedValue(null);
+  prismaMock.authorStylesheet.create.mockResolvedValue({ id: 100 } as never);
+  prismaMock.stylesheet.upsert.mockResolvedValue({ id: 1 } as never);
+
   // The flagship-community seed runs right after the user transaction commits.
   prismaMock.community.findFirst.mockResolvedValue(null);
   prismaMock.community.create.mockResolvedValue({ id: 1 } as never);

--- a/src/integration/stylesheetRegistry.integration.ts
+++ b/src/integration/stylesheetRegistry.integration.ts
@@ -1,0 +1,92 @@
+/**
+ * Registry ↔ /css delivery consistency (#286). Proves a site-registry row can
+ * never ship pointing at a `/css` delivery target that doesn't resolve — the dead
+ * theme-picker entry the issue is about. Seeds the System user + built-in fixtures
+ * on the test DB (the harness truncates registry rows in `beforeEach`, so the test
+ * seeds them itself) and asserts every `/css`-backed row maps to a real, non-empty
+ * `AuthorStylesheet`. Also pins the seeders' idempotency and the System account's
+ * non-interactive shape.
+ */
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { seedSystemUser, SYSTEM_USERNAME } from '../modules/bootstrap';
+import {
+  seedStylesheetFixtures,
+  readFixtureCss,
+  BUILTIN_STYLESHEET_FIXTURES
+} from '../modules/stylesheetFixtures';
+import { sanitizeStylesheetSource } from '../lib/cssSanitize';
+
+const fixtureFileByName = new Map<string, string>(
+  BUILTIN_STYLESHEET_FIXTURES.map((f) => [f.name, f.file])
+);
+
+// `seedDefaults()` creates the level-100 User rank that `seedSystemUser` takes.
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const CSS_ROUTE = /^\/api\/stylesheet\/author-stylesheet\/(\d+)\/css$/;
+
+const cssBackedRows = async () => {
+  const rows = await testPrisma.stylesheet.findMany();
+  return rows.filter((r) => CSS_ROUTE.test(r.cssUrl));
+};
+
+const assertAllResolve = async () => {
+  const rows = await cssBackedRows();
+  expect(rows.length).toBe(BUILTIN_STYLESHEET_FIXTURES.length);
+  for (const row of rows) {
+    const id = Number(CSS_ROUTE.exec(row.cssUrl)![1]);
+    const fixture = await testPrisma.authorStylesheet.findUnique({
+      where: { id },
+      select: { name: true, source: true }
+    });
+    expect(fixture).not.toBeNull();
+    // Fidelity: what /css serves is exactly the authored file (stored through the
+    // store-time sanitizer, a no-op on these token-only sheets).
+    const file = fixtureFileByName.get(row.name);
+    expect(file).toBeDefined();
+    expect(fixture!.source).toBe(
+      sanitizeStylesheetSource(readFixtureCss(file!))
+    );
+  }
+};
+
+describe('stylesheet registry ↔ /css delivery consistency (#286)', () => {
+  it('every /css-backed registry row resolves to a real, non-empty AuthorStylesheet', async () => {
+    const systemUserId = await seedSystemUser(testPrisma);
+    await seedStylesheetFixtures(testPrisma, systemUserId);
+    await assertAllResolve();
+  });
+
+  it('re-seeding is idempotent — no duplicate fixtures, registry still resolves', async () => {
+    const systemUserId = await seedSystemUser(testPrisma);
+    await seedStylesheetFixtures(testPrisma, systemUserId);
+
+    const again = await seedSystemUser(testPrisma);
+    expect(again).toBe(systemUserId);
+    await seedStylesheetFixtures(testPrisma, systemUserId);
+
+    const fixtureCount = await testPrisma.authorStylesheet.count({
+      where: { authorId: systemUserId }
+    });
+    expect(fixtureCount).toBe(BUILTIN_STYLESHEET_FIXTURES.length);
+    await assertAllResolve();
+  });
+
+  it('seeds the reserved System user as non-interactive', async () => {
+    const id = await seedSystemUser(testPrisma);
+    const user = await testPrisma.user.findUniqueOrThrow({
+      where: { id },
+      select: { username: true, disabled: true, rankLocked: true }
+    });
+    expect(user.username).toBe(SYSTEM_USERNAME);
+    expect(user.disabled).toBe(true);
+    expect(user.rankLocked).toBe(true);
+  });
+});

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -7,6 +7,8 @@ import {
   CommunityType,
   RegistrationStatus
 } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import { randomBytes } from 'crypto';
 import { ALL_PERMISSIONS } from '../lib/rankPermissions';
 import {
   DEFAULT_RANKS as EVALUATOR_RANKS,
@@ -489,6 +491,56 @@ export async function seedForums(client: PrismaClient): Promise<void> {
       });
     }
   }
+}
+
+/** Reserved username for the non-interactive System account. */
+export const SYSTEM_USERNAME = 'system';
+
+/**
+ * Seed the reserved, non-interactive System user that owns built-in content
+ * fixtures (the built-in stylesheet `AuthorStylesheet` rows). It can never log in
+ * — `disabled` + `rankLocked`, with an unguessable random password nobody holds —
+ * and uses an RFC-reserved `.invalid` email so it can't collide with a real
+ * signup. Idempotent on the unique username. Requires `seedRanks` to have run (it
+ * takes the base User rank). Returns the id so dependent seeders can author under
+ * it.
+ */
+export async function seedSystemUser(client: PrismaClient): Promise<number> {
+  const existing = await client.user.findUnique({
+    where: { username: SYSTEM_USERNAME },
+    select: { id: true }
+  });
+  if (existing) return existing.id;
+
+  const baseRank = await client.userRank.findFirst({ where: { level: 100 } });
+  if (!baseRank)
+    throw new Error(
+      'base User rank missing — run seedRanks before seedSystemUser'
+    );
+
+  // Unusable password: a random 32-byte secret hashed and discarded. No plaintext
+  // exists, so the account cannot authenticate even setting aside the disabled flag.
+  const unusablePassword = await bcrypt.hash(
+    randomBytes(32).toString('hex'),
+    await bcrypt.genSalt(10)
+  );
+
+  const userSettings = await client.userSettings.create({ data: {} });
+  const profile = await client.profile.create({ data: {} });
+  const user = await client.user.create({
+    data: {
+      username: SYSTEM_USERNAME,
+      email: 'system@stellar.invalid',
+      password: unusablePassword,
+      userRankId: baseRank.id,
+      userSettingsId: userSettings.id,
+      profileId: profile.id,
+      disabled: true,
+      rankLocked: true
+    },
+    select: { id: true }
+  });
+  return user.id;
 }
 
 /**

--- a/src/modules/stylesheetFixtures.spec.ts
+++ b/src/modules/stylesheetFixtures.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Drift guard for the built-in stylesheet fixtures. Pure (no DB): reads the
+ * canonical `.css` off disk and proves each is a conformant token-only theme —
+ * defines the full `--st-*` primitive set (stellar-ui ADR-0005) and survives the
+ * store-time sanitizer unchanged, so `/css` delivery is verbatim. A theme that
+ * drops a primitive or sneaks in an unsafe `url()`/`@import` fails here in CI
+ * rather than shipping as a half-painted or mutated fixture.
+ */
+import { sanitizeStylesheetSource } from '../lib/cssSanitize';
+import {
+  BUILTIN_STYLESHEET_FIXTURES,
+  REQUIRED_ST_PRIMITIVES,
+  missingStPrimitives,
+  readFixtureCss
+} from './stylesheetFixtures';
+
+const cases: [string, string][] = BUILTIN_STYLESHEET_FIXTURES.map((f) => [
+  f.name,
+  f.file
+]);
+
+describe('built-in stylesheet fixtures', () => {
+  it('the required primitive list has no duplicates', () => {
+    expect(new Set(REQUIRED_ST_PRIMITIVES).size).toBe(
+      REQUIRED_ST_PRIMITIVES.length
+    );
+  });
+
+  it.each(cases)('%s defines the full --st-* primitive set', (_name, file) => {
+    expect(missingStPrimitives(readFixtureCss(file))).toEqual([]);
+  });
+
+  it.each(cases)(
+    '%s is /css-safe: the store-time sanitizer is a no-op',
+    (_name, file) => {
+      const css = readFixtureCss(file);
+      // No sheet-pulling at-rules on a token-only theme.
+      expect(css).not.toMatch(/@import|@charset|@namespace/);
+      // Verbatim delivery: sanitizing the stored source must not change a byte.
+      expect(sanitizeStylesheetSource(css)).toBe(css);
+    }
+  );
+});

--- a/src/modules/stylesheetFixtures.ts
+++ b/src/modules/stylesheetFixtures.ts
@@ -1,0 +1,133 @@
+/**
+ * Built-in stylesheet fixtures — the api-canonical source for the themes the site
+ * ships (ADR-0024). Each built-in theme is stored as an `AuthorStylesheet` row
+ * owned by the reserved System user (bootstrap `seedSystemUser`) and delivered by
+ * `GET /api/stylesheet/author-stylesheet/:id/css`; the site-registry `Stylesheet`
+ * row's `cssUrl` points at that route, so the stored source is the single canonical
+ * artifact — no silent duplicate of a static file (#285, #286).
+ *
+ * The CSS lives on disk under `prisma/seed-assets/stylesheets/` (shipped in the
+ * image — Dockerfile copies `prisma/`) so it is authored/reviewed as real `.css`,
+ * and a drift-guard spec reads the same files. Themes are token-only (stellar-ui
+ * ADR-0005): a `:root { --st-* }` block, no selectors/assets, so the store-time
+ * `sanitizeStylesheetSource` pass is a no-op on them.
+ */
+import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { sanitizeStylesheetSource } from '../lib/cssSanitize';
+
+export const BUILTIN_STYLESHEET_FIXTURES = [
+  {
+    name: 'anorex',
+    description: 'Classic wood-toned theme — brown/cream',
+    file: 'anorex.css'
+  },
+  {
+    name: 'dark-ambient',
+    description: 'Deep atmospheric theme with muted blue',
+    file: 'dark-ambient.css'
+  }
+] as const;
+
+/**
+ * The primitive `--st-*` Role Token set a conformant token-only theme MUST define
+ * (stellar-ui ADR-0005 / docs/theming.md §3.1). Cross-repo coupling to the ui
+ * contract — the drift-guard spec pins the seed-asset CSS against this list so a
+ * built-in theme can never ship missing a primitive (the derived + geometry tokens
+ * follow via `var()` and are not restated).
+ */
+export const REQUIRED_ST_PRIMITIVES = [
+  // Surfaces
+  '--st-backdrop',
+  '--st-base',
+  '--st-panel',
+  '--st-raised',
+  // Text
+  '--st-text-strong',
+  '--st-text',
+  '--st-text-muted',
+  '--st-text-faint',
+  // Accent / Link
+  '--st-accent',
+  '--st-accent-hover',
+  '--st-accent-ring',
+  '--st-link',
+  '--st-link-hover',
+  // Borders
+  '--st-border',
+  '--st-border-subtle',
+  '--st-border-strong',
+  // Status
+  '--st-danger',
+  '--st-success',
+  '--st-warning',
+  '--st-info'
+] as const;
+
+const SEED_ASSET_DIR = resolve(
+  __dirname,
+  '../../prisma/seed-assets/stylesheets'
+);
+
+/** Read a built-in theme's canonical CSS off disk (shipped under prisma/). */
+export const readFixtureCss = (file: string): string =>
+  readFileSync(resolve(SEED_ASSET_DIR, file), 'utf8');
+
+/**
+ * Primitives absent from a theme's source, checked as *declarations* (`--st-x:`)
+ * so `--st-text` is not spuriously matched inside `--st-text-strong`.
+ */
+export const missingStPrimitives = (css: string): string[] =>
+  REQUIRED_ST_PRIMITIVES.filter(
+    (token) => !new RegExp(`${token}\\s*:`).test(css)
+  );
+
+/** The `/css` delivery route for a stored AuthorStylesheet, by id. */
+export const authorStylesheetCssUrl = (id: number): string =>
+  `/api/stylesheet/author-stylesheet/${id}/css`;
+
+/**
+ * Seed the built-in stylesheet fixtures under the System user and repoint each
+ * site-registry row at the `/css` route. Idempotent: matches an existing fixture
+ * by (authorId, name) and always reconciles the registry `cssUrl` to the fixture's
+ * live id. Requires `seedSystemUser` (the owner) to have run.
+ */
+export async function seedStylesheetFixtures(
+  client: PrismaClient,
+  systemUserId: number
+): Promise<void> {
+  for (const fixture of BUILTIN_STYLESHEET_FIXTURES) {
+    const existing = await client.authorStylesheet.findFirst({
+      where: { authorId: systemUserId, name: fixture.name },
+      select: { id: true }
+    });
+
+    let fixtureId: number;
+    if (existing) {
+      fixtureId = existing.id;
+    } else {
+      const created = await client.authorStylesheet.create({
+        data: {
+          authorId: systemUserId,
+          name: fixture.name,
+          source: sanitizeStylesheetSource(readFixtureCss(fixture.file))
+        },
+        select: { id: true }
+      });
+      fixtureId = created.id;
+    }
+
+    const cssUrl = authorStylesheetCssUrl(fixtureId);
+    await client.stylesheet.upsert({
+      where: { name: fixture.name },
+      create: {
+        name: fixture.name,
+        description: fixture.description,
+        cssUrl,
+        isDefault: false
+      },
+      update: { description: fixture.description, cssUrl }
+    });
+  }
+}

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -17,9 +17,11 @@ import {
   seedRanks,
   seedRankPromotionRules,
   seedForums,
+  seedSystemUser,
   seedDefaultCommunity
 } from '../../modules/bootstrap';
 import { seedGoldenRules } from '../../modules/goldenRules';
+import { seedStylesheetFixtures } from '../../modules/stylesheetFixtures';
 import { AppError } from '../../lib/errors';
 import { authUserSelect, toAuthUser } from '../../modules/auth';
 import { getDefaultStylesheetName } from '../../modules/stylesheet';
@@ -174,6 +176,10 @@ router.post(
     await seedRankPromotionRules(prisma);
     await seedForums(prisma);
     await seedGoldenRules(prisma);
+    // System user + built-in stylesheet fixtures it owns (repoints the registry
+    // rows at the /css delivery route). Needs ranks; independent of the SysOp.
+    const systemUserId = await seedSystemUser(prisma);
+    await seedStylesheetFixtures(prisma, systemUserId);
 
     const sysopRank = await prisma.userRank.findFirst({
       where: { level: 1000 }


### PR DESCRIPTION
0.6.3 of the v0.7.0 ladder (#287): **stylesheet registry integrity**.

## What & why

Built-in themes become single-source and **api-canonical** (ADR-0024): each is stored as an `AuthorStylesheet` fixture owned by a reserved, non-interactive **System user** and delivered by `GET /api/stylesheet/author-stylesheet/:id/css`, with the site-registry `cssUrl` repointed at that route. No silent static-file duplicate — the stored source is the one canonical artifact, verifiable from the api that serves it.

- **anorex (#285)** — canonical CSS moved into `prisma/seed-assets/stylesheets/` (the ui static file is now redundant → ui cleanup follow-up).
- **dark-ambient (#286)** — was a registered row with **no stylesheet anywhere** (a dead theme-picker entry). Authored fresh as a **token-only** theme (stellar-ui ADR-0005): a `:root { --st-* }` block, no selectors / `!important` / assets, so the store-time sanitizer is a no-op and `/css` delivery is verbatim. Legacy chrome + image refs dropped (data-scrub gate).

## System user

New reserved account (`seedSystemUser`, username `system`, `disabled` + `rankLocked`, `.invalid` email, unusable random password) that owns built-in content fixtures. Seeded before them in both `prisma/seed.ts` and the install flow (`seedRanks → seedSystemUser → seedStylesheetFixtures`). It owns content only — operational System PMs still use `senderId: null`. No schema change (a row, not a column).

## Guards (#286 consistency ask)

- **Pure spec** — pins each seed-asset CSS to the full `--st-*` primitive set (a token-based theme can never ship missing a primitive).
- **Integration** — asserts every `/css`-backed registry row resolves to a real, non-empty `AuthorStylesheet`, with byte-fidelity between the stored source and the authored file; plus seeder idempotency and the System account's non-interactive shape.

## Asset storage (ADR-0026, design only)

The `/css` route carries only CSS bytes, so asset-heavy themes (postmod/proton) can't move to api-canonical yet, and content imagery (cover art, avatars, logos) needs a home. ADR-0026 fixes the decision to build an api-owned asset store; implementation is a tracked follow-up. 0.6.3 ships regardless — both new themes are asset-free.

## Verification

`tsc`, `typecheck:test`, full unit suite (1766 tests / 96 suites), the new integration guard against real Postgres, `version:check`, lint, format — all green; pre-commit hook passed.

Closes #285
Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)