### PR TITLE
feat(assets): content-addressed binary asset store (ADR-0026 Phase 1)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -34,3 +34,6 @@ STELLAR_SERVICE_KEY=
 # KORIN_CHANNEL_WEIGHTS: optional IRCScore channel-weight map (#141), JSON
 # `{"#channel": weight}`. Empty = unweighted channel counting (the default).
 KORIN_CHANNEL_WEIGHTS=
+# Binary asset store (ADR-0026). STELLAR_ASSET_MAX_BYTES caps a single stored
+# asset; the store rejects anything larger at ingest. Default 2 MB.
+STELLAR_ASSET_MAX_BYTES=2000000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Binary asset store** ([ADR-0026](docs/adr/0026-static-asset-storage.md), #290 Phase 1) — an api-owned home for the binary assets a stored row references, so an asset is verifiable from the api that serves it rather than living unverified in another repo's static tree. An `Asset` row (content hash, mime, size, kind, optional owner) holds the bytes in Postgres, and `GET /api/asset/:hash` delivers them addressed by sha256: non-enumerable, deduplicated by content, and cacheable as genuinely `immutable` since the bytes at a hash can never change. Ingest identifies every payload by its magic bytes and rejects anything empty, oversize, unrecognized, or whose declared mime contradicts its content — the store never serves a byte it has not identified. `STELLAR_ASSET_MAX_BYTES` (default 2 MB) caps a single asset.
+
+  This is the substrate only. The authenticated upload path, reference counting / orphan sweep, and the migration of the asset-bearing themes (`proton`, `postmod`) to api-canonical `/css` fixtures are all still open — see the ADR amendment for the two blockers found while building it.
+
 ## [0.8.1] — 2026-07-18
 
 Makes the 0.8.0 stack verifiable in place: a deployed container can now seed its own e2e fixtures, so an end-to-end pass against a live box needs no temporary database exposure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Copy `.env.default` → `.env`.
 | `STELLAR_DISABLED_CHANNEL` | IRC channel `${disabled_channel}` resolves to (PRD-09; default `#disabled`)                 |
 | `STELLAR_STAFFPM_PATH`     | UI route `${staffpm}` resolves to (PRD-09; default `/inbox/staff`)                          |
 | `STELLAR_PUBLIC_KB_BASE`   | Stellar Public KB root for `${*_article}` guidance links (PRD-09; default kb.stellargra.ph) |
+| `STELLAR_ASSET_MAX_BYTES`  | Max size of a single stored binary asset (ADR-0026; default 2000000 = 2 MB)                 |
 
 ## Architecture
 
@@ -65,6 +66,7 @@ src/
     asyncHandler.ts         # Wraps async routes; catches errors, 10s timeout
     installState.ts         # In-memory cache for isInstalled() check
     logging.ts              # Winston logger factory (JSON in prod, pretty in dev)
+    assetStore.ts           # Content-addressed binary asset store (ADR-0026): putAsset/getAssetByHash over a Postgres Bytes column
     linkHealth.ts           # HEAD-request link checker + auto-warn on 3+ reports; computePulse + getCommunityHealthPulse; applyHealthAccrual (per-contribution PASS-uptime accumulator, #95/ADR-0019)
     linkHealthJob.ts        # Background job: recheck stale contribution links every 24h
     communityHealthHistory.ts # Persist/query the community health pulse as a time-series snapshot (#75); captured by statsJob
@@ -108,6 +110,7 @@ src/
     pagination.ts           # parsePage(req) → { skip, limit, page }
                             # paginatedResponse(res, data, total, pg)
     sanitize.ts             # sanitizeHtml(str), sanitizePlain(str)
+    assetValidate.ts        # Magic-byte identification + size cap for stored binaries (ADR-0026); validate-and-reject, unlike cssSanitize
     jsonHelpers.ts          # appendToJsonArray, jsonObjectArray, removeFromJsonArrayAtIndex
     ttlCache.ts             # Generic TtlCache<K,V> + top10Cache singleton
   types/
@@ -153,6 +156,7 @@ src/
     random.ts               # Random release endpoint
     siteHistory.ts          # Site history log
     stylesheet.ts           # User stylesheets
+    asset.ts                # GET /:hash — content-addressed binary delivery, immutable caching (ADR-0026)
     wiki.ts                 # Wiki pages, aliases, revisions
     docs.ts                 # API docs endpoint
     communities/

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ Copy `.env.default` → `.env`. `.env.default` is grouped and commented and is t
 | `STELLAR_SITE_NAME`, `STELLAR_IRC_URL`, `STELLAR_DISABLED_CHANNEL`, `STELLAR_STAFFPM_PATH`, `STELLAR_PUBLIC_KB_BASE` | Site identity + Golden-Rules `${...}` token resolution (PRD-09 / [ADR-0020](adr/0020-rules-tree-variable-resolution.md)); all optional with defaults |
 | `KORIN_API_URL`, `KORIN_PULL_KEY`, `KORIN_POLL_INTERVAL_MS`                                                          | korin.pink IRC metrics pull + announce push ([ADR-0013](adr/0013-korin-pink-irc-integration.md)); inert until set                                    |
 | `STELLAR_SERVICE_KEY`                                                                                                | Bearer korin presents on inbound calls; fails closed                                                                                                 |
+| `STELLAR_ASSET_MAX_BYTES`                                                                                            | Max size of a single stored binary asset ([ADR-0026](adr/0026-static-asset-storage.md)); default 2 MB                                                |
 
 **Production database access** (Google Cloud SQL): connecting to the live database uses the Cloud SQL Proxy with IAM access for a service account holding the Cloud SQL Client role; point `GOOGLE_APPLICATION_CREDENTIALS` at that account's JSON key. Deployment specifics live in the [stellar-compose](https://github.com/orphic-inc/stellar-compose) operator runbook.
 

--- a/docs/adr/0026-static-asset-storage.md
+++ b/docs/adr/0026-static-asset-storage.md
@@ -34,6 +34,26 @@ The parameters the implementation fixes:
 - **A new subsystem to own** — storage, a serve route, ingest safety, and lifecycle are real surface; the follow-up must scope them deliberately rather than growing a route per asset kind.
 - **Cross-repo drift keeps shrinking** — moving binary assets into an api-verifiable store extends the #285/#286 single-source-of-truth move from CSS to imagery.
 
+## Amendment (2026-07-19) — the parameters, fixed
+
+The store landed as #290 Phase 1. The choices this ADR left marked are now settled:
+
+- **Storage backend: a Postgres `Bytes` column**, not the object store named above as the scalable default. The api container has no writable volume and compose lives in a separate repo behind the [ADR-0027](0027-publish-vs-deploy-boundary.md) publish/deploy boundary, so a filesystem or S3 backend would not have worked anywhere until a cross-repo change landed — the feature would have shipped inert. Postgres is already the only stateful service and already covered by its bind mount, so the store inherits backup and lifecycle for free. This is deliberately bounded: it is right for theme imagery and wrong once content imagery is measured in gigabytes. `src/modules/assetStore.ts` is a two-function seam (`putAsset` / `getAssetByHash`) so a driver swap replaces bodies, not callers.
+- **Address: the content hash, not the row id.** `GET /api/asset/:hash` resolves a sha256. This makes the route non-enumerable (unlike the sibling `/css` route's sequential ids), makes `Cache-Control: immutable` literally true, and collapses duplicate bytes to one row.
+- **The serve route is unauthenticated.** Phase-1 assets are site-shipped theme imagery fetched as CSS subresources; an auth round-trip buys nothing over non-secret bytes at an unguessable address. Private user-uploaded assets are a Phase-2 concern and get an explicit visibility column and a gate then — this is not a standing licence to serve anything.
+- **Ingest is validate-and-reject.** `src/lib/assetValidate.ts` identifies a payload by magic bytes, cross-checks any declared mime against them, and throws. This inverts `sanitizeStylesheetSource`'s cleanse-don't-reject signature on purpose: you can neutralize a `url()` and still have valid CSS, but there is no partial-clean of an arbitrary binary. The fail-closed intent carries; the signature does not.
+
+**Phase 1 is the substrate only.** The authenticated upload path, reference counting / orphan sweep, and the theme-asset migration this ADR's Context motivates are all still open.
+
+### The registry split is not closed yet
+
+The migration of `proton`/`postmod` to api-canonical `/css` fixtures — the first force in the Context above — did **not** land with the store, for two independent reasons found during implementation:
+
+1. **`sanitizeStylesheetSource` corrupts escaped identifiers.** `stripOnce` emits `decodeCssEscapes(css)`, decoding the whole sheet rather than decoding only to detect danger, so `.hover\:text-white` (a class named `hover:text-white`) is rewritten to `.hover:text-white`. `proton` carries 54 such escapes, all Tailwind utility overrides. The module header calls this "the rare escape-dependent identifier … an accepted trade"; against a Tailwind ui it is the common case, and it silently mangles real author stylesheets today, independent of this ADR. Tracked separately; the theme migration is blocked on it.
+2. **`postmod` bundles commercial fonts** (Akzidenz-Grotesk, Avant Garde, Officina, Corpid). Moving them from a private ui bundle to a public API route is a redistribution question, not a technical one, and is unresolved.
+
+So the split stays temporary-by-design as this ADR predicted, with a named blocker rather than an open question.
+
 ## Follow-up
 
-Implementation is tracked separately (#290); this ADR is the design gate, not the build.
+Phase 1 shipped under #290. The upload path, lifecycle sweep, and theme migration remain tracked separately.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -61,6 +61,11 @@ erDiagram
     }
   
 
+  "assets" {
+
+    }
+  
+
   "forum_categories" {
 
     }
@@ -642,6 +647,7 @@ erDiagram
     "friend_relationships" }o--|| users : "requester"
     "friend_relationships" }o--|| users : "recipient"
     "author_stylesheets" }o--|| users : "author"
+    "assets" }o--|o users : "owner"
     "forums" }o--|| forum_categories : "forumCategory"
     "forums" }o--|o forum_topics : "lastTopic"
     "forum_topics" }o--|| forums : "forum"

--- a/openapi.json
+++ b/openapi.json
@@ -8159,6 +8159,55 @@
         }
       }
     },
+    "/asset/{hash}": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "hash",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The stored asset bytes, with the mime verified at ingest and immutable caching",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed content address (not a 64-char lowercase sha256)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/stylesheet": {
       "get": {
         "tags": [

--- a/prisma/migrations/20260719000000_add_asset_store/migration.sql
+++ b/prisma/migrations/20260719000000_add_asset_store/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "AssetKind" AS ENUM ('ThemeImage', 'ThemeFont');
+
+-- CreateTable
+-- Content-addressed binary asset store (ADR-0026, #290). `hash` is the sha256 of
+-- `data` and is the public address the serve route resolves; the unique index is
+-- what makes storing identical bytes twice collapse to one row.
+CREATE TABLE "assets" (
+    "id" SERIAL NOT NULL,
+    "hash" TEXT NOT NULL,
+    "mime" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "kind" "AssetKind" NOT NULL,
+    "data" BYTEA NOT NULL,
+    "ownerId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "assets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "assets_hash_key" ON "assets"("hash");
+
+-- CreateIndex
+CREATE INDEX "assets_ownerId_idx" ON "assets"("ownerId");
+
+-- AddForeignKey
+ALTER TABLE "assets" ADD CONSTRAINT "assets_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -534,6 +534,7 @@ model User {
   crsSnapshots             CrsSnapshot[]
   tagAliasesCreated        TagAlias[]                       @relation("TagAliasCreator")
   authoredStylesheets      AuthorStylesheet[]
+  ownedAssets              Asset[]
 
   @@index([userRankId])
   @@map("users")
@@ -654,6 +655,43 @@ model AuthorStylesheet {
 
   @@index([authorId])
   @@map("author_stylesheets")
+}
+
+enum AssetKind {
+  ThemeImage
+  ThemeFont
+}
+
+/// A binary asset a stored row references — theme imagery and web fonts today,
+/// content imagery (cover art, avatars, logos) later. ADR-0026: the api owns the
+/// bytes it serves, so a reference can be verified from the api that resolves it
+/// rather than pointing into another repo's static tree.
+///
+/// Content-addressed: `hash` (sha256 of `data`) is the public address, not `id`.
+/// That makes the serve route non-enumerable and `Cache-Control: immutable`
+/// honest — the bytes at a hash can never change. Identical bytes stored twice
+/// collapse to one row.
+///
+/// Backed by a Postgres `Bytes` column rather than an object store: the api
+/// container has no writable volume and compose lives behind the ADR-0027
+/// publish/deploy boundary, so a filesystem or S3 backend would not work until a
+/// cross-repo change landed. Deliberately bounded — revisit when content imagery
+/// makes the table large. `assetStore.ts` is the seam a driver swap replaces.
+model Asset {
+  id        Int       @id @default(autoincrement())
+  hash      String    @unique
+  mime      String
+  size      Int
+  kind      AssetKind
+  data      Bytes
+  /// Null = site-owned (the built-in theme fixtures). A user-owned asset dies
+  /// with its owner, extending the AuthorStylesheet cascade precedent.
+  ownerId   Int?
+  owner     User?     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  createdAt DateTime  @default(now())
+
+  @@index([ownerId])
+  @@map("assets")
 }
 
 // ─── Forum ────────────────────────────────────────────────────────────────────

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,6 +43,7 @@ import profileRouter from './routes/api/profile';
 import announcementsRouter from './routes/api/announcements';
 import statsRouter from './routes/api/stats';
 import stylesheetRouter from './routes/api/stylesheet';
+import assetRouter from './routes/api/asset';
 import commentsRouter from './routes/api/comments';
 import subscriptionsRouter from './routes/api/subscriptions';
 import notificationsRouter from './routes/api/notifications';
@@ -147,6 +148,7 @@ export const createApp = () => {
   app.use('/api/announcements', announcementsRouter);
   app.use('/api/stats', statsRouter);
   app.use('/api/stylesheet', stylesheetRouter);
+  app.use('/api/asset', assetRouter);
   app.use('/api/comments', commentsRouter);
   app.use('/api/subscriptions', subscriptionsRouter);
   app.use('/api/notifications', notificationsRouter);

--- a/src/asset.spec.ts
+++ b/src/asset.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Route-level tests for the asset delivery route (ADR-0026, #290) — the headers
+ * are the contract here: a wrong Content-Type or a cacheable 404 is the whole
+ * bug surface for a route that otherwise just returns bytes.
+ */
+import {
+  request,
+  app,
+  resetApiTestState,
+  prismaMock
+} from './test/apiTestHarness';
+
+beforeEach(() => resetApiTestState());
+
+const HASH = 'a'.repeat(64);
+const BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const storedAsset = {
+  id: 1,
+  hash: HASH,
+  mime: 'image/png',
+  size: BYTES.length,
+  kind: 'ThemeImage',
+  data: BYTES,
+  ownerId: null,
+  createdAt: new Date('2026-07-19T00:00:00Z')
+};
+
+describe('GET /api/asset/:hash', () => {
+  it('delivers the stored bytes with the verified mime and immutable caching', async () => {
+    prismaMock.asset.findUnique.mockResolvedValue(storedAsset as never);
+
+    const res = await request(app).get(`/api/asset/${HASH}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/image\/png/);
+    // Immutable is literally true — the bytes at a hash can never change.
+    expect(res.headers['cache-control']).toBe(
+      'public, max-age=31536000, immutable'
+    );
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['etag']).toBe(`"${HASH}"`);
+    expect(Buffer.from(res.body)).toEqual(BYTES);
+  });
+
+  it('resolves by content address, not by row id', async () => {
+    prismaMock.asset.findUnique.mockResolvedValue(storedAsset as never);
+
+    await request(app).get(`/api/asset/${HASH}`);
+
+    expect(prismaMock.asset.findUnique).toHaveBeenCalledWith({
+      where: { hash: HASH }
+    });
+  });
+
+  it('serves without authentication', async () => {
+    // Theme imagery is fetched as a CSS subresource; an auth round-trip buys
+    // nothing over site-shipped bytes at a non-enumerable address.
+    prismaMock.asset.findUnique.mockResolvedValue(storedAsset as never);
+
+    const res = await request(app).get(`/api/asset/${HASH}`).set('Cookie', '');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('404s an unknown hash as { msg }', async () => {
+    prismaMock.asset.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get(`/api/asset/${'b'.repeat(64)}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.msg).toBe('Asset not found');
+    // A missing asset must never be cached as if it were immutable.
+    expect(res.headers['cache-control']).toBeUndefined();
+  });
+
+  it.each([
+    ['too short', 'abc'],
+    ['not hex', 'g'.repeat(64)],
+    ['uppercase hex', 'A'.repeat(64)],
+    ['a row id', '1']
+  ])(
+    'rejects a malformed address (%s) without a DB read',
+    async (_label, bad) => {
+      const res = await request(app).get(`/api/asset/${bad}`);
+
+      expect(res.status).toBe(400);
+      expect(prismaMock.asset.findUnique).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/assetStore.spec.ts
+++ b/src/assetStore.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the content-addressed asset store (ADR-0026, #290). Prisma is
+ * mocked; `hashAsset` and the real `validateAsset` run for real, so these also
+ * pin that nothing unvalidated reaches the table.
+ */
+
+import { mockDeep, mockReset } from 'jest-mock-extended';
+import type { PrismaClient } from '@prisma/client';
+
+const prismaMock = mockDeep<PrismaClient>();
+jest.mock('./lib/prisma', () => ({ prisma: prismaMock }));
+
+import { AppError } from './lib/errors';
+import {
+  assetUrl,
+  getAssetByHash,
+  hashAsset,
+  putAsset
+} from './modules/assetStore';
+
+beforeEach(() => mockReset(prismaMock));
+
+const PNG = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('proton background')
+]);
+
+// sha256 of PNG, computed by the module under test — asserted stable below.
+const PNG_HASH = hashAsset(PNG);
+
+describe('hashAsset', () => {
+  it('is a 64-char sha256 hex digest', () => {
+    expect(PNG_HASH).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is stable across calls and sensitive to a single byte', () => {
+    expect(hashAsset(PNG)).toBe(PNG_HASH);
+    const altered = Buffer.from(PNG);
+    altered[altered.length - 1] ^= 0x01;
+    expect(hashAsset(altered)).not.toBe(PNG_HASH);
+  });
+});
+
+describe('putAsset', () => {
+  it('stores a validated payload under its content address', async () => {
+    prismaMock.asset.findUnique.mockResolvedValue(null);
+    prismaMock.asset.create.mockResolvedValue({ id: 1 } as never);
+
+    await putAsset({ data: PNG, kind: 'ThemeImage' });
+
+    expect(prismaMock.asset.create).toHaveBeenCalledWith({
+      data: {
+        hash: PNG_HASH,
+        mime: 'image/png',
+        size: PNG.length,
+        kind: 'ThemeImage',
+        data: PNG,
+        ownerId: null
+      }
+    });
+  });
+
+  it('is idempotent by content: a repeat put returns the existing row', async () => {
+    // What makes seeding safe to re-run on every container boot.
+    const existing = { id: 7, hash: PNG_HASH } as never;
+    prismaMock.asset.findUnique.mockResolvedValue(existing);
+
+    const result = await putAsset({ data: PNG, kind: 'ThemeImage' });
+
+    expect(result).toBe(existing);
+    expect(prismaMock.asset.create).not.toHaveBeenCalled();
+  });
+
+  it('records an owner when one is given', async () => {
+    prismaMock.asset.findUnique.mockResolvedValue(null);
+    prismaMock.asset.create.mockResolvedValue({ id: 2 } as never);
+
+    await putAsset({ data: PNG, kind: 'ThemeImage', ownerId: 42 });
+
+    expect(prismaMock.asset.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ownerId: 42 })
+      })
+    );
+  });
+
+  it('rejects an unvalidated payload without touching the table', async () => {
+    await expect(
+      putAsset({ data: Buffer.from('not an image'), kind: 'ThemeImage' })
+    ).rejects.toThrow(AppError);
+    expect(prismaMock.asset.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.asset.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a payload whose declared mime contradicts its bytes', async () => {
+    await expect(
+      putAsset({ data: PNG, mime: 'font/woff2', kind: 'ThemeFont' })
+    ).rejects.toThrow(/image\/png/);
+    expect(prismaMock.asset.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('getAssetByHash', () => {
+  it('looks the row up by content address', async () => {
+    prismaMock.asset.findUnique.mockResolvedValue({ id: 3 } as never);
+
+    await getAssetByHash(PNG_HASH);
+
+    expect(prismaMock.asset.findUnique).toHaveBeenCalledWith({
+      where: { hash: PNG_HASH }
+    });
+  });
+});
+
+describe('assetUrl', () => {
+  it('builds the public serve path', () => {
+    expect(assetUrl(PNG_HASH)).toBe(`/api/asset/${PNG_HASH}`);
+  });
+
+  it('is scheme-less and same-origin, so the CSS sanitizer keeps it', () => {
+    // Pins the property the proton fixture depends on (cssSanitize isSafeUrlTarget).
+    expect(assetUrl(PNG_HASH).startsWith('/')).toBe(true);
+    expect(assetUrl(PNG_HASH).startsWith('//')).toBe(false);
+  });
+});

--- a/src/lib/assetValidate.spec.ts
+++ b/src/lib/assetValidate.spec.ts
@@ -1,0 +1,110 @@
+import { AppError } from './errors';
+import { ALLOWED_MIMES, sniffMime, validateAsset } from './assetValidate';
+import { assets } from '../modules/config';
+
+/** A payload whose leading bytes identify it, padded so length is not the signal. */
+const payload = (magic: number[], length = 64): Buffer =>
+  Buffer.concat([
+    Buffer.from(magic),
+    Buffer.alloc(Math.max(0, length - magic.length))
+  ]);
+
+const PNG = payload([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG = payload([0xff, 0xd8, 0xff]);
+const GIF = payload([0x47, 0x49, 0x46, 0x38]);
+const WOFF2 = payload([0x77, 0x4f, 0x46, 0x32]);
+const OTF = payload([0x4f, 0x54, 0x54, 0x4f]);
+const TTF = payload([0x00, 0x01, 0x00, 0x00]);
+
+// RIFF….WEBP — the container tag sits at offset 8, past a 4-byte length.
+const webp = (tag: string): Buffer => {
+  const buf = payload([0x52, 0x49, 0x46, 0x46]);
+  buf.write(tag, 8, 'ascii');
+  return buf;
+};
+
+describe('sniffMime', () => {
+  it.each([
+    ['image/png', PNG],
+    ['image/jpeg', JPEG],
+    ['image/gif', GIF],
+    ['image/webp', webp('WEBP')],
+    ['font/woff2', WOFF2],
+    ['font/otf', OTF],
+    ['font/ttf', TTF]
+  ])('identifies %s from its magic bytes', (mime, data) => {
+    expect(sniffMime(data)).toBe(mime);
+  });
+
+  it('rejects a RIFF container that is not WEBP', () => {
+    // RIFF alone is also AVI/WAV — the container tag is what makes it an image.
+    expect(sniffMime(webp('AVI '))).toBeNull();
+  });
+
+  it('returns null for an unrecognized payload', () => {
+    expect(sniffMime(Buffer.from('<?php echo 1; ?>'))).toBeNull();
+  });
+
+  it('does not read past a truncated payload', () => {
+    // Two bytes of a PNG header must not be mistaken for a PNG.
+    expect(sniffMime(Buffer.from([0x89, 0x50]))).toBeNull();
+  });
+
+  it('every allowlisted mime is reachable', () => {
+    // Guards against an entry whose signature can never match.
+    expect(ALLOWED_MIMES).toHaveLength(7);
+  });
+});
+
+describe('validateAsset', () => {
+  it('returns the sniffed mime when no type is declared', () => {
+    expect(validateAsset(PNG)).toBe('image/png');
+  });
+
+  it('accepts a declared mime that matches the bytes', () => {
+    expect(validateAsset(JPEG, 'image/jpeg')).toBe('image/jpeg');
+  });
+
+  it('rejects a declared mime the bytes contradict', () => {
+    // The declared type becomes the served Content-Type, so trusting it
+    // unverified would let a stored blob pick how a browser reads it.
+    expect(() => validateAsset(PNG, 'image/jpeg')).toThrow(AppError);
+    expect(() => validateAsset(PNG, 'image/jpeg')).toThrow(/image\/png/);
+  });
+
+  it('rejects an unrecognized type', () => {
+    expect(() => validateAsset(Buffer.from('#!/bin/sh\nrm -rf /'))).toThrow(
+      /Unsupported asset type/
+    );
+  });
+
+  it('rejects an empty payload', () => {
+    expect(() => validateAsset(Buffer.alloc(0))).toThrow(/empty/);
+  });
+
+  it('rejects a payload over the configured ceiling', () => {
+    const oversize = payload(
+      [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+      assets.maxBytes + 1
+    );
+    expect(() => validateAsset(oversize)).toThrow(/exceeds/);
+  });
+
+  it('accepts a payload exactly at the ceiling', () => {
+    const atLimit = payload(
+      [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+      assets.maxBytes
+    );
+    expect(validateAsset(atLimit)).toBe('image/png');
+  });
+
+  it('throws AppError with a 400 status', () => {
+    try {
+      validateAsset(Buffer.from('nope'));
+      throw new Error('expected a throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).statusCode).toBe(400);
+    }
+  });
+});

--- a/src/lib/assetValidate.ts
+++ b/src/lib/assetValidate.ts
@@ -1,0 +1,95 @@
+/**
+ * Store-time validation for binary assets (ADR-0026, #290).
+ *
+ * The sibling `cssSanitize` cleans rather than rejects — it can neutralize a
+ * `url()` and still hand back valid CSS. A binary has no such middle ground: you
+ * cannot strip the dangerous part of an arbitrary file and keep a usable one. So
+ * this inverts the signature and throws, while keeping the same fail-closed
+ * intent — the store never persists a byte it has not identified.
+ *
+ * Identification is by magic bytes, not by the caller's declared mime. A caller
+ * claiming `image/png` over a payload that sniffs as something else is rejected
+ * rather than trusted, which is the whole point: the declared type is what the
+ * serve route later sends as `Content-Type`, so believing it unverified would let
+ * a stored blob choose how a browser interprets it.
+ */
+import { AppError } from './errors';
+import { assets } from '../modules/config';
+
+/**
+ * Allowlisted types and the leading bytes that identify them. Extensions live
+ * here rather than at call sites so the store has exactly one notion of what it
+ * accepts. Fonts are included for the asset-bearing themes; note that shipping a
+ * font is a redistribution question the *caller* must have settled (postmod's
+ * commercial faces are why it is not yet an api-canonical fixture).
+ */
+const SIGNATURES: { mime: string; magic: number[] }[] = [
+  {
+    mime: 'image/png',
+    magic: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  },
+  { mime: 'image/jpeg', magic: [0xff, 0xd8, 0xff] },
+  { mime: 'image/gif', magic: [0x47, 0x49, 0x46, 0x38] },
+  // RIFF....WEBP — the 4-byte length sits between the two markers, so the
+  // container tag is checked at its fixed offset rather than as one run.
+  { mime: 'image/webp', magic: [0x52, 0x49, 0x46, 0x46] },
+  { mime: 'font/woff2', magic: [0x77, 0x4f, 0x46, 0x32] },
+  { mime: 'font/otf', magic: [0x4f, 0x54, 0x54, 0x4f] },
+  // TrueType: the 0x00010000 version tag. `true`/`ttcf` variants are not served.
+  { mime: 'font/ttf', magic: [0x00, 0x01, 0x00, 0x00] }
+];
+
+const WEBP_TAG = [0x57, 0x45, 0x42, 0x50]; // "WEBP" at offset 8
+
+const startsWith = (data: Buffer, magic: number[], offset = 0): boolean =>
+  data.length >= offset + magic.length &&
+  magic.every((byte, i) => data[offset + i] === byte);
+
+/** The mime a payload's leading bytes actually identify, or null if unrecognized. */
+export const sniffMime = (data: Buffer): string | null => {
+  for (const sig of SIGNATURES) {
+    if (!startsWith(data, sig.magic)) continue;
+    // RIFF alone is also AVI/WAV; only the WEBP container tag makes it an image.
+    if (sig.mime === 'image/webp' && !startsWith(data, WEBP_TAG, 8)) continue;
+    return sig.mime;
+  }
+  return null;
+};
+
+/** Every mime the store will accept and serve. */
+export const ALLOWED_MIMES: readonly string[] = SIGNATURES.map((s) => s.mime);
+
+/**
+ * Assert a payload is storable and return the verified mime. Throws `AppError`
+ * (400) on an empty, oversize, unrecognized, or misdeclared payload.
+ *
+ * `declaredMime` is optional: seed fixtures infer the type from the bytes, while
+ * an upload path passes what the client claimed so the mismatch can be caught.
+ */
+export const validateAsset = (data: Buffer, declaredMime?: string): string => {
+  if (data.length === 0) {
+    throw new AppError(400, 'Asset is empty.');
+  }
+  if (data.length > assets.maxBytes) {
+    throw new AppError(
+      400,
+      `Asset exceeds the ${assets.maxBytes}-byte limit (got ${data.length}).`
+    );
+  }
+
+  const sniffed = sniffMime(data);
+  if (!sniffed) {
+    throw new AppError(
+      400,
+      `Unsupported asset type. Allowed: ${ALLOWED_MIMES.join(', ')}.`
+    );
+  }
+  if (declaredMime && declaredMime !== sniffed) {
+    throw new AppError(
+      400,
+      `Asset content is ${sniffed}, not the declared ${declaredMime}.`
+    );
+  }
+
+  return sniffed;
+};

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1818,6 +1818,30 @@ registry.registerPath({
   }
 });
 
+// Content-addressed binary delivery (ADR-0026). Addressed by sha256 rather than
+// row id, and unauthenticated — see the route for why. Body is the raw asset.
+registry.registerPath({
+  method: 'get',
+  path: '/asset/{hash}',
+  tags: ['Assets'],
+  request: { params: z.object({ hash: z.string() }) },
+  responses: {
+    200: {
+      description:
+        'The stored asset bytes, with the mime verified at ingest and immutable caching',
+      content: { 'application/octet-stream': { schema: z.string() } }
+    },
+    400: {
+      description: 'Malformed content address (not a 64-char lowercase sha256)',
+      content: { 'application/json': { schema: MsgResponse } }
+    },
+    404: {
+      description: 'Not found',
+      content: { 'application/json': { schema: MsgResponse } }
+    }
+  }
+});
+
 registry.registerPath({
   method: 'get',
   path: '/stylesheet',

--- a/src/modules/assetStore.ts
+++ b/src/modules/assetStore.ts
@@ -1,0 +1,72 @@
+/**
+ * Binary asset store (ADR-0026, #290) — the api-owned home for bytes a stored
+ * row references: theme imagery and web fonts today, content imagery later.
+ *
+ * Content-addressed. `hash` (sha256 of the payload) is the public address rather
+ * than the autoincrement `id`, which buys three things at once: the serve route
+ * is not enumerable, `Cache-Control: immutable` is honest because the bytes at a
+ * hash can never change, and storing the same file twice collapses to one row
+ * instead of duplicating it.
+ *
+ * These two functions are the entire seam. The backend is a Postgres `Bytes`
+ * column because the api container has no writable volume and compose sits behind
+ * the ADR-0027 publish/deploy boundary — a filesystem or S3 driver replaces the
+ * bodies here without touching a caller.
+ */
+import { createHash } from 'crypto';
+import type { AssetKind, PrismaClient } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { validateAsset } from '../lib/assetValidate';
+
+/** The content address of a payload — sha256 hex, 64 chars. */
+export const hashAsset = (data: Buffer): string =>
+  createHash('sha256').update(data).digest('hex');
+
+export interface PutAssetInput {
+  data: Buffer;
+  kind: AssetKind;
+  /** What the caller claims the bytes are; verified against them when given. */
+  mime?: string;
+  /** Omitted for site-owned assets (the built-in theme fixtures). */
+  ownerId?: number;
+}
+
+/**
+ * Validate and store a payload, returning its row. Idempotent by content: a
+ * repeat put of identical bytes returns the existing row rather than a second
+ * copy, which is what makes seeding safe to re-run on every container boot.
+ *
+ * Throws `AppError` (400) via `validateAsset` on an empty, oversize,
+ * unrecognized, or misdeclared payload — nothing unidentified reaches the table.
+ *
+ * `client` is injectable so the seed path can pass the same PrismaClient the rest
+ * of the bootstrap sequence uses.
+ */
+export const putAsset = async (
+  input: PutAssetInput,
+  client: PrismaClient = prisma
+) => {
+  const mime = validateAsset(input.data, input.mime);
+  const hash = hashAsset(input.data);
+
+  const existing = await client.asset.findUnique({ where: { hash } });
+  if (existing) return existing;
+
+  return client.asset.create({
+    data: {
+      hash,
+      mime,
+      size: input.data.length,
+      kind: input.kind,
+      data: input.data,
+      ownerId: input.ownerId ?? null
+    }
+  });
+};
+
+/** Resolve a stored asset by its content address. Null when absent. */
+export const getAssetByHash = (hash: string, client: PrismaClient = prisma) =>
+  client.asset.findUnique({ where: { hash } });
+
+/** The public serve route for a stored asset, by content address. */
+export const assetUrl = (hash: string): string => `/api/asset/${hash}`;

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -110,6 +110,13 @@ export const korin = {
   channelWeights: parseChannelWeights(process.env.KORIN_CHANNEL_WEIGHTS)
 };
 
+// Binary asset store (ADR-0026). The backend is a Postgres `Bytes` column, so
+// there is no connection to surface here — the only operational knob is the
+// store-time size ceiling, enforced by `validateAsset`.
+export const assets = {
+  maxBytes: parseInt(process.env.STELLAR_ASSET_MAX_BYTES ?? '2000000', 10) // 2 MB
+};
+
 export const email = {
   smtpHost: process.env.STELLAR_SMTP_HOST ?? '',
   smtpPort: parseInt(process.env.STELLAR_SMTP_PORT ?? '587', 10),

--- a/src/routes/api/asset.ts
+++ b/src/routes/api/asset.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../../modules/asyncHandler';
+import { validateParams, parsedParams } from '../../middleware/validate';
+import { getAssetByHash } from '../../modules/assetStore';
+
+const router = express.Router();
+
+// sha256 hex — the content address, not a row id, so no z.coerce.number here.
+const assetHashParamsSchema = z.object({
+  hash: z.string().regex(/^[0-9a-f]{64}$/)
+});
+
+// GET /api/asset/:hash — deliver a stored asset by content address (ADR-0026).
+//
+// Unauthenticated, unlike the sibling `/css` route. Two reasons: a hash is not
+// enumerable the way that route's sequential ids are, and these bytes are fetched
+// as CSS subresources by the browser, where an auth round-trip buys nothing over
+// content that is already site-shipped theme imagery. When user-uploaded private
+// assets land (Phase 2), they get an explicit visibility column and a gate here —
+// this is not a licence to serve anything.
+router.get(
+  '/:hash',
+  validateParams(assetHashParamsSchema),
+  asyncHandler(async (_req, res) => {
+    const { hash } = parsedParams<{ hash: string }>(res);
+    const asset = await getAssetByHash(hash);
+    if (!asset) {
+      res.status(404).json({ msg: 'Asset not found' });
+      return;
+    }
+
+    // Immutable is literally true here: the bytes at a hash cannot change, so a
+    // cached copy can never go stale and never needs revalidating.
+    // nosniff for the same reason the /css route sets it — the stored mime was
+    // verified against the payload's magic bytes at ingest, so pin it (no helmet).
+    res.setHeader('Content-Type', asset.mime);
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('ETag', `"${asset.hash}"`);
+    res.send(asset.data);
+  })
+);
+
+export default router;


### PR DESCRIPTION
Phase 1 of [ADR-0026](docs/adr/0026-static-asset-storage.md) — an api-owned home for the binary assets a stored row references, so an asset is verifiable from the api that serves it rather than living unverified in another repo's static tree.

Refs #290.

## What landed

- **`Asset` model + migration** — content hash, mime, size, kind, optional owner, bytes. First `Bytes` column in the schema.
- **`src/modules/assetStore.ts`** — `putAsset` / `getAssetByHash`, content-addressed and deduplicating.
- **`src/lib/assetValidate.ts`** — magic-byte identification against an allowlist, cross-checked with any declared mime, plus a size ceiling.
- **`GET /api/asset/:hash`** — immutable caching, `nosniff`, ETag.
- **`STELLAR_ASSET_MAX_BYTES`** (default 2 MB), documented in `.env.default`, `docs/README.md`, and `CLAUDE.md`.

## The decisions this fixes

ADR-0026 left four parameters marked for the implementation to settle; they are now recorded as an amendment on the ADR.

**Backend is a Postgres `Bytes` column, not the object store the ADR named as its scalable default.** The api container has no writable volume and compose lives in a separate repo behind the [ADR-0027](docs/adr/0027-publish-vs-deploy-boundary.md) publish/deploy boundary — a filesystem or S3 backend would have shipped inert until a cross-repo change landed. Postgres is already the only stateful service and already covered by its bind mount. Deliberately bounded: right for theme imagery, wrong once content imagery is measured in gigabytes. `assetStore.ts` is a two-function seam so a driver swap replaces bodies, not callers.

**Addressed by content hash, not row id.** Non-enumerable (unlike the sibling `/css` route's sequential ids), makes `Cache-Control: immutable` literally true, and collapses duplicate bytes to one row.

**The serve route is unauthenticated.** Phase-1 assets are site-shipped theme imagery fetched as CSS subresources; an auth round-trip buys nothing over non-secret bytes at an unguessable address. Private user-uploaded assets get an explicit visibility column and a gate in Phase 2 — this is not a standing licence to serve anything.

**Ingest is validate-and-reject.** This inverts `sanitizeStylesheetSource`'s cleanse-don't-reject signature on purpose: you can neutralize a `url()` and still have valid CSS, but there is no partial-clean of an arbitrary binary. The fail-closed intent carries; the signature does not.

## What is NOT here

The theme migration that motivated the ADR — moving `proton`/`postmod` to api-canonical `/css` fixtures — **did not land**, for two independent reasons found while building this:

1. **#340** — `sanitizeStylesheetSource` decodes the whole sheet and emits the decoded text rather than decoding only to detect danger, so `.hover\:text-white` (a class *named* `hover:text-white`) becomes `.hover:text-white`. `proton` carries 54 such Tailwind utility overrides and cannot round-trip verbatim. This is a live bug affecting real author stylesheets, independent of this PR.
2. **#343** — `postmod` bundles four commercial fonts, so migrating it is a redistribution question rather than a technical one.

Split out as **#341** (theme migration, blocked on #340), **#342** (upload path + visibility + lifecycle sweep), **#343** (font licensing).

The drift guard written for the migration is what caught #340, and it was reverted with the rest of the theme half rather than weakened to let a mangled fixture through.

## Verification

- Full unit suite green: **1844 tests, 102 suites** (37 new).
- `tsc --noEmit`, `typecheck:test`, `lint`, `format` clean; pre-commit hook passed.
- Migration applied against a real Postgres, then a live round-trip: mime sniffed correctly from bytes, hash matched sha256, two puts of identical bytes collapsed to one row, bytes returned byte-identical, non-image rejected.
- Integration suite and browser end-to-end were **not** run — the theme migration they would have exercised is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k9tksnd94o2uBbrn97Ho8
