### PR TITLE
chore(release): cut 0.8.2 — server-side BBCode subsystem + binary asset store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-07-22
+
 ### Added
 
 - **Server-side BBCode transcription — the API is now the single source of BBCode rendering** ([#398](https://github.com/orphic-inc/stellar-api/issues/398), [#402](https://github.com/orphic-inc/stellar-api/issues/402), [#403](https://github.com/orphic-inc/stellar-api/issues/403)) — every prose surface stored raw BBCode and left each client to parse it, so the UI shipped a second, drifting transcriber. A content-addressed BBCode subsystem (`lib/bbcode/`) now renders raw BBCode to sanitized HTML at read time, cached by content hash, behind one seam (`modules/bbcodeRender.ts`): **Phase 1** re-authored the built-in wiki seeds in the BBCode dialect and wired the wiki read path to emit an additive `bodyHtml`; **Phase 2** extended that render-at-read to forum posts, comments, collages, releases, contributions and staff bios (each gains `bodyHtml`/`descriptionHtml`/`staffBioHtml` beside its unchanged raw field), and moved profile info to store raw BBCode with a rendered `profileInfoHtml`; **Phase 3** added the `[tex]` tag as server-side KaTeX, emitting MathML + HTML spans (and a little inline SVG) and widening the authoritative DOMPurify allowlist to pass that surface. The rendered field is additive — the raw field still round-trips the editor — and the API's allowlist is the authority the UI mirrors (stellar-ui [#207]). The legacy client parser is retired downstream.
@@ -641,7 +643,8 @@ _Commits: `1e48a45` `06e4a61` `db95fc6` `3320608` `8f056e9` `c3d2568` (+ `52e9a0
 
 ---
 
-[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/orphic-inc/stellar-api/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/orphic-inc/stellar-api/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/orphic-inc/stellar-api/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/orphic-inc/stellar-api/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/orphic-inc/stellar-api/compare/v0.6.9...v0.7.0

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Stellar API",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "REST API for the Stellar community tracker. All routes under `/api/*`. Authentication uses JWT cookies (`token` cookie set on login)."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/api",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/api",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stellar/api",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Stellar API",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Cuts **v0.8.2**. Rolls up the 38 commits since v0.8.1.

## Release surfaces
- `package.json` `0.8.1 → 0.8.2`
- `openapi.json` `info.version → 0.8.2`
- CHANGELOG: `[Unreleased]` → `[0.8.2]` (2026-07-22), fresh empty `[Unreleased]`, compare-links updated
- `version:check` green — all surfaces consistent at 0.8.2

## Headline changes (see CHANGELOG `[0.8.2]` for the full set)
### Added
- **Server-side BBCode subsystem** (#398/#402/#403) — content-addressed render-at-read across every prose surface (wiki, forum, comments, collages, releases, contributions, staff bios, profiles), plus `[tex]` via server-side KaTeX. The API is now the single source of BBCode rendering; the legacy UI parser is retired downstream.
- **Binary asset store** (ADR-0026) — content-addressed Postgres-backed store, `GET /api/asset/:hash`, plus authenticated stylesheet-image uploads gated by a per-rank `assetLimit`.
- Full-shape profile percentile tiles (#280), store-time CSS boundary (ADR-0031), `proton` migrated to an api-canonical `/css` fixture, nullable `cssUrl` no-render registry rows.

### Changed / Fixed / Docs
- Registry delivery partition enforced on the write path (#375); `publish` skips PRs (#380); GitHub Releases created from the CHANGELOG on tag push. ADR-0024/0026/0031/0032 reconciled.

## Gate
- typecheck ✅ · build ✅ · unit suite ✅ (1976/1976)
- Note: a rare non-deterministic parallel-worker isolation flake in `install.spec.ts` (installState module cache surviving `resetMocks`) was observed once and does not reproduce on re-run or clean tree — pre-existing, unrelated to this diff. Worth a follow-up tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCpmAMVngqpubWKmSeA5Ha