### PR TITLE
fix(stylesheets): enforce the delivery partition on the write path

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8251,7 +8251,7 @@
                   "cssUrl": {
                     "type": "string",
                     "nullable": true,
-                    "minLength": 1
+                    "pattern": "^\\/api\\/stylesheet\\/author-stylesheet\\/(\\d+)\\/css$"
                   },
                   "isDefault": {
                     "type": "boolean",
@@ -8380,7 +8380,7 @@
                   "cssUrl": {
                     "type": "string",
                     "nullable": true,
-                    "minLength": 1
+                    "pattern": "^\\/api\\/stylesheet\\/author-stylesheet\\/(\\d+)\\/css$"
                   },
                   "isDefault": {
                     "type": "boolean"

--- a/src/modules/stylesheet.ts
+++ b/src/modules/stylesheet.ts
@@ -1,8 +1,44 @@
 import { PrismaClient } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
+import { authorStylesheetIdFromCssUrl } from './stylesheetRegistry';
 
 type Tx = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0];
+
+/**
+ * The second half of the #375 write-path guard. `schemas/stylesheet.ts` proves a
+ * delivery target is well-formed; only a DB can prove it resolves.
+ *
+ * Both halves are needed. A syntactically perfect target naming an
+ * `AuthorStylesheet` that does not exist produces exactly the failure ADR-0024
+ * set out to end: the row lands in the picker, `/css` 404s, and the member picks
+ * a theme that renders nothing. Shape validation alone would have moved the dead
+ * entry rather than removed it.
+ *
+ * `undefined` is "leave unchanged" on update and is not a target to check — as
+ * distinct from `null`, which is the legal no-delivery arm.
+ */
+const assertDeliveryTargetResolves = async (
+  cssUrl: string | null | undefined
+): Promise<void> => {
+  if (cssUrl === undefined || cssUrl === null) return;
+
+  const authorStylesheetId = authorStylesheetIdFromCssUrl(cssUrl);
+  // Unreachable through the routes — validate() runs the regex first — but this
+  // is also the module's own contract, and createStylesheet is callable directly.
+  if (authorStylesheetId === null)
+    throw new AppError(400, 'CSS URL is not a /css delivery target');
+
+  const target = await prisma.authorStylesheet.findUnique({
+    where: { id: authorStylesheetId },
+    select: { id: true }
+  });
+  if (!target)
+    throw new AppError(
+      400,
+      `CSS URL names authored stylesheet ${authorStylesheetId}, which does not exist`
+    );
+};
 
 export const getDefaultStylesheetName = async (tx?: Tx): Promise<string> => {
   const db = tx ?? prisma;
@@ -37,6 +73,8 @@ export const createStylesheet = async (data: {
   cssUrl: string | null;
   isDefault: boolean;
 }) => {
+  await assertDeliveryTargetResolves(data.cssUrl);
+
   if (data.isDefault) {
     return prisma.$transaction(async (tx) => {
       await tx.stylesheet.updateMany({
@@ -60,6 +98,8 @@ export const updateStylesheet = async (
 ) => {
   const existing = await prisma.stylesheet.findUnique({ where: { id } });
   if (!existing) throw new AppError(404, 'Stylesheet not found');
+
+  await assertDeliveryTargetResolves(data.cssUrl);
 
   if (data.isDefault) {
     return prisma.$transaction(async (tx) => {

--- a/src/schemas/stylesheet.ts
+++ b/src/schemas/stylesheet.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { CSS_DELIVERY_ROUTE } from '../modules/stylesheetRegistry';
 
 // The Personal source (ADR-0024 §3): a self-hosted external stylesheet URL.
 // `https:` only, end to end — `.url()` alone admits `ftp:`/`javascript:`, valid
@@ -22,10 +23,27 @@ export const externalStylesheetUrl = z
 // appears in the picker and renders nothing (ADR-0024 §3/§4, #371). Nullable
 // rather than merely optional, so an admin can CLEAR a target on update; a
 // missing key means "leave unchanged", which is a different intent.
+//
+// The non-null arm is the delivery partition, enforced here on the way in (#375)
+// and not only by the CI sweep — which reads rows the integration test seeds and
+// so never saw what this endpoint accepted. Shares CSS_DELIVERY_ROUTE with that
+// sweep deliberately: two encodings of "in the partition" is the drift this
+// whole area keeps producing.
+//
+// Shape only. That a target is well-formed does not mean the AuthorStylesheet it
+// names exists — modules/stylesheet.ts checks that, where there is a DB.
+const registryCssUrl = z
+  .string()
+  .regex(
+    CSS_DELIVERY_ROUTE,
+    'CSS URL must be an /api/stylesheet/author-stylesheet/{id}/css delivery target, or null'
+  )
+  .nullable();
+
 export const stylesheetSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional().default(''),
-  cssUrl: z.string().min(1, 'CSS URL is required').nullable(),
+  cssUrl: registryCssUrl,
   isDefault: z.boolean().optional().default(false)
 });
 
@@ -34,7 +52,7 @@ export const stylesheetUpdateSchema = z
   .object({
     name: z.string().min(1).optional(),
     description: z.string().optional(),
-    cssUrl: z.string().min(1, 'CSS URL is required').nullable().optional(),
+    cssUrl: registryCssUrl.optional(),
     isDefault: z.boolean().optional()
   })
   .refine(

--- a/src/stylesheet.spec.ts
+++ b/src/stylesheet.spec.ts
@@ -8,15 +8,26 @@ import {
 
 beforeEach(() => resetApiTestState());
 
+// A well-formed delivery target — the only non-null shape the registry accepts
+// (ADR-0024 §4, enforced on the write path by #375).
+const DELIVERY_URL = '/api/stylesheet/author-stylesheet/7/css';
+
+// Sublime carries `cssUrl: null`: the bundled Tailwind already is Sublime, so
+// there is no target to deliver. That is the partition's other legal arm, not a
+// missing value.
 const makeStylesheet = (overrides = {}) => ({
   id: 1,
   name: 'sublime',
   description: 'Default Stellar theme',
-  cssUrl: '/stylesheets/sublime/style.css',
+  cssUrl: null,
   isDefault: true,
   createdAt: new Date('2026-01-01'),
   ...overrides
 });
+
+/** The `AuthorStylesheet` a delivery target names, present by default. */
+const mockDeliveryTargetExists = (id = 7) =>
+  prismaMock.authorStylesheet.findUnique.mockResolvedValue({ id } as never);
 
 // ─── GET /api/stylesheet ──────────────────────────────────────────────────────
 
@@ -135,16 +146,22 @@ describe('POST /api/stylesheet', () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ admin: true })
     );
+    mockDeliveryTargetExists();
   });
 
   it('creates a stylesheet and returns 201', async () => {
     prismaMock.stylesheet.create.mockResolvedValue(
-      makeStylesheet({ id: 3, name: 'custom', isDefault: false }) as never
+      makeStylesheet({
+        id: 3,
+        name: 'custom',
+        cssUrl: DELIVERY_URL,
+        isDefault: false
+      }) as never
     );
 
     const res = await request(app).post('/api/stylesheet').send({
       name: 'custom',
-      cssUrl: '/stylesheets/custom/style.css',
+      cssUrl: DELIVERY_URL,
       description: 'Custom'
     });
 
@@ -154,12 +171,26 @@ describe('POST /api/stylesheet', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           name: 'custom',
-          cssUrl: '/stylesheets/custom/style.css',
+          cssUrl: DELIVERY_URL,
           description: 'Custom',
           isDefault: false
         })
       })
     );
+  });
+
+  it('creates a no-delivery row when cssUrl is null', async () => {
+    prismaMock.stylesheet.create.mockResolvedValue(
+      makeStylesheet({ id: 3, name: 'custom', isDefault: false }) as never
+    );
+
+    const res = await request(app)
+      .post('/api/stylesheet')
+      .send({ name: 'custom', cssUrl: null });
+
+    expect(res.status).toBe(201);
+    // The null arm must not be mistaken for a target and looked up.
+    expect(prismaMock.authorStylesheet.findUnique).not.toHaveBeenCalled();
   });
 
   it('clears existing default when creating with isDefault: true', async () => {
@@ -169,7 +200,7 @@ describe('POST /api/stylesheet', () => {
 
     const res = await request(app).post('/api/stylesheet').send({
       name: 'custom',
-      cssUrl: '/stylesheets/custom/style.css',
+      cssUrl: DELIVERY_URL,
       isDefault: true
     });
 
@@ -187,11 +218,47 @@ describe('POST /api/stylesheet', () => {
     expect(res.status).toBe(400);
   });
 
+  // ─── the #375 write-path partition guard ───────────────────────────────────
+
+  it('rejects a cssUrl pointing into the retired ui static tree', async () => {
+    const res = await request(app)
+      .post('/api/stylesheet')
+      .send({ name: 'custom', cssUrl: '/stylesheets/custom/style.css' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors.cssUrl).toBeDefined();
+    expect(prismaMock.stylesheet.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cssUrl that merely contains the delivery route', async () => {
+    const res = await request(app).post('/api/stylesheet').send({
+      name: 'custom',
+      cssUrl: 'https://evil.example/api/stylesheet/author-stylesheet/7/css'
+    });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.stylesheet.create).not.toHaveBeenCalled();
+  });
+
+  // Shape is not resolution: a well-formed target naming a sheet that does not
+  // exist is the same dead picker entry, so the module checks the DB too.
+  it('rejects a well-formed target whose authored stylesheet does not exist', async () => {
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/stylesheet')
+      .send({ name: 'custom', cssUrl: DELIVERY_URL });
+
+    expect(res.status).toBe(400);
+    expect(res.body.msg).toMatch(/does not exist/);
+    expect(prismaMock.stylesheet.create).not.toHaveBeenCalled();
+  });
+
   it('returns 403 without admin permission', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(makeUserRank());
     const res = await request(app)
       .post('/api/stylesheet')
-      .send({ name: 'custom', cssUrl: '/stylesheets/custom/style.css' });
+      .send({ name: 'custom', cssUrl: DELIVERY_URL });
     expect(res.status).toBe(403);
   });
 
@@ -201,7 +268,7 @@ describe('POST /api/stylesheet', () => {
     );
     const res = await request(app)
       .post('/api/stylesheet')
-      .send({ name: 'custom', cssUrl: '/stylesheets/custom/style.css' });
+      .send({ name: 'custom', cssUrl: DELIVERY_URL });
     expect(res.status).toBe(403);
   });
 });
@@ -213,6 +280,7 @@ describe('PUT /api/stylesheet/:id', () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ admin: true })
     );
+    mockDeliveryTargetExists();
   });
 
   it('updates a stylesheet and returns 200', async () => {
@@ -267,6 +335,75 @@ describe('PUT /api/stylesheet/:id', () => {
   it('returns 400 when body is empty', async () => {
     const res = await request(app).put('/api/stylesheet/1').send({});
     expect(res.status).toBe(400);
+  });
+
+  // ─── the #375 write-path partition guard ───────────────────────────────────
+
+  it('rejects an update moving a row outside the partition', async () => {
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet() as never
+    );
+
+    const res = await request(app)
+      .put('/api/stylesheet/1')
+      .send({ cssUrl: '/stylesheets/custom/style.css' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors.cssUrl).toBeDefined();
+    expect(prismaMock.stylesheet.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects an update to a target that does not resolve', async () => {
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet() as never
+    );
+    prismaMock.authorStylesheet.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/stylesheet/1')
+      .send({ cssUrl: DELIVERY_URL });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.stylesheet.update).not.toHaveBeenCalled();
+  });
+
+  // Explicit null clears a target; omitting the key leaves it unchanged. The
+  // schema has to keep those distinguishable, hence nullable AND optional.
+  it('accepts an explicit null cssUrl, clearing the delivery target', async () => {
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet({ cssUrl: DELIVERY_URL }) as never
+    );
+    prismaMock.stylesheet.update.mockResolvedValue(
+      makeStylesheet({ cssUrl: null }) as never
+    );
+
+    const res = await request(app)
+      .put('/api/stylesheet/1')
+      .send({ cssUrl: null });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stylesheet.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ cssUrl: null })
+      })
+    );
+  });
+
+  it('leaves an existing target alone when cssUrl is omitted', async () => {
+    prismaMock.stylesheet.findUnique.mockResolvedValue(
+      makeStylesheet({ cssUrl: DELIVERY_URL }) as never
+    );
+    prismaMock.stylesheet.update.mockResolvedValue(
+      makeStylesheet({ cssUrl: DELIVERY_URL }) as never
+    );
+
+    const res = await request(app)
+      .put('/api/stylesheet/1')
+      .send({ description: 'Updated' });
+
+    expect(res.status).toBe(200);
+    // "Leave unchanged" is not a target to validate.
+    expect(prismaMock.authorStylesheet.findUnique).not.toHaveBeenCalled();
   });
 
   it('returns 403 without admin permission', async () => {


### PR DESCRIPTION
Closes #375.

ADR-0024 §4 defines a total partition over registry rows — `/css`-backed or null `cssUrl`, nothing else. #371 defined it and guarded it in CI, but that guard truncates and re-seeds, so it only ever inspected rows the test wrote. It never saw what the endpoint accepted, and the endpoint accepted anything:

```ts
cssUrl: z.string().min(1, 'CSS URL is required').nullable()
```

A strict-admin could still create a row pointing at the retired `/stylesheets/…` tree. It lands in the picker and renders nothing — the dead-entry failure the ADR set out to end.

## Two layers, because one doesn't cover it

**Shape** (`schemas/stylesheet.ts`) — reuses `CSS_DELIVERY_ROUTE` from the CI sweep rather than restating the pattern. Two independent encodings of "in the partition" is precisely the drift this area keeps producing, so there is one. Yields a field-level `{ errors: { cssUrl: [...] } }` 400.

**Resolution** (`modules/stylesheet.ts`) — a *well-formed* target naming an `AuthorStylesheet` that doesn't exist is the same dead picker entry. Shape validation alone would have moved the failure, not removed it. Only a DB can answer that, so it lives in the module and throws `AppError(400, …)`.

`undefined` (leave unchanged) stays distinct from `null` (clear the target) on update; neither is looked up.

## Why strict rejection, and not options 2 or 3

The issue asked to check what the ui admin manager does before choosing, and flagged that strict rejection "may make the admin stylesheet-manager's create form effectively useless."

**There is no create form.** `stellar-ui/src/components/admin/StylesheetManager.tsx` is read-mostly: its only mutation is `updateStylesheet({ id, isDefault: true })`, `cssUrl` is a display-only table cell, and `createStylesheet`/POST is not exposed in `siteApi.ts` at all. The objection that made option 1 expensive was a form that does not exist, so it costs nothing. Full evidence in [the issue comment](https://github.com/orphic-inc/stellar-api/issues/375#issuecomment-5029223160).

Option 2 (resolve an `AuthorStylesheet` id server-side, so an admin picks a sheet rather than typing a URL) stays a coherent future feature — it is a nicer surface, not a prerequisite for closing this gap.

## Scope

Unchanged and still documented in `stylesheetRegistry.ts`: **migration-planted rows bypass this path entirely.** A SQL data migration inserting a `/stylesheets/…` row is still invisible to both the write guard and the CI sweep — `postmod` is that case today, gated on #343. This closes the runtime write path, not that hole.

`openapi.json` is regenerated: the partition is now part of the published contract, so stellar-ui's generated types inherit the constraint.

## Verification

- `npm test` — 1879 passed, 103 suites.
- `npm run lint`, `npx tsc --noEmit`, `npm run typecheck:test` — clean.
- `src/stylesheet.spec.ts` grew 8 cases: rejection of the retired static tree, rejection of a URL that merely *contains* the route, rejection of a dangling target, acceptance of null on both create and update, and confirmation that an omitted `cssUrl` is not looked up.
- Pre-existing fixtures updated: they seeded `cssUrl: '/stylesheets/sublime/style.css'`, which this now rejects. Sublime's fixture is `null`, which is what the row actually carries after #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwfbGBTX7u5HKZ9W2pi3gw
