### PR TITLE
fix(openapi): setupChecklist is {id,message}[], not string[] — and a release runbook

### DIFF
--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -1,0 +1,60 @@
+# Runbook — cut a release
+
+How a stellar-api version gets from `main` to a published image and a GitHub Release. The pipeline ends at publish ([ADR-0027](../adr/0027-publish-vs-deploy-boundary.md)) — promoting an image into an environment is stellar-compose's job and is deliberately outside this document.
+
+Written because the sequence has a trap that has already cost a failed CI run and a force-push, and until now that lesson lived only in a sweep ledger marked for deletion.
+
+## The ordering trap — read this first
+
+**Bump `package.json`, then regenerate `openapi.json`, then commit.** In that order.
+
+`openapi.json` embeds `info.version`, sourced from `package.json`. Running `npm run openapi:export` _before_ the version bump writes the **old** version into the spec, and the OpenAPI-freshness gate in CI then fails on a one-line diff nobody expects — the change looks unrelated to the release. This is what broke the first CI run on PR #311 during the v0.6.9 cut.
+
+The same applies to any release-adjacent regeneration: the manifest is the source, so it moves first.
+
+## What is automated and what is not
+
+| Step                                                 | Who                                                 |
+| ---------------------------------------------------- | --------------------------------------------------- |
+| Full gate (lint, types, unit, integration) on the PR | CI — required checks `test` and `integration`       |
+| Image build + boot-and-migrate verification          | CI — `smoke`, runs on PRs, **not** a required check |
+| GHCR push on a `v*` tag                              | CI — `publish`, skipped on PRs                      |
+| GitHub Release from the CHANGELOG section            | CI — `release`, tag-only, `needs: [publish]`        |
+| CHANGELOG accuracy                                   | **You.** Nothing checks it — see below              |
+| Choosing the version and pushing the tag             | **You**                                             |
+
+## The CHANGELOG is load-bearing output
+
+Since the `release` job landed, the tag's `## [x.y.z]` section **is** the published Release notes. A thin section is no longer a thin file in the repo; it is thin public notes on the surface people see first.
+
+Nothing enforces this. `npm run version:check` compares the top **dated** heading against the manifest and never inspects `[Unreleased]`, so unrecorded work accumulates silently between cuts — 20 commits did exactly that between v0.8.1 and this runbook. **Hand-diff `[Unreleased]` against `git log <last-tag>..main` as part of every cut.**
+
+If the section for the tag is missing entirely, the `release` job fails rather than publishing an empty Release. That is deliberate: a missing section means the CHANGELOG was not updated, which is worth learning at release time.
+
+## Procedure
+
+1. **Reconcile the CHANGELOG.** `git log v<last>..main --oneline`, and hand-diff against `[Unreleased]`. Verify any `docs/` links resolve — a wrong ADR filename ships as a broken link in the Release notes.
+2. **Rename `[Unreleased]`** to `## [x.y.z] — YYYY-MM-DD` and open a fresh empty `[Unreleased]`. Add the compare-link footer entry.
+3. **Bump the manifest** — `npm version <x.y.z> --no-git-tag-version` (updates `package.json` and `package-lock.json`).
+4. **Regenerate `openapi.json`** — `npm run openapi:export`. Order matters; see the trap above.
+5. **Commit all of it together**, then open a PR into `upstream/main`.
+6. **Verify CI is green**, including the freshness gates (`openapi.json`, `docs/erd.md`) and `version:check`.
+7. **Merge**, then tag the merge commit on upstream:
+
+   ```bash
+   git fetch upstream
+   git tag -a v<x.y.z> -m "v<x.y.z>" <merge-sha>
+   git push upstream v<x.y.z>
+   ```
+
+8. **Watch the tag run.** It should go `test` + `integration` → `smoke` → `publish` → `release`. Confirm the image is on GHCR and the Release exists with the right notes.
+
+## Do not push tags to the fork
+
+Actions are enabled on `obrien-k/stellar-api`, so a `v*` tag pushed to `origin` triggers the same workflow there: a stray image under `ghcr.io/obrien-k/…` and, since the `release` job landed, a Release on the fork. Tag parity buys nothing — the fork is not a release surface. Tag `upstream` only.
+
+## If something goes wrong
+
+- **Freshness gate fails on a one-line `openapi.json` version diff** — the ordering trap. Regenerate after the bump and amend.
+- **`release` fails, `publish` succeeded** — the image is published but the Release is missing. Re-run the job, or create it by hand from the CHANGELOG section; nothing needs reverting.
+- **`publish` fails** — no image and, because `release` needs it, no Release. The tag still exists; fix forward and re-run rather than deleting a pushed tag.

--- a/openapi.json
+++ b/openapi.json
@@ -6060,7 +6060,19 @@
                     "setupChecklist": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "message"
+                        ]
                       }
                     }
                   },

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -280,8 +280,15 @@ registry.registerPath({
           schema: z.object({
             installed: z.boolean(),
             registrationStatus: z.enum(['open', 'invite', 'closed']),
+            // Asymmetric on purpose (#333): the handler flattens configWarnings
+            // to `.message`, but setupChecklist keeps its `id` because that is
+            // what a dismissal writes to `dismissedLaunchChecklist`. Declaring
+            // both as string[] made generated clients type a field that never
+            // holds strings.
             configWarnings: z.array(z.string()),
-            setupChecklist: z.array(z.string())
+            setupChecklist: z.array(
+              z.object({ id: z.string(), message: z.string() })
+            )
           })
         }
       }


### PR DESCRIPTION
Closes #333. Housekeeping sweep, Phase 9 — a claims-diff finding: the contract and the handler disagreed about a response field.

## The contract fix

`GET /api/install` returns `getSetupChecklist(...)` **unflattened** — `LaunchChecklistItem[]`, i.e. `{ id, message }[]`. `src/lib/openapi.ts` declared `z.array(z.string())`, so every generated client typed a field that never contains a string. stellar-ui has been consuming it wrong.

**The neighbouring `configWarnings` stays `string[]` on purpose.** Its handler *does* flatten: `getConfigWarnings().map((item) => item.message)`. I nearly "fixed" both — that would have broken the contract in the other direction. The asymmetry is real and now carries a comment explaining it: `setupChecklist` keeps its `id` because that is what a dismissal writes to `dismissedLaunchChecklist`.

`openapi.json` regenerated. stellar-ui will pick the corrected shape up on its next `api:sync` — and should, since its current type is wrong.

## Also: docs/runbooks/release.md

There was **no release procedure recorded anywhere** — not in AGENTS.md, CONTRIBUTING.md, or `docs/`. ADR-0027 defines where the pipeline ends but not how to cut.

The one hard-won piece of it survived only in `.sweep-2026-07-09.md`, a sweep ledger whose own header read *"Delete on Phase 10 completion"*:

> **Release-cut lesson: bump package.json → regenerate openapi.json → commit.**

`openapi.json` embeds `info.version` from `package.json`, so exporting *before* the bump writes the old version into the spec and fails the freshness gate on a diff that looks unrelated to the release. That cost a failed CI run and a force-push on PR #311 during the v0.6.9 cut, and was one `rm` from being lost. Recorded in the runbook, then the ledger deleted.

The runbook also pins two things that only became true in the last few days:

- **The CHANGELOG is now published output.** The `release` job reads the tag's section, so a thin section is thin public Release notes. `version:check` never inspects `[Unreleased]`, which is exactly how 20 commits went unrecorded (see #384) — so the hand-diff is written into the procedure.
- **Never push tags to the fork.** Actions are enabled on `obrien-k/stellar-api` (74 runs), so a `v*` tag there would produce a stray `ghcr.io/obrien-k/…` image and, now, a Release on the fork.

## Verification

- `src/install.spec.ts` — 16 passed.
- `openapi.json` diff is exactly the `setupChecklist` items schema; nothing else moved.
- Runbook's ADR link checked to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwfbGBTX7u5HKZ9W2pi3gw
