### PR TITLE
docs(adr): accept ADR-0024 and reconcile the delivery-contract drift

### DIFF
--- a/docs/adr/0003-stylesheet-injection-isolation.md
+++ b/docs/adr/0003-stylesheet-injection-isolation.md
@@ -42,6 +42,6 @@ The boundary is therefore **Arm 2 only**, realized as:
 
 - **Store-time sanitization** (API, `lib/cssSanitize.ts`): strips `@import` and constrains `url()` / `@font-face src` to `data:` / same-origin, so persisted author CSS can't fetch arbitrary hosts.
 - **Inject-time CSP** (stellar-ui, prod builds, via HtmlWebpackPlugin): permissive on resource axes (`style-src`/`img-src`/`font-src`/`connect-src`) to keep theming freedom, strict on execution (`script-src 'self'`, `object-src 'none'`, `base-uri`/`form-action 'self'`) — the real XSS gate. `frame-ancestors` needs a response header (tracked separately).
-- **Injector** stays a plain `<link href>` for URL themes (no CSS-injection surface; http(s) scheme gated), and future author raw CSS is injected as already-sanitized `<style>`.
+- **Injector** stays a plain `<link href>` for URL themes (no CSS-injection surface; http(s) scheme gated). Author raw CSS is delivered the same way — [ADR-0024](0024-stylesheet-delivery-contract.md) §1 settled it as a `text/css` API route the injector links, and rejected `<style>` text injection as a second delivery shape to audit. (This line originally anticipated an already-sanitized `<style>` element; ADR-0024 is the later decision and the implemented one.)
 
 No `data-stellar-chrome` markers, no chrome `@layer`. A bypass must defeat the store-time sanitizer and the CSP — there is no chrome layer in the model.

--- a/docs/adr/0024-stylesheet-delivery-contract.md
+++ b/docs/adr/0024-stylesheet-delivery-contract.md
@@ -1,6 +1,6 @@
 # Stylesheet delivery contract — external URL + registry serving
 
-**Status: Proposed (2026-07-02).** Resolves PRD-03's open decision "AuthorStylesheetUrl storage shape (URL vs stored file) — pending ExternalStylesheet findings" and repairs the severed adopt→display pipe (adoption writes `activeAuthorStylesheetId`; nothing renders it). Companion UI decision: [stellar-ui ADR-0008](https://github.com/orphic-inc/stellar-ui/blob/main/docs/adr/0008-registry-stylesheet-injection.md) (injector third branch). Rides on the injection-safety boundary of [ADR-0003](0003-stylesheet-injection-isolation.md). (ADR number 0024 is next free on `main`.)
+**Status: Accepted (decided 2026-07-02, status recorded 2026-07-19 — the line was never updated after the code shipped; nothing in the ADR was left unresolved).** Resolves PRD-03's open decision "AuthorStylesheetUrl storage shape (URL vs stored file) — pending ExternalStylesheet findings" and repairs the severed adopt→display pipe (adoption writes `activeAuthorStylesheetId`; nothing renders it). Companion UI decision: [stellar-ui ADR-0008](https://github.com/orphic-inc/stellar-ui/blob/main/docs/adr/0008-registry-stylesheet-injection.md) (injector third branch). Rides on the injection-safety boundary of [ADR-0003](0003-stylesheet-injection-isolation.md). (ADR number 0024 is next free on `main`.)
 
 ## Context
 
@@ -55,7 +55,7 @@ First pass ships with the limit unenforced (status quo); #146 implements the gat
 - The "contest winner → official registry promotion" path (Stellarfic story) becomes mechanical later: promotion = staff creating a site `Stylesheet` row whose `cssUrl` is this ADR's `/css` route for the winning sheet. Named here, not built.
 - Serving user CSS from the API origin puts author sheets under `style-src https:` (prod) — no CSP change needed; dev proxying already routes `/api`.
 - PRD-03 edits ride along: amend `.scss/.css` → `.css` (§ Ubiquitous Language, § External disposition), close the open decision (storage shape = stored `source`, API-served; `AuthorStylesheetUrl` as a distinct URL-typed registry entry is dropped — Personal covers the URL case), and record the radio UAT flow.
-- stellar-api's `schemas/stylesheet.ts` and `lib/cssSanitize.ts` comments still cite the superseded ADR-0003 Arm 1 chrome layer — corrected in the same docs pass.
+- stellar-api's `schemas/stylesheet.ts` and `lib/cssSanitize.ts` comments still cite the superseded ADR-0003 Arm 1 chrome layer — corrected in the same docs pass. (Verified done 2026-07-19: both now describe Arm 1 as dropped and name the CSP as the boundary's other half.)
 
 ## Rejected
 


### PR DESCRIPTION
Resolves [#348](https://github.com/orphic-inc/stellar-api/issues/348), a `wayfinder:task` on the [authored-stylesheet map (#347)](https://github.com/orphic-inc/stellar-api/issues/347). Nothing here decides anything new — it writes down a decision the code has been running on for two weeks, so the tickets it blocks (#350, #353) are building on a record rather than an assumption.

## What changed

**ADR-0024 status: Proposed → Accepted.** Decided 2026-07-02, status line recorded 2026-07-19. Before flipping it I checked that the ADR's decisions are actually what shipped, so "Accepted" is a claim about the code and not just about intent:

| ADR-0024 | State on `main` |
|---|---|
| §1 `GET /api/stylesheet/author-stylesheet/:id/css` | `src/routes/api/stylesheet.ts:105` |
| §1 injector stays pure `<link href>` | stellar-ui `StylesheetInjector.tsx:81` — the only element it creates; no `createElement('style')` anywhere in `src` |
| §3 `https:`-only external URLs | `src/schemas/stylesheet.ts` — `externalStylesheetUrl` refinement |
| §4 pointer in the profile contract | `modules/profile.ts:224`, `lib/openapi.ts:377` |
| §4 Personal ⟷ Registry mutual exclusion, server-side | `modules/profile.ts:1054` |

**Drift 1 — injection shape (real contradiction, fixed).** ADR-0003's 2026-06-23 amendment said author raw CSS would be injected as an already-sanitized `<style>`. ADR-0024 §1 decided the opposite and explicitly *rejected* `<style>` text injection as a second delivery shape to audit. ADR-0024 is both later and implemented, so the amendment line now points at it instead of contradicting it, with a note on what it originally anticipated.

**Drift 2 — superseded Arm 1 citations (already clean, recorded).** ADR-0024's Consequences promised a docs pass over `schemas/stylesheet.ts` and `lib/cssSanitize.ts`. That pass happened: both files describe Arm 1 as dropped in the 2026-06-23 amendment and name the inject-time CSP as the boundary's other half. Marked verified in the ADR so the next reader doesn't re-check it.

## Nothing reopened

The ticket asked to flag anything that turned out not to be a clerical fix. Nothing did — both drifts were stale prose against correct code, and no decision was found unresolved.

Docs only; no code, no schema, no contract surface.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)