### PR TITLE
feat(deploy): seed the idempotent baseline on container boot (closes #313)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,6 +111,15 @@ jobs:
             echo "::error::No migrations applied — container did not self-migrate"
             docker logs api; exit 1
           fi
+          # Definitive check: the entrypoint also seeded the baseline, so a fresh
+          # deploy is ready for /install rather than an empty DB (api#313).
+          ranks=$(docker exec pg psql -U postgres -d stellar -tAc \
+            "SELECT count(*) FROM user_ranks")
+          echo "Seeded ranks: $ranks"
+          if [ "$ranks" -lt 1 ]; then
+            echo "::error::No ranks seeded — container did not self-seed on boot"
+            docker logs api; exit 1
+          fi
       - name: Teardown
         if: always()
         run: |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
-# Apply pending migrations before the API serves a single request, then hand off
-# to the app. Fail-fast: if `migrate deploy` errors, the container exits non-zero
-# (restart: always retries) rather than serving against a schema-behind database
+# Migrate, then seed the idempotent baseline, then hand off to the app — so a
+# fresh deploy comes up ready for /install instead of an empty database. Fail-fast
+# (`set -e`): if migrate or seed errors, the container exits non-zero (restart:
+# always retries) rather than serving against a schema-behind or unseeded database
 # — the exact break that a merged-but-unapplied migration otherwise causes.
 set -e
 
 echo "[entrypoint] Applying database migrations (prisma migrate deploy)..."
 npx prisma migrate deploy
 
-echo "[entrypoint] Migrations up to date. Starting API..."
+# Idempotent: a no-op on an already-seeded database, so it's safe on every boot.
+echo "[entrypoint] Seeding baseline data (ranks, forums, rules, fixtures)..."
+node dist/scripts/seed.js
+
+echo "[entrypoint] Ready. Starting API..."
 exec node dist/index.js

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,29 +6,17 @@
  * http://localhost:9000/install when stellar-ui is running) or directly against
  * the API: POST http://localhost:${STELLAR_HTTP_PORT:-8080}/api/install.
  *
- * Runs automatically after `prisma migrate dev` resets the database.
- * Can also be run manually: npm run db:seed (npx prisma db seed).
+ * Runs automatically after `prisma migrate dev` resets the database, and can be
+ * run manually with `npm run db:seed`. The container runs the same sequence on
+ * boot via src/scripts/seed.ts — both call seedAll(), the single source of truth.
  */
 import { PrismaClient } from '@prisma/client';
-import {
-  seedRanks,
-  seedRankPromotionRules,
-  seedForums,
-  seedSystemUser
-} from '../src/modules/bootstrap';
-import { seedGoldenRules } from '../src/modules/goldenRules';
-import { seedStylesheetFixtures } from '../src/modules/stylesheetFixtures';
+import { seedAll } from '../src/modules/seedAll';
 
 const prisma = new PrismaClient();
 
 async function main() {
-  await seedRanks(prisma);
-  await seedRankPromotionRules(prisma);
-  await seedForums(prisma);
-  await seedGoldenRules(prisma);
-  // System user must precede the stylesheet fixtures it owns (needs ranks first).
-  const systemUserId = await seedSystemUser(prisma);
-  await seedStylesheetFixtures(prisma, systemUserId);
+  await seedAll(prisma);
   const port = process.env.STELLAR_HTTP_PORT || '8080';
   console.log(
     `→ Seed complete. Create the first SysOp via the UI install page ` +

--- a/src/modules/seedAll.spec.ts
+++ b/src/modules/seedAll.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * seedAll is a thin orchestrator, but it owns one real invariant the individual
+ * seeders can't enforce alone: the System user must be seeded *before* the
+ * stylesheet fixtures it owns, and its returned id must be the one the fixtures
+ * are authored under. A reorder or a wrong id would seed orphaned fixtures — pin
+ * that wiring here.
+ */
+import type { PrismaClient } from '@prisma/client';
+
+const seedRanks = jest.fn();
+const seedRankPromotionRules = jest.fn();
+const seedForums = jest.fn();
+const seedSystemUser = jest.fn();
+const seedGoldenRules = jest.fn();
+const seedStylesheetFixtures = jest.fn();
+
+const SYSTEM_USER_ID = 4242;
+
+jest.mock('./bootstrap', () => ({
+  seedRanks: (...a: unknown[]) => seedRanks(...a),
+  seedRankPromotionRules: (...a: unknown[]) => seedRankPromotionRules(...a),
+  seedForums: (...a: unknown[]) => seedForums(...a),
+  seedSystemUser: (...a: unknown[]) => seedSystemUser(...a)
+}));
+jest.mock('./goldenRules', () => ({
+  seedGoldenRules: (...a: unknown[]) => seedGoldenRules(...a)
+}));
+jest.mock('./stylesheetFixtures', () => ({
+  seedStylesheetFixtures: (...a: unknown[]) => seedStylesheetFixtures(...a)
+}));
+
+import { seedAll } from './seedAll';
+
+describe('seedAll', () => {
+  const client = {} as PrismaClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Set here, not at module load: the suite's mock config resets
+    // implementations between tests.
+    seedSystemUser.mockResolvedValue(SYSTEM_USER_ID);
+  });
+
+  it('runs every baseline seeder once against the given client', async () => {
+    await seedAll(client);
+    for (const fn of [
+      seedRanks,
+      seedRankPromotionRules,
+      seedForums,
+      seedGoldenRules,
+      seedSystemUser,
+      seedStylesheetFixtures
+    ]) {
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn.mock.calls[0][0]).toBe(client);
+    }
+  });
+
+  it('seeds the System user before the fixtures it owns, passing its id through', async () => {
+    await seedAll(client);
+    expect(seedSystemUser.mock.invocationCallOrder[0]).toBeLessThan(
+      seedStylesheetFixtures.mock.invocationCallOrder[0]
+    );
+    // Fixtures are authored under exactly the id seedSystemUser returned.
+    expect(seedStylesheetFixtures).toHaveBeenCalledWith(client, SYSTEM_USER_ID);
+  });
+});

--- a/src/modules/seedAll.ts
+++ b/src/modules/seedAll.ts
@@ -1,0 +1,37 @@
+/**
+ * The idempotent baseline seed — everything the /install flow needs to exist
+ * before the first SysOp is minted: user ranks, the promotion-rule ladder, the
+ * default forum structure, the Golden Rules, the reserved System user, and the
+ * built-in stylesheet fixtures it owns.
+ *
+ * Deliberately does NOT create real users and does NOT stamp
+ * `SiteSettings.installedAt` — so /install stays available and required after a
+ * seed (it mints the SysOp and seeds the default community, which needs one).
+ * Every helper here is a no-op when its rows already exist, so this is safe to
+ * re-run on every container boot.
+ *
+ * Single source of truth for the seed sequence, shared by:
+ *   - prisma/seed.ts        — dev, via ts-node after `prisma migrate reset`
+ *   - src/scripts/seed.ts   — the compiled entrypoint the container runs on boot
+ *                             (docker-entrypoint.sh), from dist/ with prod deps.
+ */
+import { PrismaClient } from '@prisma/client';
+import {
+  seedRanks,
+  seedRankPromotionRules,
+  seedForums,
+  seedSystemUser
+} from './bootstrap';
+import { seedGoldenRules } from './goldenRules';
+import { seedStylesheetFixtures } from './stylesheetFixtures';
+
+export async function seedAll(client: PrismaClient): Promise<void> {
+  await seedRanks(client);
+  await seedRankPromotionRules(client);
+  await seedForums(client);
+  await seedGoldenRules(client);
+  // System user must precede the stylesheet fixtures it owns (and needs ranks
+  // to exist first — it takes the base User rank).
+  const systemUserId = await seedSystemUser(client);
+  await seedStylesheetFixtures(client, systemUserId);
+}

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,0 +1,30 @@
+/**
+ * Boot seed — the compiled entrypoint the container runs after `migrate deploy`
+ * (docker-entrypoint.sh). Applies the idempotent baseline (seedAll) so a fresh
+ * deploy comes up with ranks / forums / Golden Rules / the System user /
+ * stylesheet fixtures already present and /install immediately usable — instead
+ * of an empty database that needs a manual `docker compose exec api npm run
+ * db:seed` before the first SysOp can be created.
+ *
+ * Runs from dist/ against prod dependencies only (no ts-node), which is why the
+ * seed sequence lives in compiled src/modules and not in prisma/seed.ts. Exits
+ * non-zero on failure so the fail-fast entrypoint (`set -e`) surfaces a bad
+ * deploy as a crash-loop rather than a silently unusable API.
+ */
+import { PrismaClient } from '@prisma/client';
+import { seedAll } from '../modules/seedAll';
+
+async function main() {
+  const prisma = new PrismaClient();
+  try {
+    await seedAll(prisma);
+    console.log('[seed] Baseline data present.');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((e) => {
+  console.error('[seed] Failed:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
The self-migrating entrypoint (#276) applied migrations on boot but did **not** seed — so a fresh `docker compose up` came up with a migrated-but-**empty** database (no ranks, forums, Golden Rules, System user, or stylesheet fixtures), and `/install` couldn't run until an operator manually ran `docker compose exec api npm run db:seed`. This closes that first-run gap — the second follow-up in #313.

`prisma/seed.ts` couldn't be reused directly: it's a ts-node script importing from `src/`, but the runtime image runs `npm ci --omit=dev` (no ts-node) and copies only `dist/` + `prisma/` (not `src/`). The seed *logic*, though, lives in compiled `src/modules/*` that already ships in `dist/`.

## Changes
- **`src/modules/seedAll.ts`** — extract the seed sequence into one idempotent `seedAll()`, the single source of truth.
- **`prisma/seed.ts`** — now a thin wrapper over `seedAll()` (dev path unchanged).
- **`src/scripts/seed.ts`** — new compiled entrypoint (`dist/scripts/seed.js`) the container runs; prod-deps only, no ts-node.
- **`docker-entrypoint.sh`** — runs the seed after `migrate deploy`, before app start. Idempotent (every seeder is create-if-absent / count-guarded / upsert) so it's a no-op on an already-seeded DB; fail-fast under `set -e`.
- **`.github/workflows/publish.yml`** — the boot smoke job now asserts ranks were seeded, alongside the existing migration assertion, so seed-on-boot is a CI-gated contract.
- **`src/modules/seedAll.spec.ts`** — pins the one invariant the individual seeders can't: the System user is seeded before the fixtures it owns, with its id passed through.

Seeding deliberately does **not** stamp `installedAt`, so `/install` stays available to mint the SysOp.

## Test plan
- [x] `docker build` + boot a fresh Postgres → **9 ranks, 6 promotion rules, 6 forum categories, 23 forums, 6 Golden Rules, 1 System user, 10 stylesheet fixtures**, `installedAt` NULL (i.e. `/install` still available)
- [x] Restart against the seeded DB → all counts stable, no errors, 0 restarts (idempotent)
- [x] `npx tsc --noEmit`, `typecheck:test`, `npm run lint`, full suite (97 suites / 1786 tests) — all green
- [x] The extended CI smoke job asserts ranks seeded on boot

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)