### PR TITLE
chore(seed): deterministic ids for the built-in wiki pages (#399)

### DIFF
--- a/src/modules/wikiFixtures.spec.ts
+++ b/src/modules/wikiFixtures.spec.ts
@@ -14,7 +14,12 @@
 import { PrismaClient } from '@prisma/client';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
-import { BUILTIN_WIKI_FIXTURES, readWikiFixtureBody } from './wikiFixtures';
+import {
+  BUILTIN_WIKI_FIXTURES,
+  WIKI_USER_PAGE_ID_FLOOR,
+  readWikiFixtureBody,
+  seedWikiFixtures
+} from './wikiFixtures';
 import { resolveSiteVariables } from './siteVariables';
 
 // resolveSiteVariables only touches forum.findFirst (the Bugs forum lookup).
@@ -68,5 +73,54 @@ describe('built-in wiki fixtures', () => {
       expect(fixture.title.length).toBeLessThanOrEqual(100);
     }
     expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('pins deterministic ids: unique, contiguous from 1, below the floor (#399)', () => {
+    const ids = BUILTIN_WIKI_FIXTURES.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(ids.map((_, i) => i + 1)); // 1..N in order
+    expect(Math.max(...ids)).toBeLessThan(WIKI_USER_PAGE_ID_FLOOR);
+  });
+});
+
+describe('seedWikiFixtures', () => {
+  it('creates pages with their pinned ids and reserves the id block (#399)', async () => {
+    const create = jest.fn(async () => ({}));
+    const queryRawUnsafe = jest.fn(async (_sql: string) => 1);
+    const client = {
+      wikiPage: { findUnique: async () => null, create },
+      $queryRawUnsafe: queryRawUnsafe
+    } as unknown as PrismaClient;
+
+    await seedWikiFixtures(client, 42);
+
+    // Every fresh fixture is created with its explicit id (not autoincrement).
+    expect(create).toHaveBeenCalledTimes(BUILTIN_WIKI_FIXTURES.length);
+    for (const fixture of BUILTIN_WIKI_FIXTURES) {
+      expect(create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ id: fixture.id, slug: fixture.slug })
+      });
+    }
+
+    // The sequence is advanced once so member pages don't reuse a fixture id.
+    expect(queryRawUnsafe).toHaveBeenCalledTimes(1);
+    const sql = queryRawUnsafe.mock.calls[0][0];
+    expect(sql).toContain('setval');
+    expect(sql).toContain('wiki_pages');
+    expect(sql).toContain(String(WIKI_USER_PAGE_ID_FLOOR - 1));
+  });
+
+  it('skips fixtures that already exist but still reserves the block', async () => {
+    const create = jest.fn(async () => ({}));
+    const queryRawUnsafe = jest.fn(async (_sql: string) => 1);
+    const client = {
+      wikiPage: { findUnique: async () => ({ id: 1 }), create },
+      $queryRawUnsafe: queryRawUnsafe
+    } as unknown as PrismaClient;
+
+    await seedWikiFixtures(client, 42);
+
+    expect(create).not.toHaveBeenCalled();
+    expect(queryRawUnsafe).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/wikiFixtures.ts
+++ b/src/modules/wikiFixtures.ts
@@ -35,6 +35,13 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 export interface WikiFixture {
+  /**
+   * Deterministic page id (#399). Pinned so `/wiki/:id` (the route is numeric,
+   * not slug) is reproducible across installs and seed cross-links can hard-
+   * reference a stable id. Unique, contiguous from 1; must stay below
+   * WIKI_USER_PAGE_ID_FLOOR.
+   */
+  id: number;
   /** URL slug — also the filename stem under prisma/seed-wiki/. Max 50 chars. */
   slug: string;
   /** Display title. Max 100 chars. */
@@ -46,22 +53,45 @@ export interface WikiFixture {
   citedByCanon: boolean;
 }
 
+/**
+ * User-created wiki pages start here; ids below it are reserved for fixtures
+ * (#399). Leaves headroom (12..999) to add fixtures later without a future id
+ * colliding with member content, which begins at 1000.
+ */
+export const WIKI_USER_PAGE_ID_FLOOR = 1000;
+
 export const BUILTIN_WIKI_FIXTURES: readonly WikiFixture[] = [
-  { slug: 'forum-rules', title: 'Forum Rules', citedByCanon: true },
-  { slug: 'staff-rules', title: 'Staff Rules', citedByCanon: true },
-  { slug: 'invite', title: 'Invites', citedByCanon: true },
-  { slug: 'classes', title: 'User Classes', citedByCanon: true },
-  { slug: 'requests', title: 'Requests', citedByCanon: true },
-  { slug: 'interfaces', title: 'Interface Whitelist', citedByCanon: true },
-  { slug: 'vpns', title: 'Proxies and VPNs', citedByCanon: true },
-  { slug: 'ips', title: 'Static and Shared IP Addresses', citedByCanon: true },
-  { slug: 'autosnatch', title: 'Automated Snatching', citedByCanon: true },
+  { id: 1, slug: 'forum-rules', title: 'Forum Rules', citedByCanon: true },
+  { id: 2, slug: 'staff-rules', title: 'Staff Rules', citedByCanon: true },
+  { id: 3, slug: 'invite', title: 'Invites', citedByCanon: true },
+  { id: 4, slug: 'classes', title: 'User Classes', citedByCanon: true },
+  { id: 5, slug: 'requests', title: 'Requests', citedByCanon: true },
   {
+    id: 6,
+    slug: 'interfaces',
+    title: 'Interface Whitelist',
+    citedByCanon: true
+  },
+  { id: 7, slug: 'vpns', title: 'Proxies and VPNs', citedByCanon: true },
+  {
+    id: 8,
+    slug: 'ips',
+    title: 'Static and Shared IP Addresses',
+    citedByCanon: true
+  },
+  {
+    id: 9,
+    slug: 'autosnatch',
+    title: 'Automated Snatching',
+    citedByCanon: true
+  },
+  {
+    id: 10,
     slug: 'security-disclosure',
     title: 'Reporting a Security Vulnerability',
     citedByCanon: true
   },
-  { slug: 'exploits', title: 'Exploits', citedByCanon: true }
+  { id: 11, slug: 'exploits', title: 'Exploits', citedByCanon: true }
 ];
 
 /** Read a fixture's markdown body off disk. Exported so the drift spec reads the same bytes. */
@@ -80,6 +110,13 @@ export function readWikiFixtureBody(slug: string): string {
  * edits — but a NEW fixture added in a later release still lands on an existing
  * install. (The table-wide shape is the trap #388 records against
  * `seedGoldenRules`, where one existing row suppresses the whole set.)
+ *
+ * Ids are pinned deterministically (#399). Explicit-id inserts don't advance the
+ * autoincrement sequence, so afterwards we push it to WIKI_USER_PAGE_ID_FLOOR
+ * (never regressing past the current MAX) — otherwise the next member-created
+ * page would reuse a fixture id. Note: create-if-absent means the pin only takes
+ * on a fresh row; renumbering an already-populated table needs a reset (a
+ * destructive migration, acceptable pre-alpha per #399).
  */
 export async function seedWikiFixtures(
   client: PrismaClient,
@@ -94,6 +131,7 @@ export async function seedWikiFixtures(
 
     await client.wikiPage.create({
       data: {
+        id: fixture.id,
         slug: fixture.slug,
         title: fixture.title,
         body: readWikiFixtureBody(fixture.slug),
@@ -101,4 +139,16 @@ export async function seedWikiFixtures(
       }
     });
   }
+
+  // Reserve the fixture id block: advance the sequence to the user-page floor,
+  // but never below the current MAX (a busy install may already be past it).
+  // $queryRaw (not $executeRaw) because `SELECT setval` returns a row.
+  await client.$queryRawUnsafe(
+    `SELECT setval(
+       pg_get_serial_sequence('wiki_pages', 'id'),
+       GREATEST(${
+         WIKI_USER_PAGE_ID_FLOOR - 1
+       }, COALESCE((SELECT MAX(id) FROM wiki_pages), 0))
+     )`
+  );
 }


### PR DESCRIPTION
Closes #399.

## What

The wiki route is `/wiki/:id` (numeric, not slug), so seeded wiki pages need **stable, reproducible ids** — for the BBCode `[[wiki]]` tag's output and for seed cross-links to point at a known id (part of the BBCode parity work #398).

- Pin each of the 11 `BUILTIN_WIKI_FIXTURES` an explicit `id` (1–11) and insert it verbatim.
- Explicit-id inserts don't advance Postgres's autoincrement sequence, so after seeding, push the `wiki_pages` sequence to a reserved **user-page floor (1000)** — never regressing past the current MAX. Member-created pages start at 1000+, so they never reuse a fixture id, and ids 12–999 stay free for future fixtures without a collision.
- Kept the existing **create-if-absent per slug** idempotency (#388 rationale). The pin only takes on a fresh row; renumbering an already-populated table needs a reset — a destructive migration, which #399 explicitly blesses (pre-alpha, disposable data).

## Scope

**Wiki pages only.** Rules were considered but are addressed by **positional number** (`#X.Y`, derived from fixed array order → `sortOrder`), not by their `id` PK, so their identity is already deterministic. Changing rule `code`s to numeric was rejected: PRD-09 mandates the slug `code`s as machine keys and the API contract asserts them (`rules.spec.ts`, integration).

## No schema change

Ids remain `@default(autoincrement())` — this only writes explicit values and advances the sequence at seed time. No migration, no OpenAPI/ERD drift.

## Tests

- `wikiFixtures.spec.ts`: pinned ids are unique, contiguous from 1, below the floor; `seedWikiFixtures` creates each page with its explicit id and advances the sequence once (both fresh and already-seeded paths).
- Full unit suite green (1968 tests, 107 suites); `tsc --noEmit`, `typecheck:test`, eslint clean.

## Follow-ups

- Unblocks the #398 seed re-authoring (Markdown → BBCode with `[[wiki]]` cross-links).
- A separate stellar-ui fix is coming for the rules page: it currently displays/anchors by the slug `code` instead of the positional number, so `[rule]` anchors (`/rules#1.1`) don't yet land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCpmAMVngqpubWKmSeA5Ha