### PR TITLE
feat(stylesheets): nullable cssUrl for no-render rows + total-partition registry guard

### DIFF
--- a/docs/adr/0024-stylesheet-delivery-contract.md
+++ b/docs/adr/0024-stylesheet-delivery-contract.md
@@ -145,3 +145,15 @@ Seeding Sublime as an empty `/css` fixture was rejected: it buys uniformity by m
 §3 is what makes this expressible. With Sublime carrying a fictional `cssUrl`, the assertion needs an exception carved by name — and an exception list is exactly where the next `proton` hides. A light stellar-ui check that the theme tree stays empty is secondary: the api guard catches the failure that matters (a row nobody can serve), while the ui one catches dead bytes in a bundle, which is cheaper to be wrong about.
 
 **Known seam, recorded not closed.** Neither guard is cross-repo. The api cannot see stellar-ui's tree and the ui cannot see the registry, so adding `src/stylesheets/newtheme/` without touching the api still fails silently — which is precisely today's failure. Do not mistake the api guard for full coverage.
+
+## Amendment (2026-07-20) — what the shipped guard actually reaches
+
+§4 above says a future row pointing outside the api "fails CI on the way in". Implementing it (#371) established that this is true of _seeded_ rows only, and the gap is worth recording next to the claim rather than leaving the stronger reading in place.
+
+`stylesheetRegistry.integration.ts` truncates in `beforeEach`, so the partition is asserted over rows the tests seed — `seedStylesheetFixtures` output plus rows a test creates directly. It never inspects the registry a real `prisma migrate deploy` produces. A SQL data migration that inserts a `/stylesheets/…` row therefore still passes CI, which is the same class of vector that produced this amendment: the 2026-05-24 seed migration and `20260524200000_add_legacy_stylesheets` are exactly how the dead rows arrived.
+
+**`postmod` is that case today.** It is planted by migration, is not a seeded fixture, and stellar-ui still serves it — §2 above records it as the last thing holding `/stylesheets` open, gated on [#343](https://github.com/orphic-inc/stellar-api/issues/343). So the registry on a live database is _not_ a total partition right now, and no guard reports it. This is accepted rather than papered over: excluding `postmod` by name would be the exception list §4 exists to avoid, and failing CI until #343 clears would block unrelated work behind a licensing decision.
+
+The sequencing that closes it: #343 retires `postmod`, the partition becomes true of the shipped registry rather than only the seeded one, and the guard can then be extended to run against a migrated database. Until then, read §4's guarantee as covering seeding and fixtures — not migrations.
+
+Two adjacent gaps, both ticketed rather than fixed here: the write path (`POST`/`PUT /api/stylesheet`) accepts a null `cssUrl` but does not enforce the partition at runtime, so a strict-admin can still create an unservable row; and `getDefaultStylesheetName`'s `?? 'sublime'` fallback — named in #371 as half of the magic-string pair — is untouched, because retiring it makes `siteAppearance` nullable and is a materially larger change than the delivery contract.

--- a/openapi.json
+++ b/openapi.json
@@ -2049,7 +2049,8 @@
             "type": "string"
           },
           "cssUrl": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "isDefault": {
             "type": "boolean"
@@ -8249,6 +8250,7 @@
                   },
                   "cssUrl": {
                     "type": "string",
+                    "nullable": true,
                     "minLength": 1
                   },
                   "isDefault": {
@@ -8377,6 +8379,7 @@
                   },
                   "cssUrl": {
                     "type": "string",
+                    "nullable": true,
                     "minLength": 1
                   },
                   "isDefault": {

--- a/prisma/migrations/20260720000000_nullable_stylesheet_cssurl/migration.sql
+++ b/prisma/migrations/20260720000000_nullable_stylesheet_cssurl/migration.sql
@@ -1,0 +1,22 @@
+-- ADR-0024 §3/§4 (#371): a registry row may have NO delivery target.
+-- null `cssUrl` = appears in the picker, renders nothing.
+ALTER TABLE "stylesheets" ALTER COLUMN "cssUrl" DROP NOT NULL;
+
+-- Null every row still pointing into stellar-ui's retired `/stylesheets/…`
+-- static tree. Such a value is a delivery target that cannot resolve — the drift
+-- #371 exists to end — so the row degrades to "renders nothing" (still
+-- selectable) instead of shipping a dangling <link>.
+--
+-- Sublime is the row this is really for: its look IS the bundled Tailwind, so
+-- there was never anything to inject, and the '/stylesheets/sublime/style.css'
+-- it carried was requested by nothing. It keeps `isDefault` and its picker entry.
+-- The 2026-05-24 seed migration also planted `kuro` here; `seedStylesheetFixtures`
+-- reconciles that one to a real /css target on the next seed.
+--
+-- Scoped by path rather than by name so an operator who has since pointed a row
+-- at a real delivery target keeps it. After this, modules/stylesheetRegistry.ts
+-- holds the invariant and the registry guard fails CI on any row that reappears
+-- outside the partition.
+UPDATE "stylesheets"
+SET "cssUrl" = NULL
+WHERE "cssUrl" LIKE '/stylesheets/%';

--- a/prisma/migrations/20260720000000_nullable_stylesheet_cssurl/migration.sql
+++ b/prisma/migrations/20260720000000_nullable_stylesheet_cssurl/migration.sql
@@ -2,21 +2,20 @@
 -- null `cssUrl` = appears in the picker, renders nothing.
 ALTER TABLE "stylesheets" ALTER COLUMN "cssUrl" DROP NOT NULL;
 
--- Null every row still pointing into stellar-ui's retired `/stylesheets/…`
--- static tree. Such a value is a delivery target that cannot resolve — the drift
--- #371 exists to end — so the row degrades to "renders nothing" (still
--- selectable) instead of shipping a dangling <link>.
+-- Sublime only. Its look IS the bundled Tailwind, so there was never anything to
+-- inject, and the path it carried was requested by nothing.
 --
--- Sublime is the row this is really for: its look IS the bundled Tailwind, so
--- there was never anything to inject, and the '/stylesheets/sublime/style.css'
--- it carried was requested by nothing. It keeps `isDefault` and its picker entry.
--- The 2026-05-24 seed migration also planted `kuro` here; `seedStylesheetFixtures`
--- reconciles that one to a real /css target on the next seed.
+-- Scoped to that exact dead path, NOT to `LIKE '/stylesheets/%'`. The broad form
+-- also matches `postmod`, which ADR-0024's drift table records as "Live; gated on
+-- #343" — stellar-ui still serves it and it is not a seeded fixture, so nulling it
+-- would silently unstyle every user who selected it, ahead of the migration that
+-- is supposed to move it. The other legacy rows (`kuro`, `layer-cake`, `anorex`,
+-- `dark-ambient`, `proton`) are fixtures: `seedStylesheetFixtures` reconciles each
+-- to its `/css` target on the next seed, so they need no data migration here.
 --
--- Scoped by path rather than by name so an operator who has since pointed a row
--- at a real delivery target keeps it. After this, modules/stylesheetRegistry.ts
--- holds the invariant and the registry guard fails CI on any row that reappears
--- outside the partition.
+-- Conditioned on the value so an operator who has already repointed Sublime at a
+-- real delivery target keeps it.
 UPDATE "stylesheets"
 SET "cssUrl" = NULL
-WHERE "cssUrl" LIKE '/stylesheets/%';
+WHERE "name" = 'sublime'
+  AND "cssUrl" = '/stylesheets/sublime/style.css';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -626,11 +626,16 @@ model Profile {
 /// A partial unique index enforces exactly one default stylesheet at the DB level.
 /// This index is not representable in Prisma DSL and is created in raw SQL migration:
 /// CREATE UNIQUE INDEX "stylesheets_one_default" ON "stylesheets"("isDefault") WHERE "isDefault" = true;
+/// `cssUrl` is nullable: null means the row has no delivery target — it appears
+/// in the picker and renders nothing (Sublime, whose look is the bundled
+/// Tailwind itself). Every non-null value must be a `/css` delivery target; the
+/// total partition is defined and enforced in modules/stylesheetRegistry.ts
+/// (ADR-0024 §4, #371).
 model Stylesheet {
   id          Int      @id @default(autoincrement())
   name        String   @unique
   description String   @default("")
-  cssUrl      String
+  cssUrl      String?
   isDefault   Boolean  @default(false)
   createdAt   DateTime @default(now())
 

--- a/src/integration/stylesheetRegistry.integration.ts
+++ b/src/integration/stylesheetRegistry.integration.ts
@@ -1,11 +1,15 @@
 /**
- * Registry ↔ /css delivery consistency (#286). Proves a site-registry row can
- * never ship pointing at a `/css` delivery target that doesn't resolve — the dead
- * theme-picker entry the issue is about. Seeds the System user + built-in fixtures
- * on the test DB (the harness truncates registry rows in `beforeEach`, so the test
- * seeds them itself) and asserts every `/css`-backed row maps to a real, non-empty
- * `AuthorStylesheet`. Also pins the seeders' idempotency and the System account's
- * non-interactive shape.
+ * Registry ↔ /css delivery consistency (#286, extended by #371). Proves a
+ * site-registry row can never ship pointing at a `/css` delivery target that
+ * doesn't resolve — the dead theme-picker entry the issue is about. Seeds the
+ * System user + built-in fixtures on the test DB (the harness truncates registry
+ * rows in `beforeEach`, so the test seeds them itself) and asserts every
+ * `/css`-backed row maps to a real, non-empty `AuthorStylesheet`.
+ *
+ * #371 adds the other direction: the delivery arms are now a TOTAL partition
+ * (`/css`-backed XOR null `cssUrl`), so a row pointing outside the api fails here
+ * instead of being invisible. Also pins the seeders' idempotency and the System
+ * account's non-interactive shape.
  */
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
 import { seedSystemUser, SYSTEM_USERNAME } from '../modules/bootstrap';
@@ -19,6 +23,10 @@ import {
   BUILTIN_ASSET_FIXTURES
 } from '../modules/assetFixtures';
 import { getAssetByHash, hashAsset } from '../modules/assetStore';
+import {
+  authorStylesheetIdFromCssUrl,
+  rowsOutsideDeliveryPartition
+} from '../modules/stylesheetRegistry';
 
 const fixtureFileByName = new Map<string, string>(
   BUILTIN_STYLESHEET_FIXTURES.map((f) => [f.name, f.file])
@@ -34,18 +42,16 @@ afterAll(async () => {
   await testPrisma.$disconnect();
 });
 
-const CSS_ROUTE = /^\/api\/stylesheet\/author-stylesheet\/(\d+)\/css$/;
-
 const cssBackedRows = async () => {
   const rows = await testPrisma.stylesheet.findMany();
-  return rows.filter((r) => CSS_ROUTE.test(r.cssUrl));
+  return rows.filter((r) => authorStylesheetIdFromCssUrl(r.cssUrl) !== null);
 };
 
 const assertAllResolve = async () => {
   const rows = await cssBackedRows();
   expect(rows.length).toBe(BUILTIN_STYLESHEET_FIXTURES.length);
   for (const row of rows) {
-    const id = Number(CSS_ROUTE.exec(row.cssUrl)![1]);
+    const id = authorStylesheetIdFromCssUrl(row.cssUrl)!;
     const fixture = await testPrisma.authorStylesheet.findUnique({
       where: { id },
       select: { name: true, source: true }
@@ -65,6 +71,58 @@ describe('stylesheet registry ↔ /css delivery consistency (#286)', () => {
     const systemUserId = await seedSystemUser(testPrisma);
     await seedStylesheetFixtures(testPrisma, systemUserId);
     await assertAllResolve();
+  });
+
+  /*
+   * The partition is TOTAL (#371): every row is /css-backed or has a null
+   * cssUrl. The old guard only asserted the forward direction — that /css-backed
+   * rows resolve — so a row pointing outside the api was invisible to it. That
+   * is precisely how `anorex`/`kuro`/`layer-cake` moved to api delivery while
+   * their stellar-ui static files kept shipping to every user, referenced by
+   * nothing.
+   */
+  describe('total delivery partition', () => {
+    it('every seeded registry row is /css-backed or null — nothing else', async () => {
+      const systemUserId = await seedSystemUser(testPrisma);
+      await seedStylesheetFixtures(testPrisma, systemUserId);
+
+      const rows = await testPrisma.stylesheet.findMany();
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rowsOutsideDeliveryPartition(rows)).toEqual([]);
+    });
+
+    it('a null-cssUrl row is legal — Sublime is in the picker and renders nothing', async () => {
+      // truncateAll() drops the row the 2026-05-24 data migration plants, so the
+      // post-migration shape is reconstructed here rather than assumed.
+      const systemUserId = await seedSystemUser(testPrisma);
+      await seedStylesheetFixtures(testPrisma, systemUserId);
+      await testPrisma.stylesheet.create({
+        data: { name: 'sublime', description: 'Default', cssUrl: null }
+      });
+
+      const rows = await testPrisma.stylesheet.findMany();
+      expect(rows.find((r) => r.name === 'sublime')!.cssUrl).toBeNull();
+      expect(rowsOutsideDeliveryPartition(rows)).toEqual([]);
+    });
+
+    it('FAILS on a row pointing at the retired ui static tree', async () => {
+      // The negative control. A guard never observed failing is not a guard —
+      // and this is the exact shape that shipped undetected before #371.
+      const systemUserId = await seedSystemUser(testPrisma);
+      await seedStylesheetFixtures(testPrisma, systemUserId);
+      await testPrisma.stylesheet.create({
+        data: {
+          name: 'foo',
+          description: '',
+          cssUrl: '/stylesheets/foo/style.css'
+        }
+      });
+
+      const offenders = rowsOutsideDeliveryPartition(
+        await testPrisma.stylesheet.findMany()
+      );
+      expect(offenders.map((r) => r.name)).toEqual(['foo']);
+    });
   });
 
   it('re-seeding is idempotent — no duplicate fixtures, registry still resolves', async () => {

--- a/src/integration/stylesheetRegistry.integration.ts
+++ b/src/integration/stylesheetRegistry.integration.ts
@@ -10,6 +10,12 @@
  * (`/css`-backed XOR null `cssUrl`), so a row pointing outside the api fails here
  * instead of being invisible. Also pins the seeders' idempotency and the System
  * account's non-interactive shape.
+ *
+ * Scope limit worth knowing before trusting this file: `beforeEach` truncates,
+ * so the partition is asserted over rows these tests SEED, never over the
+ * registry a real `prisma migrate deploy` produces. A SQL data migration adding
+ * a `/stylesheets/…` row still passes CI — `postmod` is exactly that today
+ * (ADR-0024: "Live; gated on #343"). See modules/stylesheetRegistry.ts.
  */
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
 import { seedSystemUser, SYSTEM_USERNAME } from '../modules/bootstrap';

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1441,7 +1441,9 @@ const Stylesheet = registry.register(
     id: z.number(),
     name: z.string(),
     description: z.string(),
-    cssUrl: z.string(),
+    // null = no delivery target: the row is in the picker and renders nothing
+    // (Sublime). Clients must branch on null rather than on the name (#371).
+    cssUrl: z.string().nullable(),
     isDefault: z.boolean(),
     createdAt: z.string()
   })

--- a/src/modules/stylesheet.ts
+++ b/src/modules/stylesheet.ts
@@ -34,7 +34,7 @@ export const getStylesheetStats = async () => {
 export const createStylesheet = async (data: {
   name: string;
   description: string;
-  cssUrl: string;
+  cssUrl: string | null;
   isDefault: boolean;
 }) => {
   if (data.isDefault) {
@@ -54,7 +54,7 @@ export const updateStylesheet = async (
   data: Partial<{
     name: string;
     description: string;
-    cssUrl: string;
+    cssUrl: string | null;
     isDefault: boolean;
   }>
 ) => {

--- a/src/modules/stylesheetRegistry.spec.ts
+++ b/src/modules/stylesheetRegistry.spec.ts
@@ -1,5 +1,4 @@
 import {
-  CSS_DELIVERY_ROUTE,
   authorStylesheetIdFromCssUrl,
   rowsOutsideDeliveryPartition
 } from './stylesheetRegistry';
@@ -36,8 +35,8 @@ describe('registry delivery partition', () => {
   });
 
   it('flags every illegal shape, not just the first', () => {
-    // A partition check that reports one row at a time turns a sweep into a
-    // game of whack-a-mole on CI.
+    // Reporting one row per run would make a sweep take as many CI runs as
+    // there are offenders.
     const rows = [
       row('a', '/stylesheets/a/style.css'),
       row('b', 'https://cdn.example.com/b.css'),
@@ -52,9 +51,8 @@ describe('registry delivery partition', () => {
   });
 
   it('rejects near-misses of the delivery route', () => {
-    // Anchored both ends: a path that merely CONTAINS the route, or omits the
-    // id, is not a delivery target. Without anchoring, an attacker-ish or
-    // fat-fingered value could slip through the guard while 404ing in delivery.
+    // Anchored both ends: a value that merely CONTAINS the route, or omits the
+    // id, would otherwise pass the guard while 404ing in delivery.
     const nearMisses = [
       '/api/stylesheet/author-stylesheet//css',
       '/api/stylesheet/author-stylesheet/abc/css',
@@ -75,10 +73,5 @@ describe('registry delivery partition', () => {
     expect(
       authorStylesheetIdFromCssUrl('/stylesheets/foo/style.css')
     ).toBeNull();
-  });
-
-  it('the route pattern is anchored', () => {
-    expect(CSS_DELIVERY_ROUTE.source.startsWith('^')).toBe(true);
-    expect(CSS_DELIVERY_ROUTE.source.endsWith('$')).toBe(true);
   });
 });

--- a/src/modules/stylesheetRegistry.spec.ts
+++ b/src/modules/stylesheetRegistry.spec.ts
@@ -1,0 +1,84 @@
+import {
+  CSS_DELIVERY_ROUTE,
+  authorStylesheetIdFromCssUrl,
+  rowsOutsideDeliveryPartition
+} from './stylesheetRegistry';
+
+/*
+ * The registry partition (ADR-0024 §4, #371). Every site-registry row is either
+ * `/css`-backed or has a null `cssUrl` — nothing else is legal.
+ *
+ * These pin the predicate itself; stylesheetRegistry.integration.ts applies the
+ * same predicate to real seeded rows. Kept pure so the illegal shapes can be
+ * enumerated directly rather than round-tripped through a DB.
+ */
+
+const row = (name: string, cssUrl: string | null) => ({ name, cssUrl });
+
+describe('registry delivery partition', () => {
+  it('accepts a /css-backed row', () => {
+    expect(
+      rowsOutsideDeliveryPartition([
+        row('kuro', '/api/stylesheet/author-stylesheet/7/css')
+      ])
+    ).toEqual([]);
+  });
+
+  it('accepts a null-cssUrl row — present in the picker, renders nothing', () => {
+    expect(rowsOutsideDeliveryPartition([row('sublime', null)])).toEqual([]);
+  });
+
+  it('flags a row pointing at the retired ui static tree', () => {
+    const bad = row('foo', '/stylesheets/foo/style.css');
+    expect(rowsOutsideDeliveryPartition([row('sublime', null), bad])).toEqual([
+      bad
+    ]);
+  });
+
+  it('flags every illegal shape, not just the first', () => {
+    // A partition check that reports one row at a time turns a sweep into a
+    // game of whack-a-mole on CI.
+    const rows = [
+      row('a', '/stylesheets/a/style.css'),
+      row('b', 'https://cdn.example.com/b.css'),
+      row('c', ''),
+      row('ok', null)
+    ];
+    expect(rowsOutsideDeliveryPartition(rows).map((r) => r.name)).toEqual([
+      'a',
+      'b',
+      'c'
+    ]);
+  });
+
+  it('rejects near-misses of the delivery route', () => {
+    // Anchored both ends: a path that merely CONTAINS the route, or omits the
+    // id, is not a delivery target. Without anchoring, an attacker-ish or
+    // fat-fingered value could slip through the guard while 404ing in delivery.
+    const nearMisses = [
+      '/api/stylesheet/author-stylesheet//css',
+      '/api/stylesheet/author-stylesheet/abc/css',
+      '/api/stylesheet/author-stylesheet/7/css/extra',
+      'https://evil.test/api/stylesheet/author-stylesheet/7/css',
+      '/api/stylesheet/author-stylesheet/7'
+    ];
+    for (const cssUrl of nearMisses) {
+      expect(rowsOutsideDeliveryPartition([row('x', cssUrl)])).toHaveLength(1);
+    }
+  });
+
+  it('extracts the AuthorStylesheet id from a delivery target', () => {
+    expect(
+      authorStylesheetIdFromCssUrl('/api/stylesheet/author-stylesheet/42/css')
+    ).toBe(42);
+    expect(authorStylesheetIdFromCssUrl(null)).toBeNull();
+    expect(
+      authorStylesheetIdFromCssUrl('/stylesheets/foo/style.css')
+    ).toBeNull();
+  });
+
+  it('the route pattern is anchored', () => {
+    expect(CSS_DELIVERY_ROUTE.source.startsWith('^')).toBe(true);
+    expect(CSS_DELIVERY_ROUTE.source.endsWith('$')).toBe(true);
+  });
+});

--- a/src/modules/stylesheetRegistry.ts
+++ b/src/modules/stylesheetRegistry.ts
@@ -1,0 +1,66 @@
+/**
+ * The site-registry delivery partition (ADR-0024 §4, #371).
+ *
+ * Every `Stylesheet` row is exactly one of two things:
+ *
+ *   - **`/css`-backed** — `cssUrl` names an `AuthorStylesheet` delivery target,
+ *     and the stored row is canonical.
+ *   - **null `cssUrl`** — the row has no delivery target. It appears in the
+ *     picker and renders nothing (this is Sublime: the bundled Tailwind already
+ *     *is* Sublime, so there is nothing to inject).
+ *
+ * Nothing else is legal. In particular a row may not point into stellar-ui's
+ * retired `/stylesheets/…` static tree: ADR-0024 said "the stored row is
+ * canonical, no silent duplicate" and nothing enforced it, so `anorex`, `kuro`
+ * and `layer-cake` moved to api delivery while their ui static files kept
+ * shipping to every user, referenced by nothing.
+ *
+ * Expressed as a **total** partition rather than a carve-out on purpose. The
+ * nullable `cssUrl` is what makes that expressible without an exception list —
+ * and an exception list is exactly where the next `proton` would hide. If you
+ * find yourself wanting a `name !== 'sublime'` escape hatch here, the nullable
+ * migration has not landed properly.
+ *
+ * Known seam, deliberately not oversold: this is **not** cross-repo. The api
+ * cannot see stellar-ui's `src/stylesheets/` tree, so someone adding a static
+ * theme directory without touching the api still fails silently here. The ui
+ * half is its own exact-set guard (stellar-ui `stylesheetsDir.test.ts`, #167/#168).
+ */
+
+/**
+ * The `/css` delivery route. Anchored at both ends: a value that merely
+ * *contains* the route is not a delivery target, and treating it as one would
+ * let the guard pass on a URL that 404s in delivery.
+ */
+export const CSS_DELIVERY_ROUTE =
+  /^\/api\/stylesheet\/author-stylesheet\/(\d+)\/css$/;
+
+/** The registry columns the partition is defined over. */
+export interface RegistryDeliveryRow {
+  name: string;
+  cssUrl: string | null;
+}
+
+/**
+ * The `AuthorStylesheet` id a delivery target names, or `null` when `cssUrl`
+ * is not one (including the legal null-delivery case).
+ */
+export const authorStylesheetIdFromCssUrl = (
+  cssUrl: string | null
+): number | null => {
+  if (cssUrl === null) return null;
+  const match = CSS_DELIVERY_ROUTE.exec(cssUrl);
+  return match ? Number(match[1]) : null;
+};
+
+/** True when the row sits in one of the two legal arms. */
+export const isInDeliveryPartition = (row: RegistryDeliveryRow): boolean =>
+  row.cssUrl === null || CSS_DELIVERY_ROUTE.test(row.cssUrl);
+
+/**
+ * Every row outside the partition. Returns *all* offenders rather than the
+ * first, so a sweep reports the whole set instead of one row per CI run.
+ */
+export const rowsOutsideDeliveryPartition = <T extends RegistryDeliveryRow>(
+  rows: T[]
+): T[] => rows.filter((row) => !isInDeliveryPartition(row));

--- a/src/modules/stylesheetRegistry.ts
+++ b/src/modules/stylesheetRegistry.ts
@@ -20,10 +20,19 @@
  * `proton` would hide. A `name !== 'sublime'` escape hatch here means the
  * nullable migration has not landed properly.
  *
- * Not cross-repo. The api cannot see stellar-ui's `src/stylesheets/` tree, so
- * adding a static theme directory without touching the api still fails silently
- * here; the ui half is its own exact-set guard (stellar-ui
- * `stylesheetsDir.test.ts`, #167/#168).
+ * Two limits on the guard's reach, both known:
+ *
+ *   - **Not cross-repo.** The api cannot see stellar-ui's `src/stylesheets/`
+ *     tree, so adding a static theme directory without touching the api still
+ *     fails silently here; the ui half is its own exact-set guard (stellar-ui
+ *     `stylesheetsDir.test.ts`, #167/#168).
+ *   - **Migration-planted rows are out of reach.** The integration guard runs
+ *     after `truncateAll()`, so it only ever inspects rows the test seeds — not
+ *     the registry a real `prisma migrate deploy` produces. `postmod` is
+ *     currently outside the partition on a live DB (`/stylesheets/postmod/…`,
+ *     ADR-0024's "Live; gated on #343") and no guard sees it. Tighten this once
+ *     #343 retires that row, at which point the partition becomes true of the
+ *     shipped registry rather than only the seeded one.
  */
 
 /**

--- a/src/modules/stylesheetRegistry.ts
+++ b/src/modules/stylesheetRegistry.ts
@@ -15,16 +15,15 @@
  * and `layer-cake` moved to api delivery while their ui static files kept
  * shipping to every user, referenced by nothing.
  *
- * Expressed as a **total** partition rather than a carve-out on purpose. The
- * nullable `cssUrl` is what makes that expressible without an exception list —
- * and an exception list is exactly where the next `proton` would hide. If you
- * find yourself wanting a `name !== 'sublime'` escape hatch here, the nullable
- * migration has not landed properly.
+ * Total partition, not a carve-out: the nullable `cssUrl` is what makes it
+ * expressible without an exception list, and an exception list is where the next
+ * `proton` would hide. A `name !== 'sublime'` escape hatch here means the
+ * nullable migration has not landed properly.
  *
- * Known seam, deliberately not oversold: this is **not** cross-repo. The api
- * cannot see stellar-ui's `src/stylesheets/` tree, so someone adding a static
- * theme directory without touching the api still fails silently here. The ui
- * half is its own exact-set guard (stellar-ui `stylesheetsDir.test.ts`, #167/#168).
+ * Not cross-repo. The api cannot see stellar-ui's `src/stylesheets/` tree, so
+ * adding a static theme directory without touching the api still fails silently
+ * here; the ui half is its own exact-set guard (stellar-ui
+ * `stylesheetsDir.test.ts`, #167/#168).
  */
 
 /**
@@ -54,7 +53,7 @@ export const authorStylesheetIdFromCssUrl = (
 };
 
 /** True when the row sits in one of the two legal arms. */
-export const isInDeliveryPartition = (row: RegistryDeliveryRow): boolean =>
+const isInDeliveryPartition = (row: RegistryDeliveryRow): boolean =>
   row.cssUrl === null || CSS_DELIVERY_ROUTE.test(row.cssUrl);
 
 /**

--- a/src/schemas/stylesheet.ts
+++ b/src/schemas/stylesheet.ts
@@ -18,10 +18,14 @@ export const externalStylesheetUrl = z
   .optional()
   .or(z.literal(''));
 
+// `cssUrl: null` is the explicit "this row has no delivery target" value — it
+// appears in the picker and renders nothing (ADR-0024 §3/§4, #371). Nullable
+// rather than merely optional, so an admin can CLEAR a target on update; a
+// missing key means "leave unchanged", which is a different intent.
 export const stylesheetSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional().default(''),
-  cssUrl: z.string().min(1, 'CSS URL is required'),
+  cssUrl: z.string().min(1, 'CSS URL is required').nullable(),
   isDefault: z.boolean().optional().default(false)
 });
 
@@ -30,7 +34,7 @@ export const stylesheetUpdateSchema = z
   .object({
     name: z.string().min(1).optional(),
     description: z.string().optional(),
-    cssUrl: z.string().min(1, 'CSS URL is required').optional(),
+    cssUrl: z.string().min(1, 'CSS URL is required').nullable().optional(),
     isDefault: z.boolean().optional()
   })
   .refine(


### PR DESCRIPTION
Implements ADR-0024 §3/§4. Closes #371. Unblocks stellar-ui #196.

## 1. `Stylesheet.cssUrl` becomes nullable

`null` means the row has **no delivery target** — it appears in the picker and renders nothing.

Sublime is that case. Its look *is* the bundled Tailwind, so there was never anything to inject, and the `/stylesheets/sublime/style.css` it carried pointed into stellar-ui's retired static tree and was requested by nothing. It keeps `isDefault` and its picker entry.

This is what lets the ui branch on **data** instead of on a name — retiring the cross-repo magic string in `StylesheetInjector.tsx:61` (`siteAppearance === 'sublime'`). That's ui #196, which #371 records as hard-blocked on this landing.

## 2. The guard becomes a total partition

Every registry row is `/css`-backed **or** has a null `cssUrl`. Nothing else is legal.

The old guard asserted only the forward direction — that `/css`-backed rows resolve — so a row pointing *outside* the api was invisible to it. That is exactly how `anorex`/`kuro`/`layer-cake` moved to api delivery while their stellar-ui static files kept shipping to every user, referenced by nothing.

The nullable column is what makes this expressible without an exception list, per the ADR: **no `name !== 'sublime'` carve-out**, because an exception list is where the next `proton` would hide.

The predicate lives in a new pure module (`src/modules/stylesheetRegistry.ts`) so the illegal shapes can be enumerated directly rather than round-tripped through a DB; the integration test applies that same predicate to real seeded rows.

## Negative controls

Both observed failing before being relied on:

| Injected fault | Result |
| --- | --- |
| Seeded a row at `/stylesheets/foo/style.css` | guard reports it as the sole offender (kept as a test — #371 asks for exactly this) |
| Made the seeder write `/stylesheets/kuro/style.css` for one fixture | the total-partition assertion fails on real seeded drift, proving it is not vacuous |

Full suite 103 suites / 1871 tests; `stylesheetRegistry.integration.ts` 8/8; `tsc --noEmit`, `typecheck:test` and `lint` clean; `openapi.json` regenerated.

## A regression caught in review, and fixed

The first cut of the migration nulled `WHERE "cssUrl" LIKE '/stylesheets/%'`. That also matches **`postmod`** — ADR-0024's drift table records it as *"Live; gated on #343"*. It is planted by `20260524200000_add_legacy_stylesheets`, is **not** a seeded fixture, and stellar-ui still serves it from its `CopyPlugin` tree, so the broad form would have silently unstyled every user who selected it, ahead of the migration meant to move it.

Now scoped to `sublime` and its exact dead path. The other legacy rows (`kuro`, `layer-cake`, `anorex`, `dark-ambient`, `proton`) are fixtures — `seedStylesheetFixtures` reconciles each to its `/css` target on the next seed — so they need no data migration.

Verified against a real registry rather than only the truncated test DB, since `truncateAll()` means the integration suite structurally cannot reach the migration's data path:

| Row | Before | After (scoped migration) |
| --- | --- | --- |
| `sublime` | `/stylesheets/sublime/style.css` | **NULL** |
| `postmod` | `/stylesheets/postmod/style.css` | untouched |
| `proton` | `/api/…/11/css` | untouched |
| operator-repointed row | `/api/…/99/css` | untouched |

Idempotent across re-apply.

## Known gap — the guard is narrower than #371's wording

Recorded rather than oversold, in the module, the integration header, and a dated ADR-0024 amendment.

#371 says a future row pointing at `/stylesheets/anything` *"fails CI on the way in"*. Implementing it established that this holds for **seeded** rows only: the integration guard truncates in `beforeEach`, so it never inspects the registry a real `prisma migrate deploy` produces. A SQL data migration inserting such a row still passes CI — the same vector that produced the amendment in the first place.

**`postmod` is that case today**, so a live registry is not yet a total partition and nothing reports it. Accepted deliberately: excluding it by name would be the exception list §4 exists to avoid, and failing CI until #343 clears would block unrelated work behind a licensing decision. #343 retires `postmod`, at which point the partition becomes true of the shipped registry and the guard can be extended to run against a migrated database.

## Out of scope, ticketed

- **#375** — the write path (`POST`/`PUT /api/stylesheet`) accepts a null `cssUrl` but does not enforce the partition at runtime, so a strict-admin can still create an unservable row.
- **#376** — `getDefaultStylesheetName`'s `?? 'sublime'` fallback, named in #371 as half of the magic-string pair. Retiring it makes `siteAppearance` nullable across three creation paths — materially larger than the delivery contract.

`src/types/api.ts` still declares `cssUrl: string` and is now stale. It is unimported in `src/`, has no generator installed here, and is marked "do not edit by hand"; `openapi.json` and `src/lib/openapi.ts` (the real contract) are both updated. Left for opportunistic regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwfbGBTX7u5HKZ9W2pi3gw