### PR TITLE
docs(agents): fix the frontier query — three ways it silently lied

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -49,10 +49,37 @@ Read an issue's blockers with `gh api repos/orphic-inc/stellar-api/issues/<n>/de
 
 **Claiming** a ticket is assigning it: `gh issue edit <n> --add-assignee obrien-k`. An open, unassigned ticket is unclaimed.
 
-**The frontier** is the map's open children that are unassigned and have an empty `blocked_by` list. There is no single query for this — list the children, then check each one's dependencies:
+**The frontier** is the map's open children that are unassigned and whose blockers are **all closed** — not the ones with an empty `blocked_by` list. `blocked_by` keeps listing a blocker after it closes, so an empty list means "never had one", and testing for emptiness reports a frontier of nothing the moment a map starts resolving tickets. Filter on blocker _state_, not list length.
+
+There is no single query for this — list the children, then check each one's dependencies:
 
 ```bash
-gh api repos/orphic-inc/stellar-api/issues/<map>/sub_issues --jq '.[] | select(.state=="open") | .number'
+REPO=orphic-inc/stellar-api
+if ! children=$(gh api repos/$REPO/issues/<map>/sub_issues \
+    --jq '.[] | select(.state=="open") | .number' 2>/dev/null); then
+  echo "could not list children — retry"
+else
+  printf '%s\n' "$children" | while read -r n; do
+    [ -z "$n" ] && continue
+    if ! blockers=$(gh api repos/$REPO/issues/$n/dependencies/blocked_by \
+        --jq '[.[] | select(.state=="open") | .number] | join(",")' 2>/dev/null); then
+      echo "#$n UNKNOWN — request failed, retry"
+    elif [ -z "$blockers" ]; then
+      echo "#$n FRONTIER"
+    else
+      echo "#$n blocked by $blockers"
+    fi
+  done
+fi
 ```
+
+Iterate with `while read`, not `for n in $children`. Word splitting differs between the shells this gets pasted into: zsh does **not** split an unquoted `$children`, so a `for` loop runs once with all the numbers glued into a single value, while bash splits it as intended. (zsh _does_ split unquoted `$(...)`, so `for n in $(gh api …)` fails the opposite way — it shreds an error message into fake issue numbers.) Reading line by line is correct in both.
+
+**Both** exit-status guards are load-bearing, because this endpoint family 503s intermittently and every unchecked call fails in a way that looks like data:
+
+- Unchecked **inner** call — the error JSON lands in `$blockers` and reports as a bogus blocker, or as a phantom FRONTIER depending on how the filter is written.
+- Unchecked **outer** call — worse. The error text word-splits in the `for`, so each word becomes a fake issue number and you get a screenful of confident output about tickets that do not exist.
+
+Unknown is a third state, distinct from blocked and unblocked. A frontier reading with any UNKNOWN in it is incomplete — retry before acting on it.
 
 **Resolving** a ticket: post the answer as a comment, close the issue, then append a one-line pointer to the map's Decisions-so-far section.


### PR DESCRIPTION
Fixes the frontier definition I wrote in [#356](https://github.com/orphic-inc/stellar-api/pull/356). Found by using it: after #348 and #349 closed, it reported an **empty frontier** on map [#347](https://github.com/orphic-inc/stellar-api/issues/347) while three tickets were actually ready to pick up.

Three defects, and what makes each nasty is that all of them fail as *plausible output* rather than as an error.

## 1. The test was wrong

`blocked_by` keeps listing a blocker after it closes. So "empty `blocked_by`" means *never had a blocker*, not *unblocked* — and the check reports nothing available the moment a map starts resolving tickets, which is exactly when you need it. The test is now on blocker **state**.

## 2. Exit status went unchecked, on both calls

The dependencies endpoint 503s intermittently — it did so repeatedly while I was verifying this.

- **Inner call unchecked**: the error JSON lands in `$blockers` and prints as a blocker.
- **Outer call unchecked**: worse. The error text word-splits in the `for`, so each word of *"No server is currently available…"* becomes a fake issue number, and you get a screenful of confident output about tickets that don't exist.

Unknown is now a third state, distinct from blocked and unblocked.

## 3. Iteration was shell-dependent

This one bit while testing the fix. **zsh does not word-split an unquoted `$children`**, so `for n in $children` ran once with all five numbers glued into a single value; bash splits it as intended. And zsh *does* split unquoted `$(...)`, which is precisely how the error text got shredded in defect 2 — the two forms fail in opposite directions.

Now iterates with `while read`, correct under both.

## Verified

Ran against #347 until GitHub stopped 503ing:

```
#350 FRONTIER
#351 FRONTIER
#352 FRONTIER
#353 blocked by 352
#354 blocked by 350
```

Matches the dependency graph by hand — #350 and #351 have only closed blockers (#348, #349), and the two genuinely blocked tickets are correctly held. Earlier attempts reported `UNKNOWN` rather than guessing, which is the intended behaviour under 503.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)