### PR TITLE
docs(adr): accept ADR-0033; amend ADR-0021's superset invariant

### DIFF
--- a/docs/adr/0021-community-leader-role.md
+++ b/docs/adr/0021-community-leader-role.md
@@ -1,6 +1,8 @@
 # CommunityLeader: a first-class, single-holder community leader pointer
 
-**Status: Accepted.** Serves [PRD-08 collages & cover art](../prd/08-collages-and-cover-art.md) (the sole `CommunityLeader` mention); reuses the `communities_manage` gate from [ADR-0001 granular permission checks](0001-granular-permission-checks.md). Resolves #216. Ships the leader _model_; the Requests → new-community flow that will consume it is deferred (see below).
+**Status: Accepted — amended by [ADR-0033](0033-community-membership-and-the-curator-role.md) (Accepted 2026-07-24).** Serves [PRD-08 collages & cover art](../prd/08-collages-and-cover-art.md) (the sole `CommunityLeader` mention); reuses the `communities_manage` gate from [ADR-0001 granular permission checks](0001-granular-permission-checks.md). Resolves #216. Ships the leader _model_; the Requests → new-community flow that will consume it is deferred (see below).
+
+**The amendment, in one line:** the superset invariant narrows from `leaderId ⟹ user ∈ staff ∧ user is a Consumer` to `leaderId ⟹ user ∈ curators` — the `Consumer` half is dropped and `staff` is renamed `curators`. Everything else below stands. The narrowing is marked at each affected point.
 
 ## Context
 
@@ -29,7 +31,7 @@ Settled properties:
 - **Audited.** Every leader set/change emits `audit(..., 'community.leader.set', 'community', id, { leaderId, previousLeaderId? })`, so a future succession policy has history to read.
 - **Naming: `ownerId` → `leaderId`.** The `POST /communities` body param is renamed. "Owner" was always a fiction with no backing field; there is one concept here and it gets one honest name. Pre-alpha + the gated OpenAPI contract means the rename rides along with stellar-ui's `api.ts` resync.
 
-Write paths enforcing the invariant on trunk today: **`POST /communities`** and **`PUT /communities/:id`**.
+Write paths enforcing the invariant on trunk today: **`POST /communities`** and **`PUT /communities/:id`**. (Since merged, `seedDefaultCommunity` is the third — see Merge seam.) **Per ADR-0033 the `Consumer` upsert is removed from all three**; each keeps only the curator connection.
 
 ## Explicitly deferred
 
@@ -40,6 +42,8 @@ Write paths enforcing the invariant on trunk today: **`POST /communities`** and 
 ## Merge seam
 
 `seedDefaultCommunity()` does not exist on trunk — it arrives via the unmerged `feat/golden-rules-surfacing` branch (seeds the flagship community as staff+consumer). **When that branch merges, the seed must also set `leaderId = ownerUserId`** to make the SysOp the flagship community's leader and hold the invariant. This is the third write path named in #216; it is documented here rather than built because it isn't on trunk yet.
+
+**Resolved (#221):** the branch merged and the seed sets `leaderId`. Its `Consumer` upsert is removed by ADR-0033 along with the other two, so the seeded flagship leader is a curator and nothing more — the narrowed invariant. ADR-0033 also requires the curator relation survive the rename migration, so this community keeps its curator rather than being re-seeded into one.
 
 ## Consequences
 

--- a/docs/adr/0033-community-membership-and-the-curator-role.md
+++ b/docs/adr/0033-community-membership-and-the-curator-role.md
@@ -1,6 +1,6 @@
 # Community membership is the role union; community staff becomes Curator
 
-**Status: Proposed (2026-07-24).** Narrows the invariant of [ADR-0021](0021-community-leader-role.md) (Accepted) and adopts the Axis-1/Axis-2 vocabulary of [ADR-0030](0030-private-community-announce-delivery.md) §Decision 2. Follows [#419](https://github.com/orphic-inc/stellar-api/issues/419), which landed the access half of this model. Revises one line of [PRD-08](../prd/08-collages-and-cover-art.md).
+**Status: Accepted (2026-07-24).** Narrows the invariant of [ADR-0021](0021-community-leader-role.md) (Accepted, amended accordingly) and adopts the Axis-1/Axis-2 vocabulary of [ADR-0030](0030-private-community-announce-delivery.md) §Decision 2. Follows [#419](https://github.com/orphic-inc/stellar-api/issues/419), which landed the access half of this model. Revises one line of [PRD-08](../prd/08-collages-and-cover-art.md). Implementation tracked in [#422](https://github.com/orphic-inc/stellar-api/issues/422); paired UI work in stellar-ui#216. See [Acceptance note](#acceptance-note-2026-07-24).
 
 ## Context
 
@@ -63,6 +63,13 @@ The detail response gains a `members` view derived from the union, each entry ca
 - **Drop the leader upsert and leave the read surface alone.** Cheapest change, and wrong: the leader silently disappears from the rendered member roster, trading a modelling error for a visible regression.
 - **Keep "staff" for both concepts and disambiguate in prose.** This is the status quo, and ADR-0030 already paid for it once in a paragraph written solely to stop the two from being confused.
 - **Compute a true member count on the browse list.** Rejected on cost: a per-row union count across a 25-row page, for a number that is decoration on a list surface.
+
+## Acceptance note (2026-07-24)
+
+Accepted with no change to the decisions. The review looked for a blocker and found none: unlike ADR-0030, this ADR has no cross-repo prerequisite — it is stellar-api-only plus a contract resync, and stellar-ui#216 is blocked _on_ it rather than the reverse. Two things it did turn up, both handled rather than deferred:
+
+- **ADR-0021's Status line did not carry the amendment.** Decision 3 narrows an invariant of an Accepted ADR, and while ADR-0021's Decision bullet already recorded the narrowing inline, a reader checking its status would not have seen it. ADR-0021 is now marked amended at the header, and its Merge seam paragraph — which instructs `seedDefaultCommunity` to seed the flagship community as staff **and** consumer — points here for the removal.
+- **Ordering against ADR-0030's remaining slices is a real cost, not a blocker.** `communityRoleUnion` currently names its third arm `staff`; Decision 2 renames it `curators`. ADR-0030 slice 4 (announce `target` + membership reconcile) composes that same fragment, so whichever of the two lands second rewrites the other's touch points. The cost is small and symmetric — the shared fragment is exactly what bounds it — so the order is a scheduling call for #422 and #328, not a design one.
 
 ## Cross-references
 


### PR DESCRIPTION
## ADR-0033 → Accepted

The review looked for a blocker and found none. Unlike ADR-0030, this ADR has no cross-repo prerequisite — it's stellar-api plus a contract resync, and stellar-ui#216 is blocked *on* it rather than the reverse. Decisions are unchanged; an acceptance note records what the review turned up.

Two things it surfaced, both handled here rather than deferred:

**ADR-0021's Status line didn't carry the amendment.** Decision 3 narrows the central invariant of an Accepted ADR. ADR-0021's Decision bullet already recorded the narrowing inline (added when ADR-0033 was written), but the header did not — so a reader checking whether an Accepted ADR still holds would not have seen that its invariant had moved. That's the gap this PR closes.

**Ordering against ADR-0030's remaining slices is a cost, not a blocker.** `communityRoleUnion` names its third arm `staff`; Decision 2 renames it `curators`. ADR-0030 slice 4 composes that same fragment, so whichever lands second rewrites the other's touch points. Small and symmetric — the shared fragment is what bounds it — so the order is a scheduling call for #422 vs #328, not a design one. Noted, not decided.

## ADR-0021 amendment

The invariant narrows from `leaderId ⟹ user ∈ staff ∧ user is a Consumer` to `leaderId ⟹ user ∈ curators`. Marked at the header, stated in one line up front, and marked at each affected point:

- The write-path list gains `seedDefaultCommunity` and notes the `Consumer` upsert is removed from all three.
- The **Merge seam** paragraph was stale on its own terms — it described `seedDefaultCommunity` as arriving on an unmerged `feat/golden-rules-surfacing` branch and instructed that the seed "must also set `leaderId`" when it merged. It merged (#221 / PR #225) and does set it. Now recorded as resolved, along with ADR-0033's requirement that the rename migration preserve the flagship community's curator rather than re-seed it.

Docs only — no code, no contract change. Refs #422, #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)