### PR TITLE
perf(typecheck): cut the pre-commit/CI typecheck tax at its measured sources

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,41 @@ jobs:
       - name: Version consistency (tag)
         if: startsWith(github.ref, 'refs/tags/')
         run: git fetch --tags --force && npm run version:check -- --check-tag
+
+  # Split from `test` (#306): the integration suite is DB-bound (~4.5 min) and
+  # was the long pole of the required check. Running it in parallel cuts the
+  # merge-gate critical path to the cheap gates. NOTE: branch protection must
+  # require BOTH `test` and `integration` for the gate to keep covering it.
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: stellar
+          POSTGRES_PASSWORD: changeme
+          POSTGRES_DB: stellar
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      STELLAR_PSQL_URI: postgresql://stellar:changeme@localhost:5432/stellar
+      STELLAR_PSQL_URI_TEST: postgresql://stellar:changeme@localhost:5432/stellar_test
+      STELLAR_AUTH_JWT_SECRET: ci-only-not-a-secret-pad-to-32-chars
+      STELLAR_HTTP_PORT: 8080
+      STELLAR_HTTP_CORS_ORIGIN: http://localhost:3000
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
       - name: Integration tests
         run: npm run test:integration
 
@@ -127,7 +162,7 @@ jobs:
           docker network rm stellar-smoke >/dev/null 2>&1 || true
 
   publish:
-    needs: [test, smoke]
+    needs: [test, integration, smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ src/**/*.js.map
 .DS_Store
 .playwright-mcp/
 
+# Incremental typecheck caches (#306)
+.cache/
+
 # Local recovery / scratch notes — never committed
 /update.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to stellar-api are documented here.
 ### Changed
 
 - **Pre-commit and CI typecheck cost cut at the measured sources** — trace attribution showed the tax was cold whole-graph re-checks plus two Prisma type pathologies, not zod inference: both tsconfigs now persist incremental build info (warm `tsc --noEmit` re-checks only the changed subgraph), `testPrisma` is annotated as canonical `PrismaClient` (one unannotated export cost a 29s structural compare), `version:check` runs ts-node transpile-only (was ~40s of boot-time type-checking), and `jest.integration.cjs` gets the same `isolatedModules` treatment as the unit config so the CI integration step stops re-type-checking every suite's import graph [#306].
+- **Integration tests run as their own parallel CI job** — measurement on the PR showed the step is DB-bound (~4.5 min) and still the long pole of the required `test` check, so it moves out of that job's critical path; branch protection must require both `test` and `integration` once this lands [#306].
 
 ## [0.6.9] — 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **Pre-commit and CI typecheck cost cut at the measured sources** — trace attribution showed the tax was cold whole-graph re-checks plus two Prisma type pathologies, not zod inference: both tsconfigs now persist incremental build info (warm `tsc --noEmit` re-checks only the changed subgraph), `testPrisma` is annotated as canonical `PrismaClient` (one unannotated export cost a 29s structural compare), `version:check` runs ts-node transpile-only (was ~40s of boot-time type-checking), and `jest.integration.cjs` gets the same `isolatedModules` treatment as the unit config so the CI integration step stops re-type-checking every suite's import graph [#306].
+
 ## [0.6.9] — 2026-07-09
 
 A consolidation cut on the road to 0.7.0: reporters get notified when their reports resolve, two OpenAPI contract-drift bugs are closed at the source, and the last undocumented subsystems and pipeline boundaries get their governing docs.

--- a/jest.integration.cjs
+++ b/jest.integration.cjs
@@ -17,6 +17,12 @@ module.exports = {
       'ts-jest',
       {
         tsconfig: {
+          // Transpile-only, same rationale as jest.config.cjs (#306): without
+          // this, ts-jest full-type-checks each suite's import graph — the
+          // dominant term of the CI integration step. Type safety for these
+          // files is enforced by `npm run typecheck:test` (its exclude is only
+          // `dist`, so *.integration.ts is covered).
+          isolatedModules: true,
           module: 'commonjs',
           moduleResolution: 'node',
           esModuleInterop: true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch --forceExit",
     "test:integration": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ./node_modules/jest/bin/jest.js --runInBand --config jest.integration.cjs",
     "openapi:export": "ts-node src/scripts/export-openapi.ts",
-    "version:check": "ts-node src/scripts/check-version-consistency.ts",
+    "version:check": "ts-node -T src/scripts/check-version-consistency.ts",
     "db:generate": "prisma generate",
     "db:erd": "prisma generate --generator erd",
     "db:migrate": "prisma migrate dev",

--- a/src/test/dbHelpers.ts
+++ b/src/test/dbHelpers.ts
@@ -2,7 +2,11 @@ import { PrismaClient } from '@prisma/client';
 
 const testUrl = process.env.STELLAR_PSQL_URI_TEST!;
 
-export const testPrisma = new PrismaClient({
+// Annotated as canonical `PrismaClient`: without it the inferred type is the
+// non-canonical `PrismaClient<{datasources, log}>` instantiation, and every
+// call site taking a `PrismaClient` parameter pays a full structural compare
+// of the entire client (~29s in one integration test alone, #306 trace).
+export const testPrisma: PrismaClient = new PrismaClient({
   datasources: { db: { url: testUrl } },
   log: []
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,13 @@
 
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+
+    /* Performance (#306) — persist the program graph so a warm `tsc --noEmit`
+       re-checks only the changed subgraph instead of a full cold pass. The test
+       tsconfig overrides tsBuildInfoFile: each project needs its own cache. */
+    "incremental": true,
+    "tsBuildInfoFile": ".cache/tsbuildinfo.src"
   },
   "ts-node": {
     "files": true

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -11,7 +11,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "noEmit": true
+    "noEmit": true,
+    // Own cache — sharing the base project's tsbuildinfo would thrash it (#306).
+    "tsBuildInfoFile": ".cache/tsbuildinfo.test"
   },
   "include": ["src/**/*"],
   "exclude": ["dist"]


### PR DESCRIPTION
## Summary

Closes #306. Trace-attributed (details in the issue comment) and fixed the four measured costs instead of the hypothesized one:

- **Incremental typecheck** — `incremental: true` + per-project `tsBuildInfoFile` (`.cache/`, gitignored) for both tsconfigs. The pre-commit chain's two cold whole-graph passes were the dominant local term; warm runs now re-check only the changed subgraph.
- **`testPrisma: PrismaClient` annotation** (`src/test/dbHelpers.ts`) — the unannotated export inferred a non-canonical `PrismaClient<{datasources, log}>`, forcing a full structural compare of the entire client at any `PrismaClient`-typed call site (28.9s on one line of `devTools.integration.ts` in the trace).
- **`version:check` transpile-only** (`ts-node -T`) — the ~40s was ts-node type-checking the whole `include` set on boot via `"files": true`; the tsc gates immediately before it in the hook already own type safety.
- **`isolatedModules: true` in `jest.integration.cjs`** — same rationale (and comment) as the unit config; without it ts-jest full-type-checks each suite's import graph inside the CI integration step. `*.integration.ts` remains type-checked by `typecheck:test`.
- **Integration suite split into its own parallel CI job** — the first CI run on this PR measured the step at 252s vs the 267–389s baseline, proving it is DB-bound rather than typecheck-bound and still the long pole of the required `test` check. The split drops `test` to the cheap gates (~2.5 min); `publish` now needs `test + integration + smoke`. **Post-merge action: add `integration` to the required status checks on `main`** (required contexts are `test`-only today; adding it before the job exists on `main` would block every other PR).

Deliberately NOT done (measured as not worth it, see issue comment): openapi.ts restructure (~10% share), zod changes, staged-only typecheck scope, TS 5.2→5.x upgrade (separate PR). Sharding the integration suite across parallel jobs (jest `--shard` + one postgres each) is the next lever if ~4 min is still too slow.

## Measurements (local, 2019 i9 MBP)

| Gate | Before (cold, no cache) | After: warm no-change | After: warm one-module edit |
| --- | --- | --- | --- |
| `tsc --noEmit` | 75–211s | 12s | 19s |
| `typecheck:test` | 102–351s | 13s | 47s |
| `version:check` | ~40s | 2s | 2s |

Typecheck portion of the pre-commit hook: ~8 min → ~20–70s warm.

## Test plan

- [x] Unit suite green locally (97 suites / 1786 tests, 46s)
- [x] Integration suite green locally against the test DB (23 suites / 137 tests)
- [x] Cold + warm typecheck timings recorded above
- [x] CI first run (pre-split): all green; integration step 252s vs 267–389s baseline; typecheck steps unchanged; `Version consistency` 40s→0s
- [x] CI second run (post-split): all green — `test` 2m37s (was 6m48s), `integration` 6m0s in parallel, smoke + publish unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XS1FsKVAZq2nGhkrK2PUn6
