### PR TITLE
feat(install): fresh installs default registration to closed; README alpha status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to stellar-api are documented here.
 - **Announce push-path verification** (#299) — the previously-untested cursor/retry loop (`runAnnounceCycle`, extracted for testability) and the korin `POST /irc/announce` wire contract (`InboundFeedSchema` shape, plain notify-and-link) are now covered by tests, plus a live end-to-end runbook (`docs/runbooks/announce-e2e.md`).
 - **Freepass/Neutralpass ratio-exempt Contribution flags** (PRD-06 #4) — a Contribution can be flagged Freepass (consumption accrues no `consumed` for the consumer; the contributor still earns `contributed`) or Neutralpass (neither side accrues, fully ratio-neutral) [#260].
 
+### Changed
+
+- **Fresh installs default registration to `closed`** — a newly installed instance no longer accepts self-registrations until the admin deliberately opens it: the `SiteSettings.registrationStatus` default flips from `open` to `closed` (app-level `DEFAULTS` and DB `@default`, with a migration; existing rows keep their value), and the install launch-checklist item inverts from the old `registration-open` warning to a `registration-closed` advisory telling the admin to switch to `open` or `invite` when ready to accept registrations [#332].
+
 ### Removed
 
 - **The korin `ledger` client is withdrawn** — the consumption-event ingest and grant-time `canConsume` gate merged earlier in this unreleased window (#261) are removed along with `GET /api/ledger/snapshot`. Exercising the announce runbook against a live korin stack showed the gate to be redundant: its verdict rides `canDownload`, the same flag `downloads.ts` already reads authoritatively from Postgres in the same request, while stellar's stricter balance gate had no korin equivalent. No user-facing behaviour changes — the removed gate could only deny what stellar already denied, and it failed open. Stellar's own accounting (`contributed`/`consumed`, `economyTransaction`, the ADR-0006 ratio-relief substrate) is untouched. Reasoning recorded in ADR-0016, now Superseded.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 This is the Node.js API backend for **Stellar**, a modern, next-generation community content tracker and forum software.
 
-Stellar is an invite-only (`/private/`) platform built around **Communities** with granular permissions, member contributions, and a **Community Reputation Score (CRS)** that rewards long-term, healthy participation.
+Stellar is an invite-only platform built around **Communities** with granular permissions, member contributions, and a **Community Reputation Score (CRS)** that rewards long-term, healthy participation.
+
+## Status: alpha
+
+Stellar is pre-1.0 software (currently 0.7.x). Running a public instance means running an alpha: interfaces and the database schema still change between releases, migrations may be destructive (pre-1.0 carries no backfill guarantees), and no data-durability promises are made yet. Trunk is kept deployable — every merge passes the full CI chain (format, lint, type-checks, unit and integration suites, and a boot-and-migrate container smoke test) — but treat any public deployment as disposable for now. A fresh install starts with registration `closed`; open it deliberately from site settings when you are ready to accept members.
 
 ## What's here
 
@@ -110,7 +114,7 @@ A fresh instance has **no admin and is 503-walled** on `/api/*` until you comple
     -d '{"username":"admin","email":"admin@example.com","password":"<a-strong-password>"}'
   ```
 
-The response includes `configWarnings` and a `setupChecklist` flagging launch-readiness gaps (CORS default, SMTP unset, open registration, etc.). Until install completes, every other route returns `503`.
+The response includes `configWarnings` and a `setupChecklist` flagging launch-readiness gaps (CORS default, SMTP unset, registration still closed, etc.). Registration defaults to `closed` on a fresh instance — switch it to `open` or `invite` via site settings when you are ready to accept members. Until install completes, every other route returns `503`.
 
 ## Contributing
 

--- a/prisma/migrations/20260718000000_default_registration_closed/migration.sql
+++ b/prisma/migrations/20260718000000_default_registration_closed/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+-- Fresh instances should not accept registrations until the admin deliberately
+-- opens them (#332). Existing rows keep their current value.
+ALTER TABLE "site_settings" ALTER COLUMN "registrationStatus" SET DEFAULT 'closed';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2048,7 +2048,7 @@ model ReportNote {
 model SiteSettings {
   id                       Int                @id
   approvedDomains          String[]
-  registrationStatus       RegistrationStatus @default(open)
+  registrationStatus       RegistrationStatus @default(closed)
   maxUsers                 Int                @default(7000)
   dismissedLaunchChecklist String[]
   // The one recorded fact for "is this instance installed?" — stamped once by

--- a/src/install-auth.spec.ts
+++ b/src/install-auth.spec.ts
@@ -38,6 +38,17 @@ describe('API auth/profile/user flows', () => {
   });
 
   it('returns a msg response when registration hits an existing user', async () => {
+    // Registration must be open to reach the duplicate-user check — the
+    // harness default mirrors prod ('closed'), which rejects earlier.
+    prismaMock.siteSettings.upsert.mockResolvedValue({
+      id: 1,
+      approvedDomains: [],
+      registrationStatus: 'open',
+      maxUsers: 7000,
+      dismissedLaunchChecklist: [],
+      installedAt: null,
+      updatedAt: new Date()
+    });
     prismaMock.user.findFirst.mockResolvedValue(makeUser({ id: 1 }));
 
     const res = await request(app).post('/api/auth/register').send({

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -135,11 +135,34 @@ describe('GET /api/install', () => {
       res.body.setupChecklist.map((item: { message: string }) => item.message)
     ).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('registrationStatus is still "open"'),
+        expect.stringContaining('registrationStatus is "closed"'),
         expect.stringContaining('maxUsers is still the default value'),
         expect.stringContaining('approvedDomains is empty')
       ])
     );
+  });
+
+  it('omits the registration checklist item once registration is opened', async () => {
+    prismaMock.userRank.count.mockResolvedValue(0);
+    prismaMock.user.count.mockResolvedValue(0);
+    prismaMock.siteSettings.upsert.mockResolvedValue({
+      id: 1,
+      approvedDomains: [],
+      registrationStatus: 'open',
+      maxUsers: 7000,
+      dismissedLaunchChecklist: [],
+      installedAt: null,
+      updatedAt: new Date()
+    } as never);
+
+    const res = await request(app).get('/api/install');
+
+    expect(res.status).toBe(200);
+    expect(
+      res.body.setupChecklist.find(
+        (item: { id: string }) => item.id === 'registration-closed'
+      )
+    ).toBeUndefined();
   });
 
   it('omits dismissed launch checklist items', async () => {

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -7,7 +7,9 @@ type Tx = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0];
 const DEFAULTS = {
   id: 1,
   approvedDomains: [] as string[],
-  registrationStatus: 'open' as const,
+  // 'closed' until the admin deliberately opens registration (#332); the
+  // install checklist reminds them to flip it at launch.
+  registrationStatus: 'closed' as const,
   maxUsers: 7000,
   dismissedLaunchChecklist: [] as string[]
 };

--- a/src/routes/api/install.ts
+++ b/src/routes/api/install.ts
@@ -84,11 +84,11 @@ function getSetupChecklist(
   const dismissed = new Set(settings.dismissedLaunchChecklist ?? []);
   const checklist: LaunchChecklistItem[] = [];
 
-  if (settings.registrationStatus === 'open') {
+  if (settings.registrationStatus === 'closed') {
     checklist.push({
-      id: 'registration-open',
+      id: 'registration-closed',
       message:
-        'registrationStatus is still "open". Switch it to "closed" or "invite" until you are ready for public launch.'
+        'registrationStatus is "closed". Switch it to "open" or "invite" when you are ready to accept registrations.'
     });
   }
 

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -494,7 +494,9 @@ export const resetApiTestState = (): void => {
   prismaMock.siteSettings.upsert.mockResolvedValue({
     id: 1,
     approvedDomains: [],
-    registrationStatus: 'open',
+    // Mirrors the prod default (modules/settings.ts DEFAULTS): fresh
+    // instances start closed. Tests exercising registration mock 'open'.
+    registrationStatus: 'closed',
     maxUsers: 7000,
     dismissedLaunchChecklist: [],
     installedAt: null,


### PR DESCRIPTION
Part of the pre-public-deploy alpha push.

## What

- **Registration defaults to `closed` on fresh installs** (fixes #332): `SiteSettings.registrationStatus` default flips `open` → `closed` at both levels — app-level `DEFAULTS` in `modules/settings.ts` (the operative upsert-on-first-read default) and the schema `@default` with a hand-authored migration. Existing rows keep their value (`SET DEFAULT` does not rewrite).
- **Install launch-checklist inverted**: the `registration-open` warning becomes a `registration-closed` advisory — switch to `open` or `invite` when ready to accept members. Stale dismissed `registration-open` entries are inert; the dismiss route is unchanged.
- **README**: new `Status: alpha` section (pre-1.0 expectations for public instances) and the setup-checklist description follows the new default.

## Test/contract notes

- Harness `siteSettings` mock now mirrors the prod default; registration-exercising specs mock `open` explicitly. New assertion: no registration checklist item once registration is opened.
- `openapi.json`: no diff (default not encoded). Pre-existing `setupChecklist` contract drift spotted en route → tracked in #333, deliberately not bundled.
- `Community.registrationStatus` (community-level field) is unrelated and untouched.
- UI counterpart (ModBar checklist-id key + the /private removal) is on stellar-ui's `chore/alpha-deploy` (orphic-inc/stellar-ui#183).

Verified: unit suite 99/99 suites (1807 tests), typecheck + typecheck:test, prisma validate, migration applies via `migrate deploy` on the test DB, openapi export no-diff. Local integration run stalled for environment-looking reasons (jest idle, DB idle, zero suites completing — also stalls the same way untouched); CI's integration job is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT6gV5AxhhMDjjvxzVyxcy