### PR TITLE
chore(renovate): platformAutomerge off so app merges via bypass

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "platformAutomerge is off deliberately: GitHub native auto-merge ignores the branch-protection app-bypass, so Renovate merges its own automerge PRs directly as the app (the bypass on `main` covers the Renovate app). Required human review stays for everything else; the `test` required check still gates every merge.",
   "extends": ["config:recommended", ":dependencyDashboard", "schedule:weekly"],
   "prConcurrentLimit": 5,
+  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Dev tooling: safe to automerge patch/minor",


### PR DESCRIPTION
Same fix verified on stellar-compose (#26 + PR #22 auto-merged by renovate[bot] via bypass).

Native GitHub auto-merge ignores the branch-protection app-bypass and never triggers renovate-approve, so automerge PRs sat BLOCKED. `platformAutomerge: false` makes Renovate merge its own `automerge: true` PRs directly as the app; `main`'s `bypass_pull_request_allowances` (renovate app) permits it. Humans still need the 1 review; the `test` required check still gates every merge.

Requires: renovate app added to this repo's `main` bypass list (companion branch-protection change). Ref orphic-inc/stellar-compose#9.