### PR TITLE
ci(release): create GitHub Releases from the CHANGELOG on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,6 +163,12 @@ jobs:
 
   publish:
     needs: [test, integration, smoke]
+    # Skipped on PRs, where every step below was a no-op: the build was discarded
+    # unpushed and the GHCR login bought nothing. This does NOT leave the image
+    # unvalidated pre-merge — `smoke` builds the same Dockerfile on PRs and boots
+    # it against a fresh DB, which is the gap stellar-ui#186 reports on that repo.
+    # Keep `smoke` running on pull_request or this becomes that bug.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -192,6 +198,6 @@ jobs:
         with:
           context: .
           provenance: false
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,3 +201,47 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Tagging alone does not produce a GitHub Release, and creating one by hand was
+  # a habit rather than a step — it lapsed after v0.5.6, which then sat advertised
+  # as "Latest" on the repo page through nine subsequent versions. Automated here
+  # so the tag is the only manual act.
+  #
+  # `needs: [publish]` deliberately: a Release announces an artifact, so it must
+  # not exist for a version whose image never reached GHCR.
+  release:
+    needs: [publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Create the Release from its CHANGELOG section
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          # Headings are `## [x.y.z] — date`, but older ones use a hyphen instead
+          # of an em dash, so match the bracketed version and nothing after it.
+          # Dots are escaped or `0.8.1` would also match `0x8y1`.
+          notes="$(awk -v ver="$version" '
+            BEGIN { gsub(/\./, "\\.", ver) }
+            $0 ~ "^## \\[" ver "\\]" { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md)"
+          # Fail loudly rather than publishing an empty Release: a missing section
+          # means the CHANGELOG was not updated for this tag, which is worth
+          # knowing at release time.
+          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            echo "::error::No CHANGELOG.md section found for $version"
+            exit 1
+          fi
+          printf '%s\n' "$notes" > "$RUNNER_TEMP/notes.md"
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file "$RUNNER_TEMP/notes.md"


### PR DESCRIPTION
**Stacked on #381** — it contains that commit too, since both touch the tail of `publish.yml`. Merge #381 first and this reduces to the single `release` job.

## The gap

Tagging never produced a GitHub Release. No workflow created one, and the manual habit lapsed after v0.5.6 — so **nine tags have no Release** (v0.6.0, v0.6.1, v0.6.2, v0.6.3, v0.6.4, v0.6.9, v0.7.0, v0.8.0, v0.8.1).

The visible cost is worse than an unused surface: the repo page still advertises **v0.5.6 as "Latest"**, a month stale and nine versions behind, with v0.5.5 beside it marked "Pre-release". Anyone landing on the repo — or looking for a changelog anchor for a GHCR image tag — is told the current version is 0.5.6.

## The job

Runs on `refs/tags/v*` only, after `publish`. Notes are extracted from the tag's `CHANGELOG.md` section, so they keep a single source instead of being retyped into a second surface.

Three decisions worth surfacing:

- **`needs: [publish]`** — a Release announces an artifact, so it must not exist for a version whose image never reached GHCR. A failed publish now means no tag Release, which is the correct loud failure.
- **A missing CHANGELOG section fails the job** rather than publishing an empty Release. An absent section means the CHANGELOG wasn't updated for the tag; that is worth learning at release time, not from the Releases page later.
- **`gh` CLI, not a release action** — one API call doesn't justify pinning another third-party action in a workflow that otherwise SHA-pins everything.

The awk matcher handles both heading styles in the file (`## [0.8.1] — date` with an em dash, `## [0.5.6] - date` with a hyphen) by matching only the bracketed version, and escapes dots so `0.8.1` can't match `0x8y1`.

## Verification

Extraction was run locally against the real `CHANGELOG.md` before being committed:

| version | extracted |
|---|---|
| 0.8.1 | 708 chars |
| 0.6.9 | 1708 chars |
| 0.6.2 | 3088 chars |
| 0.5.6 | 1208 chars (hyphen heading) |
| 9.9.9 | 0 — the guard fires |

YAML parses; `release.needs=["publish"]`, `if=startsWith(github.ref, 'refs/tags/v')`, `permissions.contents=write`.

Note this job cannot run until a tag is pushed, so CI on this PR proves only that the workflow parses and the other jobs are unaffected. The first real exercise is the next release.

## Not included

The nine historical Releases — backfilled separately, since that's a one-time data operation rather than a workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwfbGBTX7u5HKZ9W2pi3gw
