### PR TITLE
feat(e2e): compile the fixture seeder into the image, guarded against production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **The e2e fixture seeder ships in the image** — `seed-e2e-users.ts` moves from `prisma/scripts/` (outside the `rootDir: src` build, so it needed a ts-node toolchain and a reachable database port) into `src/scripts/`, compiling to `dist/scripts/seed-e2e-users.js`. A deployed container stack can now seed its own e2e fixtures with `docker compose exec api node dist/scripts/seed-e2e-users.js` instead of temporarily exposing Postgres to the host. Because the fixtures use known weak credentials and the script now reaches every deployment, it refuses to run when `NODE_ENV=production` unless `ALLOW_E2E_SEED=true` is set explicitly.
+
 ## [0.8.0] — 2026-07-18
 
 The alpha-deploy cut. A fresh instance is now safe to stand up in public — registration starts closed and the install checklist walks the admin to launch — and the release drops the korin ledger client the announce runbook proved redundant. CRS gains a channel-weight lever, ratio gains Freepass/Neutralpass, and the CRS design frontier is settled in the spec ahead of implementation.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "db:reset": "prisma migrate reset",
     "db:seed": "ts-node prisma/seed.ts",
     "db:seed-wiki": "ts-node prisma/scripts/seed-wiki-irc-community.ts",
-    "db:seed-e2e": "ts-node prisma/scripts/seed-e2e-users.ts",
+    "db:seed-e2e": "ts-node src/scripts/seed-e2e-users.ts",
     "db:studio": "prisma studio",
     "prepare": "husky install || true"
   },

--- a/src/scripts/seed-e2e-users.ts
+++ b/src/scripts/seed-e2e-users.ts
@@ -14,8 +14,13 @@
  * Requires ranks to exist (run `npm run db:seed` first). Credentials come from
  * the same env vars stellar-ui's e2e uses; defaults match its .env.example.
  *
+ * Lives under src/ (not prisma/scripts/) so tsc compiles it into the image —
+ * a deployed container stack can seed its own e2e fixtures without a ts-node
+ * toolchain or an exposed database port.
+ *
  * Run:
- *   npm run db:seed-e2e
+ *   npm run db:seed-e2e                        # dev, from source
+ *   node dist/scripts/seed-e2e-users.js        # inside the container
  *   TEST_USER_EMAIL=qa@stellar.test TEST_USER_PASSWORD=hunter2 npm run db:seed-e2e
  */
 import { PrismaClient, Prisma } from '@prisma/client';
@@ -113,6 +118,19 @@ async function setInviter(
 }
 
 async function main(): Promise<void> {
+  // These fixtures are minted with known, weak default credentials
+  // (testuser/changeme). Compiling the script into the image means it ships to
+  // every deployment, so refuse to run against a production environment unless
+  // the operator explicitly opts in — throwaway and staging stacks only.
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.ALLOW_E2E_SEED !== 'true'
+  ) {
+    throw new Error(
+      'Refusing to seed e2e fixtures with NODE_ENV=production: these accounts use known default credentials. Set ALLOW_E2E_SEED=true to override (throwaway/staging stacks only).'
+    );
+  }
+
   const testuserId = await upsertUser({ ...REGULAR, rankLevel: 100 });
   const staffuserId = await upsertUser({ ...STAFF, rankLevel: 500 });
 


### PR DESCRIPTION
Closes the last structural gap before the e2e-against-a-live-stack pass.

## Problem

`seed-e2e-users.ts` lived in `prisma/scripts/`, which is outside tsconfig's `rootDir: "src"` / `include: ["src/**/*"]` — so it never compiled into `dist`. The production image installs `--omit=dev` (no ts-node) and compose doesn't expose the database port, so seeding a container stack required temporarily publishing Postgres to the host. That's a hack, and this deploy is meant to be repeatably testable.

## Change

Move it to `src/scripts/` beside `seed.ts` (which already compiles to `dist/scripts/seed.js` and is invoked by the entrypoint). Any deployment can now seed itself:

```bash
docker compose exec api node dist/scripts/seed-e2e-users.js
```

## The guard

The fixtures mint accounts with **known weak credentials** (`testuser`/`changeme`), and compiling the script means it now ships to every deployment — including production. So it refuses to run when `NODE_ENV=production` unless `ALLOW_E2E_SEED=true` is set explicitly.

Verified against the built output, not just the source:

- `NODE_ENV=production node dist/scripts/seed-e2e-users.js` → exits **1** with the refusal, no database contact
- `NODE_ENV=production ALLOW_E2E_SEED=true …` → seeds normally

Worth knowing: Prisma auto-loads `.env`, so the script connects to whatever `STELLAR_PSQL_URI` resolves to in the environment it runs in. That is exactly why the guard matters — without it, a stray invocation on a prod box would mint weak-credential accounts against the live database.

Behaviour is otherwise unchanged: still idempotent, still builds the fixed invite subtree the ui's `invite.spec.ts` asserts against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT6gV5AxhhMDjjvxzVyxcy