### PR TITLE
docs(agents): document wayfinder operations for the GitHub tracker

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -22,3 +22,37 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+How `/wayfinder`'s concepts map onto GitHub for this repo. Both sub-issues and issue dependencies are native here, so neither falls back to a body convention.
+
+**The map** is an issue labelled `wayfinder:map`. Find the open ones with `gh issue list --label "wayfinder:map" --state open`.
+
+**Tickets** are child issues of the map, each carrying one `wayfinder:<type>` label — `research`, `prototype`, `grilling`, or `task`.
+
+**Parentage** uses the native sub-issue API. It takes the child's internal `id`, not its number, and the field must be sent as an integer (`-F`, not `-f` — `-f` sends a string and the API rejects it with a 422):
+
+```bash
+child_id=$(gh api repos/orphic-inc/stellar-api/issues/<child>/ --jq '.id')
+gh api -X POST repos/orphic-inc/stellar-api/issues/<map>/sub_issues -F sub_issue_id="$child_id"
+```
+
+**Blocking** uses the native dependency relationship, which renders the frontier visually in GitHub's own UI. Same integer-`id` rule:
+
+```bash
+blocker_id=$(gh api repos/orphic-inc/stellar-api/issues/<blocker>/ --jq '.id')
+gh api -X POST repos/orphic-inc/stellar-api/issues/<blocked>/dependencies/blocked_by -F issue_id="$blocker_id"
+```
+
+Read an issue's blockers with `gh api repos/orphic-inc/stellar-api/issues/<n>/dependencies/blocked_by --jq '[.[].number]'`.
+
+**Claiming** a ticket is assigning it: `gh issue edit <n> --add-assignee obrien-k`. An open, unassigned ticket is unclaimed.
+
+**The frontier** is the map's open children that are unassigned and have an empty `blocked_by` list. There is no single query for this — list the children, then check each one's dependencies:
+
+```bash
+gh api repos/orphic-inc/stellar-api/issues/<map>/sub_issues --jq '.[] | select(.state=="open") | .number'
+```
+
+**Resolving** a ticket: post the answer as a comment, close the issue, then append a one-line pointer to the map's Decisions-so-far section.


### PR DESCRIPTION
The `/wayfinder` skill tells each session to consult the tracker doc's "Wayfinding operations" section for how this repo expresses maps, tickets, parentage, blocking, and the frontier. That section did not exist, so the first wayfinder session had to derive the GitHub mechanics from scratch — and the next one would have paid the same cost.

Records them in `docs/agents/issue-tracker.md`:

- **Maps** are issues labelled `wayfinder:map`; **tickets** are child issues carrying one `wayfinder:<type>` label.
- **Parentage** uses the native sub-issue API and **blocking** uses the native dependency relationship — both are available here, so neither needs a body-convention fallback, and blocking renders the frontier in GitHub's own UI.
- Both APIs take the issue's internal `id`, not its number, and it must be sent as an integer field: `-F`, not `-f`. A string 422s. That is the detail worth writing down — it is invisible from the docs and costs a round of debugging every time.
- **Claiming** is assignment; the **frontier** is the map's open, unassigned children with an empty `blocked_by`, which needs a two-step query rather than one call.
- **Resolving** is comment, close, then a one-line pointer in the map's Decisions-so-far.

Docs only. Commit predates this session; it had been sitting unpushed on a local branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)