### PR TITLE
feat(accounting): consumption-event ingest + grant-time canConsume (ADR-0016 Phase 2)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,7 @@ import { startStatsJob } from './modules/statsJob';
 import { startDonorExpiryJob } from './modules/donorExpiryJob';
 import { startIrcJob } from './modules/ircJob';
 import { startAnnounceJob } from './modules/announceJob';
+import { startLedgerJob } from './modules/ledgerJob';
 import { startRankProgressionJob } from './modules/rankProgressionJob';
 
 import installRouter from './routes/api/install';
@@ -53,6 +54,7 @@ import forumPollRouter from './routes/api/forum/forumPoll';
 import requestsRouter from './routes/api/requests';
 import downloadsRouter from './routes/api/downloads';
 import ratioPolicyRouter from './routes/api/ratioPolicy';
+import ledgerRouter from './routes/api/ledger';
 import forumPollVoteRouter from './routes/api/forum/forumPollVote';
 import forumLastReadRouter from './routes/api/forum/forumLastReadTopic';
 import forumTopicNoteRouter from './routes/api/forum/forumTopicNote';
@@ -160,6 +162,7 @@ export const createApp = () => {
   app.use('/api/requests', requestsRouter);
   app.use('/api', downloadsRouter);
   app.use('/api/ratio-policy', ratioPolicyRouter);
+  app.use('/api/ledger', ledgerRouter);
   app.use('/api/communities', communitiesRouter);
   app.use('/api/contributions', contributionsRouter);
   app.use('/api/log-check', logCheckRouter);
@@ -227,6 +230,7 @@ export const createApp = () => {
     startDonorExpiryJob();
     startIrcJob();
     startAnnounceJob();
+    startLedgerJob();
     startRankProgressionJob();
   }
 

--- a/src/integration/ledger.integration.ts
+++ b/src/integration/ledger.integration.ts
@@ -11,6 +11,16 @@ import { grantDownloadAccess } from '../modules/downloads';
 import { getLedgerSnapshot, getNewConsumptionEvents } from '../modules/ledger';
 import { korin } from '../modules/config';
 
+// grantDownloadAccess kicks off evaluateRatioPolicy as a post-commit fire-and-forget
+// (deliberately un-awaited in production). This suite tests the ledger/gate path, not
+// the policy state machine, so stub it — otherwise its queries land after the suite
+// tears down ("Cannot log after tests are done" → non-zero exit). Mirrors the unit
+// specs, which mock ./ratioPolicy for the same reason.
+jest.mock('../modules/ratioPolicy', () => ({
+  ...jest.requireActual('../modules/ratioPolicy'),
+  evaluateRatioPolicy: jest.fn(() => Promise.resolve())
+}));
+
 beforeEach(async () => {
   await truncateAll();
   await seedDefaults();

--- a/src/integration/ledger.integration.ts
+++ b/src/integration/ledger.integration.ts
@@ -1,0 +1,244 @@
+import {
+  FileType,
+  ReleaseType,
+  CommunityType,
+  RegistrationStatus,
+  RatioExempt,
+  RatioPolicyStatus
+} from '@prisma/client';
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { grantDownloadAccess } from '../modules/downloads';
+import { getLedgerSnapshot, getNewConsumptionEvents } from '../modules/ledger';
+import { korin } from '../modules/config';
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const createUser = async (
+  tag: string,
+  overrides: { contributed?: bigint; consumed?: bigint } = {}
+) => {
+  const rank = await testPrisma.userRank.findFirstOrThrow();
+  const settings = await testPrisma.userSettings.create({ data: {} });
+  const profile = await testPrisma.profile.create({ data: {} });
+  return testPrisma.user.create({
+    data: {
+      username: `lg-${tag}-${Date.now()}`,
+      email: `lg-${tag}-${Date.now()}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id,
+      contributed: overrides.contributed ?? 0n,
+      consumed: overrides.consumed ?? 0n
+    }
+  });
+};
+
+const createContribution = async (
+  userId: number,
+  sizeBytes = 1_000_000,
+  ratioExempt: RatioExempt = RatioExempt.NONE
+) => {
+  const community = await testPrisma.community.create({
+    data: {
+      name: `LG-Community-${Date.now()}-${Math.random()}`,
+      image: '',
+      registrationStatus: RegistrationStatus.open,
+      type: CommunityType.Music
+    }
+  });
+  const artist = await testPrisma.artist.create({
+    data: { name: `LG-Artist-${Date.now()}-${Math.random()}` }
+  });
+  const release = await testPrisma.release.create({
+    data: {
+      title: `LG-Release-${Date.now()}`,
+      description: 'desc',
+      type: ReleaseType.Music,
+      releaseType: 'Album',
+      year: 2020,
+      credits: { create: { artistId: artist.id } }
+    }
+  });
+  const edition = await testPrisma.edition.create({
+    data: { releaseId: release.id }
+  });
+  const contributor = await testPrisma.contributor.upsert({
+    where: { userId },
+    update: {},
+    create: { userId, communityId: community.id }
+  });
+  return testPrisma.contribution.create({
+    data: {
+      userId,
+      releaseId: release.id,
+      contributorId: contributor.id,
+      editionId: edition.id,
+      type: FileType.flac,
+      downloadUrl: 'https://example.com/file.torrent',
+      sizeInBytes: sizeBytes,
+      approvedAccountingBytes: BigInt(sizeBytes),
+      releaseDescription: 'test',
+      ratioExempt
+    }
+  });
+};
+
+describe('getLedgerSnapshot', () => {
+  it('returns per-user balances + policy state and per-contribution pass flags', async () => {
+    const contributor = await createUser('snap-k', { contributed: 5_000_000n });
+    const consumer = await createUser('snap-c', {
+      contributed: 3_000_000n,
+      consumed: 1_000_000n
+    });
+    const contribution = await createContribution(
+      contributor.id,
+      2_000_000,
+      RatioExempt.FREEPASS
+    );
+    // A policy row that isn't the default, to prove it's surfaced.
+    await testPrisma.ratioPolicyState.create({
+      data: { userId: consumer.id, status: RatioPolicyStatus.WATCH }
+    });
+
+    const snap = await getLedgerSnapshot();
+
+    const kRow = snap.users.find((u) => u.id === contributor.id);
+    const cRow = snap.users.find((u) => u.id === consumer.id);
+    expect(kRow).toMatchObject({
+      contributed: '5000000',
+      consumed: '0',
+      canDownload: true,
+      policyState: RatioPolicyStatus.OK // no row ⇒ default
+    });
+    expect(cRow).toMatchObject({
+      consumed: '1000000',
+      policyState: RatioPolicyStatus.WATCH
+    });
+
+    const cSnap = snap.contributions.find((c) => c.id === contribution.id);
+    expect(cSnap).toMatchObject({
+      userId: contributor.id,
+      approvedAccountingBytes: '2000000',
+      ratioExempt: RatioExempt.FREEPASS
+    });
+  });
+});
+
+describe('getNewConsumptionEvents', () => {
+  it('emits one event per new grant with pre-resolved deltas (NONE and FREEPASS)', async () => {
+    const contributor = await createUser('emit-k');
+    const consumer = await createUser('emit-c', { contributed: 10_000_000n });
+    const plain = await createContribution(contributor.id, 1_000_000);
+    const free = await createContribution(
+      contributor.id,
+      1_000_000,
+      RatioExempt.FREEPASS
+    );
+
+    const g1 = await grantDownloadAccess(consumer.id, plain.id);
+    const g2 = await grantDownloadAccess(consumer.id, free.id);
+
+    const events = await getNewConsumptionEvents(0);
+    expect(events.map((e) => e.grantId)).toEqual([g1.grantId, g2.grantId]);
+
+    const plainEvent = events.find((e) => e.grantId === g1.grantId);
+    expect(plainEvent).toMatchObject({
+      kind: 'grant',
+      userId: consumer.id,
+      contributorId: contributor.id,
+      consumedDelta: '1000000',
+      contributedDelta: '1000000',
+      pass: 'none'
+    });
+
+    const freeEvent = events.find((e) => e.grantId === g2.grantId);
+    expect(freeEvent).toMatchObject({
+      consumedDelta: '0', // FREEPASS suppresses the consumer side
+      contributedDelta: '1000000',
+      pass: 'freepass'
+    });
+
+    // Cursor honored — nothing new after the last grant.
+    expect(await getNewConsumptionEvents(g2.grantId)).toHaveLength(0);
+  });
+});
+
+describe('grant-time canConsume gate (korin stubbed)', () => {
+  const origFetch = global.fetch;
+  const origApiUrl = korin.apiUrl;
+  const origPullKey = korin.pullKey;
+
+  beforeEach(() => {
+    korin.apiUrl = 'http://korin.stub';
+    korin.pullKey = 'stub-key';
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+    korin.apiUrl = origApiUrl;
+    korin.pullKey = origPullKey;
+  });
+
+  it('blocks a non-exempt grant with 403 when korin says allow:false', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ allow: false, reason: 'LEECH_DISABLED' })
+    }) as unknown as typeof fetch;
+
+    const contributor = await createUser('gate-k');
+    const consumer = await createUser('gate-c', { contributed: 10_000_000n });
+    const contribution = await createContribution(contributor.id);
+
+    await expect(
+      grantDownloadAccess(consumer.id, contribution.id)
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    // Nothing accrued — the block happened before the transaction.
+    const c = await testPrisma.user.findUniqueOrThrow({
+      where: { id: consumer.id }
+    });
+    expect(c.consumed).toBe(0n);
+  });
+
+  it('lets an exempt (FREEPASS) grant through even when korin says allow:false', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ allow: false, reason: 'LEECH_DISABLED' })
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const contributor = await createUser('gate-fp-k');
+    const consumer = await createUser('gate-fp-c', { contributed: 100n });
+    const contribution = await createContribution(
+      contributor.id,
+      1_000_000,
+      RatioExempt.FREEPASS
+    );
+
+    const result = await grantDownloadAccess(consumer.id, contribution.id);
+    expect(result.status).toBe('COMPLETED');
+    // The gate was never consulted for an exempt contribution.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails open — a network error lets the grant proceed on local checks', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+
+    const contributor = await createUser('open-k');
+    const consumer = await createUser('open-c', { contributed: 10_000_000n });
+    const contribution = await createContribution(contributor.id);
+
+    const result = await grantDownloadAccess(consumer.id, contribution.id);
+    expect(result.status).toBe('COMPLETED');
+  });
+});

--- a/src/modules/downloads.spec.ts
+++ b/src/modules/downloads.spec.ts
@@ -31,13 +31,29 @@ const mockTx = {
 
 const mockEvaluateRatioPolicy = jest.fn();
 const mockTransaction = jest.fn();
+// The grant-time ratio gate pre-reads the contribution's exemption OUTSIDE the
+// transaction (never hold a tx across a network call), so the top-level prisma mock
+// needs `contribution.findUnique` in addition to `$transaction`.
+const mockGateContributionFindUnique = jest.fn();
+
+const mockCheckCanConsume = jest.fn();
+const mockPushConsumptionEvent = jest.fn();
 
 jest.mock('./ratioPolicy', () => ({
   evaluateRatioPolicy: mockEvaluateRatioPolicy
 }));
 
+jest.mock('./ledger', () => ({
+  checkCanConsume: mockCheckCanConsume,
+  buildConsumptionEvent: jest.fn(() => ({})),
+  pushConsumptionEvent: mockPushConsumptionEvent
+}));
+
 jest.mock('../lib/prisma', () => ({
-  prisma: { $transaction: mockTransaction }
+  prisma: {
+    $transaction: mockTransaction,
+    contribution: { findUnique: mockGateContributionFindUnique }
+  }
 }));
 
 import { grantDownloadAccess, reverseDownloadAccess } from './downloads';
@@ -82,6 +98,13 @@ beforeEach(() => {
     (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)
   );
   mockEvaluateRatioPolicy.mockResolvedValue(undefined);
+  // Gate defaults: non-exempt contribution + korin unreachable (null ⇒ fail open),
+  // so the gate is transparent for the existing grant/reverse cases.
+  mockGateContributionFindUnique.mockResolvedValue({
+    ratioExempt: RatioExempt.NONE
+  });
+  mockCheckCanConsume.mockReset().mockResolvedValue(null);
+  mockPushConsumptionEvent.mockReset().mockResolvedValue(true);
 });
 
 // ─── grantDownloadAccess ───────────────────────────────────────────────────────
@@ -245,6 +268,71 @@ describe('grantDownloadAccess', () => {
     });
     expect(result.downloadUrl).toBe('https://example.com/file.zip');
     expect(result.amountBytes).toBe(cost.toString());
+  });
+});
+
+// ─── grant-time canConsume gate (ADR-0016) ──────────────────────────────────────
+
+describe('grantDownloadAccess — ratio gate', () => {
+  it('blocks with 403 before opening the transaction when korin says allow:false', async () => {
+    mockCheckCanConsume.mockResolvedValue({
+      allow: false,
+      reason: 'LEECH_DISABLED'
+    });
+
+    await expect(grantDownloadAccess(7, 5)).rejects.toMatchObject({
+      statusCode: 403
+    });
+    // Gate short-circuits: the grant transaction never runs.
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('fails open (proceeds) when korin is unreachable (null verdict)', async () => {
+    mockCheckCanConsume.mockResolvedValue(null);
+    mockTx.contribution.findUnique.mockResolvedValue(makeContribution());
+    mockTx.user.findUnique.mockResolvedValue(makeUser());
+    mockTx.downloadAccessGrant.findFirst.mockResolvedValue(null);
+    mockTx.user.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.user.update.mockResolvedValue(undefined);
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('2000000000')
+    });
+    mockTx.downloadAccessGrant.create.mockResolvedValue(makeGrant());
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.consumer.upsert.mockResolvedValue({ id: 1 });
+    mockTx.consumer.update.mockResolvedValue(undefined);
+
+    await expect(grantDownloadAccess(7, 5)).resolves.toMatchObject({
+      status: DownloadGrantStatus.COMPLETED
+    });
+  });
+
+  it('skips the gate entirely for an exempt contribution', async () => {
+    // Even a hostile allow:false must not touch an exempt grant.
+    mockGateContributionFindUnique.mockResolvedValue({
+      ratioExempt: RatioExempt.FREEPASS
+    });
+    mockCheckCanConsume.mockResolvedValue({ allow: false });
+    mockTx.contribution.findUnique.mockResolvedValue(
+      makeContribution({ ratioExempt: RatioExempt.FREEPASS })
+    );
+    mockTx.user.findUnique.mockResolvedValue(makeUser());
+    mockTx.downloadAccessGrant.findFirst.mockResolvedValue(null);
+    mockTx.user.findUniqueOrThrow.mockResolvedValue({
+      consumed: BigInt(0),
+      contributed: BigInt('2000000000')
+    });
+    mockTx.downloadAccessGrant.create.mockResolvedValue(
+      makeGrant({ ratioExempt: RatioExempt.FREEPASS })
+    );
+    mockTx.economyTransaction.create.mockResolvedValue(undefined);
+    mockTx.consumer.upsert.mockResolvedValue({ id: 1 });
+    mockTx.consumer.update.mockResolvedValue(undefined);
+
+    await grantDownloadAccess(7, 5);
+
+    expect(mockCheckCanConsume).not.toHaveBeenCalled();
   });
 });
 

--- a/src/modules/downloads.ts
+++ b/src/modules/downloads.ts
@@ -8,6 +8,11 @@ import { AppError } from '../lib/errors';
 import { getLogger } from './logging';
 import { computeRatio } from './ratio';
 import { evaluateRatioPolicy } from './ratioPolicy';
+import {
+  checkCanConsume,
+  buildConsumptionEvent,
+  pushConsumptionEvent
+} from './ledger';
 
 const log = getLogger('downloads');
 
@@ -32,6 +37,25 @@ export const grantDownloadAccess = async (
   contributionId: number,
   idempotencyKey?: string
 ): Promise<GrantResult> => {
+  // Grant-time ratio gate (ADR-0016). Consult korin's hot state BEFORE opening the
+  // grant transaction — a ~2s network call must never be held inside a DB tx. Exempt
+  // contributions skip the gate entirely: a pass exists precisely to bypass ratio, so
+  // stellar enforces the skip locally rather than trusting korin to know the flag
+  // (mirrors the balance-gate skip below). korin unreachable ⇒ null ⇒ fail open to the
+  // local checks inside the transaction; a korin outage must never hard-block.
+  const gateContribution = await prisma.contribution.findUnique({
+    where: { id: contributionId },
+    select: { ratioExempt: true }
+  });
+  if (gateContribution && gateContribution.ratioExempt === RatioExempt.NONE) {
+    const verdict = await checkCanConsume(consumerId, contributionId);
+    if (verdict && verdict.allow === false)
+      throw new AppError(
+        403,
+        verdict.reason ?? 'Ratio gate: consumption not permitted'
+      );
+  }
+
   const result = await prisma.$transaction(async (tx) => {
     const contribution = await tx.contribution.findUnique({
       where: { id: contributionId },
@@ -216,7 +240,7 @@ export const reverseDownloadAccess = async (
   grantId: number,
   reason?: string
 ): Promise<{ grantId: number; status: DownloadGrantStatus }> => {
-  return prisma.$transaction(async (tx) => {
+  const { result, eventSource } = await prisma.$transaction(async (tx) => {
     const grant = await tx.downloadAccessGrant.findUnique({
       where: { id: grantId }
     });
@@ -309,6 +333,25 @@ export const reverseDownloadAccess = async (
       }
     });
 
-    return { grantId: updated.id, status: updated.status };
+    return {
+      result: { grantId: updated.id, status: updated.status },
+      // Fields for the reversal event, snapshotting the grant's exemption so the
+      // negated deltas match exactly what accrued.
+      eventSource: {
+        id: grant.id,
+        consumerId: grant.consumerId,
+        contributorId: grant.contributorId,
+        contributionId: grant.contributionId,
+        amountBytes: grant.amountBytes,
+        ratioExempt: grant.ratioExempt,
+        at: updated.reversedAt ?? new Date()
+      }
+    };
   });
+
+  // Best-effort reversal event (post-commit; ADR-0016). A miss self-heals on korin's
+  // next snapshot reload — the durable REVERSED state is authoritative regardless.
+  void pushConsumptionEvent(buildConsumptionEvent(eventSource, 'reversal'));
+
+  return result;
 };

--- a/src/modules/ledger.spec.ts
+++ b/src/modules/ledger.spec.ts
@@ -180,7 +180,9 @@ describe('checkCanConsume', () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => verdict });
     expect(await checkCanConsume(7, 5)).toEqual(verdict);
     const [url] = mockFetch.mock.calls[0];
-    expect(url).toContain('/ledger/can-consume?userId=7&contributionId=5');
+    expect(String(url)).toContain(
+      '/ledger/can-consume?userId=7&contributionId=5'
+    );
   });
 
   it('returns null (fail-open) on a non-2xx response', async () => {

--- a/src/modules/ledger.spec.ts
+++ b/src/modules/ledger.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Service-level unit tests for the korin ledger client (ADR-0016).
+ */
+
+import { RatioExempt, DownloadGrantStatus } from '@prisma/client';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+// Mutable so tests can toggle "korin configured" vs "inert".
+const mockKorin = {
+  apiUrl: '',
+  pullKey: '',
+  pollIntervalMs: 300_000,
+  serviceKey: ''
+};
+jest.mock('./config', () => ({ korin: mockKorin }));
+
+jest.mock('./logging', () => ({
+  getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+}));
+
+const mockGrantFindMany = jest.fn();
+jest.mock('../lib/prisma', () => ({
+  prisma: { downloadAccessGrant: { findMany: mockGrantFindMany } }
+}));
+
+import {
+  resolveDeltas,
+  buildConsumptionEvent,
+  pushConsumptionEvent,
+  checkCanConsume,
+  getNewConsumptionEvents
+} from './ledger';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  mockKorin.apiUrl = '';
+  mockKorin.pullKey = '';
+  mockFetch.mockReset();
+  mockGrantFindMany.mockReset();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+const withKorin = (): void => {
+  mockKorin.apiUrl = 'http://korin.test';
+  mockKorin.pullKey = 'pull-secret';
+};
+
+// ─── resolveDeltas ─────────────────────────────────────────────────────────
+
+describe('resolveDeltas', () => {
+  const bytes = 1_000_000n;
+
+  it('NONE debits and credits the full amount', () => {
+    expect(resolveDeltas(bytes, RatioExempt.NONE)).toEqual({
+      consumedDelta: bytes,
+      contributedDelta: bytes,
+      pass: 'none'
+    });
+  });
+
+  it('FREEPASS zeroes the consumer debit, keeps the contributor credit', () => {
+    expect(resolveDeltas(bytes, RatioExempt.FREEPASS)).toEqual({
+      consumedDelta: 0n,
+      contributedDelta: bytes,
+      pass: 'freepass'
+    });
+  });
+
+  it('NEUTRALPASS zeroes both sides', () => {
+    expect(resolveDeltas(bytes, RatioExempt.NEUTRALPASS)).toEqual({
+      consumedDelta: 0n,
+      contributedDelta: 0n,
+      pass: 'neutralpass'
+    });
+  });
+});
+
+// ─── buildConsumptionEvent ───────────────────────────────────────────────────
+
+describe('buildConsumptionEvent', () => {
+  const src = {
+    id: 42,
+    consumerId: 7,
+    contributorId: 99,
+    contributionId: 5,
+    amountBytes: 1_000_000n,
+    ratioExempt: RatioExempt.NONE,
+    at: new Date('2026-07-13T00:00:00.000Z')
+  };
+
+  it('maps a grant event with positive deltas and BigInt-as-string', () => {
+    expect(buildConsumptionEvent(src, 'grant')).toEqual({
+      grantId: 42,
+      kind: 'grant',
+      userId: 7,
+      contributorId: 99,
+      contributionId: 5,
+      consumedDelta: '1000000',
+      contributedDelta: '1000000',
+      pass: 'none',
+      at: '2026-07-13T00:00:00.000Z'
+    });
+  });
+
+  it('negates deltas for a reversal', () => {
+    const ev = buildConsumptionEvent(src, 'reversal');
+    expect(ev.kind).toBe('reversal');
+    expect(ev.consumedDelta).toBe('-1000000');
+    expect(ev.contributedDelta).toBe('-1000000');
+  });
+
+  it('a FREEPASS reversal only negates the contributor side (consumer never accrued)', () => {
+    const ev = buildConsumptionEvent(
+      { ...src, ratioExempt: RatioExempt.FREEPASS },
+      'reversal'
+    );
+    expect(ev.consumedDelta).toBe('0');
+    expect(ev.contributedDelta).toBe('-1000000');
+    expect(ev.pass).toBe('freepass');
+  });
+});
+
+// ─── pushConsumptionEvent ────────────────────────────────────────────────────
+
+describe('pushConsumptionEvent', () => {
+  const event = buildConsumptionEvent(
+    {
+      id: 1,
+      consumerId: 7,
+      contributorId: 99,
+      contributionId: 5,
+      amountBytes: 1000n,
+      ratioExempt: RatioExempt.NONE,
+      at: new Date()
+    },
+    'grant'
+  );
+
+  it('returns false without calling fetch when korin is unconfigured', async () => {
+    expect(await pushConsumptionEvent(event)).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs with the x-pull-key header and returns true on 2xx', async () => {
+    withKorin();
+    mockFetch.mockResolvedValue({ ok: true });
+    expect(await pushConsumptionEvent(event)).toBe(true);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://korin.test/ledger/consumption');
+    expect(init.method).toBe('POST');
+    expect(init.headers['x-pull-key']).toBe('pull-secret');
+  });
+
+  it('returns false on a non-2xx response', async () => {
+    withKorin();
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    expect(await pushConsumptionEvent(event)).toBe(false);
+  });
+
+  it('returns false on a network error', async () => {
+    withKorin();
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    expect(await pushConsumptionEvent(event)).toBe(false);
+  });
+});
+
+// ─── checkCanConsume ─────────────────────────────────────────────────────────
+
+describe('checkCanConsume', () => {
+  it('returns null (fail-open) without calling fetch when korin is unconfigured', async () => {
+    expect(await checkCanConsume(7, 5)).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns the verdict on 2xx', async () => {
+    withKorin();
+    const verdict = { allow: false, reason: 'LEECH_DISABLED' };
+    mockFetch.mockResolvedValue({ ok: true, json: async () => verdict });
+    expect(await checkCanConsume(7, 5)).toEqual(verdict);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/ledger/can-consume?userId=7&contributionId=5');
+  });
+
+  it('returns null (fail-open) on a non-2xx response', async () => {
+    withKorin();
+    mockFetch.mockResolvedValue({ ok: false, status: 503 });
+    expect(await checkCanConsume(7, 5)).toBeNull();
+  });
+
+  it('returns null (fail-open) on timeout / network error', async () => {
+    withKorin();
+    mockFetch.mockRejectedValue(new Error('timeout'));
+    expect(await checkCanConsume(7, 5)).toBeNull();
+  });
+});
+
+// ─── getNewConsumptionEvents ─────────────────────────────────────────────────
+
+describe('getNewConsumptionEvents', () => {
+  it('maps COMPLETED grants after the cursor into grant events', async () => {
+    mockGrantFindMany.mockResolvedValue([
+      {
+        id: 10,
+        consumerId: 7,
+        contributorId: 99,
+        contributionId: 5,
+        amountBytes: 2000n,
+        ratioExempt: RatioExempt.FREEPASS,
+        createdAt: new Date('2026-07-13T00:00:00.000Z')
+      }
+    ]);
+
+    const events = await getNewConsumptionEvents(9);
+
+    expect(mockGrantFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { gt: 9 }, status: DownloadGrantStatus.COMPLETED },
+        orderBy: { id: 'asc' }
+      })
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      grantId: 10,
+      kind: 'grant',
+      consumedDelta: '0', // FREEPASS suppresses the consumer side
+      contributedDelta: '2000',
+      pass: 'freepass'
+    });
+  });
+});

--- a/src/modules/ledger.ts
+++ b/src/modules/ledger.ts
@@ -168,7 +168,12 @@ export const checkCanConsume = async (
   if (!apiUrl || !pullKey) return null;
 
   try {
-    const url = `${apiUrl}/ledger/can-consume?userId=${userId}&contributionId=${contributionId}`;
+    // Build via URL/searchParams: the host is fixed trusted config and only the
+    // numeric ids vary, routed through the encoding sink (no string concat of
+    // request data into the target — closes the SSRF-taint path).
+    const url = new URL(`${apiUrl}/ledger/can-consume`);
+    url.searchParams.set('userId', String(userId));
+    url.searchParams.set('contributionId', String(contributionId));
     const res = await fetch(url, {
       headers: { 'x-pull-key': pullKey },
       signal: AbortSignal.timeout(CAN_CONSUME_TIMEOUT_MS)

--- a/src/modules/ledger.ts
+++ b/src/modules/ledger.ts
@@ -1,0 +1,301 @@
+/**
+ * korin.pink `ledger` client (ADR-0016) — the consumption-accounting + ratio-gate
+ * contract, an extension of the ADR-0013 shared-secret boundary. stellar is the
+ * system of record and the ORIGIN of every consumption event; korin's `ledger` is a
+ * derived hot-path read-model that sums stellar's authoritative events. This module
+ * is the stellar-side producer surface:
+ *
+ *   - pushConsumptionEvent    → POST /ledger/consumption  (stellar pushes; korin sums)
+ *   - checkCanConsume         → GET  /ledger/can-consume   (stellar pulls the gate; fail-open)
+ *   - getNewConsumptionEvents → the grant rows the drain job (ledgerJob) emits
+ *
+ * Inert until KORIN_API_URL + KORIN_PULL_KEY are set — same posture as irc.ts /
+ * announce.ts. stellar PRE-RESOLVES the ratio impact of each grant (Freepass →
+ * consumedDelta 0; Neutralpass → both 0) so korin never re-derives pass logic.
+ */
+import {
+  DownloadGrantStatus,
+  RatioExempt,
+  RatioPolicyStatus,
+  LinkHealthStatus
+} from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { korin } from './config';
+import { getLogger } from './logging';
+
+const log = getLogger('ledger');
+
+// Hot-path gate: bound the wait, then fail open. A korin outage must never
+// hard-block consumption (ADR-0016 ratio-gate row).
+const CAN_CONSUME_TIMEOUT_MS = 2_000;
+
+export type Pass = 'none' | 'freepass' | 'neutralpass';
+
+/**
+ * A consumption event. `kind` extends ADR-0016's illustrative body with a reversal
+ * discriminator so korin dedupes idempotently on `(grantId, kind)` — a grant and its
+ * later reversal share `grantId` but move opposite deltas. Coordinate the final wire
+ * shape with korin ADR-004. Deltas are BigInt-as-string (byte counts).
+ */
+export interface ConsumptionEvent {
+  grantId: number;
+  kind: 'grant' | 'reversal';
+  userId: number; // the consumer
+  contributorId: number;
+  contributionId: number;
+  consumedDelta: string;
+  contributedDelta: string;
+  pass: Pass;
+  at: string;
+}
+
+export interface CanConsumeVerdict {
+  allow: boolean;
+  reason?: string;
+  currentRatio?: number;
+  requiredRatio?: number;
+  policyState?: string;
+}
+
+/**
+ * The ratio impact stellar resolves for a grant before emitting it. Freepass keeps
+ * the contributor's credit but zeroes the consumer's debit; Neutralpass zeroes both.
+ * This mirrors the accrual suppression in `downloads.ts` (PRD-06 #4) exactly.
+ */
+export const resolveDeltas = (
+  amountBytes: bigint,
+  ratioExempt: RatioExempt
+): { consumedDelta: bigint; contributedDelta: bigint; pass: Pass } => {
+  switch (ratioExempt) {
+    case RatioExempt.FREEPASS:
+      return {
+        consumedDelta: 0n,
+        contributedDelta: amountBytes,
+        pass: 'freepass'
+      };
+    case RatioExempt.NEUTRALPASS:
+      return { consumedDelta: 0n, contributedDelta: 0n, pass: 'neutralpass' };
+    default:
+      return {
+        consumedDelta: amountBytes,
+        contributedDelta: amountBytes,
+        pass: 'none'
+      };
+  }
+};
+
+/** Fields a `DownloadAccessGrant` contributes to an event (grant or reversal). */
+export interface GrantEventSource {
+  id: number;
+  consumerId: number;
+  contributorId: number;
+  contributionId: number;
+  amountBytes: bigint;
+  ratioExempt: RatioExempt;
+  at: Date;
+}
+
+export const buildConsumptionEvent = (
+  grant: GrantEventSource,
+  kind: 'grant' | 'reversal'
+): ConsumptionEvent => {
+  const { consumedDelta, contributedDelta, pass } = resolveDeltas(
+    grant.amountBytes,
+    grant.ratioExempt
+  );
+  // A reversal negates exactly what the grant accrued — never a blind `amountBytes`,
+  // or an exempt grant's reversal would fabricate a delta out of nothing.
+  const sign = kind === 'reversal' ? -1n : 1n;
+  return {
+    grantId: grant.id,
+    kind,
+    userId: grant.consumerId,
+    contributorId: grant.contributorId,
+    contributionId: grant.contributionId,
+    consumedDelta: (sign * consumedDelta).toString(),
+    contributedDelta: (sign * contributedDelta).toString(),
+    pass,
+    at: grant.at.toISOString()
+  };
+};
+
+/**
+ * Push one consumption event to korin. Best-effort (returns a 2xx flag); the caller
+ * decides retry. Idempotent on `(grantId, kind)` — korin's responsibility.
+ */
+export const pushConsumptionEvent = async (
+  event: ConsumptionEvent
+): Promise<boolean> => {
+  const { apiUrl, pullKey } = korin;
+  if (!apiUrl || !pullKey) return false;
+
+  try {
+    const res = await fetch(`${apiUrl}/ledger/consumption`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-pull-key': pullKey },
+      body: JSON.stringify(event)
+    });
+    if (!res.ok) {
+      log.warn('korin /ledger/consumption returned non-2xx', {
+        status: res.status,
+        grantId: event.grantId,
+        kind: event.kind
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log.error('Failed to push consumption event to korin', {
+      err,
+      grantId: event.grantId,
+      kind: event.kind
+    });
+    return false;
+  }
+};
+
+/**
+ * Ask korin's hot state whether a user may consume a contribution now. Returns the
+ * verdict on a 2xx, or `null` on unset keys / non-2xx / timeout / network error —
+ * `null` is the FAIL-OPEN signal: the caller must fall back to stellar's own
+ * read-time checks, never hard-block (ADR-0016).
+ */
+export const checkCanConsume = async (
+  userId: number,
+  contributionId: number
+): Promise<CanConsumeVerdict | null> => {
+  const { apiUrl, pullKey } = korin;
+  if (!apiUrl || !pullKey) return null;
+
+  try {
+    const url = `${apiUrl}/ledger/can-consume?userId=${userId}&contributionId=${contributionId}`;
+    const res = await fetch(url, {
+      headers: { 'x-pull-key': pullKey },
+      signal: AbortSignal.timeout(CAN_CONSUME_TIMEOUT_MS)
+    });
+    if (!res.ok) {
+      log.warn('korin /ledger/can-consume returned non-2xx — failing open', {
+        status: res.status,
+        userId,
+        contributionId
+      });
+      return null;
+    }
+    return (await res.json()) as CanConsumeVerdict;
+  } catch (err) {
+    log.warn('korin /ledger/can-consume unreachable — failing open', {
+      err,
+      userId,
+      contributionId
+    });
+    return null;
+  }
+};
+
+/**
+ * New COMPLETED grants after `sinceId`, oldest first, as consumption events — the
+ * source the drain job (ledgerJob) pushes. One grant = one event (cleaner than the
+ * two-rows-per-grant economy ledger). Reversals aren't caught here (status changes in
+ * place, not a new id); they're pushed inline by `reverseDownloadAccess`.
+ */
+export const getNewConsumptionEvents = async (
+  sinceId: number,
+  limit = 50
+): Promise<ConsumptionEvent[]> => {
+  const grants = await prisma.downloadAccessGrant.findMany({
+    where: { id: { gt: sinceId }, status: DownloadGrantStatus.COMPLETED },
+    orderBy: { id: 'asc' },
+    take: limit,
+    select: {
+      id: true,
+      consumerId: true,
+      contributorId: true,
+      contributionId: true,
+      amountBytes: true,
+      ratioExempt: true,
+      createdAt: true
+    }
+  });
+
+  return grants.map((g) =>
+    buildConsumptionEvent(
+      {
+        id: g.id,
+        consumerId: g.consumerId,
+        contributorId: g.contributorId,
+        contributionId: g.contributionId,
+        amountBytes: g.amountBytes,
+        ratioExempt: g.ratioExempt,
+        at: g.createdAt
+      },
+      'grant'
+    )
+  );
+};
+
+// ─── Working-set snapshot (korin pulls to seed) ──────────────────────────────
+
+export interface LedgerSnapshot {
+  generatedAt: string;
+  users: {
+    id: number;
+    contributed: string;
+    consumed: string;
+    canDownload: boolean;
+    policyState: RatioPolicyStatus;
+  }[];
+  contributions: {
+    id: number;
+    userId: number;
+    approvedAccountingBytes: string | null;
+    linkStatus: LinkHealthStatus;
+    ratioExempt: RatioExempt;
+  }[];
+}
+
+/**
+ * The durable state korin pulls on boot / reload to seed its hot working set
+ * (ADR-0016 working-set-snapshot flow): per-user balances + policy state, and
+ * per-contribution accounting size / link status / pass flag. BigInt → string.
+ */
+export const getLedgerSnapshot = async (): Promise<LedgerSnapshot> => {
+  const [users, contributions] = await Promise.all([
+    prisma.user.findMany({
+      select: {
+        id: true,
+        contributed: true,
+        consumed: true,
+        canDownload: true,
+        ratioPolicyState: { select: { status: true } }
+      }
+    }),
+    prisma.contribution.findMany({
+      select: {
+        id: true,
+        userId: true,
+        approvedAccountingBytes: true,
+        linkStatus: true,
+        ratioExempt: true
+      }
+    })
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    users: users.map((u) => ({
+      id: u.id,
+      contributed: u.contributed.toString(),
+      consumed: u.consumed.toString(),
+      canDownload: u.canDownload,
+      // No policy row yet ⇒ the schema default (OK).
+      policyState: u.ratioPolicyState?.status ?? RatioPolicyStatus.OK
+    })),
+    contributions: contributions.map((c) => ({
+      id: c.id,
+      userId: c.userId,
+      approvedAccountingBytes: c.approvedAccountingBytes?.toString() ?? null,
+      linkStatus: c.linkStatus,
+      ratioExempt: c.ratioExempt
+    }))
+  };
+};

--- a/src/modules/ledgerJob.ts
+++ b/src/modules/ledgerJob.ts
@@ -1,0 +1,44 @@
+import { prisma } from '../lib/prisma';
+import { korin } from './config';
+import { getLogger } from './logging';
+import { getNewConsumptionEvents, pushConsumptionEvent } from './ledger';
+
+const log = getLogger('ledgerJob');
+
+const STARTUP_DELAY_MS = 30_000; // align with the announce/metrics jobs; let boot settle
+
+// In-process cursor (v0.x — matches the stateless announce/metrics posture).
+// Initialised to the latest grant at startup so a restart never re-emits history;
+// korin already holds those from the boot snapshot (ADR-0016 bounded-loss model).
+let cursor = 0;
+
+const tick = async (): Promise<void> => {
+  const events = await getNewConsumptionEvents(cursor);
+  for (const event of events) {
+    const ok = await pushConsumptionEvent(event);
+    if (!ok) return; // leave cursor; retry from here next tick
+    cursor = event.grantId;
+  }
+};
+
+export const startLedgerJob = (): void => {
+  if (!korin.apiUrl || !korin.pullKey) {
+    log.warn(
+      'KORIN_API_URL or KORIN_PULL_KEY not configured — consumption-event push disabled'
+    );
+    return;
+  }
+
+  const outer = setTimeout(() => {
+    void (async () => {
+      const latest = await prisma.downloadAccessGrant.aggregate({
+        _max: { id: true }
+      });
+      cursor = latest._max.id ?? 0;
+      log.info('Consumption-event push job started', { cursor });
+      void tick();
+      setInterval(() => void tick(), korin.pollIntervalMs).unref();
+    })();
+  }, STARTUP_DELAY_MS);
+  outer.unref();
+};

--- a/src/routes/api/ledger.ts
+++ b/src/routes/api/ledger.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { requireServiceKey } from '../../middleware/serviceAuth';
+import { asyncHandler } from '../../modules/asyncHandler';
+import { getLedgerSnapshot } from '../../modules/ledger';
+
+const router = Router();
+
+/**
+ * GET /api/ledger/snapshot (ADR-0016 working-set-snapshot flow).
+ *
+ * korin pulls this on boot / reload to seed its hot working set, then advances it
+ * with live consumption events. Bearer `STELLAR_SERVICE_KEY` via `requireServiceKey`
+ * (fails closed when the key is unset) — so, like the other korin-facing service
+ * endpoints (`/users/:id/reputation`, `by-irc-nick`), it is intentionally kept OUT
+ * of the public OpenAPI contract. The payload shape lives in `getLedgerSnapshot`.
+ */
+router.get(
+  '/snapshot',
+  requireServiceKey,
+  asyncHandler(async (_req, res) => {
+    res.json(await getLedgerSnapshot());
+  })
+);
+
+export default router;


### PR DESCRIPTION
Realizes the **stellar-side producer surface** of the ADR-0016 consumption-accounting contract, so korin.pink's `ledger` can act as the derived hot-path read-model. Builds directly on #260's grant path (PR #322): every grant already writes a ledger row (real DEBIT/CREDIT, or a zero-amount `FREEPASS_GRANT`/`NEUTRALPASS_GRANT` marker), and that seam is what this plugs into.

Two contract facts are **settled by ADR-0016** (not choices made here):
- **canConsume fails OPEN** — a korin outage must never hard-block consumption.
- **stellar stays the system of record** — korin owns no numbers; the local `economyTransaction` ledger remains authoritative. korin re-seeds from the snapshot on restart (bounded-loss).

## What landed (scope: Emit + Gate + Snapshot)

- **`src/modules/ledger.ts`** — korin client. `resolveDeltas` pre-resolves each grant's ratio impact (Freepass → `consumedDelta 0`; Neutralpass → both 0) so korin never re-derives pass logic. `pushConsumptionEvent` (`POST /ledger/consumption`), `checkCanConsume` (`GET /ledger/can-consume`; returns `null` = **fail-open** on unset keys / non-2xx / timeout / error), `getNewConsumptionEvents` (grant→event mapping), `getLedgerSnapshot` (working-set seed).
- **`src/modules/ledgerJob.ts`** — in-process cursor drain over new COMPLETED grants, mirroring `announceJob`. Cursor starts at `max(id)` on boot so a restart never re-emits history (korin already has it from the snapshot).
- **`downloads.ts`** — grant-time `canConsume` gate **before** the transaction (never hold a DB tx across a network call): **skipped for exempt** contributions (a pass exists to bypass ratio), blocks on `allow:false` (403), fails open on `null`. `reverseDownloadAccess` emits a best-effort negated-delta reversal event post-commit.
- **`src/routes/api/ledger.ts`** — `GET /api/ledger/snapshot` behind `requireServiceKey`. Like the other korin-facing service endpoints (`/users/:id/reputation`, `by-irc-nick`), it is **intentionally kept out of the public OpenAPI contract** — `openapi.json` is unchanged.

Additive and **inert until `KORIN_API_URL`/`KORIN_PULL_KEY`/`STELLAR_SERVICE_KEY` are set** — same posture as the IRC/announce integration. **No schema change.**

## Deferred to a follow-up

The rest of the ADR-0016 surface needs korin's Phase-2 read endpoints live first:
- `/ledger/sync` working-set mutations (contribution/policy-state drift between snapshots; full reversal-as-sync).
- `/ledger/stats` live-stats + snatch-list / consumption-history reads.

## Wire-shape note for korin ADR-004

The consumption event carries a `kind: 'grant' | 'reversal'` discriminator (extends ADR-0016's illustrative body) so korin dedupes idempotently on `(grantId, kind)`. Deltas are BigInt-as-string. Final shape to be confirmed with the korin side.

## Verification

- Unit: **1804 pass** (98 suites) — incl. 15 new `ledger` cases + 3 gate cases (block / exempt-skip / fail-open).
- Integration: snapshot shape, grant→event mapping (incl. #260 exempt deltas), gate block / exempt-skip / fail-open against a stubbed korin.
- `tsc --noEmit`, eslint, prettier clean. `openapi.json` diff-clean.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)