### PR TITLE
chore(release): cut 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-07-18
+
+Makes the 0.8.0 stack verifiable in place: a deployed container can now seed its own e2e fixtures, so an end-to-end pass against a live box needs no temporary database exposure.
+
 ### Changed
 
 - **The e2e fixture seeder ships in the image** — `seed-e2e-users.ts` moves from `prisma/scripts/` (outside the `rootDir: src` build, so it needed a ts-node toolchain and a reachable database port) into `src/scripts/`, compiling to `dist/scripts/seed-e2e-users.js`. A deployed container stack can now seed its own e2e fixtures with `docker compose exec api node dist/scripts/seed-e2e-users.js` instead of temporarily exposing Postgres to the host. Because the fixtures use known weak credentials and the script now reaches every deployment, it refuses to run when `NODE_ENV=production` unless `ALLOW_E2E_SEED=true` is set explicitly.
@@ -581,7 +585,8 @@ _Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a0
 
 ---
 
-[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/orphic-inc/stellar-api/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/orphic-inc/stellar-api/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/orphic-inc/stellar-api/compare/v0.6.9...v0.7.0
 [0.6.9]: https://github.com/orphic-inc/stellar-api/compare/v0.6.4...v0.6.9

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Stellar API",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Patch release so the alpha stack is verifiable in place.

The only change in the window is #336: the e2e fixture seeder now compiles into the image (`dist/scripts/seed-e2e-users.js`), so a deployed container can seed itself instead of requiring Postgres be temporarily exposed to the host. Guarded against `NODE_ENV=production` unless `ALLOW_E2E_SEED=true`.

This tag is what unblocks the e2e-against-a-live-stack pass — the runbook halts by design if the pinned image lacks the seeder, and 0.8.0 does.

CHANGELOG hand-diff against `v0.8.0..main` is clean; #336 was the sole commit and was already recorded. `version:check` reports all surfaces consistent at 0.8.1, and `openapi.json` is regenerated in the same commit.

After merge: tag `v0.8.1` to publish the semver image, then repin compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT6gV5AxhhMDjjvxzVyxcy