### PR TITLE
feat(irc-announce): channel-weight mechanism, announce verification, integrity + private-announce ADRs (v0.8.0)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -31,3 +31,6 @@ KORIN_API_URL=
 KORIN_PULL_KEY=
 KORIN_POLL_INTERVAL_MS=300000
 STELLAR_SERVICE_KEY=
+# KORIN_CHANNEL_WEIGHTS: optional IRCScore channel-weight map (#141), JSON
+# `{"#channel": weight}`. Empty = unweighted channel counting (the default).
+KORIN_CHANNEL_WEIGHTS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@ All notable changes to stellar-api are documented here.
 
 ### Added
 
+- **IRCScore channel-weight mechanism** (#141) — `channelQuality` now reads an `effectiveChannels` count that an optional `KORIN_CHANNEL_WEIGHTS` map (JSON `{"#channel": weight}`) can re-weight per channel, so a firehose everyone idles in can count for less than a niche channel. The map is empty by default and behaviour-identical to the previous raw channel count; actual weight values stay deferred until real multi-channel traffic exists to calibrate them (PRD-02). Ships with the first test coverage for `getIrcScore` and the CRS IRC dimension.
+- **Announce push-path verification** (#299) — the previously-untested cursor/retry loop (`runAnnounceCycle`, extracted for testability) and the korin `POST /irc/announce` wire contract (`InboundFeedSchema` shape, plain notify-and-link) are now covered by tests, plus a live end-to-end runbook (`docs/runbooks/announce-e2e.md`).
 - **Freepass/Neutralpass ratio-exempt Contribution flags** (PRD-06 #4) — a Contribution can be flagged Freepass (consumption accrues no `consumed` for the consumer; the contributor still earns `contributed`) or Neutralpass (neither side accrues, fully ratio-neutral) [#260].
 - **Consumption-event ingest + grant-time `canConsume` gate** (ADR-0016 Phase 2) — stellar now emits a server-authoritative consumption event per grant for korin's ledger to sum (`ledger.ts`, `ledgerJob.ts`), and `downloads.ts` enforces the Ratio Mechanism verdict at grant time via the ledger's hot state (`checkCanConsume`) instead of read-time-only evaluation; the check fails open (`null`) on unset keys, non-2xx, timeout, or error, so an unreachable ledger never blocks a grant. Freepass/Neutralpass contributions skip the gate entirely. Remaining ADR-0016 surface (`/ledger/sync` mutations, `/ledger/stats` reads) tracked in #324 [#261].
+
+### Docs
+
+- **ADR-0029 — integrity-monitoring / abuse-detection contract** (#300) — the follow-on ADR ADR-0016 deferred: defines the abuse-signal taxonomy, a cursor-pulled `GET /ledger/integrity` wire shape reusing the existing keys, and the stellar action model (evidence into staff review or a bounded CRS drag — never an automated gate). Reconciles ADR-0016 to Accepted (Phase 2 shipped via #261).
+- **ADR-0030 — access-gated announce delivery for private communities** (#177, design-only) — models the access-control feature ADR-0015 deferred: a dedicated `Community.visibility`, membership single-sourced from existing role relations ∩ verified nicks, an optional `target` on the announce push, and the crux decision that stellar projects membership while korin enforces the channel ACL.
+- **IRCScore magnitude reconcile** (#141) — corrected the stale `IRC_CAP = 6` in ADR-0013 to the pinned `2` and documented the channel-weight mechanism in ADR-0013 and PRD-02.
 
 ## [0.7.0] — 2026-07-11
 

--- a/docs/adr/0013-korin-pink-irc-integration.md
+++ b/docs/adr/0013-korin-pink-irc-integration.md
@@ -45,14 +45,14 @@ This ADR records that supersession and the integration design that replaces it. 
 ## IRCScore formula
 
 ```
-IRCScore = activity × consistency × channelQuality   (scaled to IRC_CAP = 6)
+IRCScore = activity × consistency × channelQuality   (scaled to IRC_CAP = 2)
 
-activity       = log1p(messageCount)   / log1p(ACTIVITY_REF=50)   → [0, 1]
-consistency    = presenceSeconds / windowDurationSeconds           → [0, 1]
-channelQuality = log1p(channelCount)   / log1p(CHANNEL_REF=5)     → [0, 1]
+activity       = log1p(messageCount)     / log1p(ACTIVITY_REF=50)   → [0, 1]
+consistency    = presenceSeconds / windowDurationSeconds             → [0, 1]
+channelQuality = log1p(effectiveChannels) / log1p(CHANNEL_REF=5)    → [0, 1]
 ```
 
-Log-scaling on message and channel counts prevents volume abuse; the product of three `[0,1]` factors bounds the dimension before the registry cap. Absence of an IRC nick earns 0 — IRC presence is optional, absence is not penalised.
+`IRC_CAP` was pinned at **2** (2026-06-23, PRD-02 — deliberately thin until real IRC traffic exists); the earlier `6` here was superseded and is corrected. `effectiveChannels` is `channelCount` by default; a configured `KORIN_CHANNEL_WEIGHTS` map (#141) instead sums per-channel weights over the joined channel list — the map is empty (behaviour-identical to the raw count) until real multi-channel traffic exists to calibrate it. Log-scaling on message and channel counts prevents volume abuse; the product of three `[0,1]` factors bounds the dimension before the registry cap. Absence of an IRC nick earns 0 — IRC presence is optional, absence is not penalised.
 
 ---
 
@@ -95,7 +95,7 @@ The reconcile lands as part of the `feat/korin-pink` integration onto `main`. Ne
 | File                             | Resolution                                                                                                                                                                                                          |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/modules/config.ts`          | Take korin — drop the `irc` `{ botToken, saslSecret }` block, keep `korin` `{ apiUrl, pullKey, pollIntervalMs }`.                                                                                                   |
-| `src/modules/reputation.ts`      | Take korin (4 hunks) — `ircScorer` reads `getIrcScore(ircNick)` from `irc.ts`, `ircNick` in `DimensionInput`, drop the `prisma.ircActivity` query. Self-consistent: imports `./irc`, defines `IRC_CAP = 6` locally. |
+| `src/modules/reputation.ts`      | Take korin (4 hunks) — `ircScorer` reads `getIrcScore(ircNick)` from `irc.ts`, `ircNick` in `DimensionInput`, drop the `prisma.ircActivity` query. Self-consistent: imports `./irc`, defines `IRC_CAP = 2` locally. |
 | `src/modules/reputation.spec.ts` | Take korin — its tests cover the external IRCScore; main's cover the deleted in-repo scorer (~166 lines, effectively two different files).                                                                          |
 | `prisma/schema.prisma`           | **Hand-merge** — main's `User` model (no `communityPass` per #134, no `ircKey`/`announceKey`) **+** korin's `ircNick String? @unique`. korin's branch still carries `communityPass`; a blind take reintroduces it.  |
 | `package.json`                   | **Hand-merge** — main's `version` + `prepare: husky install` **+** korin's `db:seed-wiki` script.                                                                                                                   |

--- a/docs/adr/0016-ledger-accounting-contract.md
+++ b/docs/adr/0016-ledger-accounting-contract.md
@@ -62,7 +62,7 @@ Auth, key names, and fail-closed semantics are inherited verbatim from ADR-0013 
 - korin gains a `Contribution`-aware working set (not just IRC metrics) and three endpoints (`/ledger/consumption`, `/ledger/can-consume`, `/ledger/stats`); stellar gains a `/api/ledger/snapshot` read and emits events + sync mutations from `downloads.ts` / the contribution + ratio-policy paths.
 - **Phasing.** korin ADR-004 Phase 1 (port IRC metrics) needs **no** new contract. This ADR is the **Phase 2** dependency; it can land incrementally — gate-only first (read path), then event ingest, then live stats, then abuse signals.
 - **Freepass / Neutralpass** (PRD-06 red-green target #4) are realized as the `pass` field on the consumption event + a `Contribution` flag synced via `/ledger/sync`. **Bonus-funded pass** rides the same `pass: "bonus"` value, debited in stellar's (deferred) bonus economy.
-- **Integrity / abuse detection** is enabled but **out of scope for this contract** — korin's hot-state + IRC vantage is the home for it; the signal shape (impossible-consumption, sybil/multi-account) is a follow-on ADR.
+- **Integrity / abuse detection** is enabled but **out of scope for this contract** — korin's hot-state + IRC vantage is the home for it; the signal shape (impossible-consumption, sybil/multi-account) is defined in the follow-on [ADR-0029 — integrity-monitoring contract](0029-integrity-monitoring-contract.md).
 - If korin is never deployed, stellar's existing read-time accounting continues unchanged — this contract is purely additive.
 
 ---

--- a/docs/adr/0029-integrity-monitoring-contract.md
+++ b/docs/adr/0029-integrity-monitoring-contract.md
@@ -1,0 +1,85 @@
+# ADR-0029: Integrity-monitoring & abuse-detection contract (korin.pink `ledger` ↔ stellar-api)
+
+**Status:** Proposed
+**Date:** 2026-07-15
+**Repos:** orphic-inc/stellar-api (decides & acts), obrien-k/korin-pink (`ledger` — detects)
+**Extends:** [ADR-0013 — korin.pink IRC integration](0013-korin-pink-irc-integration.md) (boundary + key model) · [ADR-0016 — consumption accounting & ratio-gate contract](0016-ledger-accounting-contract.md) (the hot consumption state this reads over)
+**Serves:** [PRD-06 Ratio](../prd/06-ratio.md) · [PRD-01 Community-Score / CRS](../prd/01-Community-Score.md) · [ADR-0025 moderation & messaging surfaces](0025-moderation-and-messaging-surface-model.md)
+**Counterpart:** obrien-k/korin-pink — the `ledger` sidecar's deferred "abuse/integrity signals" work (its ADR-004 lists it as out-of-scope-until-a-follow-on-ADR; this is that ADR's stellar half).
+
+---
+
+## Context
+
+Consumption is server-authoritative (ADR-0016): stellar issues every grant, so there is no client self-report and no cheat surface in the accounting itself. That closes the classic ratio-inflation hole but leaves the abuse patterns that live _around_ the numbers rather than _in_ them, and that stellar's read-time model cannot cheaply see:
+
+- **Ratio / grant abuse** — grant patterns that are individually legal but collectively gaming the ratio or pass economy (e.g. burst consumption timed against a policy-state boundary).
+- **Sybil / multi-account** — accounts correlated by shared session/IP, invite lineage, or a shared verified IRC identity, acting in concert.
+- **Impossible-consumption** — consumption velocity or volume beyond physical plausibility for one human (grant rate, concurrent-session geography).
+- **Announce / feed scraping** — automated harvesting of the announce firehose or feeds beyond human cadence.
+
+With consumption-event ingest landed (#261), korin's `ledger` now holds the hot consumption stream, and via ADR-0013 it also holds the IRC vantage (presence, mentions, nick↔account map). That combination — high-churn hot counters plus a cross-account social signal — is exactly the vantage stellar's durable, per-request Postgres model is the wrong place to compute. ADR-0016 §Consequences enabled this but deferred the signal shape to "a follow-on ADR." This is that ADR.
+
+It defines **what signals korin returns and how stellar acts on them** — deliberately _not_ a new enforcement mechanism. The reference lineage historically fired such events as one-way notices into staff channels; here the _taxonomy_ is preserved but delivery rides the existing ledger contract into stellar's own moderation and reputation surfaces.
+
+---
+
+## Decision
+
+**Detection is korin's; adjudication and action are stellar's.** korin's `ledger` computes advisory integrity **signals** over its hot window; stellar drains them and routes them into human-reviewable or bounded-automatic surfaces it already owns. korin never mutates stellar state and never gates consumption on a signal.
+
+### Ownership split
+
+- **korin.pink `ledger` — detector.** Computes signals from the hot consumption stream + IRC vantage it already holds. Holds only derived, recoverable state (bounded-loss, ADR-0013). It emits _evidence_, never a verdict, and has no authority over stellar.
+- **stellar-api — adjudicator + actor.** The system of record. Owns the accounts, the moderation/report surfaces (ADR-0025), and the CRS. It decides what a signal _means_ and what, if anything, happens — always via an existing bounded mechanism, never a new automated block.
+
+### Signal shape
+
+Each signal is `{ kind, subjects: userId[], severity: "info"|"warn"|"high", evidence: object, window: {start, end}, detectedAt }`, where `kind` is one of the taxonomy above and `evidence` is the detector-specific supporting data (correlated account ids, rate figures, geography deltas). Signals are idempotent on `(kind, subjects, window)` so re-draining never double-reports.
+
+### Wire shape — stellar pulls, cursor-based (reuses ADR-0013 keys)
+
+| Flow                  | Direction               | Endpoint                                              | Auth                         | Notes                                                                                                                                                                                                         |
+| --------------------- | ----------------------- | ----------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Integrity signals** | stellar **pulls** korin | `GET {KORIN_API_URL}/ledger/integrity?since=<cursor>` | `x-pull-key: KORIN_PULL_KEY` | Returns new signals since the cursor. A drain job advances the cursor on success, matching the `/irc/metrics` and announce posture. korin unreachable ⇒ no new signals (degrade, never break). No new secret. |
+
+Pull (not push) is chosen to match every other stellar→korin read and to keep the fail-mode a _degradation_: if korin is down, stellar simply has no fresh signals — nothing blocks and nothing errors. There is no inbound abuse surface on stellar to attack.
+
+### Action model on stellar — evidence, never an automated gate
+
+A signal is **input**, and stellar routes it to exactly one or more of these existing, bounded outcomes:
+
+1. **Staff-review substrate** — a signal materializes as a flag/report in the moderation queue (ADR-0025), where a human staffer adjudicates and takes any account action. This is the default for `warn`/`high`.
+2. **Bounded CRS input** — a signal may feed a _negative/suspicion_ CRS dimension, capped and floored like the existing `inviteContagion` drag (ADR-0004): a bounded reputational headwind, never a cliff, and never itself a gate.
+3. **Informational stats** — `info`-severity signals may surface only as staff-facing counters.
+
+**Hard constraints (non-negotiable):**
+
+- **Never an automated gate on consumption.** A detector must never disable a download or an account. Consumption stays a session-authed, ratio-accounted grant (Golden Rule 3); disabling is always a human staff action or, at most, an existing bounded CRS drag.
+- **Never a content-access path.** This contract carries signals only; it authorizes nothing (consistent with ADR-0015's permanent design-out of key-authed IRC content access).
+- **korin holds no authority over stellar state.** It returns evidence; stellar owns every mutation, and every action taken is audited.
+- **Fail-degraded.** A korin outage yields no signals, never a blocked user and never an error to the consumer.
+
+---
+
+## Rationale
+
+- **Puts detection where the hot state and the cross-account vantage already are** (korin), and adjudication where the authority and the human surfaces already are (stellar) — no new authority, no split-brain.
+- **Reuses one boundary.** Same keys, same fail-closed/degrade rules as ADR-0013/0016; the only new surface is one cursor-drained read.
+- **Safe by construction.** Because the action model tops out at "flag for a human" or "bounded CRS drag," a false positive can never auto-punish — the worst case is a staffer dismissing a flag or a small, capped reputational dip.
+- **Additive.** If korin is never deployed, stellar loses only the signals; all existing accounting and moderation continue unchanged.
+
+---
+
+## Consequences
+
+- **Implementation issues fall out of this ADR** (filed separately, gated on acceptance): (a) the `/ledger/integrity` **drain job + cursor** and the signal-ingest module on stellar; (b) **staff-queue wiring** — materializing a signal as a Report/flag in the ADR-0025 surfaces; (c) an optional **suspicion CRS dimension** (bounded/floored like `inviteContagion`); (d) the paired **korin `ledger` detector** work (the sidecar half).
+- korin's `ledger` gains detector logic over state it already holds; stellar gains one pull-drain and the routing into surfaces it already owns.
+- The taxonomy is intentionally open at the edges — new `kind`s are added on both sides without a contract change, since the wire shape carries `kind` + opaque `evidence`.
+
+---
+
+## Cross-references
+
+- **stellar-api:** ADR-0013 (boundary) · ADR-0016 (hot consumption state, §Consequences deferral this fulfils) · ADR-0025 (moderation surfaces the signals land in) · ADR-0004 / PRD-01 (bounded negative CRS dimension precedent) · ADR-0015 (no key-authed content access).
+- **korin.pink:** the `ledger` service (ADR-004) and its deferred abuse-signal work — the detector half of this contract.

--- a/docs/adr/0029-integrity-monitoring-contract.md
+++ b/docs/adr/0029-integrity-monitoring-contract.md
@@ -1,6 +1,6 @@
 # ADR-0029: Integrity-monitoring & abuse-detection contract (korin.pink `ledger` ↔ stellar-api)
 
-**Status:** Proposed
+**Status:** Proposed — **blocked: no substrate.** The korin `ledger` this contract reads over is being withdrawn (see ADR-0016, Superseded); `GET /ledger/integrity` therefore has nothing to attach to. The signal taxonomy and action model below stand on their own and are worth keeping, but any implementation must **first specify and justify its own substrate** rather than inherit one. Do not build against the endpoint shape in this document until that is done.
 **Date:** 2026-07-15
 **Repos:** orphic-inc/stellar-api (decides & acts), obrien-k/korin-pink (`ledger` — detects)
 **Extends:** [ADR-0013 — korin.pink IRC integration](0013-korin-pink-irc-integration.md) (boundary + key model) · [ADR-0016 — consumption accounting & ratio-gate contract](0016-ledger-accounting-contract.md) (the hot consumption state this reads over)

--- a/docs/adr/0030-private-community-announce-delivery.md
+++ b/docs/adr/0030-private-community-announce-delivery.md
@@ -1,0 +1,80 @@
+# ADR-0030: Access-gated announce delivery for private communities
+
+**Status:** Proposed
+**Date:** 2026-07-15
+**Repos:** orphic-inc/stellar-api (membership + emit), obrien-k/korin-pink (channel ACL enforcement)
+**Extends:** [ADR-0013 — korin.pink IRC integration](0013-korin-pink-irc-integration.md) (ownership split) · [ADR-0015 — verified IRC nick link](0015-verified-irc-nick-link.md) (§Scope names this as the deferred, unmodeled access-control feature)
+**Serves:** [PRD-02 IRC & Announce](../prd/02-irc-and-announce.md)
+**Origin:** #177. ADR-0015 retired the per-user `IRCKey`/`AnnounceKey` and mapped their four old jobs to replacements; three landed, and **private-community announce delivery** was explicitly deferred as "a separate, unmodeled access-control feature … tracked separately." This ADR models it.
+
+---
+
+## Context
+
+Today the announce path is a single public firehose: `announceJob` pushes every new Contribution to korin `POST /irc/announce`, which renders it into `#announce`. The only community signal on the wire is the RSS `<category>` string; nothing gates delivery. A **private** community's releases should reach **only that community's members** over IRC, not the public channel.
+
+This is greenfield on both sides, and that is the whole reason it is design-first:
+
+- **stellar** has no privacy concept on `Community`. The model carries `registrationStatus` (`open`/`invite`/`closed`), `leaderId`, a `staff[]` relation, a `Consumer[]` membership relation, and `Contributor` — but no visibility flag, and `registrationStatus` gates _joining_, not _visibility_.
+- **korin** models no channel ACL in its API. Ergo/ChanServ can enforce per-channel membership/op at the ircd layer, but korin exposes no endpoint to gate an announcement to a private channel's members. Nick ownership is proven (ADR-0015), which is the identity substrate an ACL would stand on, but the ACL itself does not exist.
+
+So four things must be decided before any code: the privacy model, the membership source of truth, the announce contract extension, and — the crux — **who enforces the channel ACL**.
+
+### Hard constraint (frames every decision)
+
+This gates the **visibility of an announcement**, never content access. It must **never authorize a download** (ADR-0015; Golden Rule 3): consumption stays a session-authed, ratio-accounted grant, and the announce item stays notify-and-link (#136) — a plain link into the app, resolved by the normal authed grant. The gated channel controls who _sees the line_, nothing more. Key-authenticated content access over IRC is permanently designed out and is not reintroduced here.
+
+---
+
+## Decision
+
+### 1. Privacy model — a dedicated `Community.visibility`
+
+Add `Community.visibility` (`PUBLIC` | `PRIVATE`, default `PUBLIC`). Do **not** overload `registrationStatus`: "invite-only registration" and "private/hidden" are orthogonal (a community can have open registration but private announce, or vice versa), and conflating them repeats the overloaded-field trap. Only `PRIVATE` communities route announces to a gated channel; `PUBLIC` keeps the current `#announce` behaviour unchanged.
+
+### 2. Membership source of truth — the existing relations, resolved in stellar, single-sourced
+
+Eligible viewers of a private community's announce = the **union of its existing role relations** — `Consumer[]` (the membership relation), `Contributor`, `staff[]`, and `leaderId` — intersected with **verified IRC links** (`ircNick`, ADR-0015). No new `CommunityMember` join table: introducing a parallel membership store is exactly the dual-source drift ADR-0010 warned against. A single stellar resolver computes the eligible verified-nick set on demand; stellar remains the sole authority for "who belongs."
+
+### 3. Announce contract extension — an optional target, backward-compatible
+
+Extend the `POST /irc/announce` body with an optional `target: { visibility, community, channel? }`. Omitted or `PUBLIC` ⇒ today's `#announce` path (no breaking change). `PRIVATE` ⇒ korin routes the rendered line to the community's gated channel instead of the firehose. The stellar side derives the target from the Contribution's community `visibility`.
+
+### 4. ACL ownership — **stellar projects membership, korin enforces** (the crux)
+
+Consistent with ADR-0013's non-overlapping ownership: **stellar owns "who may see community X" and korin owns the IRC substrate that enforces it.** stellar projects the eligible verified-nick set to korin (event-driven on membership/visibility change, mirroring the ADR-0016 `/ledger/sync` posture — push deltas, do not have korin cache a second copy it can drift from); korin translates that into Ergo/ChanServ channel membership (invite/op) and gates delivery. stellar never runs IRC ACLs; korin never becomes a second source of truth for membership. The projection is the seam, and keeping it delta-pushed from the single stellar authority is what prevents the ADR-0010 failure mode.
+
+### 5. Permissions
+
+Configuring a community's `visibility` rides the existing community-management authority — the community `leaderId`/`staff` for their own community, and site-staff via the existing data-driven `communities_manage` rank permission. No new permission key is expected; if one proves warranted it is a catalog addition (auto-surfaced in the UserRanks editor), decided at implementation time — not a new gating model.
+
+---
+
+## Rationale
+
+- **Reuses ADR-0013's ownership split** rather than inventing a new one: membership authority stays in stellar (where the data lives), enforcement stays in korin (where the ircd lives).
+- **No parallel membership store**, so no drift — the single most likely failure mode for this feature (ADR-0010).
+- **Backward-compatible wire change** — public communities are untouched; only a `PRIVATE` community opts into gated routing.
+- **The hard constraint is structural**, not a runtime check: because the announce is notify-and-link and consumption is independently session-authed, even a mis-gated channel leaks at most the _existence_ of a release, never access to it.
+
+---
+
+## Consequences — implementation issues (gated on acceptance)
+
+Filed separately; none built in this pass (#177 is design-only):
+
+1. **stellar:** `Community.visibility` field + migration (default `PUBLIC`).
+2. **stellar:** membership resolver module (union of role relations ∩ verified nicks) + tests — the single source of truth.
+3. **stellar:** announce contract extension (`target` on the push) + deriving it from community visibility, and the membership-projection emit (delta push to korin).
+4. **korin (paired issue):** the channel-ACL receiver + Ergo/ChanServ enforcement (the gated channel, invite/op from the projected nick set).
+5. **stellar-ui:** a `visibility` toggle (and any announce-channel affordance) in the community manager (`CommunityManager.tsx`), gated by `communities_manage`.
+6. **permission confirmation:** verify `communities_manage` + leader/staff covers visibility config; add a key only if warranted.
+
+Until accepted and implemented, all announces remain public (current behaviour), and #177 stays the tracker for this design.
+
+---
+
+## Cross-references
+
+- **stellar-api:** ADR-0013 (ownership split, extended) · ADR-0015 (§Scope charter; verified-nick identity substrate) · ADR-0010 (dual-source-of-truth failure mode this avoids) · ADR-0016 (`/ledger/sync` delta-push posture mirrored by the membership projection) · PRD-02 (IRC & Announce) · #136 (notify-and-link).
+- **korin.pink:** the IRC substrate (Ergo/ChanServ) that would enforce the channel ACL — the paired implementation issue.

--- a/docs/prd/02-irc-and-announce.md
+++ b/docs/prd/02-irc-and-announce.md
@@ -63,7 +63,7 @@ consistency    = min(presenceSeconds / windowDuration, 1)     → [0, 1]
 channelQuality = log1p(channelCount)  / log1p(CHANNEL_REF)    → [0, 1]
 ```
 
-Anti-farming is structural: log-scaling on message count gives hard diminishing returns, `consistency` rewards sustained presence over one-session marathons, and `channelQuality` (also log-scaled) defeats single-channel spamming. The reputation registry applies the per-dimension cap (`IRC_CAP` = **2**, pinned 2026-06-23 — deliberately thin until real IRC traffic exists) so IRC can never dominate the CRS. `ACTIVITY_REF` = 50 and `CHANNEL_REF` = 5 are likewise pinned; the only **HITL/TBD** magnitude that remains is the channel-weight map ([#141](https://github.com/orphic-inc/stellar-api/issues/141)), deferred until there is real multi-channel traffic to weight.
+Anti-farming is structural: log-scaling on message count gives hard diminishing returns, `consistency` rewards sustained presence over one-session marathons, and `channelQuality` (also log-scaled) defeats single-channel spamming. The reputation registry applies the per-dimension cap (`IRC_CAP` = **2**, pinned 2026-06-23 — deliberately thin until real IRC traffic exists) so IRC can never dominate the CRS. `ACTIVITY_REF` = 50 and `CHANNEL_REF` = 5 are likewise pinned. The channel-weight **mechanism** ([#141](https://github.com/orphic-inc/stellar-api/issues/141)) now ships: `channelQuality` reads an `effectiveChannels` count that a `KORIN_CHANNEL_WEIGHTS` map (JSON `{"#channel": weight}`) can re-weight per channel. The map is **empty by default — behaviour-identical to raw channel counting** — and pinning actual weights remains the one **HITL/TBD** magnitude, deferred until there is real multi-channel traffic to calibrate against.
 
 ## Concept → code (descent map)
 
@@ -83,11 +83,11 @@ Anti-farming is structural: log-scaling on message count gives hard diminishing 
 
 - ✅ **korin.pink integration** — metrics pull + in-process cache, IRCScore read-time scorer registered into the CRS, announce push, and the Bearer-gated `by-irc-nick` / `reputation` inbound calls (ADR-0013; in-repo build #134–140 shipped-then-superseded, removed via #148/#150).
 - ✅ **Verified nick link** — challenge/nonce claim → `!verify` → `POST /irc-nick/verify` → promotion; only verified links credit IRCScore or resolve (ADR-0015; #175).
-- ✅ **IRCScore magnitudes** — cap pinned at **2** and `ACTIVITY_REF` = 50 / `CHANNEL_REF` = 5 confirmed (2026-06-23). ⏳ Only the channel-weight map remains, deferred until real multi-channel traffic exists ([#141](https://github.com/orphic-inc/stellar-api/issues/141), HITL).
+- ✅ **IRCScore magnitudes** — cap pinned at **2** and `ACTIVITY_REF` = 50 / `CHANNEL_REF` = 5 confirmed (2026-06-23); the channel-weight **mechanism** (config-driven `KORIN_CHANNEL_WEIGHTS`, neutral empty default) shipped with test coverage. ⏳ Only the actual weight **values** remain, deferred until real multi-channel traffic exists ([#141](https://github.com/orphic-inc/stellar-api/issues/141), HITL).
 
 ## Open questions
 
-- **Channel-weight map** — the one IRCScore magnitude still TBD (cap and the refs were pinned 2026-06-23); deferred until real multi-channel traffic exists to weight (#141).
+- **Channel-weight map values** — the mechanism ships (config-driven `KORIN_CHANNEL_WEIGHTS`, neutral empty default); pinning the actual per-channel weights is the one IRCScore magnitude still TBD (cap and refs pinned 2026-06-23), deferred until real multi-channel traffic exists to weight (#141). korin exposes no canonical channel-list endpoint today — the de-facto channels are the bridge join set (`#announce,#stellar,#korin`).
 - **IRCScore teeth (positive reinforcement) — noted 2026-06-13, not scoped.** Today IRCScore only feeds CRS as substrate. The intended downstream: high scorers _earn capability_ — rights to create official channels, moderation in specific community channels — administered via the **Staff Toolbox** / **Community Toolbox** (see [PRD-01 → Future direction: making CRS bite](01-Community-Score.md)). Privilege-granting, never a download gate.
 - **Periodic re-verification.** Verified links don't expire in v1 (ADR-0015); a member abandoning a nick later re-registered by someone else is an accepted narrow window. Re-verification cadence is a future option.
 

--- a/docs/runbooks/announce-e2e.md
+++ b/docs/runbooks/announce-e2e.md
@@ -1,0 +1,51 @@
+# Runbook — verify the release-announce push path end-to-end (#299)
+
+The announce path is stellar-authoritative and korin-delivered (ADR-0013): `announceJob` cursors over new Contributions and `announce.ts` POSTs each as a one-item RSS artifact to korin `POST /irc/announce`, which renders it into the IRC `#announce` channel. The in-process contract is covered by automated tests (`src/announce.spec.ts`, `src/modules/announceJob.spec.ts`); those pin the wire shape and the cursor/retry semantics but cannot observe the rendered IRC line. This runbook is the manual half — driving one real Contribution through a live korin and confirming it lands, correctly formatted, in the intended channel.
+
+## What the automated tests already guarantee
+
+- The POST body is exactly korin's `InboundFeedSchema`: `{ xmlPayload: string, templateType: 'minimal', environment: { osc8: boolean } }`, sent with the `x-pull-key` header to `${KORIN_API_URL}/irc/announce`.
+- The RSS `<link>` is the plain release page (`/releases/:id`), never a tokenized download URL (notify-and-link, #136 / Golden Rule 3).
+- The cursor seeds to the latest Contribution at boot (no history replay), advances only on a 2xx, and holds on failure so the item retries in order (at-least-once).
+
+What remains manual: that a live korin accepts the payload, routes it to `#announce`, and renders the line as expected.
+
+## Preconditions
+
+- korin api reachable and `KORIN_API_URL` set on stellar; `KORIN_PULL_KEY` (stellar) equals korin's `STELLAR_PULL_KEY`.
+- korin's `stellar-bridge` bot is joined to `#announce` and holds channel op (the channel name is load-bearing on the korin side).
+- A stellar instance with the announce job running (`KORIN_API_URL` + `KORIN_PULL_KEY` both set — the job is inert otherwise).
+
+## Fast path — direct contract smoke against korin
+
+korin's `/irc/announce` renders synchronously and returns the artifact in the HTTP response, so the wire contract can be checked without waiting for the poll interval:
+
+```bash
+curl -sS -X POST "$KORIN_API_URL/irc/announce" \
+  -H 'content-type: application/json' \
+  -H "x-pull-key: $KORIN_PULL_KEY" \
+  -d '{
+    "xmlPayload": "<?xml version=\"1.0\"?><rss version=\"2.0\"><channel><item><title>Artist — Album [FLAC]</title><link>https://stellar.example/releases/1</link><guid isPermaLink=\"false\">stellar-contribution-1</guid><category>Music</category></item></channel></rss>",
+    "templateType": "minimal",
+    "environment": { "osc8": true }
+  }'
+```
+
+Expect `200` with `{ "success": true, "mode": "minimal", "artifact": "<rendered IRC line>" }`. A `400` means the payload drifted from `InboundFeedSchema`; a `401` means the pull key mismatched.
+
+## Full path — a real Contribution to the channel
+
+1. Create a new Contribution on stellar (via the normal contribution flow, or seed one in the test DB), noting its id.
+2. Wait for the next announce tick (up to `KORIN_POLL_INTERVAL_MS`, default 5 min) or restart stellar to trigger the startup tick. The cursor only picks up Contributions created after the last recorded id.
+3. In an IRC client joined to `#announce`, confirm a single line appears for that Contribution.
+4. Verify the rendered line:
+   - category badge/icon matches the item type (contribution/release/contest/announcement);
+   - the title reads `Artists — Title [Type]`;
+   - the hyperlink target (OSC-8 or plain) is the release page `/releases/:id`, not a tokenized URL;
+   - exactly one line per Contribution (no duplicate/replay).
+
+## On drift
+
+- Payload rejected (400): the stellar-side DTO diverged from `InboundFeedSchema` — fix `publishAnnounceItem` in `src/modules/announce.ts` and update the contract assertion in `src/announce.spec.ts`.
+- Wrong/blank channel: the bridge is not op in `#announce` (korin-side deploy), not a stellar concern — file against korin.
+- Duplicate lines: cursor advance regression — check `runAnnounceCycle` and the startup seed in `src/modules/announceJob.ts`.

--- a/src/announce.spec.ts
+++ b/src/announce.spec.ts
@@ -11,9 +11,15 @@ jest.mock('./modules/logging', () => ({
   })
 }));
 
+const mockContributionFindMany = jest.fn();
+jest.mock('./lib/prisma', () => ({
+  prisma: { contribution: { findMany: mockContributionFindMany } }
+}));
+
 import {
   renderAnnounceRss,
   publishAnnounceItem,
+  getNewAnnounceItems,
   AnnounceItem
 } from './modules/announce';
 
@@ -71,5 +77,85 @@ describe('publishAnnounceItem', () => {
       .fn()
       .mockResolvedValue({ ok: false, status: 502 }) as never;
     expect(await publishAnnounceItem(item)).toBe(false);
+  });
+
+  // #299 — pin the exact wire contract korin's InboundFeedSchema accepts:
+  // `{ xmlPayload: string, templateType: 'minimal', environment: { osc8: boolean } }`.
+  // A drift here (extra/renamed field, wrong templateType) is a rejected push.
+  it('sends exactly korin InboundFeedSchema keys with a plain (non-tokenized) link', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock as never;
+
+    await publishAnnounceItem(item);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(Object.keys(body).sort()).toEqual([
+      'environment',
+      'templateType',
+      'xmlPayload'
+    ]);
+    expect(body.templateType).toBe('minimal');
+    expect(Object.keys(body.environment)).toEqual(['osc8']);
+    expect(typeof body.xmlPayload).toBe('string');
+    // Notify-and-link (#136 / Golden Rule 3): the announce carries the release
+    // page URL, never a tokenized one-shot download link.
+    expect(body.xmlPayload).toContain('<link>https://stellar.test/releases/9');
+    expect(body.xmlPayload).not.toMatch(/token|passkey|[?&]key=/i);
+  });
+});
+
+describe('getNewAnnounceItems', () => {
+  afterEach(() => mockContributionFindMany.mockReset());
+
+  it('queries contributions strictly newer than the cursor, oldest first, capped', async () => {
+    mockContributionFindMany.mockResolvedValue([]);
+    await getNewAnnounceItems(42);
+
+    const arg = mockContributionFindMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: { gt: 42 } });
+    expect(arg.orderBy).toEqual({ id: 'asc' });
+    expect(arg.take).toBe(50);
+  });
+
+  it('flattens the release/collaborator join into the AnnounceItem shape', async () => {
+    mockContributionFindMany.mockResolvedValue([
+      {
+        id: 7,
+        releaseId: 3,
+        type: 'FLAC',
+        createdAt: new Date('2026-06-15T00:00:00Z'),
+        release: { title: 'Kid A', community: { name: 'Music' } },
+        collaborators: [{ name: 'Radiohead' }]
+      }
+    ]);
+
+    const [out] = await getNewAnnounceItems(0);
+    expect(out).toEqual({
+      id: 7,
+      releaseId: 3,
+      title: 'Kid A',
+      artists: ['Radiohead'],
+      community: 'Music',
+      type: 'FLAC',
+      createdAt: new Date('2026-06-15T00:00:00Z'),
+      link: 'https://stellar.test/releases/3'
+    });
+  });
+
+  it('maps a null community to null (no community join)', async () => {
+    mockContributionFindMany.mockResolvedValue([
+      {
+        id: 8,
+        releaseId: 4,
+        type: 'MP3',
+        createdAt: new Date('2026-06-16T00:00:00Z'),
+        release: { title: 'Loner', community: null },
+        collaborators: []
+      }
+    ]);
+
+    const [out] = await getNewAnnounceItems(0);
+    expect(out.community).toBeNull();
+    expect(out.artists).toEqual([]);
   });
 });

--- a/src/modules/announceJob.spec.ts
+++ b/src/modules/announceJob.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the announce push job (#299) — cursor advance, in-order delivery,
+ * at-least-once retry on failure, and the startup seed that prevents history
+ * replay. The cycle logic is tested through the exported `runAnnounceCycle`
+ * (no timers); the startup seed is tested through `startAnnounceJob` with fake
+ * timers.
+ */
+
+const mockAggregate = jest.fn();
+jest.mock('../lib/prisma', () => ({
+  prisma: { contribution: { aggregate: mockAggregate } }
+}));
+jest.mock('./config', () => ({
+  korin: { apiUrl: 'https://korin.test', pullKey: 'pk', pollIntervalMs: 1000 }
+}));
+jest.mock('./logging', () => ({
+  getLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  })
+}));
+
+const mockGetNewAnnounceItems = jest.fn();
+const mockPublishAnnounceItem = jest.fn();
+jest.mock('./announce', () => ({
+  getNewAnnounceItems: mockGetNewAnnounceItems,
+  publishAnnounceItem: mockPublishAnnounceItem
+}));
+
+import { runAnnounceCycle, startAnnounceJob } from './announceJob';
+import { AnnounceItem } from './announce';
+
+const item = (id: number): AnnounceItem => ({
+  id,
+  releaseId: id,
+  title: `Release ${id}`,
+  artists: ['Artist'],
+  community: null,
+  type: 'FLAC',
+  createdAt: new Date('2026-06-15T00:00:00Z'),
+  link: `https://stellar.test/releases/${id}`
+});
+
+beforeEach(() => {
+  mockGetNewAnnounceItems.mockReset();
+  mockPublishAnnounceItem.mockReset();
+  mockAggregate.mockReset();
+});
+
+describe('runAnnounceCycle', () => {
+  it('returns the same cursor and pushes nothing when there are no new items', async () => {
+    mockGetNewAnnounceItems.mockResolvedValue([]);
+    expect(await runAnnounceCycle(100)).toBe(100);
+    expect(mockPublishAnnounceItem).not.toHaveBeenCalled();
+  });
+
+  it('pushes every new item in id order and advances to the last id', async () => {
+    mockGetNewAnnounceItems.mockResolvedValue([item(1), item(2), item(3)]);
+    mockPublishAnnounceItem.mockResolvedValue(true);
+
+    expect(await runAnnounceCycle(0)).toBe(3);
+    expect(mockPublishAnnounceItem.mock.calls.map(([i]) => i.id)).toEqual([
+      1, 2, 3
+    ]);
+  });
+
+  it('holds the cursor at the last success when a push fails mid-batch', async () => {
+    mockGetNewAnnounceItems.mockResolvedValue([item(1), item(2), item(3)]);
+    mockPublishAnnounceItem
+      .mockResolvedValueOnce(true) // id 1
+      .mockResolvedValueOnce(false); // id 2 fails
+
+    // Cursor resumes at 1 (id 2 must be retried); id 3 is never attempted.
+    expect(await runAnnounceCycle(0)).toBe(1);
+    expect(mockPublishAnnounceItem.mock.calls.map(([i]) => i.id)).toEqual([
+      1, 2
+    ]);
+  });
+
+  it('retries the failed item on the next cycle — at-least-once, in-order', async () => {
+    // korin's cursor query returns items strictly newer than `sinceId`.
+    mockGetNewAnnounceItems.mockImplementation((sinceId: number) =>
+      Promise.resolve(
+        sinceId < 1 ? [item(1), item(2)] : sinceId < 2 ? [item(2)] : []
+      )
+    );
+    mockPublishAnnounceItem
+      .mockResolvedValueOnce(true) // cycle 1: id 1
+      .mockResolvedValueOnce(false) // cycle 1: id 2 fails
+      .mockResolvedValueOnce(true); // cycle 2: id 2 retried, succeeds
+
+    const afterFirst = await runAnnounceCycle(0);
+    expect(afterFirst).toBe(1);
+    const afterSecond = await runAnnounceCycle(afterFirst);
+    expect(afterSecond).toBe(2);
+
+    // id 2 was pushed twice (the retry); id 1 exactly once.
+    const pushed = mockPublishAnnounceItem.mock.calls.map(([i]) => i.id);
+    expect(pushed).toEqual([1, 2, 2]);
+  });
+});
+
+describe('startAnnounceJob — startup seed', () => {
+  afterEach(() => jest.useRealTimers());
+
+  it('seeds the cursor to the latest contribution so history is never replayed', async () => {
+    jest.useFakeTimers();
+    mockAggregate.mockResolvedValue({ _max: { id: 100 } });
+    mockGetNewAnnounceItems.mockResolvedValue([]);
+
+    startAnnounceJob();
+    await jest.advanceTimersByTimeAsync(30_000); // STARTUP_DELAY_MS
+
+    expect(mockAggregate).toHaveBeenCalledTimes(1);
+    // The first fetch starts *after* id 100 — nothing already recorded is re-sent.
+    expect(mockGetNewAnnounceItems).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/modules/announceJob.ts
+++ b/src/modules/announceJob.ts
@@ -12,13 +12,26 @@ const STARTUP_DELAY_MS = 30_000; // align with the metrics job; let boot settle
 // re-announces history; only contributions created after boot are pushed.
 let cursor = 0;
 
-const tick = async (): Promise<void> => {
-  const items = await getNewAnnounceItems(cursor);
+/**
+ * Push every contribution newer than `from` to korin, in id order, and return
+ * the cursor to resume from. Stops at the first push failure so that item (and
+ * everything after it) is retried on the next cycle — at-least-once, in-order,
+ * never skipping. Successfully-pushed items advance the returned cursor even
+ * when a later item in the same batch fails.
+ */
+export const runAnnounceCycle = async (from: number): Promise<number> => {
+  let resume = from;
+  const items = await getNewAnnounceItems(resume);
   for (const item of items) {
     const ok = await publishAnnounceItem(item);
-    if (!ok) return; // leave cursor; retry from here next tick
-    cursor = item.id;
+    if (!ok) return resume; // hold here; retry from this item next cycle
+    resume = item.id;
   }
+  return resume;
+};
+
+const tick = async (): Promise<void> => {
+  cursor = await runAnnounceCycle(cursor);
 };
 
 export const startAnnounceJob = (): void => {

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -13,6 +13,42 @@ const requireEnv = (key: string, minLength = 0): string => {
   return value;
 };
 
+// Parse the optional IRCScore channel-weight map (#141). Malformed input is
+// non-fatal — a bad tuning value must not crash boot — so it fails soft to an
+// empty map.
+const parseChannelWeights = (raw?: string): Record<string, number> => {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      console.warn('KORIN_CHANNEL_WEIGHTS is not a JSON object — ignoring');
+      return {};
+    }
+    const out: Record<string, number> = {};
+    for (const [channel, weight] of Object.entries(parsed)) {
+      if (
+        typeof weight === 'number' &&
+        Number.isFinite(weight) &&
+        weight >= 0
+      ) {
+        out[channel] = weight;
+      } else {
+        console.warn(
+          `KORIN_CHANNEL_WEIGHTS["${channel}"] is not a non-negative number — ignoring`
+        );
+      }
+    }
+    return out;
+  } catch {
+    console.warn('KORIN_CHANNEL_WEIGHTS is not valid JSON — ignoring');
+    return {};
+  }
+};
+
 export const auth = {
   jwtSecret: requireEnv('STELLAR_AUTH_JWT_SECRET', 32)
 };
@@ -66,7 +102,12 @@ export const korin = {
   // Bearer key korin presents on its INBOUND service calls to stellar
   // (by-irc-nick lookup, link-nick, reputation-by-id). Fails closed when unset
   // — the korin-facing endpoints reject all requests (ADR-0013 contract).
-  serviceKey: process.env.STELLAR_SERVICE_KEY ?? ''
+  serviceKey: process.env.STELLAR_SERVICE_KEY ?? '',
+  // Per-channel weights for the IRCScore channelQuality factor (#141). Values
+  // stay DEFERRED until real multi-channel traffic exists (PRD-02); the default
+  // empty map is behaviour-identical to unweighted channel counting. Format:
+  // JSON object of `{ "#channel": weight }`, e.g. `{"#announce":0.2,"#help":1.5}`.
+  channelWeights: parseChannelWeights(process.env.KORIN_CHANNEL_WEIGHTS)
 };
 
 export const email = {

--- a/src/modules/irc.spec.ts
+++ b/src/modules/irc.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the IRCScore scorer and the channel-weight mechanism (#141).
+ * getIrcScore is pure over the in-process metrics cache; we seed the cache via
+ * pollKorinMetrics with a mocked fetch (the only writer).
+ */
+
+const mockKorin = {
+  apiUrl: 'https://korin.test',
+  pullKey: 'pk',
+  pollIntervalMs: 1000,
+  channelWeights: {} as Record<string, number>
+};
+jest.mock('./config', () => ({ korin: mockKorin }));
+jest.mock('./logging', () => ({
+  getLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  })
+}));
+
+import { pollKorinMetrics, getIrcScore, IrcUserMetrics } from './irc';
+
+const HOUR_MS = 3_600_000;
+
+// A user whose three factors are all 1.0: msg == ACTIVITY_REF (50), full
+// presence over the window, channelCount == CHANNEL_REF (5). Score == 1.
+const fullUser = (over: Partial<IrcUserMetrics> = {}): IrcUserMetrics => ({
+  nick: 'nova',
+  presenceSeconds: HOUR_MS / 1000,
+  messageCount: 50,
+  channelCount: 5,
+  channels: ['#a', '#b', '#c', '#d', '#e'],
+  windowStart: 0,
+  windowEnd: HOUR_MS,
+  ...over
+});
+
+const seedCache = async (users: IrcUserMetrics[]): Promise<void> => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ users, lastFlushAt: HOUR_MS })
+  }) as never;
+  await pollKorinMetrics();
+};
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  mockKorin.channelWeights = {};
+});
+
+describe('getIrcScore', () => {
+  // Runs first, before any seedCache call, so the module cache is still empty —
+  // exercising the "no cached flush" branch without re-importing the module.
+  it('returns null when there is no cached flush', () => {
+    expect(getIrcScore('nobody-has-polled')).toBeNull();
+  });
+
+  it('returns null when the nick is absent from the flush', async () => {
+    await seedCache([fullUser({ nick: 'nova' })]);
+    expect(getIrcScore('ghost')).toBeNull();
+  });
+
+  it('scores 1.0 when activity, consistency and channelQuality all saturate', async () => {
+    await seedCache([fullUser()]);
+    expect(getIrcScore('nova')).toBeCloseTo(1, 10);
+  });
+
+  it('halves the score when presence covers half the window', async () => {
+    await seedCache([fullUser({ presenceSeconds: HOUR_MS / 2 / 1000 })]);
+    expect(getIrcScore('nova')).toBeCloseTo(0.5, 10);
+  });
+
+  describe('channel-weight mechanism (#141)', () => {
+    it('is neutral by default — an empty weight map uses channelCount, ignoring the channel list', async () => {
+      // Two users, same channelCount, different joined-channel lists. With the
+      // default empty map both must score identically (channels[] is unused).
+      await seedCache([
+        fullUser({
+          nick: 'listy',
+          channelCount: 3,
+          channels: ['#a', '#b', '#c']
+        }),
+        fullUser({ nick: 'empty', channelCount: 3, channels: [] })
+      ]);
+      const listy = getIrcScore('listy');
+      const empty = getIrcScore('empty');
+      expect(listy).not.toBeNull();
+      expect(listy).toBeCloseTo(empty as number, 12);
+      // And it equals the raw-channelCount formula.
+      const expected = Math.log1p(3) / Math.log1p(5); // activity=consistency=1
+      expect(listy).toBeCloseTo(expected, 10);
+    });
+
+    it('applies configured per-channel weights over the joined channel list', async () => {
+      mockKorin.channelWeights = { '#a': 2 }; // #b/#c fall back to default 1
+      await seedCache([
+        fullUser({
+          nick: 'weighted',
+          channelCount: 3,
+          channels: ['#a', '#b', '#c']
+        })
+      ]);
+      // effective = 2 + 1 + 1 = 4  (not the raw channelCount of 3)
+      const expected = Math.log1p(4) / Math.log1p(5);
+      const score = getIrcScore('weighted');
+      expect(score).toBeCloseTo(expected, 10);
+      // Sanity: this genuinely differs from the neutral channelCount=3 result.
+      expect(score).not.toBeCloseTo(Math.log1p(3) / Math.log1p(5), 3);
+    });
+
+    it('treats a zero weight as fully discounting a channel', async () => {
+      mockKorin.channelWeights = { '#firehose': 0 };
+      await seedCache([
+        fullUser({
+          nick: 'quiet',
+          channelCount: 2,
+          channels: ['#firehose', '#niche']
+        })
+      ]);
+      // effective = 0 + 1 = 1
+      expect(getIrcScore('quiet')).toBeCloseTo(
+        Math.log1p(1) / Math.log1p(5),
+        10
+      );
+    });
+  });
+});

--- a/src/modules/irc.ts
+++ b/src/modules/irc.ts
@@ -84,6 +84,23 @@ export const pollKorinMetrics = async (): Promise<void> => {
 const ACTIVITY_REF = 50;
 /** Reference channel count where channelQuality reaches ~63% of max. */
 const CHANNEL_REF = 5;
+/** Weight applied to a channel absent from the configured weight map (#141). */
+const DEFAULT_CHANNEL_WEIGHT = 1;
+
+/**
+ * Effective channel count feeding channelQuality (#141). Empty weight map (the
+ * default) returns the raw `channelCount` — weights are deferred until real
+ * multi-channel traffic exists to calibrate them (PRD-02). A configured map
+ * instead sums per-channel weights over the user's joined `channels`.
+ */
+const effectiveChannelCount = (user: IrcUserMetrics): number => {
+  const weights = korinConfig.channelWeights;
+  if (Object.keys(weights).length === 0) return user.channelCount;
+  return user.channels.reduce(
+    (sum, channel) => sum + (weights[channel] ?? DEFAULT_CHANNEL_WEIGHT),
+    0
+  );
+};
 
 /**
  * Compute IRCScore factors for a nick from a single flush window.
@@ -101,7 +118,7 @@ export const getIrcScore = (nick: string): number | null => {
   const activity = Math.log1p(user.messageCount) / Math.log1p(ACTIVITY_REF);
   const consistency = Math.min(user.presenceSeconds / windowDurationSeconds, 1);
   const channelQuality =
-    Math.log1p(user.channelCount) / Math.log1p(CHANNEL_REF);
+    Math.log1p(effectiveChannelCount(user)) / Math.log1p(CHANNEL_REF);
 
   return activity * consistency * channelQuality;
 };

--- a/src/modules/reputation.spec.ts
+++ b/src/modules/reputation.spec.ts
@@ -25,6 +25,11 @@ jest.mock('../lib/prisma', () => ({
   }
 }));
 
+// The IRC dimension reads getIrcScore over the in-process metrics cache; mock
+// it so computeCrs is deterministic without seeding the cache.
+const mockGetIrcScore = jest.fn();
+jest.mock('./irc', () => ({ getIrcScore: mockGetIrcScore }));
+
 // A donation aggregate with no rows.
 const emptyDonationAgg = {
   _count: { _all: 0 },
@@ -523,6 +528,42 @@ describe('computeCrs — signed dimension floor', () => {
     // Without the floor the clamp would force this to 0; with floor −1 it survives.
     expect(community.subScore).toBe(-1);
     expect(community.weighted).toBe(-1);
+  });
+});
+
+// ─── computeCrs / IRC dimension (#141) ────────────────────────────────────────
+
+describe('computeCrs — IRC dimension', () => {
+  const ircOf = (input: Parameters<typeof computeCrs>[0]) =>
+    computeCrs(input).dimensions.find((d) => d.name === 'irc')!;
+
+  beforeEach(() => mockGetIrcScore.mockReset());
+
+  it('scores 0 and never consults the scorer when the user has no linked nick', () => {
+    expect(ircOf({ userId: 1, createdAt: NOW, now: NOW }).subScore).toBe(0);
+    expect(mockGetIrcScore).not.toHaveBeenCalled();
+  });
+
+  it('scores 0 when the nick has no data in the current window (null)', () => {
+    mockGetIrcScore.mockReturnValue(null);
+    expect(
+      ircOf({ userId: 1, createdAt: NOW, now: NOW, ircNick: 'ghost' }).subScore
+    ).toBe(0);
+    expect(mockGetIrcScore).toHaveBeenCalledWith('ghost');
+  });
+
+  it('scales the [0,1] raw score up to the dimension cap of 2', () => {
+    mockGetIrcScore.mockReturnValue(1);
+    const dim = ircOf({ userId: 1, createdAt: NOW, now: NOW, ircNick: 'nova' });
+    expect(dim.subScore).toBe(2); // raw 1 × IRC_CAP 2
+    expect(dim.weighted).toBe(2); // IRC_WEIGHT 1.0
+  });
+
+  it('scales a partial raw score proportionally within the cap', () => {
+    mockGetIrcScore.mockReturnValue(0.5);
+    expect(
+      ircOf({ userId: 1, createdAt: NOW, now: NOW, ircNick: 'nova' }).subScore
+    ).toBe(1); // 0.5 × 2
   });
 });
 


### PR DESCRIPTION
The v0.8.0 **IRC/Announce delivery** cluster — #141, #299, #300, #177. The batch isn't one buildable feature, so this is deliberately phased: two builds, two design ADRs.

## What's in

### #141 — IRCScore channel-weight mechanism (build, neutral default)
- Config-driven `KORIN_CHANNEL_WEIGHTS` map threaded through `getIrcScore`'s `channelQuality` via `effectiveChannels`. **Empty map (the default) is behaviour-identical to the old raw channel count** — actual weight *values* stay deferred per PRD-02 until real multi-channel traffic exists.
- First test coverage for `getIrcScore` and the CRS IRC dimension (incl. a neutrality proof).
- Reconciled the stale `IRC_CAP = 6` → `2` in ADR-0013; documented the mechanism in ADR-0013 + PRD-02.

### #299 — verify the announce push path (build)
- Extracted `runAnnounceCycle` for deterministic cursor/retry tests: advance-on-2xx, hold-and-retry-in-order on failure, startup seed to `MAX(id)` (no history replay).
- Pinned the korin `POST /irc/announce` `InboundFeedSchema` contract (`{xmlPayload, templateType:'minimal', environment:{osc8}}`, plain notify-and-link, no tokenized URL); covered `getNewAnnounceItems`.
- Added `docs/runbooks/announce-e2e.md` for the observe-on-korin half.
- **Exercised for real** against a live korin stack: `POST /irc/announce` → `200`, correctly rendered IRC line with an OSC-8 link to the release page (not a tokenized URL). The runbook is no longer theoretical.

### #300 — integrity-monitoring ADR (design)
- Authored `docs/adr/0029-integrity-monitoring-contract.md`: signal taxonomy, action model = evidence into staff review or a bounded CRS drag, **never an automated gate**.
- **Status: Proposed — blocked, no substrate.** Running #299's runbook end-to-end exposed that the korin `ledger` this ADR reads over is redundant with stellar's own accounting, and it is being withdrawn (see below). The taxonomy and action model are transport-independent and worth keeping, so the ADR stays Proposed rather than Rejected — but any implementation must specify and justify its own substrate rather than inherit `GET /ledger/integrity`.

### #177 — private-community announce ADR (design only)
- Authored `docs/adr/0030-private-community-announce-delivery.md` (Proposed): dedicated `Community.visibility`, membership single-sourced from existing role relations ∩ verified nicks, optional announce `target`, and the crux — **stellar projects membership, korin enforces the channel ACL**; gates visibility only, never a download.

## Follow-on: the korin `ledger` is being withdrawn

Driving the #299 runbook against a live stack surfaced that korin's `ledger` sidecar (ADR-0016 / korin ADR-004) is redundant:

- its `can-consume` verdict is `Allow: u.canDownload` and nothing else — the same flag `downloads.ts` reads authoritatively from Postgres ~20 lines later in the same request;
- ADR-0016's stated rationale (avoiding per-request Postgres aggregation) isn't realized, since the grant transaction reads that user row anyway for the CAS;
- the "hot, high-churn counters" premise is a swarm-tracker load profile, which ADR-0016's own Context section explains does not apply here ("Stellar has no swarm").

**That backout is a separate PR** off `main` — this one is unchanged in scope apart from ADR-0029's status. korin's side is PR obrien-k/korin-pink#65, unmerged.

## Verification
`format`, `lint`, `tsc --noEmit`, `typecheck:test`, `prisma validate` all clean; full suite **100 suites / 1824 tests** passing.

## Not in scope (by design)
No schema/route/feature code for #300/#177 (design-only). Implementation tracked in #327 / #328; paired korin halves in obrien-k/korin-pink#51 / #67.

Closes #299. Refs #141 (mechanism only — values still HITL-deferred), #300, #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
