### PR TITLE
feat(reports): System PM to the reporter on resolution (closes #273)

### DIFF
--- a/src/modules/reports.spec.ts
+++ b/src/modules/reports.spec.ts
@@ -36,6 +36,14 @@ jest.mock('../lib/prisma', () => ({
   prisma: prismaMock
 }));
 
+jest.mock('./logging', () => ({
+  getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+}));
+
+jest.mock('./pm', () => ({
+  sendSystemMessage: jest.fn().mockResolvedValue({ ok: true })
+}));
+
 import {
   addNote,
   claimReport,
@@ -48,6 +56,9 @@ import {
   resolveReport,
   unclaimReport
 } from './reports';
+import { sendSystemMessage } from './pm';
+
+const mockSendSystemMessage = sendSystemMessage as jest.Mock;
 
 const makeReport = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
@@ -323,6 +334,32 @@ describe('resolveReport', () => {
         reason: 'not_found'
       }
     );
+  });
+
+  it('sends a null-sender System PM to the reporter on resolve', async () => {
+    prismaMock.report.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.report.findUnique.mockResolvedValueOnce({ reporterId: 42 });
+
+    await expect(
+      resolveReport(9, 7, 'Removed the offending post', 'ContentRemoved')
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockSendSystemMessage).toHaveBeenCalledTimes(1);
+    const [toId, , body] = mockSendSystemMessage.mock.calls[0];
+    expect(toId).toBe(42);
+    expect(body).toContain('Removed the offending post');
+    expect(body).toContain('ContentRemoved');
+    expect(body).toContain('/private/reports/9');
+  });
+
+  it('does not fail the resolve when the System PM send throws', async () => {
+    prismaMock.report.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.report.findUnique.mockResolvedValueOnce({ reporterId: 42 });
+    mockSendSystemMessage.mockRejectedValueOnce(new Error('pm boom'));
+
+    await expect(resolveReport(9, 7, 'Handled', 'Dismissed')).resolves.toEqual({
+      ok: true
+    });
   });
 });
 

--- a/src/modules/reports.ts
+++ b/src/modules/reports.ts
@@ -7,6 +7,10 @@ import {
 } from '@prisma/client';
 import type { ReportResolutionAction } from '../schemas/reports';
 import { audit } from '../lib/audit';
+import { getLogger } from './logging';
+import { sendSystemMessage } from './pm';
+
+const log = getLogger('reports');
 
 const PAGE_SIZE = 25;
 
@@ -416,6 +420,29 @@ export async function resolveReport(
   await audit(prisma, staffUserId, 'report.resolve', 'Report', id, {
     resolutionAction
   });
+
+  // Fire-and-forget: let the reporter know their report was resolved. Runs
+  // after the CAS commits, in its own try/catch — a PM failure must never
+  // roll back or fail the resolve (#273).
+  try {
+    const report = await prisma.report.findUnique({
+      where: { id },
+      select: { reporterId: true }
+    });
+    if (report) {
+      await sendSystemMessage(
+        report.reporterId,
+        'Your report has been resolved',
+        `Your report has been resolved.\n\n` +
+          `Action taken: ${resolutionAction}\n` +
+          `Resolution: ${resolution}\n\n` +
+          `View your report: /private/reports/${id}`
+      );
+    }
+  } catch (err) {
+    log.warn('System report-resolved PM failed', { reportId: id, err });
+  }
+
   return { ok: true as const };
 }
 


### PR DESCRIPTION
## Summary
- `resolveReport` (`src/modules/reports.ts`) now sends a null-sender System PM to the reporter after the resolve compare-and-swap commits, containing the resolution text, the resolution action, and a link back to the report (`/private/reports/:id`, matching stellar-ui's `MyReportsPage` route).
- Uses the established `sendSystemMessage` pattern (same as the link-health WARN→FAIL contributor notice) — a PM with `senderId: null`, no new `NotificationType` enum value.
- The send is fire-and-forget in its own try/catch; failure is logged (`getLogger('reports')`) but never fails or rolls back the resolve.
- Reports only — staff-inbox ticket resolution is untouched (that thread already carries its own outcome; a PM would duplicate it). No batch handling added — only the single-report resolve path exists.

Closes #273.

## Test plan
- [x] `npm run format` — clean, no diffs beyond the two changed files
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm run test --no-coverage` — 96 suites / 1784 tests passing
- [x] New spec in `src/modules/reports.spec.ts` (`resolveReport` describe block): asserts a System PM is sent to the reporter's id with a body containing the resolution text, the resolution action, and the report link; asserts a rejected `sendSystemMessage` does not fail the resolve
- [x] Verified against regression: stashing `src/modules/reports.ts` while keeping the new spec reproduces a failing assertion (`Expected number of calls: 1, Received number of calls: 0`), confirming the test exercises real behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mqp8ygTX8VkxjZBBYXWgmg