### PR TITLE
feat(wiki): re-author built-in wiki seeds in the BBCode dialect — Phase 1 of #398

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@
 # committed file never drifts from a fresh `prisma generate` / export.
 docs/erd.md
 openapi.json
+
+# Wiki seed bodies carry BBCode, not Markdown (transcribed at read time by
+# renderBBCode, #398). Prettier's Markdown formatter corrupts them — it escapes
+# the `[*]` list markers to `[\*]`, which the tokenizer no longer recognizes.
+prisma/seed-wiki/

--- a/prisma/seed-wiki/autosnatch.md
+++ b/prisma/seed-wiki/autosnatch.md
@@ -1,28 +1,26 @@
-# Automated Snatching
-
 Golden Rule 5.3 prohibits the automatic snatching of freepass releases by any method involving little or no user input. This page explains what that covers and why the rule exists.
 
-## What freepass is
+==What freepass is==
 
-A **freepass** contribution can be downloaded without the bytes counting against your consumed total, while the contributor is still credited for what others take. It is a deliberate subsidy: staff apply it to selected contributions to promote them and to give members a route to rebuild a difficult ratio.
+A [b]freepass[/b] contribution can be downloaded without the bytes counting against your consumed total, while the contributor is still credited for what others take. It is a deliberate subsidy: staff apply it to selected contributions to promote them and to give members a route to rebuild a difficult ratio.
 
 Because the subsidy is finite and aimed at particular members, how it gets distributed matters as much as that it exists.
 
-## What the rule prohibits
+==What the rule prohibits==
 
 Snatching freepass releases through any method that requires little or no user input at the moment of the snatch. The rule names API-based scripts and log or site scraping as examples; the list is illustrative, not exhaustive.
 
-The test is **whether a human decided to take that particular item**. A script that watches for freepass flags and downloads what it finds is prohibited regardless of language, hosting, or how modest its request rate is. Rate-limiting an automated snatcher makes it a well-behaved automated snatcher.
+The test is [b]whether a human decided to take that particular item[/b]. A script that watches for freepass flags and downloads what it finds is prohibited regardless of language, hosting, or how modest its request rate is. Rate-limiting an automated snatcher makes it a well-behaved automated snatcher.
 
 Some specific cases worth naming:
 
-**Notification tooling is not the problem.** Being told promptly that something is available is fine. Acting on that notification without a human in the loop is not. The line falls at the download, not at the alert.
+[b]Notification tooling is not the problem.[/b] Being told promptly that something is available is fine. Acting on that notification without a human in the loop is not. The line falls at the download, not at the alert.
 
-**Browser automation counts.** Driving a browser, replaying requests, or scripting the web interface is automated access however it is implemented. See [Interface Whitelist](/wiki/interfaces), which covers approved clients generally.
+[b]Browser automation counts.[/b] Driving a browser, replaying requests, or scripting the web interface is automated access however it is implemented. See [[interfaces]], which covers approved clients generally.
 
-**Speed alone is not a breach.** A member who happens to be online and clicks quickly has not broken this rule. Watching the site attentively is not automation.
+[b]Speed alone is not a breach.[/b] A member who happens to be online and clicks quickly has not broken this rule. Watching the site attentively is not automation.
 
-## Why this exists
+==Why this exists==
 
 Freepass exists to be distributed among members, and it is a limited pool. An automated snatcher does not merely get there first — it gets there first every time, on every release, without the member being present.
 
@@ -30,12 +28,12 @@ Left unchecked, the entire subsidy accrues to whoever wrote the best script. The
 
 There is a second effect. Automated snatching inflates a contributor's credited bytes without any corresponding member actually wanting the content, which distorts both the ratio economy and the signals the site uses to judge what is worth promoting.
 
-## Consequences
+==Consequences==
 
 Breaches are handled at staff discretion, and the response takes account of scale and intent — a member who wrote something clumsy and stopped when asked is not in the same position as one running a sustained operation.
 
 Ratio benefit obtained through automated snatching may be reversed. Retaining a subsidy taken this way is not an outcome the rule contemplates.
 
-## If you are unsure
+==If you are unsure==
 
 Send a Staff PM and describe what you want to build before you run it. Tooling that assists a member without deciding for them is often fine, and asking first is routine.

--- a/prisma/seed-wiki/classes.md
+++ b/prisma/seed-wiki/classes.md
@@ -1,50 +1,46 @@
-# User Classes
-
 Your class determines which forums you can see, which features you can reach, and how much of the site is open to you. It is shown on your profile.
 
-## The ladder
+==The ladder==
 
-| Class         | Reached by                           |
-| ------------- | ------------------------------------ |
-| User          | Registration. Where everyone starts. |
-| Member        | Automatic progression                |
-| Power User    | Automatic progression                |
-| Elite         | Automatic progression                |
-| Stellarific   | Automatic progression                |
-| Stellartastic | Automatic progression                |
-| Stellarige    | Automatic progression                |
-| Staff         | Appointment only                     |
-| SysOp         | Appointment only                     |
+[*][b]User[/b] — Registration. Where everyone starts.
+[*][b]Member[/b] — Automatic progression.
+[*][b]Power User[/b] — Automatic progression.
+[*][b]Elite[/b] — Automatic progression.
+[*][b]Stellarific[/b] — Automatic progression.
+[*][b]Stellartastic[/b] — Automatic progression.
+[*][b]Stellarige[/b] — Automatic progression.
+[*][b]Staff[/b] — Appointment only.
+[*][b]SysOp[/b] — Appointment only.
 
 Staff and SysOp are never reached automatically and never demoted into. Everything below them is evaluated by an automated sweep.
 
-## How promotion works
+==How promotion works==
 
-The sweep runs on a schedule and checks each member against the rung above them. Promotion moves you **one step at a time** — meeting the criteria for a class three rungs up promotes you one rung, then the next on a later pass.
+The sweep runs on a schedule and checks each member against the rung above them. Promotion moves you [b]one step at a time[/b] — meeting the criteria for a class three rungs up promotes you one rung, then the next on a later pass.
 
 Each rung is defined by a combination of:
 
-- **Contributed volume** — bytes contributed
-- **Ratio** — contributed against consumed
-- **Contribution count** — how many separate contributions
-- **Account age** — measured in days since registration
+[*][b]Contributed volume[/b] — bytes contributed
+[*][b]Ratio[/b] — contributed against consumed
+[*][b]Contribution count[/b] — how many separate contributions
+[*][b]Account age[/b] — measured in days since registration
 
 Some rungs carry an additional requirement beyond these, such as a number of contributions meeting a quality bar or a spread across distinct releases.
 
 The exact thresholds are not listed here on purpose. They are tunable by staff at runtime, and a copy on this page would drift out of date silently. Your profile shows your current standing against the next rung.
 
-## What blocks promotion
+==What blocks promotion==
 
-**An active warning.** Warnings expire; until yours does, the sweep will not promote you.
+[b]An active warning.[/b] Warnings expire; until yours does, the sweep will not promote you.
 
-**A rank lock.** Staff can pin an account to its current class. If you are locked you will not progress regardless of your numbers.
+[b]A rank lock.[/b] Staff can pin an account to its current class. If you are locked you will not progress regardless of your numbers.
 
-## Demotion
+==Demotion==
 
 The same sweep can move an account down when it no longer meets the criteria for the class it holds — most often a ratio that has fallen. Demotion is not a punishment and carries no warning; it reflects current standing, and recovering the numbers reverses it.
 
 An account that consumes nothing at all does not drift downward indefinitely. Inactivity stalls progression rather than driving demotion.
 
-## Classes are not the whole picture
+==Classes are not the whole picture==
 
 Some access is granted separately from the ladder — donor status and specific staff-granted permissions sit alongside your class rather than replacing it. Losing a secondary status does not change your class, and gaining one does not promote you.

--- a/prisma/seed-wiki/exploits.md
+++ b/prisma/seed-wiki/exploits.md
@@ -1,30 +1,28 @@
-# Exploits
-
 Golden Rule 6.2 prohibits the publication, organization, dissemination, sharing, technical discussion, or technical facilitation of exploits, at staff discretion. This page unpacks that definition and explains how it is applied.
 
-## The definition
+==The definition==
 
-An exploit is an **unanticipated or unaccepted use of a service** — internal, external, non-profit, or for-profit.
+An exploit is an [b]unanticipated or unaccepted use of a service[/b] — internal, external, non-profit, or for-profit.
 
 Two things about that definition surprise members, and both are deliberate.
 
-**It is not limited to this site.** A method of obtaining paid goods, media, or services without paying is an exploit here even though it targets someone else entirely, and even though this site is not harmed by it.
+[b]It is not limited to this site.[/b] A method of obtaining paid goods, media, or services without paying is an exploit here even though it targets someone else entirely, and even though this site is not harmed by it.
 
-**It does not require a technical flaw.** Abusing a returns process, a free trial, a promotional offer, or a support desk is an unanticipated use of a service. That it involves no code does not put it outside the rule.
+[b]It does not require a technical flaw.[/b] Abusing a returns process, a free trial, a promotional offer, or a support desk is an unanticipated use of a service. That it involves no code does not put it outside the rule.
 
-## What the rule covers
+==What the rule covers==
 
 The prohibited conduct is broad by design and does not stop at instructions.
 
-**Publication and sharing** — posting a method, or passing it along privately.
+[b]Publication and sharing[/b] — posting a method, or passing it along privately.
 
-**Organization** — coordinating others to use one, or running a space where that happens.
+[b]Organization[/b] — coordinating others to use one, or running a space where that happens.
 
-**Technical discussion** — analysing how a method works, in public or in a members-only forum. A discussion framed as curiosity, security research, or a warning to others still carries the method to everyone reading it. This is the clause members most often trip over, and it is not an oversight.
+[b]Technical discussion[/b] — analysing how a method works, in public or in a members-only forum. A discussion framed as curiosity, security research, or a warning to others still carries the method to everyone reading it. This is the clause members most often trip over, and it is not an oversight.
 
-**Technical facilitation** — supplying the tooling, hosting, accounts, or infrastructure that makes a method usable, without describing the method itself.
+[b]Technical facilitation[/b] — supplying the tooling, hosting, accounts, or infrastructure that makes a method usable, without describing the method itself.
 
-## Where the line falls
+==Where the line falls==
 
 Referring to the existence of a problem is not the same as explaining how to reproduce it.
 
@@ -32,13 +30,13 @@ Saying that a service has a known weakness, or that a category of fraud exists, 
 
 If you find yourself trimming detail so a post stays acceptable, that is a signal the subject does not belong on the site rather than a technique for making it fit.
 
-## "At staff discretion"
+=="At staff discretion"==
 
 The rule says exploits are prohibited at staff discretion, and that discretion is real rather than decorative. It is what allows staff to distinguish a member who asked a naive question from one running a distribution channel, and to respond proportionately.
 
 It runs in both directions. Discretion does not mean a breach will be overlooked because it seemed harmless, and staff are not obliged to explain why a particular subject is off limits.
 
-## Reclassification
+==Reclassification==
 
 Exploits are subject to reclassification at any time.
 
@@ -46,10 +44,10 @@ Something acceptable when posted may later be classified as an exploit — becau
 
 When that happens, the material comes down. Staff are not seeking to punish members for content that was acceptable when written; complying with the reclassification is what is expected, and arguing that it was fine at the time does not change the outcome.
 
-## Vulnerabilities in this site
+==Vulnerabilities in this site==
 
-Bugs and vulnerabilities in this site are governed by Golden Rule 6.1 and have their own route. See [Reporting a Security Vulnerability](/wiki/security-disclosure) — report privately, do not discuss it publicly, and do not test against the live site.
+Bugs and vulnerabilities in this site are governed by Golden Rule 6.1 and have their own route. See [[security-disclosure]] — report privately, do not discuss it publicly, and do not test against the live site.
 
-## If you are unsure
+==If you are unsure==
 
 Send a Staff PM before posting. A question asked in advance is never a breach; a post made in the hope that it falls on the right side of the line may be.

--- a/prisma/seed-wiki/forum-rules.md
+++ b/prisma/seed-wiki/forum-rules.md
@@ -1,47 +1,45 @@
-# Forum Rules
-
 The Golden Rules govern the forums as they govern everything else — Rule 4 (Conduct) is the one you will meet most often. This page covers what is specific to the forums: who can see what, how threads are moderated, and what gets a post removed.
 
-## Access is by class, not by permission
+==Access is by class, not by permission==
 
 Every forum carries three independent thresholds:
 
-- **Read** — whether the forum appears to you at all. A forum above your class is not visible; it is not hidden with an error, it simply is not listed.
-- **Write** — whether you can reply to existing topics.
-- **Create** — whether you can start new topics.
+[*][b]Read[/b] — whether the forum appears to you at all. A forum above your class is not visible; it is not hidden with an error, it simply is not listed.
+[*][b]Write[/b] — whether you can reply to existing topics.
+[*][b]Create[/b] — whether you can start new topics.
 
-These are separate on purpose. A forum can be readable by everyone but writable only by established members, which is how announcement and archive forums work. Your class is shown on your profile; see [User Classes](/wiki/classes) for how it changes.
+These are separate on purpose. A forum can be readable by everyone but writable only by established members, which is how announcement and archive forums work. Your class is shown on your profile; see [[classes]] for how it changes.
 
 If a forum you expect to see is missing, the usual cause is that you have not reached its read class yet. That is not a bug and staff will not grant exceptions on request.
 
-## Posting
+==Posting==
 
-**Search before you post.** Duplicate threads get merged or trashed, and the merge loses replies.
+[b]Search before you post.[/b] Duplicate threads get merged or trashed, and the merge loses replies.
 
-**One topic per thread.** Threads that sprawl get split, which is more work for staff than starting a second thread was for you.
+[b]One topic per thread.[/b] Threads that sprawl get split, which is more work for staff than starting a second thread was for you.
 
-**No bumping.** Replying to an old thread to raise it without adding anything is treated as spam. Adding real content to an old thread is fine and welcome.
+[b]No bumping.[/b] Replying to an old thread to raise it without adding anything is treated as spam. Adding real content to an old thread is fine and welcome.
 
-**Quote sparingly.** Quote the part you are replying to, not the entire post above you. Nested quote pyramids get edited down.
+[b]Quote sparingly.[/b] Quote the part you are replying to, not the entire post above you. Nested quote pyramids get edited down.
 
-**Formatting is not decoration.** Oversized text, walls of colour, and full-post emphasis are edited without notice.
+[b]Formatting is not decoration.[/b] Oversized text, walls of colour, and full-post emphasis are edited without notice.
 
-## Moderation
+==Moderation==
 
 Moderators can edit, lock, sticky, trash, and split topics, and can attach notes to a thread that other staff can see. Actions are logged.
 
 Deleted posts are soft-deleted — they are removed from view but retained. This matters in two directions: staff can review what was removed, and you should assume nothing you post is truly gone.
 
-**Do not moderate on staff's behalf.** Replying to a rule-breaking post to say it breaks the rules adds noise to a thread that already needs cleaning. Report it instead. This is Golden Rule 4 (`no-backseat-moderate`), and it is enforced.
+[b]Do not moderate on staff's behalf.[/b] Replying to a rule-breaking post to say it breaks the rules adds noise to a thread that already needs cleaning. Report it instead. This is Golden Rule 4 ([code]no-backseat-moderate[/code]), and it is enforced.
 
-**Disputes go to staff, not to the thread.** If you think a moderation call was wrong, raise it privately through Staff PM. Re-litigating it publicly is itself a conduct matter.
+[b]Disputes go to staff, not to the thread.[/b] If you think a moderation call was wrong, raise it privately through Staff PM. Re-litigating it publicly is itself a conduct matter.
 
-## What gets a post removed
+==What gets a post removed==
 
-- Anything breaching a Golden Rule — the rules page is canonical, this list is not a substitute.
-- Personal attacks, targeted mockery, and pile-ons. Disagreement about music, gear, or code is fine; disagreement about people is not.
-- Posting another member's identifying information, in any amount, for any reason.
-- Advertising, referral links, and solicitation.
-- Requesting invites. Invites may be offered in the Invites forum, never requested — including by private message.
+[*]Anything breaching a Golden Rule — the rules page is canonical, this list is not a substitute.
+[*]Personal attacks, targeted mockery, and pile-ons. Disagreement about music, gear, or code is fine; disagreement about people is not.
+[*]Posting another member's identifying information, in any amount, for any reason.
+[*]Advertising, referral links, and solicitation.
+[*]Requesting invites. Invites may be offered in the Invites forum, never requested — including by private message.
 
 Removal is not automatically a warning. Repeated removal is.

--- a/prisma/seed-wiki/interfaces.md
+++ b/prisma/seed-wiki/interfaces.md
@@ -1,30 +1,28 @@
-# Interface Whitelist
-
 An interface is any client or tool that talks to the site on your behalf. Golden Rule 3 requires that yours is on this whitelist and is unmodified.
 
-## The rule, before the list
+==The rule, before the list==
 
-**Whitelisted means the specific published build.** A client on this list, patched or rebuilt with changes, is not whitelisted — it is an unapproved interface that shares a name with an approved one.
+[b]Whitelisted means the specific published build.[/b] A client on this list, patched or rebuilt with changes, is not whitelisted — it is an unapproved interface that shares a name with an approved one.
 
-**Automated access goes through the API.** The API is rate-limited and documented. Scripting the web interface — scraping pages, replaying form submissions, driving a browser — is not automated access through an approved route, whatever it is written in.
+[b]Automated access goes through the API.[/b] The API is rate-limited and documented. Scripting the web interface — scraping pages, replaying form submissions, driving a browser — is not automated access through an approved route, whatever it is written in.
 
-**Absence from this list is not permission.** If your client is not listed, it is not approved. There is no default-allow.
+[b]Absence from this list is not permission.[/b] If your client is not listed, it is not approved. There is no default-allow.
 
-## The list
+==The list==
 
 The whitelist is maintained by staff. Its current contents are published on the site rather than in this page, so that a client can be added or withdrawn without a documentation change lagging behind it.
 
 If you cannot find the current list, send a Staff PM and ask. Do not guess, and do not rely on a list you saw elsewhere or previously — entries are withdrawn when a client starts misbehaving, and using a withdrawn client is a rule breach even though it was fine last month.
 
-## Developing an interface
+==Developing an interface==
 
 Developers are welcome, and this is not intended to shut the door on new clients.
 
-If you are building or testing something that is not yet approved, get staff approval **before** pointing it at the site. Approval for testing is routine and is usually granted; running an unapproved client against production first and asking afterwards is not, and the fact that you intended to submit it does not retroactively make it approved.
+If you are building or testing something that is not yet approved, get staff approval [b]before[/b] pointing it at the site. Approval for testing is routine and is usually granted; running an unapproved client against production first and asking afterwards is not, and the fact that you intended to submit it does not retroactively make it approved.
 
 What staff will want to know: what it does, how it authenticates, what it requests and how often, and how it backs off when rate-limited.
 
-## Why this exists
+==Why this exists==
 
 An interface acts with your credentials and your ratio. A client that requests too aggressively degrades the site for everyone; one that mishandles credentials exposes your account; one that reports inaccurate data corrupts the ledger, which is the same offence as manipulating it by hand.
 

--- a/prisma/seed-wiki/invite.md
+++ b/prisma/seed-wiki/invite.md
@@ -1,40 +1,38 @@
-# Invites
-
 Registration is closed. The only ways in are an invite from an existing member or an interview.
 
-## You are responsible for who you invite
+==You are responsible for who you invite==
 
-This is the part people skip, so it is first: **an invite is a reference, not a gift.** If the person you invite cheats the ratio ledger, sells their account, or is banned, that is recorded against you. Repeatedly inviting members who are banned costs you the ability to invite and can cost you your own account.
+This is the part people skip, so it is first: [b]an invite is a reference, not a gift.[/b] If the person you invite cheats the ratio ledger, sells their account, or is banned, that is recorded against you. Repeatedly inviting members who are banned costs you the ability to invite and can cost you your own account.
 
 Invite people you actually know and would vouch for. "They seemed fine in a chat once" is not vouching.
 
-## Sending an invite
+==Sending an invite==
 
 Invites are sent by email from your profile. The recipient gets a link and creates their account from it.
 
 Before you send one, tell them plainly:
 
-- One account per person, forever. Not one at a time — one ever.
-- They must keep live links and honest metadata on anything they contribute.
-- Their ratio is their responsibility from day one.
-- If they are banned, it reflects on you.
+[*]One account per person, forever. Not one at a time — one ever.
+[*]They must keep live links and honest metadata on anything they contribute.
+[*]Their ratio is their responsibility from day one.
+[*]If they are banned, it reflects on you.
 
 Someone who is not willing to hear that list is someone you should not invite.
 
-## What you cannot do with invites
+==What you cannot do with invites==
 
-**Do not request them.** Requesting an invite — here, elsewhere, publicly, or by private message — is prohibited. This applies to invites for this site and for any other.
+[b]Do not request them.[/b] Requesting an invite — here, elsewhere, publicly, or by private message — is prohibited. This applies to invites for this site and for any other.
 
-**Do not offer them publicly.** Invites may be offered in the Invites forum, which is restricted to Power User class and above. Offering them anywhere else, including other sites and public chat, is prohibited.
+[b]Do not offer them publicly.[/b] Invites may be offered in the Invites forum, which is restricted to Power User class and above. Offering them anywhere else, including other sites and public chat, is prohibited.
 
-**Do not trade or sell them.** Invites have no price. Anyone offering to buy one is trying to buy a way past the interview, and anyone selling one is trading the reference they were trusted with.
+[b]Do not trade or sell them.[/b] Invites have no price. Anyone offering to buy one is trying to buy a way past the interview, and anyone selling one is trading the reference they were trusted with.
 
 You may message a member about an invite only when they have already offered one in the Invites forum. Unsolicited requests by private message are still requests.
 
-## If you have no invites
+==If you have no invites==
 
 Invite allocation comes with class progression. If you have none available, the answer is not to ask staff for one — it is to keep contributing until you reach a class that carries them.
 
-## The other way in
+==The other way in==
 
 Someone without an invite can be interviewed on IRC instead. That route is open to anyone and does not require knowing an existing member. Point people there rather than inviting someone you cannot vouch for; the interview exists precisely so that you do not have to put your own account behind a stranger.

--- a/prisma/seed-wiki/ips.md
+++ b/prisma/seed-wiki/ips.md
@@ -1,24 +1,22 @@
-# Static and Shared IP Addresses
+Golden Rule 5.1 turns on the address your connection arrives from. [[vpns]] covers the route you take to reach the site; this page covers the address itself — what "static and unique to you" means in practice, and what to do when your circumstances do not fit that description neatly.
 
-Golden Rule 5.1 turns on the address your connection arrives from. [Proxies and VPNs](/wiki/vpns) covers the route you take to reach the site; this page covers the address itself — what "static and unique to you" means in practice, and what to do when your circumstances do not fit that description neatly.
+==Static, dynamic, and unique==
 
-## Static, dynamic, and unique
-
-A **static** address is one that does not change between connections. A **dynamic** address is reassigned by your provider periodically or on reconnection.
+A [b]static[/b] address is one that does not change between connections. A [b]dynamic[/b] address is reassigned by your provider periodically or on reconnection.
 
 The rule asks for an address that is static and unique to you, but ordinary residential connections are frequently dynamic, and that is not itself a problem. A home connection whose address changes occasionally is the normal case, and members are not expected to buy a static address to use the site. What the rule is aimed at is the deliberate use of an address shared with people you do not know — a commercial VPN exit, a public proxy, a Tor exit node.
 
-The distinction that matters is not static versus dynamic. It is **yours** versus **shared with strangers**.
+The distinction that matters is not static versus dynamic. It is [b]yours[/b] versus [b]shared with strangers[/b].
 
-## Shared connections you have not chosen
+==Shared connections you have not chosen==
 
 Some members connect from addresses shared with others as a matter of circumstance rather than choice: university halls, student accommodation, some corporate networks, and carrier-grade NAT on certain mobile and residential providers.
 
 These are not rule breaches, and members in this position are not doing anything wrong. They do, however, create the same ambiguity a VPN does — several accounts appearing from one address — and staff cannot tell the difference between that and a genuine problem without being told.
 
-**If you know you are on a shared connection of this kind, send a Staff PM and say so.** A short note recorded in advance resolves the question permanently and costs nothing.
+[b]If you know you are on a shared connection of this kind, send a Staff PM and say so.[/b] A short note recorded in advance resolves the question permanently and costs nothing.
 
-## Households and multiple accounts
+==Households and multiple accounts==
 
 More than one member legitimately using the site from one household is a common and accepted arrangement. It is also, from the outside, indistinguishable from one person running several accounts, which is not accepted.
 
@@ -26,13 +24,13 @@ The way to keep it uncontroversial is to declare it. Send a Staff PM naming the 
 
 Note that each account remains individually accountable. Sharing a household does not mean sharing accounts, credentials, or invites — Golden Rule 1 applies unchanged, and the fact that two accounts are declared as a household is not a defence to one person operating both.
 
-## If your address is flagged or blocked
+==If your address is flagged or blocked==
 
 Address-based blocks exist and are applied by staff. If you find yourself unable to reach the site and believe an address block is the reason, contact staff through the disabled-account support channel on IRC — you may not be able to reach the in-app Staff PM to raise it.
 
 A block is not always aimed at you personally. Addresses are reassigned by providers, and ranges are sometimes blocked for reasons that predate your use of one. Ask; it is resolvable.
 
-## What not to do
+==What not to do==
 
 Do not attempt to work around an address problem by changing how you connect. Reaching the site through a VPN, proxy, or someone else's connection to get past a block converts a resolvable administrative question into a Golden Rule 5.1 breach, and does so visibly.
 

--- a/prisma/seed-wiki/requests.md
+++ b/prisma/seed-wiki/requests.md
@@ -1,8 +1,6 @@
-# Requests
-
 A request asks someone to contribute something the site does not have. A bounty is what you attach to make it worth their while.
 
-## How it works
+==How it works==
 
 You create a request describing what you want, precisely enough that someone can tell whether a given release satisfies it. Vague requests go unfilled.
 
@@ -10,7 +8,7 @@ Other members can vote on a request by adding to its bounty. Bounties are pooled
 
 When a contribution satisfying the request is submitted, the request is filled and the bounty transfers.
 
-## Writing a request that gets filled
+==Writing a request that gets filled==
 
 Be specific about what would satisfy you. A request that does not say which edition, format, or quality is acceptable will either sit unfilled or be filled by something you did not want — and once it is filled, it is filled.
 
@@ -18,24 +16,24 @@ Say what you have already checked. A request for something that is already on th
 
 Do not re-request something that was recently declined or removed. If it was removed for a reason, requesting it again does not change the reason.
 
-## Bounties
+==Bounties==
 
 You can add to any request's bounty, including your own. What you add leaves your buffer at the moment you add it.
 
-**Bounties are not refundable on a whim.** Adding to a bounty is a commitment; treat it as spent. A request being filled by something you personally did not want is not grounds for reversal — that is an argument for having written the request properly.
+[b]Bounties are not refundable on a whim.[/b] Adding to a bounty is a commitment; treat it as spent. A request being filled by something you personally did not want is not grounds for reversal — that is an argument for having written the request properly.
 
 There is a minimum for a bounty to be worth recording. Very small bounties do not meaningfully motivate anyone.
 
-## Request abuse
+==Request abuse==
 
 This is the part that carries a rule behind it. Requests and bounties move buffer between accounts, which makes them an obvious target for manipulation — and manipulating them is ratio manipulation under Golden Rule 3, not a lesser offence.
 
 Specifically prohibited:
 
-- **Filling your own request**, directly or through an account you control, to move buffer to yourself.
-- **Arranged fills** — agreeing with another member that they will fill your request and you will fill theirs, to move buffer between you.
-- **Bounty inflation** — stacking a bounty with the understanding that it will return to you.
-- **Requesting to launder buffer** through an account you also control.
+[*][b]Filling your own request[/b], directly or through an account you control, to move buffer to yourself.
+[*][b]Arranged fills[/b] — agreeing with another member that they will fill your request and you will fill theirs, to move buffer between you.
+[*][b]Bounty inflation[/b] — stacking a bounty with the understanding that it will return to you.
+[*][b]Requesting to launder buffer[/b] through an account you also control.
 
 The common thread is buffer moving without a real contribution behind it. If a sequence of requests and fills leaves buffer somewhere it would not otherwise have gone, and no genuine contribution caused it, that is manipulation regardless of how it was structured.
 

--- a/prisma/seed-wiki/security-disclosure.md
+++ b/prisma/seed-wiki/security-disclosure.md
@@ -1,22 +1,20 @@
-# Reporting a Security Vulnerability
-
 Golden Rule 6.1 asks you to report a critical bug or security vulnerability immediately, and in accordance with this page. This is the member's route: where to send it, what to include, and what happens next.
 
-## Critical or not
+==Critical or not==
 
-Report **privately** if the issue could let someone read, change, or destroy data that is not theirs; act as another member or as staff; bypass a permission, class, or ratio check; or take the site down.
+Report [b]privately[/b] if the issue could let someone read, change, or destroy data that is not theirs; act as another member or as staff; bypass a permission, class, or ratio check; or take the site down.
 
-Report in the **Bugs forum** if it could not. Display glitches, broken links, wrong counts, layout problems, and confusing behaviour all belong there, in the open, where other members can confirm them.
+Report in the [b]Bugs forum[/b] if it could not. Display glitches, broken links, wrong counts, layout problems, and confusing behaviour all belong there, in the open, where other members can confirm them.
 
 If you cannot tell which it is, treat it as critical and send it privately. Raising a display bug through the private route wastes a little staff time; discussing a live vulnerability in public exposes every member until it is fixed. Those are not comparable mistakes, and nobody will mind the first one.
 
-## How to report privately
+==How to report privately==
 
-Send a **Staff PM**. If your account is disabled or you cannot reach the site at all, use the disabled-account support channel on IRC.
+Send a [b]Staff PM[/b]. If your account is disabled or you cannot reach the site at all, use the disabled-account support channel on IRC.
 
 Do not post it in a forum, a comment, a public channel, or anywhere else visible to members while it is unfixed — including as a vague hint that something is wrong. Golden Rule 6.2 covers publication and technical facilitation of exploits, and a public description of a live vulnerability is both.
 
-## What to include
+==What to include==
 
 Enough for someone else to reproduce it: the page or endpoint affected, the steps you took, what you expected, and what happened instead.
 
@@ -24,7 +22,7 @@ A minimal demonstration that the issue is real is welcome. A working exploit, or
 
 If you found it accidentally, say so and describe what you were doing. That context is genuinely useful and is not held against you.
 
-## Do not test the live site
+==Do not test the live site==
 
 This is the part members most often get wrong with good intentions.
 
@@ -32,7 +30,7 @@ Golden Rule 6.1 prohibits seeking or exploiting bugs on the live site. Confirmin
 
 Reporting a bug you found by looking is fine and welcome. Reporting a bug you found by probing is a breach that happens to come with a report attached.
 
-## What happens next
+==What happens next==
 
 Staff will acknowledge the report and investigate. You may be asked for detail or for help reproducing it.
 
@@ -40,6 +38,6 @@ Please keep it to yourself until it is fixed, including after a fix is announced
 
 Good-faith reporting is not a Golden Rule violation and is not treated as one. A member who reports honestly, privately, and without exploiting what they found has done the site a service, and staff treat it that way.
 
-## Security researchers
+==Security researchers==
 
-If you are working from the source repository rather than as a member of the site, the repository's `SECURITY.md` carries the coordinated-disclosure terms and rules of engagement that apply to you. This page covers the in-app member route only.
+If you are working from the source repository rather than as a member of the site, the repository's [code]SECURITY.md[/code] carries the coordinated-disclosure terms and rules of engagement that apply to you. This page covers the in-app member route only.

--- a/prisma/seed-wiki/staff-rules.md
+++ b/prisma/seed-wiki/staff-rules.md
@@ -1,10 +1,8 @@
-# Staff Rules
-
 Staff are volunteers. They are members first, bound by every Golden Rule, and additionally bound by this page. Holding a permission is not a licence to use it.
 
 This page is public to members deliberately. Rules that only staff can read are rules members cannot hold staff to.
 
-## How staff authority actually works
+==How staff authority actually works==
 
 There is no "is staff" flag that unlocks the site. Every staff action is gated by a specific named permission attached to a rank — the ability to resolve reports, to manage rules content, to moderate a forum. Someone who can lock a thread may have no ability to view another member's account, and the reverse.
 
@@ -12,30 +10,30 @@ This matters for two reasons. A staff member cannot do something simply because 
 
 Staff ranks are grouped for organisation, but the group does not carry the power — the permissions do.
 
-## What staff must do
+==What staff must do==
 
-**Act within your permissions.** If you cannot do something, escalate it. Do not ask another staff member to action something you were told not to.
+[b]Act within your permissions.[/b] If you cannot do something, escalate it. Do not ask another staff member to action something you were told not to.
 
-**Log the reasoning, not just the action.** Warnings, removals, and report resolutions are audited. A record that says only what happened, without why, is not usable by whoever handles the follow-up.
+[b]Log the reasoning, not just the action.[/b] Warnings, removals, and report resolutions are audited. A record that says only what happened, without why, is not usable by whoever handles the follow-up.
 
-**Recuse yourself.** Do not moderate a dispute you are part of, act on a report naming you, or rule on a member you have a personal conflict with. Hand it to someone else.
+[b]Recuse yourself.[/b] Do not moderate a dispute you are part of, act on a report naming you, or rule on a member you have a personal conflict with. Hand it to someone else.
 
-**Keep member information inside staff channels.** Account details, reports, and correspondence seen through staff tooling stay there. This does not expire when you stop being staff.
+[b]Keep member information inside staff channels.[/b] Account details, reports, and correspondence seen through staff tooling stay there. This does not expire when you stop being staff.
 
-**Answer, or say you cannot.** A member waiting on a decision is entitled to know it is being handled. Silence is the most common legitimate complaint about staff.
+[b]Answer, or say you cannot.[/b] A member waiting on a decision is entitled to know it is being handled. Silence is the most common legitimate complaint about staff.
 
-## What staff must not do
+==What staff must not do==
 
-**Do not trade on the position.** No favours, no fast-tracking, no leniency for people you know, no invites or access granted outside the normal path. This is the one that ends staff tenure rather than earning a warning.
+[b]Do not trade on the position.[/b] No favours, no fast-tracking, no leniency for people you know, no invites or access granted outside the normal path. This is the one that ends staff tenure rather than earning a warning.
 
-**Do not use staff tooling out of curiosity.** Read access exists to resolve specific matters. Browsing accounts because you can is a breach even when nothing is disclosed.
+[b]Do not use staff tooling out of curiosity.[/b] Read access exists to resolve specific matters. Browsing accounts because you can is a breach even when nothing is disclosed.
 
-**Do not moderate while angry.** Nothing in a thread requires action within the next ten minutes. Hand it over if you are in it.
+[b]Do not moderate while angry.[/b] Nothing in a thread requires action within the next ten minutes. Hand it over if you are in it.
 
-**Do not invent rules.** If the behaviour is not covered, take it to the rest of staff and get the rule written down. Enforcing an unwritten standard is how a rule ends up meaning different things depending on who read it.
+[b]Do not invent rules.[/b] If the behaviour is not covered, take it to the rest of staff and get the rule written down. Enforcing an unwritten standard is how a rule ends up meaning different things depending on who read it.
 
-## Holding staff to this
+==Holding staff to this==
 
 If a staff member breaches this page, report it the same way you would report anything else, through Staff PM. It reaches staff who are not the subject of the report.
 
-Staff decisions are final in the moment — argue them privately, afterwards, not in-channel or in-thread (Golden Rule 4, `respect-staff-decisions`). "Final in the moment" means you comply now and appeal after; it does not mean the decision cannot be reviewed.
+Staff decisions are final in the moment — argue them privately, afterwards, not in-channel or in-thread (Golden Rule 4, [code]respect-staff-decisions[/code]). "Final in the moment" means you comply now and appeal after; it does not mean the decision cannot be reviewed.

--- a/prisma/seed-wiki/vpns.md
+++ b/prisma/seed-wiki/vpns.md
@@ -1,14 +1,12 @@
-# Proxies and VPNs
-
 Golden Rule 5.1 governs how you may reach the site. This page explains what it permits, what it does not, and how to get an arrangement approved before you rely on it.
 
-## What the rule permits
+==What the rule permits==
 
-You may browse through a private server or proxy **only if it has a static IP address unique to you**, or through your own private or shared VPS.
+You may browse through a private server or proxy [b]only if it has a static IP address unique to you[/b], or through your own private or shared VPS.
 
-The operative word is **unique**. The test is not whether a connection is encrypted, paid for, or reputable — it is whether the address your traffic arrives from belongs to you and to nobody else. An address you share with strangers fails that test however good the service is.
+The operative word is [b]unique[/b]. The test is not whether a connection is encrypted, paid for, or reputable — it is whether the address your traffic arrives from belongs to you and to nobody else. An address you share with strangers fails that test however good the service is.
 
-## What the rule does not permit
+==What the rule does not permit==
 
 The rule applies to every kind of proxy. That includes commercial VPN services, Tor, and public proxies of any sort.
 
@@ -16,7 +14,7 @@ Commercial VPNs are the common case and the one members most often assume is fin
 
 Tor is excluded for the same reason and more strongly: exit nodes are shared by design and change between circuits.
 
-## Why the site cares
+==Why the site cares==
 
 Every action here is attributed to an account, and the address a connection arrives from is one of the few independent signals that an account is being used by the person it belongs to.
 
@@ -24,16 +22,16 @@ When many accounts share one address, that signal disappears. Staff can no longe
 
 This also means the rule protects you. If your account is accessed by someone else, the address is part of how that gets established.
 
-## Getting approval
+==Getting approval==
 
-If your situation is not clearly covered above, **send a Staff PM and ask before you connect through it**, not after.
+If your situation is not clearly covered above, [b]send a Staff PM and ask before you connect through it[/b], not after.
 
 Approval is a routine request and asking is not treated as suspicious. What staff will want to know: what the service or server is, whether the address is static, and whether anyone else uses it.
 
 Two things worth being clear about. Approval is specific to the arrangement you described — changing provider, server, or address means asking again. And connecting first and seeking approval afterwards is not the same thing as approval, even where the arrangement would have been permitted had you asked.
 
-## If your address changes
+==If your address changes==
 
 A static address that changes because your provider renumbered, or a VPS you have migrated, is worth a Staff PM. This is housekeeping rather than an accusation, and it is much easier to explain in advance than to explain once an automated check has flagged it.
 
-See also [Static and Shared IP Addresses](/wiki/ips), which covers the address itself rather than the route your traffic takes to reach it.
+See also [[ips]], which covers the address itself rather than the route your traffic takes to reach it.


### PR DESCRIPTION
Closes the last remaining Phase 1 task of #398: the built-in wiki seeds were authored in Markdown, but wiki bodies are now transcribed at read time by `renderBBCode` (via `withBodyHtml` in `wiki.ts`). Their `#` headings, `**bold**`, `[text](url)` links, bullet lists, and the `classes.md` table were rendering as literal characters. This re-authors all 11 `prisma/seed-wiki/*.md` into the BBCode dialect `render.ts` actually supports.

## Conversions
- Markdown `## Section` → `==h2==`. The redundant leading `# Title` line is **dropped** — the UI renders `WikiPage.title` as the page `<h1>` (`WikiViewPage.tsx:102`), so body sections start at h2.
- `**bold**` → `[b]…[/b]`; bullets `- item` → loose `[*]` lists.
- The 5 internal cross-links `[Title](/wiki/<slug>)` → `[[<slug>]]` (resolves to the page title as link text — a clean 1:1 swap since every label already equals its fixture title).
- The 3 inline backtick codes → `[code]…[/code]`.
- The `classes.md` Class/Reached-by table → a `[*]` list (no `[table]` tag in v1, per the #398 grill).

## Prettier guard (root cause)
These files carry **BBCode, not Markdown**, so `.prettierignore` now excludes `prisma/seed-wiki/`. Prettier's Markdown formatter escapes the `[*]` markers to `[\*]`, which the tokenizer no longer recognizes — it silently broke every list until the exclusion was added.

## Scope
Content + fixtures only — no route or schema change. No `${…}` tokens (wiki bodies are served verbatim; only `GET /api/rules/tree` substitutes, guarded by `wikiFixtures.spec.ts`).

## Verification
- Spot-rendered every converted construct through the real parser (`tokenize`→`parse`→`render`): `<h2>`, `<strong>`, `<ul class="bbcode-list"><li>`, `<a href="/wiki/4">User Classes</a>`, `<code class="bbcode-code">` all correct.
- `wikiFixtures.spec.ts` / `bbcode.spec.ts` / `wiki.spec.ts` green (103 tests); full unit suite green (1968 tests).
- `tsc --noEmit`, `eslint`, and `openapi:export` (no diff) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)