### PR TITLE
docs(adr): record the /css addressing decision and strike a control that never shipped

### DIFF
--- a/docs/adr/0024-stylesheet-delivery-contract.md
+++ b/docs/adr/0024-stylesheet-delivery-contract.md
@@ -19,7 +19,7 @@ New route: `GET /api/stylesheet/author-stylesheet/:id/css` → `200`, `Content-T
 
 The injector stays a pure `<link href>` — the Registry branch links this route, same as Personal links an external URL. No `<style>` text injection path is added in stellar-ui; a single delivery mechanism keeps the ADR-0003 boundary one-shaped.
 
-The existing JSON read (`GET /author-stylesheet/:id`) continues to return `source` for editing (author + staff use). Registry listings return metadata only (id, authorId, name, timestamps) — no `source` in list payloads.
+The existing JSON read (`GET /author-stylesheet/:id`) continues to return `source` for editing (~~author + staff use~~ — see the 2026-07-19 amendment below: this parenthetical describes an access control that never shipped and cannot be enforced; the read is open to any authenticated member). Registry listings return metadata only (id, authorId, name, timestamps) — no `source` in list payloads.
 
 ### 2. The user contract is plain CSS — SCSS is rejected as user input
 
@@ -62,3 +62,38 @@ First pass ships with the limit unenforced (status quo); #146 implements the gat
 - **`<style>` text injection in the UI** — a second delivery shape, a second thing to audit; the link route is sufficient and keeps ADR-0003's "href, never CSS text" invariant.
 - **User-facing SCSS (compile-on-ingest or compile-on-serve)** — untrusted compilation surface + runtime dep; ADR-0003 scope-out stands.
 - **Fetching/validating external URLs at save time** — an SSRF surface for a liveness check link-health already owns.
+
+## Amendment (2026-07-19) — addressing, and why it differs from the asset store
+
+Decides [#350](https://github.com/orphic-inc/stellar-api/issues/350) on the [authored-stylesheet wayfinder map](https://github.com/orphic-inc/stellar-api/issues/347). The asset store ([ADR-0026](0026-static-asset-storage.md)) deliberately went content-addressed while this route serves sequential ids behind `requireAuth`, and the difference had no recorded reason — so it read as an oversight in a subsystem where the two paths will eventually sit adjacent serving the same themes.
+
+**Sequential ids stay. The asymmetry is provenance and mutability, not secrecy.**
+
+### Adoption tracks edits, so identity must be stable
+
+When an author edits an adopted sheet, every adopter sees the edit. The pointer (`UserSettings.activeAuthorStylesheetId`) names a stable identity whose content varies, which is what §1's `Cache-Control: no-cache` has assumed since this ADR shipped.
+
+Content-addressing is the opposite arrangement: the address _is_ the content, so it changes on every save, and every pointer at the sheet goes stale — each adopter's `activeAuthorStylesheetId` plus the registry row's `cssUrl`. Making a mutable resource content-addressed requires an indirection layer mapping stable identity to current hash, and that layer is the sequential id. It adds a hop to arrive where we started.
+
+This also runs the other way: [#351](https://github.com/orphic-inc/stellar-api/issues/351) decided `seedStylesheetFixtures` must propagate `source` on update, so a built-in theme's bytes change while its address holds. Content-addressing would rewrite every registry `cssUrl` on every fixture edit.
+
+### There is no confidentiality boundary here to defend
+
+An earlier reading held that enumerating ids leaks only metadata because the route is authed. That is wrong, and the correction matters: neither `GET /author-stylesheet/:id` nor `/css` is ownership-scoped (`getAuthorStylesheetById` is a bare `findUnique`), so any authenticated member can walk the ids and read every sheet's full `source`.
+
+That is **acceptable, and not fixable by addressing**. `/css` must serve non-authors or adoption cannot work — the adopter's browser is what fetches the sheet. An unguessable address is a capability, and this capability is published in a `<link>` in every adopter's DOM the moment the sheet is adopted. Authored stylesheets carry no confidentiality expectation.
+
+Consequently §1's "(author + staff use)" is struck as never-implemented and unenforceable, rather than treated as a gap to close. The list-payload exclusion of `source` stands as a payload-size measure, not a confidentiality control — the ids it returns lead straight to the bytes.
+
+### Why `/css` keeps `requireAuth` while `/api/asset/:hash` does not
+
+- **`/api/asset`** serves site-shipped bytes reviewed in the repository — `putAsset` is reachable only from the seeder, which [ADR-0031](0031-injected-css-threat-model.md) §4 relies on normatively. Public and immutable by construction, so auth buys nothing over the address, and `Cache-Control: immutable` is literally true.
+- **`/css`** serves member-authored, mutable content. "No confidentiality expectation" is scoped to _members of an invite-only instance_ — the instance boundary, not the open internet. Dropping auth would publish every member's authored CSS to anyone holding a URL.
+
+So content-addressing follows from **immutability**, which is what makes it possible, not from secrecy, which it does not provide. Enumerability is a side effect of the sequential form, not a weakness the asset route was designed to avoid; `src/routes/api/asset.ts` is corrected to say so.
+
+### Consequence for promotion (recorded, not decided here)
+
+§5 above defines contest-winner promotion as staff creating a `Stylesheet` row whose `cssUrl` points at the winning sheet's `/css` route. Combined with "adoption tracks edits", that would leave a promoted theme editable by its original author _after_ it became site-official — the first built-in whose bytes live under member control, and a case where the reviewed artifact is not the served artifact.
+
+Promotion therefore **copies** the source into a System-owned row rather than pointing at the author's live row, matching how the ten built-in fixtures already work. Noted against [#258](https://github.com/orphic-inc/stellar-api/issues/258), which owns the promotion lifecycle.

--- a/src/modules/authorStylesheet.ts
+++ b/src/modules/authorStylesheet.ts
@@ -87,8 +87,15 @@ export const listAuthorStylesheets = (authorId: number, pg: PageParams) =>
 
 /**
  * Read a single AuthorStylesheet by its id, or null if it does not exist.
- * Returns `source` — this is the edit-path read (author + staff, ADR-0024 §1),
- * not the browser delivery path.
+ * Returns `source` — this is the edit-path read (ADR-0024 §1), not the browser
+ * delivery path.
+ *
+ * NOT ownership-scoped, deliberately: any authenticated member can read any
+ * sheet's source here, and the sibling `/css` route serves the same bytes because
+ * an adopter's browser must be able to fetch another member's sheet. Authored
+ * stylesheets carry no confidentiality expectation (ADR-0024, 2026-07-19
+ * amendment) — an earlier "author + staff" framing described a control that never
+ * shipped and cannot be enforced without breaking adoption.
  */
 export const getAuthorStylesheetById = (id: number) =>
   prisma.authorStylesheet.findUnique({ where: { id } });

--- a/src/routes/api/asset.ts
+++ b/src/routes/api/asset.ts
@@ -13,12 +13,21 @@ const assetHashParamsSchema = z.object({
 
 // GET /api/asset/:hash — deliver a stored asset by content address (ADR-0026).
 //
-// Unauthenticated, unlike the sibling `/css` route. Two reasons: a hash is not
-// enumerable the way that route's sequential ids are, and these bytes are fetched
-// as CSS subresources by the browser, where an auth round-trip buys nothing over
-// content that is already site-shipped theme imagery. When user-uploaded private
-// assets land (Phase 2), they get an explicit visibility column and a gate here —
-// this is not a licence to serve anything.
+// Unauthenticated, unlike the sibling `/css` route, because of what these bytes
+// ARE: site-shipped theme imagery reviewed in the repository (`putAsset` is
+// reachable only from the seeder — ADR-0031 §4 leans on that normatively), so an
+// auth round-trip buys nothing over content that is already public and immutable.
+// `/css` stays authed because it serves member-authored content, and the instance
+// is invite-only (ADR-0024, 2026-07-19 amendment).
+//
+// Non-enumerability is a side effect of the content address, not the reason for
+// it — content-addressing follows from immutability, which is what makes it work.
+// The sibling route's sequential ids are enumerable and that is accepted: authored
+// sheets carry no confidentiality expectation, since adoption requires any member
+// to be able to fetch another member's sheet.
+//
+// When user-uploaded private assets land (Phase 2), they get an explicit
+// visibility column and a gate here — this is not a licence to serve anything.
 router.get(
   '/:hash',
   validateParams(assetHashParamsSchema),


### PR DESCRIPTION
Decides [#350](https://github.com/orphic-inc/stellar-api/issues/350) on the [authored-stylesheet wayfinder map](https://github.com/orphic-inc/stellar-api/issues/347). Comments and docs only — no behaviour change.

## What was decided

**Sequential ids stay.** The asymmetry with the asset store's content-addressing is provenance and mutability, not secrecy:

- `/api/asset` serves site-shipped bytes reviewed in the repo (`putAsset` is seeder-only, which ADR-0031 §4 relies on) — public and immutable, so content-addressing works and `Cache-Control: immutable` is literally true.
- `/css` serves member-authored, mutable content on an invite-only instance, so it keeps `requireAuth`.

Content-addressing follows from **immutability**, not from secrecy. Adoption tracks an author's edits, so the pointer must name a stable identity whose content varies — content-addressing a mutable row would stale every adopter's `activeAuthorStylesheetId` and the registry `cssUrl` on every save, and the indirection layer that fixes it is the sequential id. [#351](https://github.com/orphic-inc/stellar-api/issues/351)'s decision that `seedStylesheetFixtures` propagates `source` on update rests on the same property.

## The error this corrects

#350 assumed enumeration leaks metadata "rather than content." Neither read is ownership-scoped — `getAuthorStylesheetById` is a bare `findUnique` — so any authenticated member can walk the ids and read **every sheet's full `source`**.

That is acceptable and not fixable by addressing: `/css` must serve non-authors or adoption cannot work, and an unguessable address is a capability that appears in a `<link>` in every adopter's DOM on first adoption.

So ADR-0024 §1's "(author + staff use)" is **struck as never-implemented and unenforceable**, not treated as a gap to close. Same claim corrected in `src/modules/authorStylesheet.ts`.

`src/routes/api/asset.ts` gave non-enumerability as a co-reason for serving unauthenticated, which read as an unaddressed weakness in the sibling route. Reframed as a side effect.

## Recorded, not decided here

Promotion must **copy** source into a System-owned row rather than point at the author's live row — otherwise a promoted theme stays editable by its author after becoming site-official, and the reviewed artifact stops being the served artifact. Noted against [#258](https://github.com/orphic-inc/stellar-api/issues/258), which owns the promotion lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)