### PR TITLE
chore(release): cut 0.6.9 — reporter notify + openapi contract fixes + governing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.6.9] — 2026-07-09
+
+A consolidation cut on the road to 0.7.0: reporters get notified when their reports resolve, two OpenAPI contract-drift bugs are closed at the source, and the last undocumented subsystems and pipeline boundaries get their governing docs.
+
+### Added
+
+- **Reporters are notified when their report is resolved** — on report resolution a null-sender System PM is sent to the reporter with the resolution text, the resolution action, and a link back to the report. It is fire-and-forget: a failure to send never rolls back or blocks the resolve [#273].
+
+### Fixed
+
+- **`Notification.type` now advertises all ten notification kinds** — the OpenAPI contract derives the enum from the Prisma `NotificationType` instead of a hand-maintained list of six, so `site_news`, `global_notice`, `rank_promoted`, and `rank_demoted` are type-narrowable by clients and the enum can no longer drift from the source [#302].
+- **Nullable profile references no longer drop their `null`** — `PublicProfile`/`MyProfile` `community`, `donorPresentation`, and `staffPmOverview` generate as `T | null` instead of `T & unknown`, matching what the routes actually return; the codegen shape that swallowed the null is normalized during export [#295].
+
+### Docs
+
+- **ADR-0027 — the publish/deploy boundary** — the stellar-api pipeline's responsibility ends at the versioned GHCR publish; deployment and environment promotion live in stellar-compose, with a pinned semver image tag as the handoff artifact [#293].
+- **ADR-0028 and PRD-10 — the user-classes ladder and automated progression** — the shipped class-progression system (rank ladder, promotion rules, sweep job, `rankLocked`) finally has a governing doc, recording the classes-versus-CRS firewall, link-health-eligible byte accounting, the prestige predicate, and the demotion guards [#303].
+- **CONTEXT retires the Chrome Layer entry** — the retired stylesheet-injection term is marked do-not-rebuild and the stellar-ui cross-links are resolved [#305].
+
 ## [0.6.4] — 2026-07-07
 
 The built-in theme catalog becomes api-canonical and single-sourced, and the api version aligns with stellar-ui.
@@ -514,7 +533,8 @@ _Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a0
 
 ---
 
-[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.4...HEAD
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.6.9...HEAD
+[0.6.9]: https://github.com/orphic-inc/stellar-api/compare/v0.6.4...v0.6.9
 [0.6.4]: https://github.com/orphic-inc/stellar-api/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/orphic-inc/stellar-api/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/orphic-inc/stellar-api/compare/v0.6.1...v0.6.2

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Stellar API",
-    "version": "0.6.4",
+    "version": "0.6.9",
     "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.6.4",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.6.4",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.6.4",
+  "version": "0.6.9",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Consolidation release on the road to 0.7.0. Folds the remaining 0.6.x ladder rungs (0.6.5 buffer → 0.6.6 #273 → 0.6.7 release-prep) into a single **v0.6.9** cut; the **v0.7.0 milestone is left open** to catch any remaining/forgotten tasks before the terminal release.

## Wave (since v0.6.4)
- **#273** — System PM to the reporter on report resolution (PR #309)
- **#302 + #295** — Notification enum derived from Prisma + nullable `$ref` codegen fix (PR #310)
- **#293** — ADR-0027 publish/deploy boundary (PR #307)
- **#303** — ADR-0028 + PRD-10 user-classes governing doc (PR #308)
- **#305** — CONTEXT Chrome Layer retirement (PR #305)

Paired stellar-ui type resync: orphic-inc/stellar-ui#170.

## This PR
- CHANGELOG `[0.6.9]` section (Added / Fixed / Docs) + compare-link footer.
- Version surfaces realigned to 0.6.9: `package.json`, `package-lock.json` (version:check green).
- Freshness gates (OpenAPI / ERD) verified clean; no schema change this wave.

**Tag held:** `v0.6.9` is not pushed. Cut the annotated tag on `main` after this merges — that fires the `v*` GHCR publish (ADR-0027).

Co-Authored-By: Mr. Robot <mr.robot@fsociety.dat>