### PR TITLE
ci(publish): skip the publish job on pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,6 +163,12 @@ jobs:
 
   publish:
     needs: [test, integration, smoke]
+    # Skipped on PRs, where every step below was a no-op: the build was discarded
+    # unpushed and the GHCR login bought nothing. This does NOT leave the image
+    # unvalidated pre-merge — `smoke` builds the same Dockerfile on PRs and boots
+    # it against a fresh DB, which is the gap stellar-ui#186 reports on that repo.
+    # Keep `smoke` running on pull_request or this becomes that bug.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -192,6 +198,6 @@ jobs:
         with:
           context: .
           provenance: false
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes #380.

On a pull request the `publish` job logged into GHCR, built the image, and discarded it — `push:` was already gated to non-PR events. Cost without benefit on every PR, docs-only ones included.

This gates the job itself rather than the push step:

```yaml
publish:
  needs: [test, integration, smoke]
  if: github.event_name != 'pull_request'
```

## Why this isn't stellar-ui#186

[ui#186](https://github.com/orphic-inc/stellar-ui/issues/186) asks for the *opposite* on that repo: its publish job skips on PRs, so the Dockerfile build is never validated pre-merge. The reason that argument doesn't transfer is `smoke`, which runs on `pull_request` with no `if:` and does a full `docker build`, then boots the image against a fresh Postgres and asserts migrations applied and ranks seeded.

So the Dockerfile is still validated before merge — by the job that also proves the image runs, which is more than publish's discarded build ever proved. The `if:` carries a comment recording this, including "keep `smoke` running on pull_request or this becomes that bug."

Anyone porting this to stellar-ui should copy the pairing, not just the `if:` — that repo has no `smoke` job, so the gate alone would implement ui#186 rather than fix it.

## Not included: a `paths:` filter

Skipping the expensive jobs on docs-only PRs is the obvious companion change and is a trap. Branch protection requires `test` and `integration`; a required check suppressed by a `paths:` filter never reports, so a docs-only PR would block forever. Doing it safely needs a skip-shim reporting the same context names, or a filter scoped to only the non-required jobs. Out of scope here, documented in #380.

Neither `publish` nor `smoke` is a required check (`required_checks: ["test","integration"]`), so this change cannot hang a PR.

## Verification

- YAML parses; `publish.if` resolves as intended and `smoke` confirmed to carry no `if:`.
- Expected effect on this PR's own check list: `test`, `integration`, `smoke` run; `publish` shows as skipped — which is the change working.
- Publish behaviour on `main`, `v*` tags, and `workflow_dispatch` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwfbGBTX7u5HKZ9W2pi3gw
