### PR TITLE
feat(bbcode): parser subsystem + wiki read-time rendering — Phase 1 (#398)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,7 @@ module.exports = {
           '@sentry/node',
           'bcryptjs',
           'express-rate-limit',
+          'isomorphic-dompurify',
           'jest-mock-extended',
           'nodemailer'
         ]

--- a/src/lib/bbcode/bbcode.spec.ts
+++ b/src/lib/bbcode/bbcode.spec.ts
@@ -1,0 +1,308 @@
+import { BBCtx } from './ctx';
+import { parse } from './parse';
+import { render } from './render';
+import { ResolveMaps } from './resolve';
+import { tokenize } from './tokenize';
+
+// Avoid pulling isomorphic-dompurify (jsdom ESM) through index.ts → sanitizeConfig;
+// the escaping done by the emitter is the real defense we assert here, and the
+// server sanitize is a second net exercised at the route/integration level.
+jest.mock('./sanitizeConfig', () => ({ sanitizeBBCode: (v: string) => v }));
+
+// eslint-disable-next-line import/first, @typescript-eslint/no-var-requires
+import { renderBBCode } from './index';
+
+const SITE = 'https://stellar.test';
+
+const emptyMaps = (): ResolveMaps => ({
+  usersById: new Map(),
+  usersByName: new Map(),
+  artistsByName: new Map(),
+  releasesById: new Map(),
+  wikisByRef: new Map(),
+  postsById: new Map()
+});
+
+// The pure pipeline (no DB, no cache, no sanitize) for the non-DB tags.
+const bb = (src: string): string =>
+  render(parse(tokenize(src)), emptyMaps(), {
+    db: {} as BBCtx['db'],
+    siteUrl: SITE
+  });
+
+describe('bbcode — inline formatting', () => {
+  const cases: [string, string, string][] = [
+    [
+      'bold',
+      '[b]This is bold text.[/b]',
+      '<strong>This is bold text.</strong>'
+    ],
+    ['italic', '[i]x[/i]', '<em>x</em>'],
+    ['underline', '[u]x[/u]', '<u>x</u>'],
+    ['strikethrough', '[s]x[/s]', '<s>x</s>'],
+    [
+      'important',
+      '[important]x[/important]',
+      '<span class="bbcode-important">x</span>'
+    ],
+    [
+      'color name',
+      '[color=blue]x[/color]',
+      '<span style="color:blue">x</span>'
+    ],
+    [
+      'color hex',
+      '[color=#0000ff]x[/color]',
+      '<span style="color:#0000ff">x</span>'
+    ],
+    [
+      'colour alias',
+      '[colour=blue]x[/colour]',
+      '<span style="color:blue">x</span>'
+    ],
+    ['size 4', '[size=4]x[/size]', '<span style="font-size:1.35em">x</span>'],
+    [
+      'align center',
+      '[align=center]x[/align]',
+      '<div style="text-align:center">x</div>'
+    ]
+  ];
+  it.each(cases)('%s', (_name, input, expected) => {
+    expect(bb(input)).toBe(expected);
+  });
+
+  it('drops an invalid color value, keeping the text', () => {
+    expect(bb('[color=red;x:url(y)]hi[/color]')).toBe('hi');
+  });
+  it('drops an out-of-range size, keeping the text', () => {
+    expect(bb('[size=99]hi[/size]')).toBe('hi');
+  });
+  it('drops an invalid align, keeping the text', () => {
+    expect(bb('[align=sideways]hi[/align]')).toBe('hi');
+  });
+});
+
+describe('bbcode — headings', () => {
+  it('renders == / === / ==== as h2 / h3 / h4', () => {
+    expect(bb('==Two==')).toBe('<h2>Two</h2>');
+    expect(bb('===Three===')).toBe('<h3>Three</h3>');
+    expect(bb('====Four====')).toBe('<h4>Four</h4>');
+  });
+  it('parses inline BBCode inside a heading', () => {
+    expect(bb('==[b]About[/b]==')).toBe('<h2><strong>About</strong></h2>');
+  });
+});
+
+describe('bbcode — links and images', () => {
+  it('labeled url', () => {
+    expect(bb('[url=https://x.com/]Search[/url]')).toBe(
+      '<a href="https://x.com/" rel="noopener noreferrer" target="_blank">Search</a>'
+    );
+  });
+  it('bare url', () => {
+    expect(bb('[url]https://x.com[/url]')).toBe(
+      '<a href="https://x.com" rel="noopener noreferrer" target="_blank">https://x.com</a>'
+    );
+  });
+  it('auto-links a naked url in flowing text', () => {
+    expect(bb('see https://x.com ok')).toBe(
+      'see <a href="https://x.com" rel="noopener noreferrer" target="_blank">https://x.com</a> ok'
+    );
+  });
+  it('shortens on-site urls to their path and drops target', () => {
+    expect(bb(`[url]${SITE}/wiki/5[/url]`)).toBe(
+      '<a href="https://stellar.test/wiki/5">/wiki/5</a>'
+    );
+  });
+  it('refuses a javascript: url, keeping the label', () => {
+    expect(bb('[url=javascript:alert(1)]click[/url]')).toBe('click');
+  });
+  it('image with a valid extension', () => {
+    expect(bb('[img]https://x.com/a.png[/img]')).toBe(
+      '<img src="https://x.com/a.png" alt="" class="bbcode-img" />'
+    );
+  });
+  it('image with a bad extension degrades to text', () => {
+    expect(bb('[img]https://x.com/a.txt[/img]')).toBe('https://x.com/a.txt');
+  });
+});
+
+describe('bbcode — blocks', () => {
+  it('plain quote', () => {
+    expect(bb('[quote]hi[/quote]')).toBe(
+      '<blockquote class="bbcode-quote">hi</blockquote>'
+    );
+  });
+  it('attributed quote', () => {
+    expect(bb('[quote=John Doe]hi[/quote]')).toBe(
+      '<blockquote class="bbcode-quote"><cite>John Doe wrote:</cite>hi</blockquote>'
+    );
+  });
+  it('hide with default and custom summary', () => {
+    expect(bb('[hide]s[/hide]')).toBe(
+      '<details class="bbcode-hide"><summary>Hidden text</summary>s</details>'
+    );
+    expect(bb('[hide=Spoiler]s[/hide]')).toBe(
+      '<details class="bbcode-hide"><summary>Spoiler</summary>s</details>'
+    );
+  });
+  it('mature renders a collapsed disclosure (ungated in phase 1)', () => {
+    expect(bb('[mature=nsfw]s[/mature]')).toBe(
+      '<details class="bbcode-mature"><summary>nsfw</summary>s</details>'
+    );
+  });
+  it('unordered and ordered loose lists', () => {
+    expect(bb('[*] one\n[*] two\n')).toBe(
+      '<ul class="bbcode-list"><li>one</li><li>two</li></ul>'
+    );
+    expect(bb('[#] one\n[#] two\n')).toBe(
+      '<ol class="bbcode-list"><li>one</li><li>two</li></ol>'
+    );
+  });
+  it('tolerates an explicit [list] wrapper', () => {
+    expect(bb('[list][*] a[*] b[/list]')).toBe(
+      '<ul class="bbcode-list"><li>a</li><li>b</li></ul>'
+    );
+  });
+});
+
+describe('bbcode — raw-content tags', () => {
+  it('plain strips BBCode to literal text', () => {
+    expect(bb('[plain][b]x[/b][/plain]')).toBe('[b]x[/b]');
+  });
+  it('code escapes and does not parse its body', () => {
+    expect(bb('[code]a < [b]b[/b][/code]')).toBe(
+      '<code class="bbcode-code">a &lt; [b]b[/b]</code>'
+    );
+  });
+  it('pre preserves its body verbatim (escaped)', () => {
+    expect(bb('[pre]  two  spaces[/pre]')).toBe(
+      '<pre class="bbcode-pre">  two  spaces</pre>'
+    );
+  });
+});
+
+describe('bbcode — tokenizer/stack semantics', () => {
+  it('auto-closes inner tags when an outer close arrives', () => {
+    expect(bb('[b][i][u]hi[/b]')).toBe('<strong><em><u>hi</u></em></strong>');
+  });
+  it('auto-closes unbalanced opens at end of input', () => {
+    expect(bb('[b]hi')).toBe('<strong>hi</strong>');
+  });
+  it('renders a stray close as literal text', () => {
+    expect(bb('hi[/b]')).toBe('hi[/b]');
+  });
+  it('renders an unknown tag as literal text', () => {
+    expect(bb('[spoiler]x[/spoiler]')).toBe('[spoiler]x[/spoiler]');
+  });
+  it('[n] breaks a tag from triggering and is itself consumed', () => {
+    expect(bb('[b[n]]Hello[/b]')).toBe('[b]Hello[/b]');
+  });
+});
+
+describe('bbcode — security (escaping is the real guarantee)', () => {
+  it('escapes raw html in text', () => {
+    expect(bb('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;'
+    );
+  });
+  it('escapes html inside a formatting tag', () => {
+    expect(bb('[b]<img src=x onerror=alert(1)>[/b]')).toBe(
+      '<strong>&lt;img src=x onerror=alert(1)&gt;</strong>'
+    );
+  });
+  it('neutralizes a style-breakout attempt in color', () => {
+    expect(bb('[color=x"onmouseover="alert(1)]hi[/color]')).toBe('hi');
+  });
+});
+
+describe('bbcode — DB-resolved tags', () => {
+  const db = {
+    user: {
+      findMany: async () => [{ id: 42, username: 'WhatMan' }]
+    },
+    artist: {
+      findMany: async () => [{ id: 7, name: 'Pink Floyd' }]
+    },
+    release: {
+      findMany: async () => [{ id: 1179, communityId: 1512 }]
+    },
+    wikiPage: {
+      findMany: async () => [{ id: 23, title: 'BB Code', slug: 'bb-code' }]
+    },
+    wikiAlias: {
+      findMany: async () => [
+        { alias: 'bbcode', page: { id: 23, title: 'BB Code' } }
+      ]
+    },
+    forumPost: {
+      findMany: async () => [
+        { id: 900, forumTopicId: 12, forumTopic: { forumId: 3 } }
+      ]
+    }
+  } as unknown as BBCtx['db'];
+  const ctx: BBCtx = { db, siteUrl: SITE };
+
+  it('resolves [user] by name to a profile link', async () => {
+    expect(await renderBBCode('[user]WhatMan[/user]', ctx)).toBe(
+      '<a href="/user/42">WhatMan</a>'
+    );
+  });
+  it('resolves [artist] to an artist link', async () => {
+    expect(await renderBBCode('[artist]Pink Floyd[/artist]', ctx)).toBe(
+      '<a href="/artists/7">Pink Floyd</a>'
+    );
+  });
+  it('resolves [release] by id, building the community-scoped url', async () => {
+    expect(await renderBBCode('[release]1179[/release]', ctx)).toBe(
+      '<a href="/communities/1512/releases/1179">1179</a>'
+    );
+  });
+  it('resolves [[wiki]] via alias to a numeric page link', async () => {
+    expect(await renderBBCode('[[bbcode]]', ctx)).toBe(
+      '<a href="/wiki/23">BB Code</a>'
+    );
+  });
+  it('links an attributed quote to its post', async () => {
+    expect(await renderBBCode('[quote=Kai|900]hi[/quote]', ctx)).toBe(
+      '<blockquote class="bbcode-quote"><cite><a href="/forums/3/topics/12#post-900">Kai wrote:</a></cite>hi</blockquote>'
+    );
+  });
+
+  it('falls back to plain text for an unresolved reference', async () => {
+    const emptyDb = {
+      user: { findMany: async () => [] },
+      artist: { findMany: async () => [] },
+      release: { findMany: async () => [] },
+      wikiPage: { findMany: async () => [] },
+      wikiAlias: { findMany: async () => [] },
+      forumPost: { findMany: async () => [] }
+    } as unknown as BBCtx['db'];
+    expect(
+      await renderBBCode('[artist]Nobody[/artist]', {
+        db: emptyDb,
+        siteUrl: SITE
+      })
+    ).toBe('Nobody');
+  });
+});
+
+describe('bbcode — rule links (pure, no DB)', () => {
+  it('links a numeric sub-rule to its anchor', () => {
+    expect(bb('[rule]2.3[/rule]')).toBe('<a href="/rules#2.3">2.3</a>');
+  });
+  it('links an h-prefixed group heading', () => {
+    expect(bb('[rule]h2[/rule]')).toBe('<a href="/rules#2">h2</a>');
+  });
+  it('leaves a malformed rule code as plain text', () => {
+    expect(bb('[rule]nope[/rule]')).toBe('nope');
+  });
+});
+
+describe('bbcode — full render entry', () => {
+  it('sanitizes and returns html, empty for empty input', async () => {
+    const ctx: BBCtx = { db: {} as BBCtx['db'], siteUrl: SITE };
+    expect(await renderBBCode('', ctx)).toBe('');
+    expect(await renderBBCode('[b]hi[/b]', ctx)).toBe('<strong>hi</strong>');
+  });
+});

--- a/src/lib/bbcode/ctx.ts
+++ b/src/lib/bbcode/ctx.ts
@@ -1,0 +1,14 @@
+import type { PrismaClient, Prisma } from '@prisma/client';
+
+// Everything the renderer needs from the caller. Prisma is injected (not the
+// singleton import) so the lib stays decoupled and unit-testable with a mock,
+// and a caller can hand in a transaction client. `siteUrl` drives on-site URL
+// shortening (#398 Q12). `viewer` is the seam for the future `[mature]` gate
+// (#400) — once it exists it also becomes a render-cache-key dimension.
+export interface BBCtx {
+  db: PrismaClient | Prisma.TransactionClient;
+  siteUrl: string;
+  viewer?: {
+    showMature: boolean;
+  };
+}

--- a/src/lib/bbcode/index.ts
+++ b/src/lib/bbcode/index.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'crypto';
+import { TtlCache } from '../ttlCache';
+import { BBCtx } from './ctx';
+import { parse } from './parse';
+import { render } from './render';
+import { resolveRefs } from './resolve';
+import { sanitizeBBCode } from './sanitizeConfig';
+import { tokenize } from './tokenize';
+import { PARSER_VERSION } from './version';
+
+export type { BBCtx } from './ctx';
+
+const RENDER_TTL_MS = 10 * 60 * 1000; // 10 min — the staleness bound for DB tags (#398 Q16)
+const cache = new TtlCache();
+
+function cacheKey(raw: string, ctx: BBCtx): string {
+  const hash = createHash('sha256').update(raw).digest('hex');
+  // Viewer-independent today; when [mature] gates on a setting (#400) the render
+  // diverges per viewer and this key must gain that dimension.
+  const mature = ctx.viewer ? (ctx.viewer.showMature ? '1' : '0') : '-';
+  return `bbcode:v${PARSER_VERSION}:m${mature}:${hash}`;
+}
+
+// Render-time transcription of BBCode to sanitized HTML. Store raw BBCode; call
+// this on read. The API is the single source of transcription (#398).
+export async function renderBBCode(raw: string, ctx: BBCtx): Promise<string> {
+  if (!raw) return '';
+
+  const key = cacheKey(raw, ctx);
+  const cached = cache.get<string>(key);
+  if (cached !== undefined) return cached;
+
+  const tree = parse(tokenize(raw));
+  const maps = await resolveRefs(tree, ctx);
+  const html = sanitizeBBCode(render(tree, maps, ctx));
+
+  cache.set(key, html, RENDER_TTL_MS);
+  return html;
+}

--- a/src/lib/bbcode/legacy.ts
+++ b/src/lib/bbcode/legacy.ts
@@ -1,3 +1,6 @@
+// The pre-#398 store-time regex parser. Superseded by renderBBCode (this
+// directory's index) and kept only for its one remaining consumer, profile.ts,
+// until Phase 2 migrates it and deletes this file (#402). Do not add callers.
 const escape = (str: string) =>
   str
     .replace(/&/g, '&amp;')

--- a/src/lib/bbcode/parse.ts
+++ b/src/lib/bbcode/parse.ts
@@ -1,0 +1,161 @@
+import { Node, Token } from './types';
+
+// Tags that become elements. Anything else that arrives as a clean tag is
+// unknown and degrades to literal text (lenient case 1). `ul`/`ol`/`li` are
+// never authored — the parser synthesizes them from `[*]`/`[#]` items.
+const ELEMENT_TAGS = new Set([
+  'b',
+  'i',
+  'u',
+  's',
+  'color',
+  'size',
+  'url',
+  'img',
+  'artist',
+  'user',
+  'release',
+  'important',
+  'quote',
+  'align',
+  'hide',
+  'mature',
+  'rule',
+  'wikilink',
+  'h2',
+  'h3',
+  'h4'
+]);
+
+// Block-level tags force an open loose list to close before they open.
+const BLOCK_TAGS = new Set([
+  'quote',
+  'align',
+  'hide',
+  'mature',
+  'h2',
+  'h3',
+  'h4'
+]);
+
+type Frame = { tag: string; arg?: string; children: Node[] };
+
+function literalOpen(tag: string, arg?: string): string {
+  return arg !== undefined ? `[${tag}=${arg}]` : `[${tag}]`;
+}
+
+export function parse(tokens: Token[]): Node[] {
+  const root: Node[] = [];
+  const stack: Frame[] = [];
+
+  const top = (): Frame | undefined => stack[stack.length - 1];
+  const childrenOf = (): Node[] =>
+    stack.length ? stack[stack.length - 1].children : root;
+
+  const pushEl = (tag: string, arg?: string) =>
+    stack.push({ tag, arg, children: [] });
+  const popAsNode = () => {
+    const el = stack.pop();
+    if (!el) return;
+    childrenOf().push({
+      kind: 'element',
+      tag: el.tag,
+      arg: el.arg,
+      children: el.children
+    });
+  };
+
+  const appendText = (value: string) =>
+    childrenOf().push({ kind: 'text', value });
+
+  const inListItem = () => top()?.tag === 'li';
+
+  const closeLooseList = () => {
+    if (top()?.tag === 'li') popAsNode();
+    const t = top()?.tag;
+    if (t === 'ul' || t === 'ol') popAsNode();
+  };
+
+  const ensureListItem = (ordered: boolean) => {
+    const listTag = ordered ? 'ol' : 'ul';
+    if (top()?.tag === 'li') popAsNode();
+    if (top()?.tag !== listTag) {
+      const t = top()?.tag;
+      if (t === 'ul' || t === 'ol') popAsNode(); // switching list type mid-run
+      pushEl(listTag);
+    }
+    pushEl('li');
+  };
+
+  for (const tok of tokens) {
+    switch (tok.type) {
+      case 'item':
+        ensureListItem(tok.ordered);
+        break;
+
+      case 'text': {
+        // A blank line ends a loose list; the remainder rejoins normal flow.
+        if (inListItem()) {
+          const idx = tok.value.indexOf('\n\n');
+          if (idx === -1) {
+            appendText(tok.value);
+          } else {
+            const before = tok.value.slice(0, idx);
+            if (before) appendText(before);
+            closeLooseList();
+            const after = tok.value.slice(idx);
+            if (after) appendText(after);
+          }
+        } else {
+          appendText(tok.value);
+        }
+        break;
+      }
+
+      case 'raw':
+        childrenOf().push({ kind: 'raw', tag: tok.tag, content: tok.content });
+        break;
+
+      case 'open': {
+        // `[list]` is a tolerated, transparent wrapper — the `[*]` items inside
+        // synthesize the real list, so the wrapper itself is a no-op.
+        if (tok.tag === 'list') break;
+
+        if (!ELEMENT_TAGS.has(tok.tag)) {
+          appendText(literalOpen(tok.tag, tok.arg));
+          break;
+        }
+        if (BLOCK_TAGS.has(tok.tag)) closeLooseList();
+        pushEl(tok.tag, tok.arg);
+        break;
+      }
+
+      case 'close': {
+        if (tok.tag === 'list') break;
+
+        let idx = -1;
+        for (let k = stack.length - 1; k >= 0; k--) {
+          if (stack[k].tag === tok.tag) {
+            idx = k;
+            break;
+          }
+        }
+        if (idx === -1) {
+          // Stray close with no matching open -> literal text (lenient case 3).
+          appendText(`[/${tok.tag}]`);
+          break;
+        }
+        // Auto-close everything above the match, then the match itself
+        // (lenient case 4). Force-closed inners leave their own later close
+        // tags stray, which fall to case 3.
+        while (stack.length > idx) popAsNode();
+        break;
+      }
+    }
+  }
+
+  // Unbalanced opens auto-close at end of input (lenient case 2).
+  while (stack.length) popAsNode();
+
+  return root;
+}

--- a/src/lib/bbcode/render.ts
+++ b/src/lib/bbcode/render.ts
@@ -1,0 +1,271 @@
+import { BBCtx } from './ctx';
+import { extractReleaseId, ResolveMaps } from './resolve';
+import { Node } from './types';
+
+// [size=n], n in 1..10 (2 = normal). Relative units so themes scale it (#398 Q9).
+const SIZE_EM = [0.85, 1, 1.15, 1.35, 1.6, 1.9, 2.2, 2.5, 2.8, 3.2];
+
+const HEX = /^#[0-9a-f]{6}$/i;
+const NAMED = /^[a-z]+$/i; // letters-only named colors are safe in a style value
+const RULE_CODE = /^h?\d+(?:\.\d+)*$/;
+const IMG_EXT = /\.(gif|jpe?g|png)$/i;
+
+const escapeText = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const escapeFlow = (s: string): string => escapeText(s).replace(/\n/g, '<br>');
+
+// href lives in a double-quoted attribute; safeUrl has already gated the scheme.
+const escapeAttr = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/"/g, '%22').replace(/'/g, '%27');
+
+function safeUrl(u: string): string | null {
+  const s = u.trim();
+  if (/^https?:\/\//i.test(s) || s.startsWith('/') || s.startsWith('mailto:'))
+    return s;
+  return null;
+}
+
+function textContent(node: Node): string {
+  if (node.kind === 'text') return node.value;
+  if (node.kind === 'raw') return node.content;
+  return node.children.map(textContent).join('');
+}
+
+interface Opts {
+  autoLink: boolean; // false inside links, so we never nest an <a> in an <a>
+}
+
+function anchor(href: string, display: string, external: boolean): string {
+  const rel = external ? ' rel="noopener noreferrer" target="_blank"' : '';
+  return `<a href="${escapeAttr(href)}"${rel}>${display}</a>`;
+}
+
+// On-site URLs display as their path only; off-site display in full (#398 Q12).
+function linkFromUrl(url: string, ctx: BBCtx): string {
+  const safe = safeUrl(url);
+  if (!safe) return escapeFlow(url);
+  const external = /^https?:\/\//i.test(safe) || safe.startsWith('mailto:');
+  let display = safe;
+  if (ctx.siteUrl && safe.startsWith(ctx.siteUrl)) {
+    display = safe.slice(ctx.siteUrl.length) || '/';
+  }
+  return anchor(
+    safe,
+    escapeText(display),
+    external && !safe.startsWith(ctx.siteUrl)
+  );
+}
+
+function emitText(value: string, ctx: BBCtx, opts: Opts): string {
+  if (!opts.autoLink) return escapeFlow(value);
+  // Spec: bare URLs auto-hyperlink. Never re-link inside an existing link, a
+  // raw block, or `[plain]` (those never reach here with autoLink on).
+  const re = /https?:\/\/[^\s<>")\]]+/gi;
+  let out = '';
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(value)) !== null) {
+    out += escapeFlow(value.slice(last, m.index));
+    out += linkFromUrl(m[0], ctx);
+    last = m.index + m[0].length;
+  }
+  out += escapeFlow(value.slice(last));
+  return out;
+}
+
+function emitChildren(
+  nodes: Node[],
+  maps: ResolveMaps,
+  ctx: BBCtx,
+  opts: Opts
+): string {
+  return nodes.map((n) => emitNode(n, maps, ctx, opts)).join('');
+}
+
+function emitElement(
+  node: Node & { kind: 'element' },
+  maps: ResolveMaps,
+  ctx: BBCtx,
+  opts: Opts
+): string {
+  const { tag, arg } = node;
+  const inner = () => emitChildren(node.children, maps, ctx, opts);
+  const body = () => textContent(node).trim();
+
+  switch (tag) {
+    case 'b':
+      return `<strong>${inner()}</strong>`;
+    case 'i':
+      return `<em>${inner()}</em>`;
+    case 'u':
+      return `<u>${inner()}</u>`;
+    case 's':
+      return `<s>${inner()}</s>`;
+    case 'important':
+      return `<span class="bbcode-important">${inner()}</span>`;
+    case 'h2':
+    case 'h3':
+    case 'h4':
+      return `<${tag}>${inner()}</${tag}>`;
+
+    case 'color': {
+      const v = (arg ?? '').trim();
+      if (HEX.test(v) || NAMED.test(v))
+        return `<span style="color:${v}">${inner()}</span>`;
+      return inner(); // invalid value: drop the styling, keep the text
+    }
+    case 'size': {
+      const n = /^\d+$/.test(arg ?? '') ? parseInt(arg!, 10) : NaN;
+      if (n >= 1 && n <= 10)
+        return `<span style="font-size:${SIZE_EM[n - 1]}em">${inner()}</span>`;
+      return inner();
+    }
+    case 'align': {
+      const v = (arg ?? '').trim().toLowerCase();
+      if (v === 'left' || v === 'right' || v === 'center')
+        return `<div style="text-align:${v}">${inner()}</div>`;
+      return inner();
+    }
+
+    case 'url': {
+      if (arg !== undefined) {
+        const safe = safeUrl(arg);
+        const label = emitChildren(node.children, maps, ctx, {
+          autoLink: false
+        });
+        if (!safe) return label;
+        const external =
+          /^https?:\/\//i.test(safe) || safe.startsWith('mailto:');
+        return anchor(safe, label, external);
+      }
+      return linkFromUrl(body(), ctx);
+    }
+    case 'img': {
+      const src = body();
+      if (/^https?:\/\//i.test(src) && IMG_EXT.test(src))
+        return `<img src="${escapeAttr(src)}" alt="" class="bbcode-img" />`;
+      return escapeFlow(src);
+    }
+
+    case 'quote': {
+      const content = inner();
+      if (!arg)
+        return `<blockquote class="bbcode-quote">${content}</blockquote>`;
+      const bar = arg.indexOf('|');
+      const who = escapeText((bar === -1 ? arg : arg.slice(0, bar)).trim());
+      let cite = `${who} wrote:`;
+      if (bar !== -1) {
+        const pid = parseInt(arg.slice(bar + 1).trim(), 10);
+        const post = maps.postsById.get(pid);
+        if (post)
+          cite = anchor(
+            `/forums/${post.forumId}/topics/${post.forumTopicId}#post-${post.id}`,
+            `${who} wrote:`,
+            false
+          );
+      }
+      return `<blockquote class="bbcode-quote"><cite>${cite}</cite>${content}</blockquote>`;
+    }
+    case 'hide': {
+      const summary = escapeText((arg ?? 'Hidden text').trim());
+      return `<details class="bbcode-hide"><summary>${summary}</summary>${inner()}</details>`;
+    }
+    case 'mature': {
+      // Phase 1: no viewer gate yet (#400) — a collapsed disclosure, content still
+      // present. When `ctx.viewer.showMature` lands this branch omits the content
+      // server-side when off, and the render becomes viewer-dependent (cache dim).
+      const summary = escapeText((arg ?? 'Mature content').trim());
+      return `<details class="bbcode-mature"><summary>${summary}</summary>${inner()}</details>`;
+    }
+
+    case 'ul':
+    case 'ol': {
+      const items = node.children
+        .filter(
+          (c): c is Node & { kind: 'element' } =>
+            c.kind === 'element' && c.tag === 'li'
+        )
+        .map((li) => {
+          // The item's line break rides along in its text; drop the trailing one.
+          const c = emitChildren(li.children, maps, ctx, opts)
+            .trim()
+            .replace(/(?:<br>)+$/, '');
+          return `<li>${c}</li>`;
+        })
+        .join('');
+      return `<${tag} class="bbcode-list">${items}</${tag}>`;
+    }
+    case 'li':
+      // Only reached if an <li> escaped its list; render defensively.
+      return `<li>${inner()}</li>`;
+
+    case 'rule': {
+      const code = body();
+      if (!RULE_CODE.test(code)) return escapeText(code);
+      const anchorId = code.replace(/^h/i, '');
+      return anchor(`/rules#${anchorId}`, escapeText(code), false);
+    }
+    case 'user': {
+      const raw = body();
+      const hit = /^\d+$/.test(raw)
+        ? maps.usersById.get(parseInt(raw, 10))
+        : maps.usersByName.get(raw.toLowerCase());
+      if (!hit) return escapeText(raw);
+      return anchor(`/user/${hit.id}`, escapeText(hit.username), false);
+    }
+    case 'artist': {
+      const name = body();
+      const hit = maps.artistsByName.get(name.toLowerCase());
+      if (!hit) return escapeText(name);
+      return anchor(`/artists/${hit.id}`, escapeText(hit.name), false);
+    }
+    case 'release': {
+      const raw = body();
+      const id = extractReleaseId(raw);
+      const hit = id !== null ? maps.releasesById.get(id) : undefined;
+      if (!hit || hit.communityId == null) return escapeText(raw);
+      return anchor(
+        `/communities/${hit.communityId}/releases/${hit.id}`,
+        escapeText(raw),
+        false
+      );
+    }
+    case 'wikilink': {
+      const ref = (arg ?? '').trim();
+      const hit = maps.wikisByRef.get(ref.toLowerCase());
+      if (!hit) return escapeText(ref);
+      return anchor(`/wiki/${hit.id}`, escapeText(hit.title), false);
+    }
+
+    default:
+      // Unknown tags never reach here (the parser turns them into text), but be safe.
+      return inner();
+  }
+}
+
+function emitNode(
+  node: Node,
+  maps: ResolveMaps,
+  ctx: BBCtx,
+  opts: Opts
+): string {
+  if (node.kind === 'text') return emitText(node.value, ctx, opts);
+  if (node.kind === 'raw') {
+    const content = escapeText(node.content);
+    if (node.tag === 'pre') return `<pre class="bbcode-pre">${content}</pre>`;
+    if (node.tag === 'code')
+      return `<code class="bbcode-code">${content}</code>`;
+    // tex: Phase 1 shows the literal LaTeX source; #403 swaps in server KaTeX.
+    return `<code class="bbcode-tex">${content}</code>`;
+  }
+  return emitElement(node, maps, ctx, opts);
+}
+
+export function render(nodes: Node[], maps: ResolveMaps, ctx: BBCtx): string {
+  return emitChildren(nodes, maps, ctx, { autoLink: true });
+}

--- a/src/lib/bbcode/resolve.ts
+++ b/src/lib/bbcode/resolve.ts
@@ -1,0 +1,212 @@
+import { BBCtx } from './ctx';
+import { Node } from './types';
+
+// Batch-resolved lookup maps for the DB-dependent tags. Pass 1 collects the
+// references from the tree; one query per type fills these; pass 2 (render)
+// reads them. Unresolved references fall back to plain text (#398 Q5).
+export interface ResolveMaps {
+  usersById: Map<number, { id: number; username: string }>;
+  usersByName: Map<string, { id: number; username: string }>;
+  artistsByName: Map<string, { id: number; name: string }>;
+  releasesById: Map<number, { id: number; communityId: number | null }>;
+  wikisByRef: Map<string, { id: number; title: string }>;
+  postsById: Map<number, { id: number; forumTopicId: number; forumId: number }>;
+}
+
+function textContent(node: Node): string {
+  if (node.kind === 'text') return node.value;
+  if (node.kind === 'raw') return node.content;
+  return node.children.map(textContent).join('');
+}
+
+// A [release] body is either a bare group id or an on-site release URL.
+export function extractReleaseId(raw: string): number | null {
+  const s = raw.trim();
+  if (/^\d+$/.test(s)) return parseInt(s, 10);
+  const m = /\/releases\/(\d+)/.exec(s);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+interface Refs {
+  userIds: Set<number>;
+  userNames: Set<string>;
+  artistNames: Set<string>;
+  releaseIds: Set<number>;
+  wikiRefs: Set<string>;
+  postIds: Set<number>;
+}
+
+function collect(nodes: Node[], refs: Refs): void {
+  for (const node of nodes) {
+    if (node.kind !== 'element') continue;
+    switch (node.tag) {
+      case 'user': {
+        const body = textContent(node).trim();
+        if (/^\d+$/.test(body)) refs.userIds.add(parseInt(body, 10));
+        else if (body) refs.userNames.add(body.toLowerCase());
+        break;
+      }
+      case 'artist': {
+        const name = textContent(node).trim();
+        if (name) refs.artistNames.add(name.toLowerCase());
+        break;
+      }
+      case 'release': {
+        const id = extractReleaseId(textContent(node));
+        if (id !== null) refs.releaseIds.add(id);
+        break;
+      }
+      case 'wikilink': {
+        const ref = (node.arg ?? '').trim();
+        if (ref) refs.wikiRefs.add(ref.toLowerCase());
+        break;
+      }
+      case 'quote': {
+        const arg = node.arg ?? '';
+        const bar = arg.indexOf('|');
+        if (bar !== -1) {
+          const pid = parseInt(arg.slice(bar + 1).trim(), 10);
+          if (!Number.isNaN(pid)) refs.postIds.add(pid);
+        }
+        break;
+      }
+    }
+    collect(node.children, refs);
+  }
+}
+
+const empty = (): ResolveMaps => ({
+  usersById: new Map(),
+  usersByName: new Map(),
+  artistsByName: new Map(),
+  releasesById: new Map(),
+  wikisByRef: new Map(),
+  postsById: new Map()
+});
+
+export async function resolveRefs(
+  nodes: Node[],
+  ctx: BBCtx
+): Promise<ResolveMaps> {
+  const refs: Refs = {
+    userIds: new Set(),
+    userNames: new Set(),
+    artistNames: new Set(),
+    releaseIds: new Set(),
+    wikiRefs: new Set(),
+    postIds: new Set()
+  };
+  collect(nodes, refs);
+
+  const maps = empty();
+  const db = ctx.db;
+
+  const jobs: Promise<void>[] = [];
+
+  if (refs.userIds.size || refs.userNames.size) {
+    jobs.push(
+      db.user
+        .findMany({
+          where: {
+            OR: [
+              { id: { in: [...refs.userIds] } },
+              { username: { in: [...refs.userNames], mode: 'insensitive' } }
+            ]
+          },
+          select: { id: true, username: true }
+        })
+        .then((rows) => {
+          for (const r of rows) {
+            maps.usersById.set(r.id, r);
+            maps.usersByName.set(r.username.toLowerCase(), r);
+          }
+        })
+    );
+  }
+
+  if (refs.artistNames.size) {
+    jobs.push(
+      db.artist
+        .findMany({
+          where: { name: { in: [...refs.artistNames], mode: 'insensitive' } },
+          select: { id: true, name: true }
+        })
+        .then((rows) => {
+          for (const r of rows) maps.artistsByName.set(r.name.toLowerCase(), r);
+        })
+    );
+  }
+
+  if (refs.releaseIds.size) {
+    jobs.push(
+      db.release
+        .findMany({
+          where: { id: { in: [...refs.releaseIds] } },
+          select: { id: true, communityId: true }
+        })
+        .then((rows) => {
+          for (const r of rows) maps.releasesById.set(r.id, r);
+        })
+    );
+  }
+
+  if (refs.wikiRefs.size) {
+    const refList = [...refs.wikiRefs];
+    // A wiki ref matches a page slug, an exact title, or an alias (#398 Q6).
+    jobs.push(
+      db.wikiPage
+        .findMany({
+          where: {
+            OR: [
+              { slug: { in: refList, mode: 'insensitive' } },
+              { title: { in: refList, mode: 'insensitive' } }
+            ]
+          },
+          select: { id: true, title: true, slug: true }
+        })
+        .then((rows) => {
+          for (const r of rows) {
+            maps.wikisByRef.set(r.slug.toLowerCase(), r);
+            maps.wikisByRef.set(r.title.toLowerCase(), r);
+          }
+        })
+    );
+    jobs.push(
+      db.wikiAlias
+        .findMany({
+          where: { alias: { in: refList, mode: 'insensitive' } },
+          select: { alias: true, page: { select: { id: true, title: true } } }
+        })
+        .then((rows) => {
+          for (const r of rows)
+            maps.wikisByRef.set(r.alias.toLowerCase(), r.page);
+        })
+    );
+  }
+
+  if (refs.postIds.size) {
+    jobs.push(
+      db.forumPost
+        .findMany({
+          where: { id: { in: [...refs.postIds] } },
+          select: {
+            id: true,
+            forumTopicId: true,
+            forumTopic: { select: { forumId: true } }
+          }
+        })
+        .then((rows) => {
+          for (const r of rows) {
+            maps.postsById.set(r.id, {
+              id: r.id,
+              forumTopicId: r.forumTopicId,
+              forumId: r.forumTopic.forumId
+            });
+          }
+        })
+    );
+  }
+
+  await Promise.all(jobs);
+  return maps;
+}

--- a/src/lib/bbcode/sanitizeConfig.ts
+++ b/src/lib/bbcode/sanitizeConfig.ts
@@ -1,0 +1,39 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+// The authoritative allowlist for rendered BBCode (#398 Q15). The API is the
+// source of truth; the UI's DOMPurify config must mirror this tag/attr set, and
+// a UI test asserts the match. Wider than lib/sanitize.ts because BBCode emits
+// headings, disclosures, aligned blocks, images, and validated inline styles.
+const BBCODE_CONFIG = {
+  ALLOWED_TAGS: [
+    'strong',
+    'em',
+    'u',
+    's',
+    'span',
+    'div',
+    'a',
+    'br',
+    'blockquote',
+    'cite',
+    'details',
+    'summary',
+    'pre',
+    'code',
+    'ul',
+    'ol',
+    'li',
+    'h2',
+    'h3',
+    'h4',
+    'img'
+  ],
+  // Values are already whitelist-validated by the emitter before they reach an
+  // attribute; DOMPurify is the second net.
+  ALLOWED_ATTR: ['href', 'class', 'style', 'rel', 'target', 'src', 'alt'],
+  ALLOW_DATA_ATTR: false
+};
+
+export function sanitizeBBCode(html: string): string {
+  return DOMPurify.sanitize(html, BBCODE_CONFIG);
+}

--- a/src/lib/bbcode/tokenize.ts
+++ b/src/lib/bbcode/tokenize.ts
@@ -1,0 +1,128 @@
+import { RawTag, Token, WrappingRawTag } from './types';
+
+// A clean tag: [tag], [tag=arg], or [/tag]. The arg deliberately forbids brackets
+// (`[^\]\[]`) so an embedded `[n]` (e.g. `[b[n]]`) fails to match here and falls
+// through to be handled as the no-trigger marker below.
+const TAG_RE = /^\[(\/?)([a-zA-Z0-9*#]+)(?:=([^\][]*))?\]/;
+// A heading, only at line start: ==h2==, ===h3===, ====h4====. Backreference \1
+// requires the same run of `=` on both sides.
+const HEADING_RE = /^(={2,4})([^\n]+?)\1[ \t]*(?=\n|$)/;
+const RAW_OPEN_RE = /^\[(plain|code|pre|tex)\]/i;
+// [[wiki-ref]] — a wiki link; double brackets, no inner BBCode.
+const WIKI_RE = /^\[\[([^\]\n]+)\]\]/;
+
+function normalizeTag(tag: string): string {
+  const t = tag.toLowerCase();
+  return t === 'colour' ? 'color' : t; // spec: [colour] is an alias for [color]
+}
+
+export function tokenize(raw: string): Token[] {
+  const tokens: Token[] = [];
+  const len = raw.length;
+  let i = 0;
+  let text = '';
+
+  const flush = () => {
+    if (text) {
+      tokens.push({ type: 'text', value: text });
+      text = '';
+    }
+  };
+
+  while (i < len) {
+    const atLineStart = i === 0 || raw[i - 1] === '\n';
+
+    // Headings — line-start only. The inner is re-tokenized so inline BBCode
+    // inside a heading (e.g. `==[b]About[/b]==`) still works.
+    if (atLineStart && raw[i] === '=') {
+      const m = HEADING_RE.exec(raw.slice(i));
+      if (m) {
+        flush();
+        const level = m[1].length; // 2, 3, or 4
+        tokens.push({ type: 'open', tag: `h${level}` });
+        for (const t of tokenize(m[2])) tokens.push(t);
+        tokens.push({ type: 'close', tag: `h${level}` });
+        i += m[0].length;
+        continue;
+      }
+    }
+
+    if (raw[i] === '[') {
+      const rest = raw.slice(i);
+
+      const wiki = WIKI_RE.exec(rest);
+      if (wiki) {
+        flush();
+        tokens.push({ type: 'open', tag: 'wikilink', arg: wiki[1] });
+        tokens.push({ type: 'close', tag: 'wikilink' });
+        i += wiki[0].length;
+        continue;
+      }
+
+      // Raw-content open tag: consume through the matching close; body stays literal.
+      const rawOpen = RAW_OPEN_RE.exec(rest);
+      if (rawOpen) {
+        const tag = rawOpen[1].toLowerCase() as RawTag;
+        const close = `[/${tag}]`;
+        const closeIdx = raw
+          .toLowerCase()
+          .indexOf(close, i + rawOpen[0].length);
+        if (closeIdx !== -1) {
+          const content = raw.slice(i + rawOpen[0].length, closeIdx);
+          flush();
+          if (tag === 'plain') tokens.push({ type: 'text', value: content });
+          else
+            tokens.push({ type: 'raw', tag: tag as WrappingRawTag, content });
+          i = closeIdx + close.length;
+          continue;
+        }
+        // Unbalanced raw open: fall through and treat '[' as a literal below.
+      }
+
+      const m = TAG_RE.exec(rest);
+      if (m) {
+        const slash = m[1];
+        const tag = normalizeTag(m[2]);
+        const arg = m[3];
+
+        if (!slash && tag === 'n') {
+          // No-trigger marker: consumed, emits nothing. TAG_RE already refused to
+          // match an outer tag wrapping this (its arg forbids brackets), so a
+          // construct like `[b[n]]` has left `[b]` as literal text and this only
+          // swallows the marker.
+          i += m[0].length;
+          continue;
+        }
+        if (!slash && tag === '*') {
+          flush();
+          tokens.push({ type: 'item', ordered: false });
+          i += m[0].length;
+          continue;
+        }
+        if (!slash && tag === '#') {
+          flush();
+          tokens.push({ type: 'item', ordered: true });
+          i += m[0].length;
+          continue;
+        }
+
+        flush();
+        if (slash) tokens.push({ type: 'close', tag });
+        else tokens.push({ type: 'open', tag, arg });
+        i += m[0].length;
+        continue;
+      }
+
+      // Not a recognizable tag: a literal '['.
+      text += '[';
+      i += 1;
+      continue;
+    }
+
+    text += raw[i];
+    i += 1;
+  }
+
+  flush();
+  return tokens;
+}

--- a/src/lib/bbcode/types.ts
+++ b/src/lib/bbcode/types.ts
@@ -1,0 +1,23 @@
+// Raw-content tags: their bodies are NOT parsed as BBCode. `plain` strips (emits
+// its body verbatim with no wrapper); `code`/`pre`/`tex` wrap but keep the body
+// literal. Kept in one place because the tokenizer, parser, and emitter all key
+// off this set.
+export const RAW_TAGS = ['plain', 'code', 'pre', 'tex'] as const;
+export type RawTag = (typeof RAW_TAGS)[number];
+export type WrappingRawTag = Exclude<RawTag, 'plain'>;
+
+export type Token =
+  | { type: 'text'; value: string }
+  | { type: 'open'; tag: string; arg?: string }
+  | { type: 'close'; tag: string }
+  // `plain` is folded into a text token by the tokenizer; only the wrapping raw
+  // tags reach the parser as a raw token.
+  | { type: 'raw'; tag: WrappingRawTag; content: string }
+  | { type: 'item'; ordered: boolean }; // [*] (ul) or [#] (ol)
+
+// Loose lists are synthesized into `ul`/`ol`/`li` element nodes by the parser, so
+// the tree needs only three node kinds.
+export type Node =
+  | { kind: 'text'; value: string }
+  | { kind: 'element'; tag: string; arg?: string; children: Node[] }
+  | { kind: 'raw'; tag: WrappingRawTag; content: string };

--- a/src/lib/bbcode/version.ts
+++ b/src/lib/bbcode/version.ts
@@ -1,0 +1,4 @@
+// Bump when the parser output or sanitize allowlist changes. It is part of the
+// render-cache key, so a bump rotates every cached entry without a manual flush
+// (ADR-0026-adjacent; see #398). Keep it a plain integer.
+export const PARSER_VERSION = 1;

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -8,7 +8,10 @@ import { prisma } from '../lib/prisma';
 import { AppError } from '../lib/errors';
 import { primaryArtist, releaseCreditsSelect } from './releaseCredits';
 import { sanitizeHtml, sanitizePlain } from '../lib/sanitize';
-import { parseBBCode } from '../lib/bbcode';
+// The pre-#398 store-time parser; Phase 2 migrates profile onto renderBBCode and
+// retires this (#402). Imported from legacy directly so this consumer doesn't pull
+// the render subsystem's DOMPurify dependency.
+import { parseBBCode } from '../lib/bbcode/legacy';
 import { sendInviteEmail } from '../lib/mailer';
 import { getLogger } from './logging';
 import { computeRatio } from './ratio';

--- a/src/routes/api/wiki.ts
+++ b/src/routes/api/wiki.ts
@@ -15,7 +15,9 @@ import {
   parsedParams,
   parsedQuery
 } from '../../middleware/validate';
-import { sanitizeHtml, sanitizePlain } from '../../lib/sanitize';
+import { sanitizePlain } from '../../lib/sanitize';
+import { renderBBCode } from '../../lib/bbcode';
+import { email } from '../../modules/config';
 import { audit } from '../../lib/audit';
 import {
   createWikiPageSchema,
@@ -38,6 +40,21 @@ const router = express.Router();
 
 // ID of the root wiki article — protected from deletion
 const INDEX_ARTICLE_ID = 1;
+
+// Bodies are stored as raw BBCode and transcribed at read time — the API is the
+// single source of transcription (#398). `renderBBCode` is cached and sanitizes
+// its own output; `siteUrl` drives on-site URL shortening. Attach `bodyHtml`
+// alongside the raw `body` so the editor round-trips the source and the view
+// renders the HTML.
+async function withBodyHtml<T extends { body: string }>(
+  page: T
+): Promise<T & { bodyHtml: string }> {
+  const bodyHtml = await renderBBCode(page.body, {
+    db: prisma,
+    siteUrl: email.siteUrl
+  });
+  return { ...page, bodyHtml };
+}
 
 const PAGE_SELECT = {
   id: true,
@@ -177,7 +194,7 @@ router.get(
         .status(403)
         .json({ msg: 'Insufficient rank to view this page' });
     }
-    res.json(record.page);
+    res.json(await withBodyHtml(record.page));
   })
 );
 
@@ -198,7 +215,7 @@ router.get(
         .status(403)
         .json({ msg: 'Insufficient rank to view this page' });
     }
-    res.json(page);
+    res.json(await withBodyHtml(page));
   })
 );
 
@@ -392,7 +409,8 @@ router.post(
     const minEditLevel = canManage ? (input.minEditLevel ?? 0) : 0;
 
     const title = sanitizePlain(input.title).trim();
-    const body = sanitizeHtml(input.body);
+    // Store raw BBCode; transcription + sanitization happen at read time (#398).
+    const body = input.body;
     const slug = input.slug ? normalizeSlug(input.slug) : normalizeSlug(title);
 
     if (!slug)
@@ -472,7 +490,8 @@ router.put(
     );
 
     const title = input.title ? sanitizePlain(input.title).trim() : page.title;
-    const body = input.body ? sanitizeHtml(input.body) : page.body;
+    // Store raw BBCode; transcription + sanitization happen at read time (#398).
+    const body = input.body ? input.body : page.body;
     const minReadLevel =
       canManage && input.minReadLevel !== undefined
         ? input.minReadLevel

--- a/src/test/apiTestHarness.ts
+++ b/src/test/apiTestHarness.ts
@@ -244,6 +244,13 @@ jest.mock('../lib/sanitize', () => ({
   sanitizePlain: (value: string) => value
 }));
 
+// Same reason as lib/sanitize: the BBCode server sanitizer eagerly loads
+// isomorphic-dompurify (jsdom ESM), which jest can't parse. The emitter's
+// escaping is the real guarantee; render output is asserted in bbcode.spec.ts.
+jest.mock('../lib/bbcode/sanitizeConfig', () => ({
+  sanitizeBBCode: (value: string) => value
+}));
+
 import supertest from 'supertest';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';

--- a/src/wiki.spec.ts
+++ b/src/wiki.spec.ts
@@ -155,6 +155,18 @@ describe('GET /api/wiki/:id', () => {
     expect(res.body.title).toBe('Test Page');
   });
 
+  it('transcribes the raw BBCode body into bodyHtml at read time (#398)', async () => {
+    prismaMock.wikiPage.findFirst.mockResolvedValue(
+      makePage({ body: '[b]Wiki[/b] body' }) as never
+    );
+
+    const res = await request(app).get('/api/wiki/2');
+
+    expect(res.status).toBe(200);
+    expect(res.body.body).toBe('[b]Wiki[/b] body'); // raw source round-trips for the editor
+    expect(res.body.bodyHtml).toBe('<strong>Wiki</strong> body');
+  });
+
   it('returns 404 when page does not exist', async () => {
     prismaMock.wikiPage.findFirst.mockResolvedValue(null);
 


### PR DESCRIPTION
Phase 1 of the BBCode parity work (#398). Closes the wiki's BBCode-transcription gap on the API side; the stellar-ui view change and seed re-authoring are the remaining Phase-1 pieces (tracked, one blocked on #399).

## What & why

The wiki rendered bodies as raw HTML, forums/comments ran a thin client-side regex parser, and profile ran a different store-time one — three half-measures that diverged. This replaces the regex chain with a real parser and makes the **API the single source of BBCode → HTML transcription** (render-time, cached).

Design was settled by a full grill; the phase structure lives under the `BBCode` label (#399–#403).

## The parser — `src/lib/bbcode/`

| File | Role |
| --- | --- |
| `tokenize` | headings (`==`/`===`/`====`), `[[wiki]]`, raw-content tags (`plain`/`code`/`pre`/`tex`), the `[n]` no-trigger marker, `[*]`/`[#]` list items, clean `[tag]`/`[tag=arg]`/`[/tag]` |
| `parse` | stack-based tree with **auto-closing** (a close pops every open above it), lenient degradation (unknown/stray/unbalanced → literal or auto-balanced), `[*]`/`[#]` synthesized into real `ul/ol/li` |
| `resolve` | **two-pass batch** DB resolver — collect refs, then ≤6 batched queries (user/artist/release/wiki/post); no N+1. Unresolved → plain text |
| `render` | every tag from the spec; whitelist-validated `color`/`size`/`align` before anything reaches a `style` attr; URL scheme gating + on-site shortening; naked-URL autolinking; image extension check; the three quote forms |
| `index` | `async renderBBCode(raw, ctx)` with a 10-min TTL cache keyed by `PARSER_VERSION` + body hash (the staleness bound for live DB tags) |
| `sanitizeConfig` | API-authoritative DOMPurify allowlist; the UI config mirrors it |

## Wiki wiring

- Bodies are stored as **raw BBCode** (store path no longer `sanitizeHtml`s them).
- `GET /:id` and `/by-alias/:alias` attach a rendered, cached, sanitized **`bodyHtml`** next to the raw `body` — additive, backward-compatible.
- Old `lib/bbcode.ts` folded into `lib/bbcode/legacy.ts`, kept only for `profile.ts` until Phase 2 (#402).

## Decisions worth knowing

- **`[rule]` is a pure format-validated tag** (seed rule codes are slugs, so `2.3` numbering is positional) → emits `/rules#X.Y`; the UI rules page owns the matching anchors.
- **`[mature]` is ungated in Phase 1** (collapsed disclosure, content still present) — the real server-side gate needs a `showMatureContent` setting (#400). A cache-key seam is left for when the render becomes viewer-dependent.

## Not in this PR

- stellar-ui `WikiViewPage` → render `bodyHtml` with a mirrored allowlist; UI rules page `#X.Y` anchors.
- Seed re-authoring in BBCode — **blocked on #399** (deterministic page IDs).

## Verification

- **49** parser unit tests (exact HTML per tag, tokenizer edge cases, DB resolution + plain-text fallback, escaping-based XSS defense).
- Full suite green: **1940 tests**, `tsc`/lint clean, OpenAPI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)