### PR TITLE
feat(bookmarks): bulk-remove consumed release bookmarks (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to stellar-api are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Bulk-remove consumed release bookmarks** ([#296](https://github.com/orphic-inc/stellar-api/issues/296)) — the bookmark list is a consumption queue, but it was read-only once a member started grabbing from it: clearing the releases you had already consumed meant unbookmarking them one at a time. `DELETE /api/bookmarks/releases/consumed` now removes the caller's release bookmarks for any release they hold a live (`COMPLETED`) `DownloadAccessGrant` on, returning `{ removed: n }`. A release fans out to many contributions (editions/rips), so a single grab clears the bookmark; a reversed grant (claw-back flips the status to `REVERSED`) does not count, while a Freepass/Neutralpass grant does, since the member still downloaded it. Self-scoped and idempotent — `removed: 0` is a success, not a 404. The paired stellar-ui "Remove consumed" button is tracked downstream.
+
 ### Changed
 
 - **`User.ratio` is computed at read time, not stored** ([#294](https://github.com/orphic-inc/stellar-api/issues/294)) — the column was a denormalization of `computeRatio(contributed, consumed)`, a pure function of two adjacent columns, and it appeared in no `WHERE` and no `ORDER BY` (the top-10 user ranking orders by contribution/consume _speed_, never ratio), so the stored copy bought no query performance and only created drift surface. Every read site now derives it — `auth.ts`, `profile.ts`, `search.ts`, and both the ORM and raw-SQL branches of `top10.ts` — and every response payload still carries `ratio`, so the API contract is unchanged. Two dead columns go with it: `ratioWatchDownload`, superseded by `RatioPolicyState` (which carries `consumedAtWatchStart` and derives the watch-period delta), and `totalEarned`, which nothing read. `canDownload` stays — it is an independent download-capability flag read as a hard gate on the grant path, documented in the schema as such rather than a projection of ratio.

--- a/openapi.json
+++ b/openapi.json
@@ -19052,6 +19052,38 @@
         }
       }
     },
+    "/bookmarks/releases/consumed": {
+      "delete": {
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Removed the caller’s release bookmarks they have consumed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "removed": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "removed"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/random/release": {
       "get": {
         "tags": [

--- a/src/integration/bookmarks.integration.ts
+++ b/src/integration/bookmarks.integration.ts
@@ -1,0 +1,148 @@
+import {
+  FileType,
+  ReleaseType,
+  CommunityType,
+  RegistrationStatus
+} from '@prisma/client';
+import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import {
+  grantDownloadAccess,
+  reverseDownloadAccess
+} from '../modules/downloads';
+import { removeConsumedReleaseBookmarks } from '../modules/bookmark';
+
+beforeEach(async () => {
+  await truncateAll();
+  await seedDefaults();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+const createUser = async (tag: string, contributed = 0n) => {
+  const rank = await testPrisma.userRank.findFirstOrThrow();
+  const settings = await testPrisma.userSettings.create({ data: {} });
+  const profile = await testPrisma.profile.create({ data: {} });
+  return testPrisma.user.create({
+    data: {
+      username: `bm-${tag}-${Date.now()}-${Math.random()}`,
+      email: `bm-${tag}-${Date.now()}-${Math.random()}@example.com`,
+      password: 'x',
+      avatar: '',
+      userRankId: rank.id,
+      userSettingsId: settings.id,
+      profileId: profile.id,
+      contributed,
+      consumed: 0n,
+      canDownload: true
+    }
+  });
+};
+
+/** A release with one contribution; returns both ids. */
+const createReleaseWithContribution = async (contributorUserId: number) => {
+  const community = await testPrisma.community.create({
+    data: {
+      name: `BM-Community-${Date.now()}-${Math.random()}`,
+      image: '',
+      registrationStatus: RegistrationStatus.open,
+      type: CommunityType.Music
+    }
+  });
+  const artist = await testPrisma.artist.create({
+    data: { name: `BM-Artist-${Date.now()}-${Math.random()}` }
+  });
+  const release = await testPrisma.release.create({
+    data: {
+      title: `BM-Release-${Date.now()}-${Math.random()}`,
+      description: 'desc',
+      type: ReleaseType.Music,
+      releaseType: 'Album',
+      year: 2020,
+      credits: { create: { artistId: artist.id } }
+    }
+  });
+  const edition = await testPrisma.edition.create({
+    data: { releaseId: release.id }
+  });
+  const contributor = await testPrisma.contributor.upsert({
+    where: { userId: contributorUserId },
+    update: {},
+    create: { userId: contributorUserId, communityId: community.id }
+  });
+  const contribution = await testPrisma.contribution.create({
+    data: {
+      userId: contributorUserId,
+      releaseId: release.id,
+      contributorId: contributor.id,
+      editionId: edition.id,
+      type: FileType.flac,
+      downloadUrl: 'https://example.com/file.torrent',
+      sizeInBytes: 1_000_000,
+      approvedAccountingBytes: 1_000_000n,
+      releaseDescription: 'test'
+    }
+  });
+  return { releaseId: release.id, contributionId: contribution.id };
+};
+
+const bookmark = (userId: number, releaseId: number) =>
+  testPrisma.bookmarkRelease.create({ data: { userId, releaseId } });
+
+describe('removeConsumedReleaseBookmarks', () => {
+  it('removes only bookmarks for releases the caller has a COMPLETED grant on', async () => {
+    const COST = 1_000_000;
+    const contributor = await createUser('contrib');
+    const viewer = await createUser('viewer', BigInt(COST * 10));
+    const other = await createUser('other', BigInt(COST * 10));
+
+    // A: viewer consumed (COMPLETED grant) -> should be removed
+    const a = await createReleaseWithContribution(contributor.id);
+    await grantDownloadAccess(viewer.id, a.contributionId);
+
+    // B: bookmarked, never consumed -> kept
+    const b = await createReleaseWithContribution(contributor.id);
+
+    // C: consumed by ANOTHER user, only bookmarked by viewer -> kept
+    const c = await createReleaseWithContribution(contributor.id);
+    await grantDownloadAccess(other.id, c.contributionId);
+
+    // D: viewer's only grant was REVERSED -> kept
+    const d = await createReleaseWithContribution(contributor.id);
+    const dGrant = await grantDownloadAccess(viewer.id, d.contributionId);
+    await reverseDownloadAccess(contributor.id, dGrant.grantId, 'test');
+
+    await Promise.all([
+      bookmark(viewer.id, a.releaseId),
+      bookmark(viewer.id, b.releaseId),
+      bookmark(viewer.id, c.releaseId),
+      bookmark(viewer.id, d.releaseId)
+    ]);
+
+    const removed = await removeConsumedReleaseBookmarks(viewer.id);
+    expect(removed).toBe(1);
+
+    const surviving = await testPrisma.bookmarkRelease.findMany({
+      where: { userId: viewer.id },
+      select: { releaseId: true }
+    });
+    expect(surviving.map((r) => r.releaseId).sort()).toEqual(
+      [b.releaseId, c.releaseId, d.releaseId].sort()
+    );
+  });
+
+  it('returns 0 and removes nothing when the caller has consumed no bookmarks', async () => {
+    const contributor = await createUser('contrib');
+    const viewer = await createUser('viewer');
+    const b = await createReleaseWithContribution(contributor.id);
+    await bookmark(viewer.id, b.releaseId);
+
+    const removed = await removeConsumedReleaseBookmarks(viewer.id);
+    expect(removed).toBe(0);
+    const count = await testPrisma.bookmarkRelease.count({
+      where: { userId: viewer.id }
+    });
+    expect(count).toBe(1);
+  });
+});

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -6978,6 +6978,23 @@ registerBookmark('releases', 'releaseId', releaseBookmark);
 registerBookmark('communities', 'communityId', communityBookmark);
 registerBookmark('requests', 'requestId', requestBookmark);
 
+registry.registerPath({
+  method: 'delete',
+  path: '/bookmarks/releases/consumed',
+  tags: ['Bookmarks'],
+  security: [{ cookieAuth: [] }],
+  responses: {
+    200: {
+      description: 'Removed the caller’s release bookmarks they have consumed',
+      content: {
+        'application/json': {
+          schema: z.object({ removed: z.number() })
+        }
+      }
+    }
+  }
+});
+
 // ─── Random ───────────────────────────────────────────────────────────────────
 
 registry.registerPath({

--- a/src/modules/bookmark.ts
+++ b/src/modules/bookmark.ts
@@ -1,0 +1,31 @@
+import { DownloadGrantStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+
+// Bulk-clear the caller's release bookmarks they've already consumed (#296).
+// "Consumed" = the caller holds a live (COMPLETED) DownloadAccessGrant on any
+// contribution under the release. A release fans out to many contributions
+// (editions/rips), so a single grab clears the bookmark. REVERSED grants don't
+// count — a claw-back flips the status, so the queue entry stays. Freepass /
+// Neutralpass grants stay COMPLETED and do count; the member still downloaded it.
+export async function removeConsumedReleaseBookmarks(
+  userId: number
+): Promise<number> {
+  const { count } = await prisma.bookmarkRelease.deleteMany({
+    where: {
+      userId,
+      release: {
+        contributions: {
+          some: {
+            downloadAccessGrants: {
+              some: {
+                consumerId: userId,
+                status: DownloadGrantStatus.COMPLETED
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+  return count;
+}

--- a/src/routes/api/bookmarks.ts
+++ b/src/routes/api/bookmarks.ts
@@ -8,6 +8,7 @@ import {
   releaseCreditsSelect,
   withPrimaryArtist
 } from '../../modules/releaseCredits';
+import { removeConsumedReleaseBookmarks } from '../../modules/bookmark';
 
 const router = express.Router();
 
@@ -122,6 +123,17 @@ router.post(
       data: { userId: req.user.id, releaseId }
     });
     res.json({ bookmarked: true });
+  })
+);
+
+// Static segment must precede '/releases/:releaseId' or Express shadows it and
+// validateParams 400s on "consumed".
+router.delete(
+  '/releases/consumed',
+  requireAuth,
+  authHandler(async (req, res) => {
+    const removed = await removeConsumedReleaseBookmarks(req.user.id);
+    res.json({ removed });
   })
 );
 


### PR DESCRIPTION
Closes #296.

## What

`BookmarksPage` is a consumption queue, but the release-bookmark list was read-only once a member started grabbing from it — clearing the releases already consumed meant unbookmarking them one at a time. This adds a one-click bulk clear.

`DELETE /api/bookmarks/releases/consumed` removes the caller's release bookmarks for any release they hold a live (`COMPLETED`) `DownloadAccessGrant` on, returning `200 { removed: n }`.

## Design decisions (grilled)

- **"Consumed" = any COMPLETED grant.** A release fans out to many contributions (editions/rips); a single grab clears the bookmark. `Consumer.releases` is a dead relation (never populated), so the grant ledger is the only real signal.
- **Reversed grants do not count.** A claw-back flips status to `REVERSED`, so the bookmark stays. Freepass/Neutralpass grants stay `COMPLETED` and *do* count — the member still downloaded it.
- **Self-scoped, idempotent.** `requireAuth` only, no rate limiter / audit (matches sibling bookmark routes). `removed: 0` is a success, not a 404.
- **Route ordering.** The static `/releases/consumed` is registered before `/releases/:releaseId` so the param route can't shadow it.
- **Placement.** Logic in new `modules/bookmark.ts`; route stays a thin HTTP shell.

## Testing

Integration test (`src/integration/bookmarks.integration.ts`) seeds a viewer with four bookmarks and asserts only the consumed one is removed:

| bookmark | grant state | outcome |
| --- | --- | --- |
| A | COMPLETED (viewer) | removed |
| B | none | kept |
| C | COMPLETED (other user) | kept |
| D | REVERSED | kept |

Plus a `removed: 0` no-op case. Verified: both pass, lint + `tsc --noEmit` clean, OpenAPI regenerated.

## Paired downstream work

- orphic-inc/stellar-ui#212 — "Remove consumed" button on the Releases tab
- orphic-inc/stellar-ui#213 — rename the non-sanctioned `pages/private/snatch/` directory (kept separate per the blueprint naming note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)