### PR TITLE
ci: add Renovate config for automated dependency + image bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard", "schedule:weekly"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "description": "Dev tooling: safe to automerge patch/minor",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "description": "Group non-major npm deps to keep PR volume low",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm non-major"
+    },
+    {
+      "description": "Pin GitHub Action digests fresh; safe to automerge",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Base images: review every bump (ADR-0001 / api#99 class)",
+      "matchDatasources": ["docker"],
+      "automerge": false,
+      "groupName": null
+    },
+    {
+      "description": "Prisma is engine-sensitive + a live 6->7 migration: review, grouped, never automerge",
+      "matchPackageNames": ["prisma", "@prisma/client"],
+      "automerge": false,
+      "groupName": "prisma"
+    },
+    {
+      "description": "Major bumps always reviewed",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
+  "lockFileMaintenance": { "enabled": true, "automerge": true }
+}


### PR DESCRIPTION
## Summary
Adds a committed `renovate.json` so Renovate (once the GitHub App is enabled on the org) manages `npm`, `dockerfile`, and `github-actions` updates without an onboarding PR.

Policy encoded (see orphic-inc/stellar-compose#9):
- Keep the pinned `node:24-alpine3.23` base fresh — never unpin to a floating tag (ADR-0001); every base-image bump stays individually reviewable (the api#99 Alpine/Prisma class of outage).
- `prisma` + `@prisma/client` never automerge at any level — engine-sensitive, and there's a live 6→7 migration (seed logs warn `package.json#prisma` is deprecated → `prisma.config.ts`).
- Dev-tooling patch/minor and GitHub Actions digest bumps automerge; major bumps and Docker base images always require review.
- Weekly schedule, grouped npm non-major + github-actions, `prConcurrentLimit: 5`.

Validated offline: `npx renovate-config-validator renovate.json` → `Config validated successfully`.

Part of the fleet-wide Renovate adoption tracked in orphic-inc/stellar-compose#9 (all three repos — compose, api, ui — are co-equal deliverables).

## Test plan
- [x] `renovate-config-validator` passes
- [ ] After merge + Renovate App enabled: confirm Dependency Dashboard issue lists npm/dockerfile/github-actions managers and current pins
- [ ] Confirm Prisma and base-image PRs land un-automerged
