### PR TITLE
feat(ratio): Freepass/Neutralpass — ratio-exempt Contribution flags (PRD-06 #4)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2979,6 +2979,14 @@
             "type": "string",
             "nullable": true
           },
+          "ratioExempt": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "FREEPASS",
+              "NEUTRALPASS"
+            ]
+          },
           "collaborators": {
             "type": "array",
             "items": {
@@ -3012,6 +3020,7 @@
           "type",
           "downloadUrl",
           "linkStatus",
+          "ratioExempt",
           "collaborators"
         ]
       },
@@ -3149,6 +3158,14 @@
             "type": "string",
             "nullable": true
           },
+          "ratioExempt": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "FREEPASS",
+              "NEUTRALPASS"
+            ]
+          },
           "type": {
             "type": "string"
           },
@@ -3215,6 +3232,7 @@
           "sizeInBytes",
           "linkStatus",
           "linkCheckedAt",
+          "ratioExempt",
           "type",
           "createdAt",
           "updatedAt",

--- a/prisma/migrations/20260713065519_ratio_exempt_contribution_flags/migration.sql
+++ b/prisma/migrations/20260713065519_ratio_exempt_contribution_flags/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "RatioExempt" AS ENUM ('NONE', 'FREEPASS', 'NEUTRALPASS');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "EconomyTransactionReason" ADD VALUE 'FREEPASS_GRANT';
+ALTER TYPE "EconomyTransactionReason" ADD VALUE 'NEUTRALPASS_GRANT';
+
+-- AlterTable
+ALTER TABLE "contributions" ADD COLUMN     "ratioExempt" "RatioExempt" NOT NULL DEFAULT 'NONE';
+
+-- AlterTable
+ALTER TABLE "download_access_grants" ADD COLUMN     "ratioExempt" "RatioExempt" NOT NULL DEFAULT 'NONE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -190,6 +190,11 @@ enum EconomyTransactionReason {
   DOWNLOAD_CREDIT
   STAFF_REVERSAL
   CRS_STYLESHEET_ADOPTION
+  // Ratio-exempt grants (PRD-06 #4): a zero-amount marker row so the grant
+  // event still exists in the ledger for the ADR-0016 korin handoff (#261),
+  // even though no balance moved.
+  FREEPASS_GRANT
+  NEUTRALPASS_GRANT
 }
 
 enum DownloadGrantStatus {
@@ -201,6 +206,17 @@ enum RatioPolicyStatus {
   OK
   WATCH
   LEECH_DISABLED
+}
+
+// Ratio-exempt Contribution flags (PRD-06 #4). Read at consumption time by the
+// accounting path (downloads.ts). Mutually exclusive by construction — a single
+// enum encodes that a Contribution can't be both Freepass and Neutralpass.
+//   FREEPASS    — consumer's `consumed` not accrued; contributor still earns `contributed`.
+//   NEUTRALPASS — neither side accrues; fully ratio-invisible.
+enum RatioExempt {
+  NONE
+  FREEPASS
+  NEUTRALPASS
 }
 
 enum LinkHealthStatus {
@@ -1068,6 +1084,9 @@ model Contribution {
   // User.contributed — a substrate accumulator, not a score (ADR-0007).
   healthyMs               BigInt                @default(0)
   healthySince            DateTime?
+  // Ratio-exempt flag (PRD-06 #4). Read at consumption time in downloads.ts to
+  // suppress accrual; staff-settable and audited. See RatioExempt.
+  ratioExempt             RatioExempt           @default(NONE)
   type                    FileType
   createdAt               DateTime              @default(now())
   updatedAt               DateTime              @updatedAt
@@ -1524,6 +1543,10 @@ model DownloadAccessGrant {
   contributionId Int
   contribution   Contribution        @relation(fields: [contributionId], references: [id])
   amountBytes    BigInt
+  // Snapshot of the Contribution's exemption at grant time. Reversal reads this
+  // to claw back exactly what accrued — never assume `amountBytes` moved, or an
+  // exempt grant's reversal would manufacture negative balance (PRD-06 #4).
+  ratioExempt    RatioExempt         @default(NONE)
   status         DownloadGrantStatus @default(COMPLETED)
   idempotencyKey String?
   reversedAt     DateTime?

--- a/src/integration/contributions.integration.ts
+++ b/src/integration/contributions.integration.ts
@@ -2,12 +2,14 @@ import {
   ReleaseType,
   FileType,
   CommunityType,
-  RegistrationStatus
+  RegistrationStatus,
+  RatioExempt
 } from '@prisma/client';
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
 import {
   createContributionSubmission,
-  addContributionToRelease
+  addContributionToRelease,
+  setContributionRatioExempt
 } from '../modules/contribution';
 import type { CreateContributionInput } from '../schemas/contribution';
 
@@ -412,5 +414,63 @@ describe('addContributionToRelease', () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe('setContributionRatioExempt', () => {
+  it('sets the flag and writes an audit row', async () => {
+    const staff = await createUser('rx-staff');
+    const owner = await createUser('rx-owner');
+    const community = await createCommunity();
+    const contribution = await createContributionSubmission({
+      userId: owner.id,
+      input: baseInput(community.id)
+    });
+
+    const updated = await setContributionRatioExempt(
+      staff.id,
+      contribution!.id,
+      RatioExempt.FREEPASS
+    );
+    expect(updated.ratioExempt).toBe(RatioExempt.FREEPASS);
+
+    const row = await testPrisma.contribution.findUniqueOrThrow({
+      where: { id: contribution!.id }
+    });
+    expect(row.ratioExempt).toBe(RatioExempt.FREEPASS);
+
+    const auditRow = await testPrisma.auditLog.findFirst({
+      where: {
+        action: 'contribution.ratio_exempt.set',
+        targetId: contribution!.id
+      }
+    });
+    expect(auditRow).not.toBeNull();
+    expect(auditRow!.actorId).toBe(staff.id);
+  });
+
+  it('is a no-op that writes no audit row when the flag is unchanged', async () => {
+    const staff = await createUser('rx-noop-staff');
+    const owner = await createUser('rx-noop-owner');
+    const community = await createCommunity();
+    const contribution = await createContributionSubmission({
+      userId: owner.id,
+      input: baseInput(community.id)
+    });
+
+    // Default is NONE; setting NONE again should not audit.
+    await setContributionRatioExempt(
+      staff.id,
+      contribution!.id,
+      RatioExempt.NONE
+    );
+
+    const auditRows = await testPrisma.auditLog.findMany({
+      where: {
+        action: 'contribution.ratio_exempt.set',
+        targetId: contribution!.id
+      }
+    });
+    expect(auditRows).toHaveLength(0);
   });
 });

--- a/src/integration/downloads.integration.ts
+++ b/src/integration/downloads.integration.ts
@@ -2,10 +2,15 @@ import {
   FileType,
   ReleaseType,
   CommunityType,
-  RegistrationStatus
+  RegistrationStatus,
+  RatioExempt,
+  EconomyTransactionReason
 } from '@prisma/client';
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
-import { grantDownloadAccess } from '../modules/downloads';
+import {
+  grantDownloadAccess,
+  reverseDownloadAccess
+} from '../modules/downloads';
 
 beforeEach(async () => {
   await truncateAll();
@@ -44,7 +49,11 @@ const createUser = async (
 };
 
 /** sizeInBytes is stored as Int in the schema; approvedAccountingBytes is BigInt. */
-const createContribution = async (userId: number, sizeBytes = 1_000_000) => {
+const createContribution = async (
+  userId: number,
+  sizeBytes = 1_000_000,
+  ratioExempt: RatioExempt = RatioExempt.NONE
+) => {
   const community = await testPrisma.community.create({
     data: {
       name: `DL-Community-${Date.now()}`,
@@ -84,7 +93,8 @@ const createContribution = async (userId: number, sizeBytes = 1_000_000) => {
       downloadUrl: 'https://example.com/file.torrent',
       sizeInBytes: sizeBytes,
       approvedAccountingBytes: BigInt(sizeBytes),
-      releaseDescription: 'test'
+      releaseDescription: 'test',
+      ratioExempt
     }
   });
 };
@@ -172,5 +182,149 @@ describe('grantDownloadAccess', () => {
     await expect(
       grantDownloadAccess(consumer.id, contribution.id)
     ).rejects.toMatchObject({ statusCode: 403 });
+  });
+});
+
+describe('grantDownloadAccess — ratio-exempt (PRD-06 #4)', () => {
+  it('FREEPASS: consumer consumed NOT accrued; contributor contributed still accrued', async () => {
+    const COST = 1_000_000;
+    const contributor = await createUser('fp-contrib', { contributed: 0n });
+    const consumer = await createUser('fp-consumer', {
+      contributed: BigInt(COST * 5)
+    });
+    const contribution = await createContribution(
+      contributor.id,
+      COST,
+      RatioExempt.FREEPASS
+    );
+
+    const result = await grantDownloadAccess(consumer.id, contribution.id);
+    expect(result.status).toBe('COMPLETED');
+
+    const c = await testPrisma.user.findUniqueOrThrow({
+      where: { id: consumer.id }
+    });
+    expect(c.consumed).toBe(0n); // suppressed
+
+    const k = await testPrisma.user.findUniqueOrThrow({
+      where: { id: contributor.id }
+    });
+    expect(k.contributed).toBe(BigInt(COST)); // still earns availability credit
+
+    const grant = await testPrisma.downloadAccessGrant.findUniqueOrThrow({
+      where: { id: result.grantId }
+    });
+    expect(grant.ratioExempt).toBe(RatioExempt.FREEPASS);
+
+    // Ledger: consumer gets a zero-amount marker, contributor a real credit.
+    const rows = await testPrisma.economyTransaction.findMany({
+      where: { contextId: result.grantId, contextType: 'download' }
+    });
+    const consumerRow = rows.find((r) => r.userId === consumer.id);
+    const contribRow = rows.find((r) => r.userId === contributor.id);
+    expect(consumerRow?.reason).toBe(EconomyTransactionReason.FREEPASS_GRANT);
+    expect(consumerRow?.amount).toBe(0n);
+    expect(contribRow?.reason).toBe(EconomyTransactionReason.DOWNLOAD_CREDIT);
+    expect(contribRow?.amount).toBe(BigInt(COST));
+  });
+
+  it('NEUTRALPASS: neither side accrues', async () => {
+    const COST = 1_000_000;
+    const contributor = await createUser('np-contrib', { contributed: 0n });
+    const consumer = await createUser('np-consumer', {
+      contributed: BigInt(COST * 5)
+    });
+    const contribution = await createContribution(
+      contributor.id,
+      COST,
+      RatioExempt.NEUTRALPASS
+    );
+
+    const result = await grantDownloadAccess(consumer.id, contribution.id);
+    expect(result.status).toBe('COMPLETED');
+
+    const c = await testPrisma.user.findUniqueOrThrow({
+      where: { id: consumer.id }
+    });
+    const k = await testPrisma.user.findUniqueOrThrow({
+      where: { id: contributor.id }
+    });
+    expect(c.consumed).toBe(0n);
+    expect(k.contributed).toBe(0n);
+  });
+
+  it('FREEPASS bypasses the balance gate for a below-ratio consumer', async () => {
+    const COST = 1_000_000;
+    const contributor = await createUser('fp-gate-contrib');
+    const consumer = await createUser('fp-gate-consumer', {
+      contributed: 100n // far below cost — would 400 without a Freepass
+    });
+    const contribution = await createContribution(
+      contributor.id,
+      COST,
+      RatioExempt.FREEPASS
+    );
+
+    const result = await grantDownloadAccess(consumer.id, contribution.id);
+    expect(result.status).toBe('COMPLETED');
+
+    const c = await testPrisma.user.findUniqueOrThrow({
+      where: { id: consumer.id }
+    });
+    expect(c.consumed).toBe(0n);
+  });
+
+  it('reversing a FREEPASS grant is symmetric — no negative balance manufactured', async () => {
+    const COST = 1_000_000;
+    const staff = await createUser('fp-staff');
+    const contributor = await createUser('fp-rev-contrib', { contributed: 0n });
+    const consumer = await createUser('fp-rev-consumer', {
+      contributed: BigInt(COST * 5)
+    });
+    const contribution = await createContribution(
+      contributor.id,
+      COST,
+      RatioExempt.FREEPASS
+    );
+
+    const grant = await grantDownloadAccess(consumer.id, contribution.id);
+    await reverseDownloadAccess(staff.id, grant.grantId);
+
+    const c = await testPrisma.user.findUniqueOrThrow({
+      where: { id: consumer.id }
+    });
+    const k = await testPrisma.user.findUniqueOrThrow({
+      where: { id: contributor.id }
+    });
+    // Consumer never accrued, so reversal must not drive it negative.
+    expect(c.consumed).toBe(0n);
+    // Contributor's Freepass credit is clawed back.
+    expect(k.contributed).toBe(0n);
+  });
+
+  it('reversing a NEUTRALPASS grant leaves both balances untouched', async () => {
+    const COST = 1_000_000;
+    const staff = await createUser('np-staff');
+    const contributor = await createUser('np-rev-contrib', { contributed: 0n });
+    const consumer = await createUser('np-rev-consumer', {
+      contributed: BigInt(COST * 5)
+    });
+    const contribution = await createContribution(
+      contributor.id,
+      COST,
+      RatioExempt.NEUTRALPASS
+    );
+
+    const grant = await grantDownloadAccess(consumer.id, contribution.id);
+    await reverseDownloadAccess(staff.id, grant.grantId);
+
+    const c = await testPrisma.user.findUniqueOrThrow({
+      where: { id: consumer.id }
+    });
+    const k = await testPrisma.user.findUniqueOrThrow({
+      where: { id: contributor.id }
+    });
+    expect(c.consumed).toBe(0n);
+    expect(k.contributed).toBe(0n);
   });
 });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2838,6 +2838,7 @@ const Contribution = registry.register(
     sizeInBytes: z.number().nullable().optional(),
     linkStatus: z.enum(['UNKNOWN', 'PASS', 'WARN', 'FAIL']),
     linkCheckedAt: z.string().nullable().optional(),
+    ratioExempt: z.enum(['NONE', 'FREEPASS', 'NEUTRALPASS']),
     collaborators: z.array(
       z.object({
         id: z.number(),
@@ -2916,6 +2917,7 @@ const ReleaseContributionDetail = registry.register(
     sizeInBytes: z.number().nullable(),
     linkStatus: z.enum(['UNKNOWN', 'PASS', 'WARN', 'FAIL']).nullable(),
     linkCheckedAt: z.string().nullable(),
+    ratioExempt: z.enum(['NONE', 'FREEPASS', 'NEUTRALPASS']),
     type: z.string(),
     createdAt: z.string(),
     updatedAt: z.string(),

--- a/src/modules/contribution.ts
+++ b/src/modules/contribution.ts
@@ -2,10 +2,13 @@ import {
   ArtistRole,
   FileType,
   Prisma,
+  RatioExempt,
   ReleaseCategory,
   ReleaseType
 } from '@prisma/client';
 import { prisma } from '../lib/prisma';
+import { AppError } from '../lib/errors';
+import { audit } from '../lib/audit';
 import { sizeBytesToNumber } from '../lib/serialize';
 import { getLogger } from './logging';
 import { checkContributionLink } from './linkHealth';
@@ -366,4 +369,39 @@ export const addContributionToRelease = async ({
         sizeInBytes: sizeBytesToNumber(contribution.sizeInBytes)
       };
     });
+};
+
+// Staff lever (PRD-06 #4): set/clear a Contribution's ratio exemption. Applies to
+// future consumption only — already-completed grants snapshotted their exemption,
+// so this never retroactively rewrites past accounting. Audited as an economy lever.
+export const setContributionRatioExempt = async (
+  actorId: number,
+  contributionId: number,
+  ratioExempt: RatioExempt
+): Promise<{ id: number; ratioExempt: RatioExempt }> => {
+  const contribution = await prisma.contribution.findUnique({
+    where: { id: contributionId },
+    select: { id: true, ratioExempt: true }
+  });
+  if (!contribution) throw new AppError(404, 'Contribution not found');
+
+  if (contribution.ratioExempt === ratioExempt)
+    return { id: contribution.id, ratioExempt };
+
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.contribution.update({
+      where: { id: contributionId },
+      data: { ratioExempt },
+      select: { id: true, ratioExempt: true }
+    });
+    await audit(
+      tx,
+      actorId,
+      'contribution.ratio_exempt.set',
+      'contribution',
+      contributionId,
+      { from: contribution.ratioExempt, to: ratioExempt }
+    );
+    return updated;
+  });
 };

--- a/src/modules/downloads.spec.ts
+++ b/src/modules/downloads.spec.ts
@@ -3,7 +3,11 @@
  */
 
 import { AppError } from '../lib/errors';
-import { DownloadGrantStatus, EconomyTransactionReason } from '@prisma/client';
+import {
+  DownloadGrantStatus,
+  EconomyTransactionReason,
+  RatioExempt
+} from '@prisma/client';
 
 // ─── Prisma mock ──────────────────────────────────────────────────────────────
 
@@ -46,6 +50,7 @@ const makeContribution = (overrides = {}) => ({
   downloadUrl: 'https://example.com/file.zip',
   sizeInBytes: 209715200,
   approvedAccountingBytes: null,
+  ratioExempt: RatioExempt.NONE,
   ...overrides
 });
 
@@ -62,6 +67,7 @@ const makeGrant = (overrides = {}) => ({
   contributorId: 99,
   contributionId: 5,
   amountBytes: BigInt('209715200'),
+  ratioExempt: RatioExempt.NONE,
   status: DownloadGrantStatus.COMPLETED,
   idempotencyKey: null,
   reversedAt: null,

--- a/src/modules/downloads.ts
+++ b/src/modules/downloads.ts
@@ -1,4 +1,8 @@
-import { DownloadGrantStatus, EconomyTransactionReason } from '@prisma/client';
+import {
+  DownloadGrantStatus,
+  EconomyTransactionReason,
+  RatioExempt
+} from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import { getLogger } from './logging';
@@ -8,6 +12,12 @@ import { evaluateRatioPolicy } from './ratioPolicy';
 const log = getLogger('downloads');
 
 const IDEMPOTENCY_WINDOW_MS = 120_000; // 2 minutes
+
+// The zero-amount ledger reason for a suppressed accrual side (PRD-06 #4).
+const exemptLedgerReason = (exempt: RatioExempt): EconomyTransactionReason =>
+  exempt === RatioExempt.NEUTRALPASS
+    ? EconomyTransactionReason.NEUTRALPASS_GRANT
+    : EconomyTransactionReason.FREEPASS_GRANT;
 
 export interface GrantResult {
   grantId: number;
@@ -30,7 +40,8 @@ export const grantDownloadAccess = async (
         userId: true,
         downloadUrl: true,
         sizeInBytes: true,
-        approvedAccountingBytes: true
+        approvedAccountingBytes: true,
+        ratioExempt: true
       }
     });
     if (!contribution) throw new AppError(404, 'Contribution not found');
@@ -81,38 +92,53 @@ export const grantDownloadAccess = async (
       };
     }
 
-    if (consumer.contributed - consumer.consumed < cost)
-      throw new AppError(400, 'Insufficient contributed balance');
+    // Ratio-exempt handling (PRD-06 #4). FREEPASS suppresses the consumer's
+    // `consumed`; NEUTRALPASS suppresses both sides. The balance gate is skipped
+    // when consumer accrual is suppressed — the point of a Freepass is to let a
+    // below-ratio member consume freely to rebuild, so there is nothing to guard.
+    const exempt = contribution.ratioExempt;
+    const suppressConsumer = exempt !== RatioExempt.NONE;
+    const suppressContributor = exempt === RatioExempt.NEUTRALPASS;
 
-    // CAS: atomically increment consumed, guarding against concurrent balance drain
-    const newConsumed = consumer.consumed + cost;
-    const newRatio = computeRatio(consumer.contributed, newConsumed);
-    const debited = await tx.user.updateMany({
-      where: { id: consumerId, consumed: { lte: consumer.contributed - cost } },
-      data: {
-        consumed: { increment: cost },
-        ratio: newRatio
-      }
-    });
-    if (debited.count === 0)
-      throw new AppError(409, 'Balance changed concurrently, please retry');
+    if (!suppressConsumer) {
+      if (consumer.contributed - consumer.consumed < cost)
+        throw new AppError(400, 'Insufficient contributed balance');
 
-    // Credit contributor balance and recompute ratio
-    const contributor = await tx.user.findUniqueOrThrow({
-      where: { id: contribution.userId },
-      select: { consumed: true, contributed: true }
-    });
-    const newContributorRatio = computeRatio(
-      contributor.contributed + cost,
-      contributor.consumed
-    );
-    await tx.user.update({
-      where: { id: contribution.userId },
-      data: {
-        contributed: { increment: cost },
-        ratio: newContributorRatio
-      }
-    });
+      // CAS: atomically increment consumed, guarding against concurrent balance drain
+      const newConsumed = consumer.consumed + cost;
+      const newRatio = computeRatio(consumer.contributed, newConsumed);
+      const debited = await tx.user.updateMany({
+        where: {
+          id: consumerId,
+          consumed: { lte: consumer.contributed - cost }
+        },
+        data: {
+          consumed: { increment: cost },
+          ratio: newRatio
+        }
+      });
+      if (debited.count === 0)
+        throw new AppError(409, 'Balance changed concurrently, please retry');
+    }
+
+    // Credit contributor balance and recompute ratio (skipped for NEUTRALPASS).
+    if (!suppressContributor) {
+      const contributor = await tx.user.findUniqueOrThrow({
+        where: { id: contribution.userId },
+        select: { consumed: true, contributed: true }
+      });
+      const newContributorRatio = computeRatio(
+        contributor.contributed + cost,
+        contributor.consumed
+      );
+      await tx.user.update({
+        where: { id: contribution.userId },
+        data: {
+          contributed: { increment: cost },
+          ratio: newContributorRatio
+        }
+      });
+    }
 
     const grant = await tx.downloadAccessGrant.create({
       data: {
@@ -120,28 +146,35 @@ export const grantDownloadAccess = async (
         contributorId: contribution.userId,
         contributionId,
         amountBytes: cost,
+        // Snapshot the exemption so reversal claws back exactly what accrued.
+        ratioExempt: exempt,
         status: DownloadGrantStatus.COMPLETED,
         idempotencyKey: idempotencyKey ?? null
       }
     });
 
-    // Immutable ledger: debit consumer
+    // Immutable ledger. A suppressed side writes a zero-amount marker row (rather
+    // than a real DEBIT/CREDIT) so the grant event still exists in the ledger for
+    // the ADR-0016 korin handoff (#261), even though no balance moved.
     await tx.economyTransaction.create({
       data: {
         userId: consumerId,
-        amount: -cost,
-        reason: EconomyTransactionReason.DOWNLOAD_DEBIT,
+        amount: suppressConsumer ? 0n : -cost,
+        reason: suppressConsumer
+          ? exemptLedgerReason(exempt)
+          : EconomyTransactionReason.DOWNLOAD_DEBIT,
         contextId: grant.id,
         contextType: 'download'
       }
     });
 
-    // Immutable ledger: credit contributor
     await tx.economyTransaction.create({
       data: {
         userId: contribution.userId,
-        amount: cost,
-        reason: EconomyTransactionReason.DOWNLOAD_CREDIT,
+        amount: suppressContributor ? 0n : cost,
+        reason: suppressContributor
+          ? exemptLedgerReason(exempt)
+          : EconomyTransactionReason.DOWNLOAD_CREDIT,
         contextId: grant.id,
         contextType: 'download'
       }
@@ -202,43 +235,53 @@ export const reverseDownloadAccess = async (
       })
     ]);
 
-    const consumerNewConsumed = consumer.consumed - grant.amountBytes;
-    const consumerNewRatio = computeRatio(
-      consumer.contributed,
-      consumerNewConsumed < 0n ? 0n : consumerNewConsumed
-    );
-    const contribNewContributed =
-      contributor.contributed >= grant.amountBytes
-        ? contributor.contributed - grant.amountBytes
-        : 0n;
-    const contribNewRatio = computeRatio(
-      contribNewContributed,
-      contributor.consumed
-    );
+    // Mirror the grant's exemption (snapshotted at grant time): only reverse a
+    // side that actually accrued. Clawing back `amountBytes` on a suppressed side
+    // would manufacture negative balance out of nothing (PRD-06 #4).
+    const suppressConsumer = grant.ratioExempt !== RatioExempt.NONE;
+    const suppressContributor = grant.ratioExempt === RatioExempt.NEUTRALPASS;
 
-    // Claw back from contributor balance
-    await tx.user.update({
-      where: { id: grant.contributorId },
-      data: {
-        contributed: { decrement: grant.amountBytes },
-        ratio: contribNewRatio
-      }
-    });
+    // Refund consumer (consumed decrements; contributed unchanged).
+    if (!suppressConsumer) {
+      const consumerNewConsumed = consumer.consumed - grant.amountBytes;
+      const consumerNewRatio = computeRatio(
+        consumer.contributed,
+        consumerNewConsumed < 0n ? 0n : consumerNewConsumed
+      );
+      await tx.user.update({
+        where: { id: grant.consumerId },
+        data: {
+          consumed: { decrement: grant.amountBytes },
+          ratio: consumerNewRatio
+        }
+      });
+    }
 
-    // Refund consumer (consumed decrements; contributed unchanged)
-    await tx.user.update({
-      where: { id: grant.consumerId },
-      data: {
-        consumed: { decrement: grant.amountBytes },
-        ratio: consumerNewRatio
-      }
-    });
+    // Claw back from contributor balance.
+    if (!suppressContributor) {
+      const contribNewContributed =
+        contributor.contributed >= grant.amountBytes
+          ? contributor.contributed - grant.amountBytes
+          : 0n;
+      const contribNewRatio = computeRatio(
+        contribNewContributed,
+        contributor.consumed
+      );
+      await tx.user.update({
+        where: { id: grant.contributorId },
+        data: {
+          contributed: { decrement: grant.amountBytes },
+          ratio: contribNewRatio
+        }
+      });
+    }
 
-    // Reversal ledger entries
+    // Reversal ledger entries — zero on a side whose grant accrual was suppressed,
+    // mirroring the marker rows the grant wrote (every grant stays paired).
     await tx.economyTransaction.create({
       data: {
         userId: grant.consumerId,
-        amount: grant.amountBytes,
+        amount: suppressConsumer ? 0n : grant.amountBytes,
         reason: EconomyTransactionReason.STAFF_REVERSAL,
         contextId: grant.id,
         contextType: 'download',
@@ -248,7 +291,7 @@ export const reverseDownloadAccess = async (
     await tx.economyTransaction.create({
       data: {
         userId: grant.contributorId,
-        amount: -grant.amountBytes,
+        amount: suppressContributor ? 0n : -grant.amountBytes,
         reason: EconomyTransactionReason.STAFF_REVERSAL,
         contextId: grant.id,
         contextType: 'download',

--- a/src/routes/api/communities/contributions.ts
+++ b/src/routes/api/communities/contributions.ts
@@ -1,13 +1,18 @@
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
+import { RatioExempt } from '@prisma/client';
 import { prisma } from '../../../lib/prisma';
 import { sizeBytesToNumber } from '../../../lib/serialize';
 import { asyncHandler, authHandler } from '../../../modules/asyncHandler';
-import { createContributionSubmission } from '../../../modules/contribution';
+import {
+  createContributionSubmission,
+  setContributionRatioExempt
+} from '../../../modules/contribution';
 import { fileReport } from '../../../modules/reports';
 import { recordContributionReport } from '../../../modules/linkHealth';
 import { emitNotifications } from '../../../lib/notifications';
 import { requireAuth } from '../../../middleware/auth';
+import { requirePermission } from '../../../middleware/permissions';
 import {
   parsedBody,
   validate,
@@ -35,6 +40,9 @@ const contributionIdParamsSchema = z.object({
 const reportSchema = z.object({
   reason: z.string().min(1).max(1000)
 });
+const ratioExemptSchema = z.object({
+  ratioExempt: z.nativeEnum(RatioExempt)
+});
 const contributionsQuerySchema = z.object({ ...paginationBase });
 
 // GET /api/contributions
@@ -61,6 +69,7 @@ router.get(
           approvedAccountingBytes: true,
           linkStatus: true,
           linkCheckedAt: true,
+          ratioExempt: true,
           type: true,
           releaseFile: {
             select: {
@@ -110,6 +119,7 @@ router.get(
         approvedAccountingBytes: true,
         linkStatus: true,
         linkCheckedAt: true,
+        ratioExempt: true,
         type: true,
         releaseFile: {
           select: { bitrate: true, hasLog: true, hasCue: true, isScene: true }
@@ -217,6 +227,24 @@ router.post(
     });
     await recordContributionReport(id, req.user.id, reason);
     res.status(201).json({ msg: 'Report submitted' });
+  })
+);
+
+// PUT /api/contributions/:id/ratio-exempt — staff: set/clear Freepass/Neutralpass
+router.put(
+  '/:id/ratio-exempt',
+  ...requirePermission('contributions_manage'),
+  validateParams(contributionIdParamsSchema),
+  validate(ratioExemptSchema),
+  authHandler(async (req, res) => {
+    const { id } = parsedParams<{ id: number }>(res);
+    const { ratioExempt } = parsedBody<{ ratioExempt: RatioExempt }>(res);
+    const updated = await setContributionRatioExempt(
+      req.user.id,
+      id,
+      ratioExempt
+    );
+    res.json(updated);
   })
 );
 


### PR DESCRIPTION
## Summary
Implements the settled PRD-06 §4 ratio-exempt design — two consumption-time exemptions read at grant time by the accounting path:

| Flag | Consumer `consumed` | Contributor `contributed` |
|---|---|---|
| **FREEPASS** | not accrued | still accrued |
| **NEUTRALPASS** | not accrued | not accrued |

Modeled as a single `RatioExempt {NONE,FREEPASS,NEUTRALPASS}` enum (mutually exclusive by construction; matches the `z.nativeEnum` contract precedent).

## Changes
- **Schema**: `ratioExempt` on `Contribution`; exemption snapshot on `DownloadAccessGrant`; `FREEPASS_GRANT`/`NEUTRALPASS_GRANT` ledger reasons. Migration `20260713065519_ratio_exempt_contribution_flags`.
- **Grant path** (`downloads.ts`): suppress `consumed` (both flags) / `contributed` (Neutralpass); **skip the balance gate** when consumer accrual is suppressed so a below-ratio member can consume a Freepass to rebuild; write a **zero-amount marker ledger row** (per suppressed side) so the grant event still exists for the ADR-0016 korin handoff (#261).
- **Reversal symmetry** ⚠️: the exemption is snapshotted on the grant, and `reverseDownloadAccess` mirrors it — a suppressed side is never clawed back, so reversing an exempt grant can't manufacture negative balance.
- **Staff surface**: `PUT /api/contributions/:id/ratio-exempt` (gated `contributions_manage`, audited as an economy lever). Applies to future consumption only — completed grants keep their snapshot.
- **Read + contract**: flag on contribution read selects and the OpenAPI contract (`openapi.json` regenerated).

## Kickoff decisions (settled with maintainer)
1. Single `RatioExempt` enum over two booleans (mutual exclusion).
2. Balance gate bypassed for exempt consumers (matches "consume freely to rebuild").
3. Exempt grants write a zero-amount marker ledger row (keeps the event present for #261).

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run format`, `npm run version:check` — clean
- [x] `npm run openapi:export` — `ratioExempt` in the contract; `git diff --exit-code openapi.json` gate satisfied
- [x] Integration: grant + reversal for both flags, balance-gate bypass, ledger markers, audited setter (set + no-op)
- [x] Unit: 27 downloads specs green (mock factories updated for the non-null column)

## Follow-ups
- Paired **stellar-ui** issue for the Freepass/Neutralpass badge (filed alongside this PR).
- #261 (consumption-event ingest) builds on this grant path and honors these flags.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)