### PR TITLE
feat(bbcode): render [tex] via server-side KaTeX — Phase 3 (#403)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,6 +31,7 @@ module.exports = {
           'express-rate-limit',
           'isomorphic-dompurify',
           'jest-mock-extended',
+          'katex',
           'nodemailer'
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ git remote add upstream git@github.com:orphic-inc/stellar-api.git   # or: git wi
 
 **Dependency bumps** are isolated (own branch/PR), pinned, ADR'd, and atomic with the regen/migration they force — never entangled with feature work (ADR-0009).
 
+> **Adding a dependency with a conditional `exports` map.** Packages whose `package.json` resolves through a conditional `exports` map (e.g. `katex`, `isomorphic-dompurify`, `@sentry/node`, `@prisma/client`) can't be followed by the `import/no-unresolved` resolver Codacy Static Code Analysis runs, so the **Codacy** PR check fails with an unresolved-import issue even though `import katex from 'katex'` type-checks and runs fine. Local `npm run lint` can pass — the local node resolver reads the package's `main` field — so a green local lint is **not** proof the Codacy check will pass. The fix is the established one: add the bare package name to the `ignore` array of the `import/no-unresolved` rule in `.eslintrc.cjs` (that list exists for exactly this class of module). Verify with `npm run lint`, and confirm the Codacy check on the PR goes green.
+
 ## Local pre-commit gate
 
 The **husky** `pre-commit` hook does more than format staged files — it runs, in order:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "isomorphic-dompurify": "^3.9.0",
         "jsdom": "^29.0.2",
         "jsonwebtoken": "^9.0.2",
+        "katex": "^0.16.47",
         "nodemailer": "^8.0.7",
         "prisma": "^6.19.3",
         "swagger-ui-express": "^5.0.1",
@@ -61,6 +62,9 @@
         "ts-jest": "^29.4.9",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=22 <23"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10387,7 +10391,6 @@
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
       "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -10404,7 +10407,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@prisma/client": "^6.19.3",
     "@sentry/node": "^10.55.0",
-    "prisma": "^6.19.3",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
@@ -55,7 +54,9 @@
     "isomorphic-dompurify": "^3.9.0",
     "jsdom": "^29.0.2",
     "jsonwebtoken": "^9.0.2",
+    "katex": "^0.16.47",
     "nodemailer": "^8.0.7",
+    "prisma": "^6.19.3",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.10.0",
     "zod": "^4.3.6"

--- a/src/lib/bbcode/bbcode.spec.ts
+++ b/src/lib/bbcode/bbcode.spec.ts
@@ -180,6 +180,20 @@ describe('bbcode — raw-content tags', () => {
       '<pre class="bbcode-pre">  two  spaces</pre>'
     );
   });
+  it('tex renders LaTeX via server KaTeX (MathML + html)', () => {
+    const out = bb('[tex]E = mc^2[/tex]');
+    expect(out).toContain('<span class="katex">');
+    expect(out).toContain('<math xmlns="http://www.w3.org/1998/Math/MathML">');
+    // The source round-trips verbatim in the MathML annotation.
+    expect(out).toContain(
+      '<annotation encoding="application/x-tex">E = mc^2</annotation>'
+    );
+  });
+  it('tex does not parse its body as BBCode', () => {
+    const out = bb('[tex][i]x[/i][/tex]');
+    expect(out).not.toContain('<em>'); // [i] reached KaTeX as literal LaTeX
+    expect(out).toContain('[i]x[/i]'); // preserved verbatim in the annotation
+  });
 });
 
 describe('bbcode — tokenizer/stack semantics', () => {

--- a/src/lib/bbcode/render.ts
+++ b/src/lib/bbcode/render.ts
@@ -1,3 +1,4 @@
+import katex from 'katex';
 import { BBCtx } from './ctx';
 import { extractReleaseId, ResolveMaps } from './resolve';
 import { Node } from './types';
@@ -59,6 +60,23 @@ function linkFromUrl(url: string, ctx: BBCtx): string {
     escapeText(display),
     external && !safe.startsWith(ctx.siteUrl)
   );
+}
+
+// [tex] is a raw-content tag: its body is literal LaTeX, rendered server-side by
+// KaTeX (#403). The output (MathML + HTML spans + a little SVG) is passed through
+// the sanitize allowlist like everything else. `throwOnError: false` renders a
+// parse error inline as a red node rather than throwing; the try/catch is the
+// belt-and-suspenders so a render-at-read call can never 500 — on any failure we
+// fall back to the Phase 1 literal-source rendering.
+function renderTex(src: string): string {
+  try {
+    return katex.renderToString(src, {
+      throwOnError: false,
+      output: 'htmlAndMathml'
+    });
+  } catch {
+    return `<code class="bbcode-tex">${escapeText(src)}</code>`;
+  }
 }
 
 function emitText(value: string, ctx: BBCtx, opts: Opts): string {
@@ -256,12 +274,11 @@ function emitNode(
 ): string {
   if (node.kind === 'text') return emitText(node.value, ctx, opts);
   if (node.kind === 'raw') {
-    const content = escapeText(node.content);
-    if (node.tag === 'pre') return `<pre class="bbcode-pre">${content}</pre>`;
+    if (node.tag === 'pre')
+      return `<pre class="bbcode-pre">${escapeText(node.content)}</pre>`;
     if (node.tag === 'code')
-      return `<code class="bbcode-code">${content}</code>`;
-    // tex: Phase 1 shows the literal LaTeX source; #403 swaps in server KaTeX.
-    return `<code class="bbcode-tex">${content}</code>`;
+      return `<code class="bbcode-code">${escapeText(node.content)}</code>`;
+    return renderTex(node.content);
   }
   return emitElement(node, maps, ctx, opts);
 }

--- a/src/lib/bbcode/sanitizeConfig.ts
+++ b/src/lib/bbcode/sanitizeConfig.ts
@@ -1,9 +1,84 @@
 import DOMPurify from 'isomorphic-dompurify';
 
+// KaTeX (#403) emits MathML for accessibility, HTML spans for visual layout, and
+// a little inline SVG for radicals/delimiters/accents. These are the element and
+// attribute names it uses; the MathML/SVG tag lists are finite and enumerated
+// rather than pulled from a profile so the base BBCode allowlist stays narrow
+// (#398 Q15) — only the KaTeX surface is added, nothing else from full MathML/SVG.
+const KATEX_MATHML_TAGS = [
+  'math',
+  'semantics',
+  'annotation',
+  'mrow',
+  'mi',
+  'mo',
+  'mn',
+  'ms',
+  'mtext',
+  'mspace',
+  'msup',
+  'msub',
+  'msubsup',
+  'mfrac',
+  'msqrt',
+  'mroot',
+  'mover',
+  'munder',
+  'munderover',
+  'mmultiscripts',
+  'mprescripts',
+  'none',
+  'mtable',
+  'mtr',
+  'mtd',
+  'mpadded',
+  'mphantom',
+  'menclose',
+  'mstyle',
+  'merror'
+];
+const KATEX_SVG_TAGS = ['svg', 'path', 'line', 'rect', 'g'];
+// Presentational MathML + SVG attributes KaTeX emits. All layout-only; DOMPurify
+// still strips event handlers and validates URI attributes regardless.
+const KATEX_ATTR = [
+  'xmlns',
+  'encoding',
+  'aria-hidden',
+  'title',
+  'mathvariant',
+  'mathcolor',
+  'displaystyle',
+  'scriptlevel',
+  'stretchy',
+  'fence',
+  'accent',
+  'accentunder',
+  'notation',
+  'linethickness',
+  'columnalign',
+  'columnspacing',
+  'rowspacing',
+  'width',
+  'height',
+  'viewBox',
+  'preserveAspectRatio',
+  'd',
+  'fill',
+  'stroke',
+  'stroke-width',
+  'x',
+  'y',
+  'x1',
+  'y1',
+  'x2',
+  'y2'
+];
+
 // The authoritative allowlist for rendered BBCode (#398 Q15). The API is the
 // source of truth; the UI's DOMPurify config must mirror this tag/attr set, and
 // a UI test asserts the match. Wider than lib/sanitize.ts because BBCode emits
-// headings, disclosures, aligned blocks, images, and validated inline styles.
+// headings, disclosures, aligned blocks, images, validated inline styles, and
+// server-rendered KaTeX math (#403).
 const BBCODE_CONFIG = {
   ALLOWED_TAGS: [
     'strong',
@@ -26,11 +101,22 @@ const BBCODE_CONFIG = {
     'h2',
     'h3',
     'h4',
-    'img'
+    'img',
+    ...KATEX_MATHML_TAGS,
+    ...KATEX_SVG_TAGS
   ],
   // Values are already whitelist-validated by the emitter before they reach an
   // attribute; DOMPurify is the second net.
-  ALLOWED_ATTR: ['href', 'class', 'style', 'rel', 'target', 'src', 'alt'],
+  ALLOWED_ATTR: [
+    'href',
+    'class',
+    'style',
+    'rel',
+    'target',
+    'src',
+    'alt',
+    ...KATEX_ATTR
+  ],
   ALLOW_DATA_ATTR: false
 };
 

--- a/src/lib/bbcode/version.ts
+++ b/src/lib/bbcode/version.ts
@@ -1,4 +1,4 @@
 // Bump when the parser output or sanitize allowlist changes. It is part of the
 // render-cache key, so a bump rotates every cached entry without a manual flush
 // (ADR-0026-adjacent; see #398). Keep it a plain integer.
-export const PARSER_VERSION = 1;
+export const PARSER_VERSION = 2;


### PR DESCRIPTION
Closes #403. Phase 3 of the BBCode parity work (#398), stacked on the merged render-at-read seam (#402).

## What

Implements the `[tex]` tag as **server-side KaTeX** in the render-at-read emit pass.

- **Render** — `[tex]` bodies (already raw-content per #398) now go through `katex.renderToString(src, { throwOnError: false, output: 'htmlAndMathml' })`, wrapped in a try/catch so a render-at-read call can never 500 — any failure falls back to the Phase 1 literal-source `<code class="bbcode-tex">`.
- **Sanitize** — widened the authoritative DOMPurify allowlist (`src/lib/bbcode/sanitizeConfig.ts`) to pass KaTeX's output surface: MathML presentation tags, KaTeX's inline-SVG subset (radicals/delimiters use `<svg><path>`), and its presentational attributes. Enumerated explicitly rather than pulled from a MathML/SVG profile so the base BBCode allowlist stays narrow (#398 Q15) — only the KaTeX surface is added.
- **Cache** — bumped `PARSER_VERSION` 1 → 2 so the render cache rotates (emit output + allowlist both changed).
- **Dependency** — added `katex ^0.16.47` as a direct dependency (was transitive-only via the ERD dev-dep). Justified per the issue: KaTeX is the standard runtime-dependency-free LaTeX renderer.

## Verification

- `tsc --noEmit` clean; eslint/prettier clean (pre-commit gate green).
- New specs assert `[tex]` renders KaTeX MathML+HTML and that its body is **not** BBCode-parsed (`[i]` reaches KaTeX as literal LaTeX).
- Ran the **real** pipeline end-to-end (actual `renderBBCode` → actual `sanitizeConfig`, not the jest mock) over a corpus (matrices, delimiters, accents, `\boxed`, `\cancel`, integrals): MathML, `<mfrac>`, and the SVG radical all survive sanitize, no `<script>` leaks through.

## Cross-repo follow-up

The UI companion — mirroring the widened sanitize allowlist and shipping KaTeX CSS/fonts — is tracked as a Phase 3 checklist on **stellar-ui#207**. The feature is latent until then (the #398 seed pages use zero math), but math will render wherever a member authors `[tex]` once the UI lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCpmAMVngqpubWKmSeA5Ha