### PR TITLE
refactor(communities): membership is the role union; community staff becomes Curator (#422)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ src/
     ircNick.ts                # IRC nick verification (ADR-0015) — challenge/nonce proof-of-control promoting a Nick Claim to a verified nick
     contributionLimits.ts     # Per-ReleaseType contribution size ceilings (#93) — the real product limits, distinct from the overflow guard
     contributionQuality.ts    # Per-contribution quality grade (ADR-0002) off the typed Bitrate enum on the ReleaseFile satellite
-    communityAccess.ts        # The shared community access predicate (#419, ADR-0030): communityRoleUnion where-fragment (consumer ∪ contributor ∪ staff), the hasCommunityAccess gate (ex-`isCommunityMember`) and its load-then-gate assertCommunityAccess. Never reads announceVisibility
+    communityAccess.ts        # Community membership + access (#419, ADR-0030, ADR-0033): the communityRoleUnion where-fragment (consumer ∪ contributor ∪ curator) that DEFINES membership, the hasCommunityAccess gate (ex-`isCommunityMember`) and its load-then-gate assertCommunityAccess, plus listCommunityMembers projecting the same union into a roster. Never reads announceVisibility
     releaseBrowse.ts          # listCommunityReleases — the community release browse/list read
     releaseCredits.ts         # ReleaseArtist role credits; derives the legacy release.artist display field from the Main credit
     releaseLifecycle.ts       # Community release create/delete with history + snapshotting

--- a/openapi.json
+++ b/openapi.json
@@ -2767,7 +2767,7 @@
           "readState"
         ]
       },
-      "CommunityStaffMember": {
+      "CommunityCurator": {
         "type": "object",
         "properties": {
           "id": {
@@ -2782,27 +2782,32 @@
           "username"
         ]
       },
-      "CommunityConsumer": {
+      "CommunityMember": {
         "type": "object",
         "properties": {
-          "user": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              },
-              "username": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "username"
-            ]
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "consumer",
+                "contributor",
+                "curator",
+                "leader"
+              ]
+            }
           }
         },
         "required": [
-          "user"
+          "id",
+          "username",
+          "roles"
         ]
       },
       "Community": {
@@ -2844,16 +2849,16 @@
             "type": "number",
             "nullable": true
           },
-          "staff": {
+          "curators": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CommunityStaffMember"
+              "$ref": "#/components/schemas/CommunityCurator"
             }
           },
-          "consumers": {
+          "members": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CommunityConsumer"
+              "$ref": "#/components/schemas/CommunityMember"
             }
           },
           "_count": {

--- a/prisma/migrations/20260724120000_rename_community_staff_to_curators/migration.sql
+++ b/prisma/migrations/20260724120000_rename_community_staff_to_curators/migration.sql
@@ -1,0 +1,24 @@
+-- ADR-0033: Community.staff → Community.curators.
+--
+-- "Staff" is reserved site-wide for the Axis-2 rank capability
+-- (rankPermissions.ts); this is an Axis-1 per-community role relation, and the
+-- two met in the same code path often enough to cost design work.
+--
+-- WRITTEN BY HAND, DELIBERATELY. Prisma regenerates an implicit M:N table by
+-- dropping and recreating it, which would silently discard every existing
+-- curator row — including the flagship community's, seeded by
+-- seedDefaultCommunity. Losing them would be survivable pre-alpha (that seed is
+-- idempotent) but discarding a relation by default is not a thing to do.
+--
+-- ALTER TABLE ... RENAME does not carry constraints or indexes with it, so each
+-- is renamed explicitly to the name Prisma derives from the new relation name.
+-- Renaming a constraint also renames its backing index, which is why the PK
+-- needs no separate ALTER INDEX.
+
+ALTER TABLE "_CommunityStaff" RENAME TO "_CommunityCurators";
+
+ALTER TABLE "_CommunityCurators" RENAME CONSTRAINT "_CommunityStaff_AB_pkey" TO "_CommunityCurators_AB_pkey";
+ALTER TABLE "_CommunityCurators" RENAME CONSTRAINT "_CommunityStaff_A_fkey" TO "_CommunityCurators_A_fkey";
+ALTER TABLE "_CommunityCurators" RENAME CONSTRAINT "_CommunityStaff_B_fkey" TO "_CommunityCurators_B_fkey";
+
+ALTER INDEX "_CommunityStaff_B_index" RENAME TO "_CommunityCurators_B_index";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -467,7 +467,7 @@ model User {
   invitees                 InviteTree[]                     @relation("InviteTreeInviter")
   friendRequestsSent       FriendRelationship[]             @relation("FriendRequester")
   friendRequestsReceived   FriendRelationship[]             @relation("FriendRecipient")
-  communityStaff           Community[]                      @relation("CommunityStaff")
+  communitiesCurated       Community[]                      @relation("CommunityCurators")
   communitiesLed           Community[]                      @relation("CommunityLeader")
   consumer                 Consumer?
   contributor              Contributor?
@@ -1049,9 +1049,13 @@ model Community {
   contributors          Contributor[]
   releases              Release[]
   comments              Comment[]
-  staff                 User[]                    @relation("CommunityStaff")
-  // The founding/owning member. A superset of `staff`: setting it always
-  // connects the same user to `staff` + upserts a Consumer (ADR-0021).
+  // Per-community role relation (Axis-1). Named Curator, not staff: "staff" is
+  // reserved site-wide for the Axis-2 rank capability in rankPermissions.ts,
+  // and the two meet in the same code path (ADR-0033).
+  curators              User[]                    @relation("CommunityCurators")
+  // The founding/owning member. A superset of `curators`: setting it always
+  // connects the same user to `curators` (ADR-0021, narrowed by ADR-0033 —
+  // no Consumer is written; belonging is the role union, not consumption).
   // Nullable so a disabled/departed leader leaves a recoverable pointer
   // rather than orphaning the community.
   leaderId              Int?

--- a/src/communities.spec.ts
+++ b/src/communities.spec.ts
@@ -24,8 +24,13 @@ const makeCommunity = (overrides: Record<string, unknown> = {}) => ({
   allowDuplicateFormats: false,
   createdAt: new Date(),
   updatedAt: new Date(),
-  staff: [],
+  curators: [],
+  leaderId: null,
+  // GET /:id issues a second findUnique for the member roster; the shared mock
+  // answers both, so it carries the roster's relations too.
+  leader: null,
   consumers: [],
+  contributors: [],
   _count: {
     contributors: 0,
     releases: 0,
@@ -84,14 +89,14 @@ describe('GET /api/communities/:id', () => {
     expect(res.body).toEqual({ msg: 'Not a member of this community' });
   });
 
-  it('lets a staff-only member read a closed community (#419)', async () => {
+  it('lets a curator-only member read a closed community (#419)', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
       makeCommunity({
         registrationStatus: RegistrationStatus.closed,
-        staff: [{ id: 7, username: 'staffer' }]
+        curators: [{ id: 7, username: 'curator' }]
       }) as never
     );
-    // The role union matches on the staff arm — no Consumer row involved.
+    // The role union matches on the curator arm — no Consumer row involved.
     prismaMock.community.findFirst.mockResolvedValue({ id: 1 } as never);
 
     const res = await request(app).get('/api/communities/1');
@@ -110,6 +115,45 @@ describe('GET /api/communities/:id', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Jazz');
+  });
+
+  it('reports members as the role union, not the consumer list', async () => {
+    // ADR-0033 §4. The curator holds no Consumer row and the consumer holds no
+    // curator row; both are members, and the response says which is which.
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({
+        leaderId: 9,
+        leader: { id: 9, username: 'ada' },
+        curators: [
+          { id: 9, username: 'ada' },
+          { id: 11, username: 'grace' }
+        ],
+        consumers: [{ user: { id: 8, username: 'bob' } }],
+        contributors: [{ user: { id: 12, username: 'carol' } }]
+      }) as never
+    );
+
+    const res = await request(app).get('/api/communities/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.members).toEqual([
+      { id: 9, username: 'ada', roles: ['curator', 'leader'] },
+      { id: 8, username: 'bob', roles: ['consumer'] },
+      { id: 12, username: 'carol', roles: ['contributor'] },
+      { id: 11, username: 'grace', roles: ['curator'] }
+    ]);
+    // The detail query stops fetching `consumers[]` — the array `members`
+    // replaces. Asserted on the query, not the body: the shared mock ignores
+    // `include` and would echo it back regardless. `_count` stays as it was.
+    expect(prismaMock.community.findUnique).toHaveBeenCalledWith({
+      where: { id: 1 },
+      include: {
+        curators: { select: { id: true, username: true } },
+        _count: {
+          select: { contributors: true, releases: true, consumers: true }
+        }
+      }
+    });
   });
 });
 
@@ -159,7 +203,7 @@ describe('GET /api/communities/:id/health', () => {
     expect(getCommunityHealthPulseMock).not.toHaveBeenCalled();
   });
 
-  it('serves the pulse to a staff-only member of a closed community (#419)', async () => {
+  it('serves the pulse to a curator-only member of a closed community (#419)', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
       makeCommunity({ registrationStatus: RegistrationStatus.closed }) as never
     );
@@ -264,7 +308,7 @@ describe('GET /api/communities/:id/health/history', () => {
     expect(prismaMock.communityHealthSnapshot.findMany).not.toHaveBeenCalled();
   });
 
-  it('serves history to a staff-only member of a closed community (#419)', async () => {
+  it('serves history to a curator-only member of a closed community (#419)', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
       makeCommunity({ registrationStatus: RegistrationStatus.closed }) as never
     );
@@ -292,7 +336,7 @@ describe('POST /api/communities/:id/members', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 403 when the caller lacks admin or community staff access', async () => {
+  it('returns 403 when the caller lacks admin or curator access', async () => {
     prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
 
     const res = await request(app)
@@ -305,7 +349,7 @@ describe('POST /api/communities/:id/members', () => {
 
   it('returns 404 when the target user does not exist', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
-      makeCommunity({ staff: [{ id: 7 }] }) as never
+      makeCommunity({ curators: [{ id: 7 }] }) as never
     );
     prismaMock.user.findUnique.mockResolvedValue(null);
 
@@ -316,9 +360,9 @@ describe('POST /api/communities/:id/members', () => {
     expect(res.status).toBe(404);
   });
 
-  it('adds a member for community staff', async () => {
+  it('adds a consuming member for a curator', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
-      makeCommunity({ staff: [{ id: 7 }] }) as never
+      makeCommunity({ curators: [{ id: 7 }] }) as never
     );
     prismaMock.user.findUnique.mockResolvedValue({ id: 8 } as never);
     prismaMock.consumer.upsert.mockResolvedValue({ id: 9, userId: 8 } as never);
@@ -339,13 +383,51 @@ describe('POST /api/communities/:id/members', () => {
 describe('DELETE /api/communities/:id/members/:userId', () => {
   it('returns 404 when the consumer record does not exist', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
-      makeCommunity({ staff: [{ id: 7 }] }) as never
+      makeCommunity({ curators: [{ id: 7 }] }) as never
     );
     prismaMock.consumer.findUnique.mockResolvedValue(null);
 
     const res = await request(app).delete('/api/communities/1/members/8');
 
     expect(res.status).toBe(404);
+  });
+
+  it('refuses with 409 when the target is a curator', async () => {
+    // ADR-0033 §5: no route strips a role as a side effect of removing a
+    // membership. Removing a curator goes through DELETE /:id/curators/:userId.
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ curators: [{ id: 7 }, { id: 8 }] }) as never
+    );
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+
+    const res = await request(app).delete('/api/communities/1/members/8');
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      msg: 'User is the community curator; remove that role first'
+    });
+    expect(prismaMock.consumer.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses with 409 when the target is the leader, naming that role', async () => {
+    prismaMock.community.findUnique.mockResolvedValue(
+      makeCommunity({ leaderId: 8, curators: [{ id: 8 }] }) as never
+    );
+    prismaMock.userRank.findUnique.mockResolvedValue(
+      makeUserRank({ communities_manage: true })
+    );
+
+    const res = await request(app).delete('/api/communities/1/members/8');
+
+    expect(res.status).toBe(409);
+    // Leader wins over curator in the message — it is the blocking role that
+    // has to be reassigned, via PUT /:id.
+    expect(res.body).toEqual({
+      msg: 'User is the community leader; remove that role first'
+    });
+    expect(prismaMock.consumer.update).not.toHaveBeenCalled();
   });
 
   it('disconnects a member for admins', async () => {
@@ -366,21 +448,21 @@ describe('DELETE /api/communities/:id/members/:userId', () => {
   });
 });
 
-describe('POST /api/communities/:id/staff', () => {
+describe('POST /api/communities/:id/curators', () => {
   it('returns 404 when the user does not exist', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
-      makeCommunity({ staff: [{ id: 7 }] }) as never
+      makeCommunity({ curators: [{ id: 7 }] }) as never
     );
     prismaMock.user.findUnique.mockResolvedValue(null);
 
     const res = await request(app)
-      .post('/api/communities/1/staff')
+      .post('/api/communities/1/curators')
       .send({ userId: 8 });
 
     expect(res.status).toBe(404);
   });
 
-  it('adds staff membership for admins', async () => {
+  it('adds a curator for admins', async () => {
     prismaMock.community.findUnique.mockResolvedValue(makeCommunity() as never);
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
@@ -389,30 +471,30 @@ describe('POST /api/communities/:id/staff', () => {
     prismaMock.community.update.mockResolvedValue(makeCommunity() as never);
 
     const res = await request(app)
-      .post('/api/communities/1/staff')
+      .post('/api/communities/1/curators')
       .send({ userId: 8 });
 
     expect(res.status).toBe(204);
     expect(prismaMock.community.update).toHaveBeenCalledWith({
       where: { id: 1 },
-      data: { staff: { connect: { id: 8 } } }
+      data: { curators: { connect: { id: 8 } } }
     });
   });
 });
 
-describe('DELETE /api/communities/:id/staff/:userId', () => {
-  it('removes staff membership for community staff', async () => {
+describe('DELETE /api/communities/:id/curators/:userId', () => {
+  it('removes a curator for another curator', async () => {
     prismaMock.community.findUnique.mockResolvedValue(
-      makeCommunity({ staff: [{ id: 7 }] }) as never
+      makeCommunity({ curators: [{ id: 7 }] }) as never
     );
     prismaMock.community.update.mockResolvedValue(makeCommunity() as never);
 
-    const res = await request(app).delete('/api/communities/1/staff/8');
+    const res = await request(app).delete('/api/communities/1/curators/8');
 
     expect(res.status).toBe(204);
     expect(prismaMock.community.update).toHaveBeenCalledWith({
       where: { id: 1 },
-      data: { staff: { disconnect: { id: 8 } } }
+      data: { curators: { disconnect: { id: 8 } } }
     });
   });
 });
@@ -445,13 +527,13 @@ describe('POST /api/communities', () => {
     expect(res.body).toEqual({ msg: 'Leader user not found' });
   });
 
-  it('creates a community, setting the leader as a superset of staff', async () => {
+  it('creates a community, setting the leader as a superset of curators', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
     prismaMock.user.findUnique.mockResolvedValue({ id: 9 } as never);
     prismaMock.community.create.mockResolvedValue(
-      makeCommunity({ id: 4, staff: [] }) as never
+      makeCommunity({ id: 4, curators: [] }) as never
     );
     prismaMock.consumer.upsert.mockResolvedValue({
       id: 10,
@@ -465,7 +547,7 @@ describe('POST /api/communities', () => {
         type: 'Music',
         registrationStatus: 'open',
         leaderId: 9,
-        staffIds: [9, 11]
+        curatorIds: [9, 11]
       });
 
     expect(res.status).toBe(201);
@@ -476,16 +558,15 @@ describe('POST /api/communities', () => {
         registrationStatus: 'open',
         image: '/images/defaults/music.png',
         leaderId: 9,
-        staff: {
+        curators: {
           connect: [{ id: 9 }, { id: 11 }]
         }
       })
     });
-    expect(prismaMock.consumer.upsert).toHaveBeenCalledWith({
-      where: { userId: 9 },
-      create: { userId: 9, communities: { connect: { id: 4 } } },
-      update: { communities: { connect: { id: 4 } } }
-    });
+    // ADR-0033 §3: no Consumer is synthesised for the leader. `Consumer` is the
+    // consumption identity, not a membership marker — the leader belongs via
+    // the curator connection above.
+    expect(prismaMock.consumer.upsert).not.toHaveBeenCalled();
     expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -497,13 +578,13 @@ describe('POST /api/communities', () => {
     );
   });
 
-  it('folds the leader into staff even when omitted from staffIds', async () => {
+  it('folds the leader into curators even when omitted from curatorIds', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
     prismaMock.user.findUnique.mockResolvedValue({ id: 9 } as never);
     prismaMock.community.create.mockResolvedValue(
-      makeCommunity({ id: 4, staff: [] }) as never
+      makeCommunity({ id: 4, curators: [] }) as never
     );
     prismaMock.consumer.upsert.mockResolvedValue({
       id: 10,
@@ -517,14 +598,14 @@ describe('POST /api/communities', () => {
         type: 'Music',
         registrationStatus: 'open',
         leaderId: 9,
-        staffIds: [11]
+        curatorIds: [11]
       });
 
     expect(res.status).toBe(201);
     expect(prismaMock.community.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         leaderId: 9,
-        staff: { connect: [{ id: 11 }, { id: 9 }] }
+        curators: { connect: [{ id: 11 }, { id: 9 }] }
       })
     });
   });
@@ -601,7 +682,7 @@ describe('PUT /api/communities/:id', () => {
     expect(res.status).toBe(404);
   });
 
-  it('updates mutable fields and staff assignments', async () => {
+  it('updates mutable fields and curator assignments', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
@@ -615,7 +696,7 @@ describe('PUT /api/communities/:id', () => {
       .send({
         name: 'Updated',
         registrationStatus: 'invite',
-        staffIds: [8, 9]
+        curatorIds: [8, 9]
       });
 
     expect(res.status).toBe(200);
@@ -624,7 +705,7 @@ describe('PUT /api/communities/:id', () => {
       data: {
         name: 'Updated',
         registrationStatus: 'invite',
-        staff: { set: [{ id: 8 }, { id: 9 }] }
+        curators: { set: [{ id: 8 }, { id: 9 }] }
       }
     });
   });
@@ -668,7 +749,7 @@ describe('PUT /api/communities/:id', () => {
     expect(res.body).toEqual({ msg: 'Leader user not found' });
   });
 
-  it('reassigns the leader and connects them to staff (transfer)', async () => {
+  it('reassigns the leader and connects them to curators (transfer)', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
@@ -688,14 +769,11 @@ describe('PUT /api/communities/:id', () => {
       where: { id: 1 },
       data: {
         leaderId: 7,
-        staff: { connect: { id: 7 } }
+        curators: { connect: { id: 7 } }
       }
     });
-    expect(prismaMock.consumer.upsert).toHaveBeenCalledWith({
-      where: { userId: 7 },
-      create: { userId: 7, communities: { connect: { id: 1 } } },
-      update: { communities: { connect: { id: 1 } } }
-    });
+    // No Consumer on transfer either (ADR-0033 §3).
+    expect(prismaMock.consumer.upsert).not.toHaveBeenCalled();
     expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -707,7 +785,7 @@ describe('PUT /api/communities/:id', () => {
     );
   });
 
-  it('folds the new leader into a replaced staff set', async () => {
+  it('folds the new leader into a replaced curator set', async () => {
     prismaMock.userRank.findUnique.mockResolvedValue(
       makeUserRank({ communities_manage: true })
     );
@@ -720,14 +798,14 @@ describe('PUT /api/communities/:id', () => {
 
     const res = await request(app)
       .put('/api/communities/1')
-      .send({ leaderId: 7, staffIds: [8, 9] });
+      .send({ leaderId: 7, curatorIds: [8, 9] });
 
     expect(res.status).toBe(200);
     expect(prismaMock.community.update).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         leaderId: 7,
-        staff: { set: [{ id: 8 }, { id: 9 }, { id: 7 }] }
+        curators: { set: [{ id: 8 }, { id: 9 }, { id: 7 }] }
       }
     });
   });

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -408,17 +408,18 @@ describe('POST /api/install', () => {
     });
 
     expect(res.status).toBe(201);
-    // Named after the site, public, with the SysOp connected as CommunityStaff.
+    // Named after the site, public, with the SysOp connected as curator.
     expect(prismaMock.community.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           name: 'Stellar',
           registrationStatus: 'open',
-          staff: { connect: { id: 1 } }
+          curators: { connect: { id: 1 } }
         })
       })
     );
-    // Owner is also registered as a Consumer (mirrors POST /api/communities).
-    expect(prismaMock.consumer.upsert).toHaveBeenCalled();
+    // And NOT as a Consumer (ADR-0033 §3): belonging is the role union, not a
+    // claim that whoever installed the site downloads from it.
+    expect(prismaMock.consumer.upsert).not.toHaveBeenCalled();
   });
 });

--- a/src/integration/communityAccess.integration.ts
+++ b/src/integration/communityAccess.integration.ts
@@ -8,8 +8,10 @@ import {
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
 import {
   communityRoleUnion,
-  hasCommunityAccess
+  hasCommunityAccess,
+  listCommunityMembers
 } from '../modules/communityAccess';
+import { seedDefaultCommunity } from '../modules/bootstrap';
 import { listCommunityReleases } from '../modules/releaseBrowse';
 import { loadReleaseWorkbenchAuthority } from '../modules/releaseWorkbench/authority';
 
@@ -41,7 +43,7 @@ const createUser = async (tag: string) => {
 
 const createCommunity = (
   registrationStatus: RegistrationStatus,
-  staffId?: number,
+  curatorId?: number,
   announceVisibility?: AnnounceVisibility
 ) =>
   testPrisma.community.create({
@@ -51,7 +53,9 @@ const createCommunity = (
       registrationStatus,
       type: CommunityType.Music,
       ...(announceVisibility !== undefined && { announceVisibility }),
-      ...(staffId !== undefined && { staff: { connect: { id: staffId } } })
+      ...(curatorId !== undefined && {
+        curators: { connect: { id: curatorId } }
+      })
     }
   });
 
@@ -67,28 +71,28 @@ const createRelease = (communityId: number) =>
     }
   });
 
-describe('a staff-only member of a closed community (#419)', () => {
+describe('a curator-only member of a closed community (#419)', () => {
   it('reaches every surface gated by hasCommunityAccess', async () => {
-    const staffer = await createUser('staff');
+    const curator = await createUser('curator');
     const community = await createCommunity(
       RegistrationStatus.closed,
-      staffer.id
+      curator.id
     );
     const release = await createRelease(community.id);
 
-    // The bug this fixes: POST /:id/staff connects a staff row and nothing
-    // else, so a staff-only member holds no Consumer record.
+    // The bug this fixes: POST /:id/curators connects a curator row and
+    // nothing else, so a curator-only member holds no Consumer record.
     const consumer = await testPrisma.consumer.findUnique({
-      where: { userId: staffer.id }
+      where: { userId: curator.id }
     });
     expect(consumer).toBeNull();
 
     await expect(
-      hasCommunityAccess(community.id, staffer.id, community.registrationStatus)
+      hasCommunityAccess(community.id, curator.id, community.registrationStatus)
     ).resolves.toBe(true);
 
     const browsed = await listCommunityReleases({
-      actorId: staffer.id,
+      actorId: curator.id,
       communityId: community.id,
       page: 1,
       limit: 25
@@ -97,18 +101,18 @@ describe('a staff-only member of a closed community (#419)', () => {
     expect(browsed.data[0].id).toBe(release.id);
 
     const authority = await loadReleaseWorkbenchAuthority({
-      actorId: staffer.id,
+      actorId: curator.id,
       communityId: community.id,
       releaseId: release.id
     });
     expect(authority.releaseId).toBe(release.id);
   });
 
-  it('appears in the browse filter for the communities they staff', async () => {
-    const staffer = await createUser('browse');
-    const staffed = await createCommunity(
+  it('appears in the browse filter for the communities they curate', async () => {
+    const curator = await createUser('browse');
+    const curated = await createCommunity(
       RegistrationStatus.closed,
-      staffer.id
+      curator.id
     );
     const unrelated = await createCommunity(RegistrationStatus.closed);
 
@@ -116,13 +120,13 @@ describe('a staff-only member of a closed community (#419)', () => {
       where: {
         OR: [
           { registrationStatus: RegistrationStatus.open },
-          communityRoleUnion(staffer.id)
+          communityRoleUnion(curator.id)
         ]
       },
       select: { id: true }
     });
 
-    expect(visible.map((c) => c.id)).toEqual([staffed.id]);
+    expect(visible.map((c) => c.id)).toEqual([curated.id]);
     expect(visible.map((c) => c.id)).not.toContain(unrelated.id);
   });
 });
@@ -231,5 +235,86 @@ describe('registrationStatus is the only thing that opens a community', () => {
         community.registrationStatus
       )
     ).resolves.toBe(false);
+  });
+});
+
+describe('the member roster is the role union (ADR-0033)', () => {
+  it('lists a curator who holds no Consumer row', async () => {
+    const curator = await createUser('roster-curator');
+    const consumer = await createUser('roster-consumer');
+    const community = await createCommunity(
+      RegistrationStatus.closed,
+      curator.id
+    );
+    await testPrisma.consumer.create({
+      data: {
+        userId: consumer.id,
+        communities: { connect: { id: community.id } }
+      }
+    });
+
+    // The bug ADR-0033 fixes for display: this user is absent from a
+    // consumers-only roster despite administering the community.
+    await expect(
+      testPrisma.consumer.findUnique({ where: { userId: curator.id } })
+    ).resolves.toBeNull();
+
+    const members = await listCommunityMembers(community.id);
+    expect(members).toEqual(
+      expect.arrayContaining([
+        { id: curator.id, username: curator.username, roles: ['curator'] },
+        { id: consumer.id, username: consumer.username, roles: ['consumer'] }
+      ])
+    );
+    expect(members).toHaveLength(2);
+  });
+
+  it('lists a leader created through POST /communities, who has no Consumer row', async () => {
+    const leader = await createUser('roster-leader');
+    const community = await testPrisma.community.create({
+      data: {
+        name: `Community-led-${Date.now()}`,
+        image: '',
+        registrationStatus: RegistrationStatus.closed,
+        type: CommunityType.Music,
+        leader: { connect: { id: leader.id } },
+        curators: { connect: { id: leader.id } }
+      }
+    });
+
+    await expect(
+      testPrisma.consumer.findUnique({ where: { userId: leader.id } })
+    ).resolves.toBeNull();
+
+    await expect(listCommunityMembers(community.id)).resolves.toEqual([
+      { id: leader.id, username: leader.username, roles: ['curator', 'leader'] }
+    ]);
+    // And the union agrees — the roster is not a second opinion on membership.
+    await expect(
+      hasCommunityAccess(community.id, leader.id, community.registrationStatus)
+    ).resolves.toBe(true);
+  });
+});
+
+describe('seedDefaultCommunity survives the curator rename (#422)', () => {
+  it('is idempotent and leaves the SysOp a curator and leader, not a consumer', async () => {
+    const sysop = await createUser('seed-sysop');
+
+    await seedDefaultCommunity(testPrisma, sysop.id);
+    await seedDefaultCommunity(testPrisma, sysop.id);
+
+    const communities = await testPrisma.community.findMany({
+      where: { curators: { some: { id: sysop.id } } },
+      include: { curators: { select: { id: true } } }
+    });
+    expect(communities).toHaveLength(1);
+    expect(communities[0].curators.map((c) => c.id)).toEqual([sysop.id]);
+    expect(communities[0].leaderId).toBe(sysop.id);
+
+    // The rename migrated the relation rather than dropping and recreating it,
+    // and the seed no longer synthesises consumption (ADR-0033 §3).
+    await expect(
+      testPrisma.consumer.findUnique({ where: { userId: sysop.id } })
+    ).resolves.toBeNull();
   });
 });

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -2834,17 +2834,23 @@ registry.registerPath({
 
 // ─── Communities ──────────────────────────────────────────────────────────────
 
-const CommunityStaffMember = registry.register(
-  'CommunityStaffMember',
+const CommunityCurator = registry.register(
+  'CommunityCurator',
   z.object({
     id: z.number(),
     username: z.string()
   })
 );
 
-const CommunityConsumer = registry.register(
-  'CommunityConsumer',
-  z.object({ user: z.object({ id: z.number(), username: z.string() }) })
+// A community's membership is the role union, not its consumer list (ADR-0033):
+// `roles` is why a curator who has never downloaded still appears in the roster.
+const CommunityMember = registry.register(
+  'CommunityMember',
+  z.object({
+    id: z.number(),
+    username: z.string(),
+    roles: z.array(z.enum(['consumer', 'contributor', 'curator', 'leader']))
+  })
 );
 
 const Community = registry.register(
@@ -2860,8 +2866,9 @@ const Community = registry.register(
     image: z.string().nullable().optional(),
     allowDuplicateFormats: z.boolean(),
     leaderId: z.number().nullable().optional(),
-    staff: z.array(CommunityStaffMember).optional(),
-    consumers: z.array(CommunityConsumer).optional(),
+    curators: z.array(CommunityCurator).optional(),
+    // Detail view only — the browse list keeps cheap relation counts instead.
+    members: z.array(CommunityMember).optional(),
     _count: z
       .object({
         releases: z.number(),

--- a/src/modules/bootstrap.ts
+++ b/src/modules/bootstrap.ts
@@ -576,7 +576,10 @@ export async function seedDefaultCommunity(
   });
   if (existing) return;
 
-  const community = await client.community.create({
+  // The SysOp becomes leader and curator, and nothing more: no Consumer is
+  // written (ADR-0033 §Decision 3). Belonging is the role union, not a claim
+  // that whoever installed the site downloads from it.
+  await client.community.create({
     data: {
       name: site.name,
       description: `The official ${site.name} community.`,
@@ -584,16 +587,7 @@ export async function seedDefaultCommunity(
       registrationStatus: RegistrationStatus.open,
       image: '/images/defaults/music.png',
       leader: { connect: { id: ownerUserId } },
-      staff: { connect: { id: ownerUserId } }
+      curators: { connect: { id: ownerUserId } }
     }
-  });
-
-  await client.consumer.upsert({
-    where: { userId: ownerUserId },
-    create: {
-      userId: ownerUserId,
-      communities: { connect: { id: community.id } }
-    },
-    update: { communities: { connect: { id: community.id } } }
   });
 }

--- a/src/modules/communityAccess.spec.ts
+++ b/src/modules/communityAccess.spec.ts
@@ -2,14 +2,19 @@
  * Unit tests for the shared community access predicate (#419, ADR-0030 slice 3).
  */
 
-const mockPrismaCommunity = { findFirst: jest.fn() };
+const mockPrismaCommunity = { findFirst: jest.fn(), findUnique: jest.fn() };
 
 jest.mock('../lib/prisma', () => ({
   prisma: { community: mockPrismaCommunity }
 }));
 
 import { RegistrationStatus } from '@prisma/client';
-import { communityRoleUnion, hasCommunityAccess } from './communityAccess';
+import {
+  COMMUNITY_ROLES,
+  communityRoleUnion,
+  hasCommunityAccess,
+  listCommunityMembers
+} from './communityAccess';
 
 describe('communityRoleUnion', () => {
   it('unions every Axis-1 relation that makes a user part of a community', () => {
@@ -17,7 +22,7 @@ describe('communityRoleUnion', () => {
       OR: [
         { consumers: { some: { userId: 7 } } },
         { contributors: { some: { userId: 7 } } },
-        { staff: { some: { id: 7 } } },
+        { curators: { some: { id: 7 } } },
         { leaderId: 7 }
       ]
     });
@@ -36,9 +41,66 @@ describe('communityRoleUnion', () => {
     expect(arms.flatMap((arm) => Object.keys(arm))).toEqual([
       'consumers',
       'contributors',
-      'staff',
+      'curators',
       'leaderId'
     ]);
+  });
+});
+
+describe('listCommunityMembers', () => {
+  const community = {
+    leader: { id: 1, username: 'ada' },
+    curators: [
+      { id: 1, username: 'ada' },
+      { id: 2, username: 'grace' }
+    ],
+    consumers: [{ user: { id: 3, username: 'bob' } }],
+    contributors: [{ user: { id: 4, username: 'carol' } }]
+  };
+
+  it('reports every role-holder, including one who holds a single role', async () => {
+    mockPrismaCommunity.findUnique.mockResolvedValueOnce(community);
+
+    // The point of ADR-0033: a curator with no Consumer row is a member.
+    // Alphabetical by username, roles in COMMUNITY_ROLES order.
+    await expect(listCommunityMembers(1)).resolves.toEqual([
+      { id: 1, username: 'ada', roles: ['curator', 'leader'] },
+      { id: 3, username: 'bob', roles: ['consumer'] },
+      { id: 4, username: 'carol', roles: ['contributor'] },
+      { id: 2, username: 'grace', roles: ['curator'] }
+    ]);
+  });
+
+  it('agrees with communityRoleUnion on which relations confer membership', () => {
+    // The roster projects the union the other way round and cannot reuse it
+    // literally, so this is the guard against the two drifting: a fifth arm
+    // added to one and not the other fails here (ADR-0010).
+    const arms = communityRoleUnion(7).OR as Array<Record<string, unknown>>;
+    const unionRelations = arms.flatMap((arm) => Object.keys(arm));
+    const rosterRelations = COMMUNITY_ROLES.map((role) =>
+      role === 'leader' ? 'leaderId' : `${role}s`
+    );
+    expect(rosterRelations).toEqual(unionRelations);
+  });
+
+  it('still lists a leader whose curator row drifted away', async () => {
+    // The union's leaderId arm would match them, so the roster must too —
+    // otherwise the gate and the display disagree about who belongs.
+    mockPrismaCommunity.findUnique.mockResolvedValueOnce({
+      ...community,
+      curators: [{ id: 2, username: 'grace' }]
+    });
+
+    await expect(listCommunityMembers(1)).resolves.toContainEqual({
+      id: 1,
+      username: 'ada',
+      roles: ['leader']
+    });
+  });
+
+  it('returns an empty roster for a community that does not exist', async () => {
+    mockPrismaCommunity.findUnique.mockResolvedValueOnce(null);
+    await expect(listCommunityMembers(99)).resolves.toEqual([]);
   });
 });
 

--- a/src/modules/communityAccess.ts
+++ b/src/modules/communityAccess.ts
@@ -4,13 +4,17 @@ import { AppError } from '../lib/errors';
 
 /**
  * The community role union — every Axis-1 relation that makes a user part of a
- * community: `consumer ∪ contributor ∪ staff`. A composable
- * `Prisma.CommunityWhereInput` so the browse filter and the access gate below
- * ask one question in one place (ADR-0030 §Decision 2, #419).
+ * community: `consumer ∪ contributor ∪ curator`. A composable
+ * `Prisma.CommunityWhereInput` so the browse filter, the access gate below and
+ * the member roster ask one question in one place (ADR-0030 §Decision 2,
+ * ADR-0033 §Decision 1, #419).
+ *
+ * This is the definition of membership, not merely of access: `Consumer` is the
+ * consumption identity, one role within the union rather than a synonym for
+ * belonging (ADR-0033).
  *
  * `leaderId` is defensively redundant: ADR-0021 makes the leader a superset of
- * `staff` (setting it connects the staff row and upserts a Consumer), so the
- * arm only bites if a row drifts from that invariant.
+ * `curators`, so the arm only bites if a row drifts from that invariant.
  *
  * Deliberately omits `Community.announceVisibility`. That field routes
  * announcements and nothing else; access is governed by
@@ -24,10 +28,95 @@ export const communityRoleUnion = (
   OR: [
     { consumers: { some: { userId } } },
     { contributors: { some: { userId } } },
-    { staff: { some: { id: userId } } },
+    { curators: { some: { id: userId } } },
     { leaderId: userId }
   ]
 });
+
+/** The roles the union is built from, in the order a member's roles are reported. */
+export const COMMUNITY_ROLES = [
+  'consumer',
+  'contributor',
+  'curator',
+  'leader'
+] as const;
+
+export type CommunityRole = (typeof COMMUNITY_ROLES)[number];
+
+export interface CommunityMember {
+  id: number;
+  username: string;
+  roles: CommunityRole[];
+}
+
+/**
+ * The community's member roster: the same union as above, projected the other
+ * way round — given a community, which users hold a role in it, and which
+ * (ADR-0033 §Decision 4).
+ *
+ * `communityRoleUnion` cannot be reused literally here. It is a
+ * `CommunityWhereInput` — it filters *communities* by a user — and the roster
+ * needs the inverse: *users* for one community. The arms are the same four and
+ * must stay the same four, which is what `COMMUNITY_ROLES` above and the
+ * agreement test in communityAccess.spec.ts exist to enforce; a fifth arm added
+ * to one and not the other is the drift ADR-0010 warns about.
+ *
+ * `leader` is reported alongside `curator` rather than instead of it: ADR-0021's
+ * invariant makes the leader a curator, and a caller that wants "can this user
+ * curate" should not have to know about the distinguished case.
+ */
+export const listCommunityMembers = async (
+  communityId: number
+): Promise<CommunityMember[]> => {
+  const community = await prisma.community.findUnique({
+    where: { id: communityId },
+    select: {
+      leader: { select: { id: true, username: true } },
+      curators: { select: { id: true, username: true } },
+      consumers: { select: { user: { select: { id: true, username: true } } } },
+      contributors: {
+        select: { user: { select: { id: true, username: true } } }
+      }
+    }
+  });
+  if (!community) return [];
+
+  const members = new Map<number, CommunityMember>();
+  const add = (
+    user: { id: number; username: string },
+    role: CommunityRole
+  ): void => {
+    const existing = members.get(user.id);
+    if (existing) {
+      if (!existing.roles.includes(role)) existing.roles.push(role);
+      return;
+    }
+    members.set(user.id, {
+      id: user.id,
+      username: user.username,
+      roles: [role]
+    });
+  };
+
+  for (const { user } of community.consumers) add(user, 'consumer');
+  for (const { user } of community.contributors) add(user, 'contributor');
+  for (const curator of community.curators) add(curator, 'curator');
+  // Normally additive — the invariant already put the leader in `curators`. If a
+  // row drifted, `add` enters them anyway, because the union's `leaderId` arm
+  // would still count them and the roster must agree with the union.
+  if (community.leader) add(community.leader, 'leader');
+
+  // Roles in COMMUNITY_ROLES order, members alphabetical — a roster is read by
+  // people, and a stable order keeps the response diffable.
+  for (const member of members.values()) {
+    member.roles.sort(
+      (a, b) => COMMUNITY_ROLES.indexOf(a) - COMMUNITY_ROLES.indexOf(b)
+    );
+  }
+  return [...members.values()].sort(
+    (a, b) => a.username.localeCompare(b.username) || a.id - b.id
+  );
+};
 
 /**
  * Can this user reach this community's contents? `open || roleUnion`.

--- a/src/modules/devTools/generators/communities.ts
+++ b/src/modules/devTools/generators/communities.ts
@@ -123,13 +123,13 @@ export async function generateCommunities(
 
     createdCommunityIds.push(community.id);
 
-    // Add staff users as community staff
-    for (const staffId of staffUsers.slice(0, 2)) {
+    // Add staff-ranked users as community curators
+    for (const curatorId of staffUsers.slice(0, 2)) {
       try {
         await prisma.community.update({
           where: { id: community.id },
           data: {
-            staff: { connect: { id: staffId } }
+            curators: { connect: { id: curatorId } }
           }
         });
       } catch {

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -226,12 +226,12 @@ router.delete(
     // route strips a role as a side effect of removing a membership
     // (ADR-0033 §Decision 5). Curators go through DELETE /:id/curators/:userId,
     // the leader through PUT /:id.
-    const blockingRole =
-      community.leaderId === userId
-        ? 'leader'
-        : community.curators.some((c) => c.id === userId)
-        ? 'curator'
-        : null;
+    // Leader is checked first: it is the role that has to be reassigned, and
+    // the invariant means a leader is always also a curator.
+    let blockingRole: string | null = null;
+    if (community.leaderId === userId) blockingRole = 'leader';
+    else if (community.curators.some((c) => c.id === userId))
+      blockingRole = 'curator';
     if (blockingRole) {
       return res.status(409).json({
         msg: `User is the community ${blockingRole}; remove that role first`

--- a/src/routes/api/communities/communities.ts
+++ b/src/routes/api/communities/communities.ts
@@ -8,7 +8,8 @@ import { getCommunityHealthPulse } from '../../../modules/linkHealth';
 import { getCommunityHealthHistory } from '../../../modules/communityHealthHistory';
 import {
   communityRoleUnion,
-  hasCommunityAccess
+  hasCommunityAccess,
+  listCommunityMembers
 } from '../../../modules/communityAccess';
 import { requireAuth } from '../../../middleware/auth';
 import {
@@ -63,7 +64,7 @@ router.get(
   authHandler(async (req, res) => {
     const pg = parsedPage(res);
     const userId = req.user.id;
-    // Same union the gates use (#419), so a staff-only member sees the
+    // Same union the gates use (#419), so a curator-only member sees the
     // communities they administer instead of only the ones they consume.
     const accessFilter = {
       OR: [
@@ -77,7 +78,7 @@ router.get(
         skip: pg.skip,
         take: pg.limit,
         include: {
-          staff: { select: { id: true, username: true } },
+          curators: { select: { id: true, username: true } },
           _count: {
             select: { contributors: true, releases: true, consumers: true }
           }
@@ -99,10 +100,7 @@ router.get(
     const community = await prisma.community.findUnique({
       where: { id },
       include: {
-        staff: { select: { id: true, username: true } },
-        consumers: {
-          select: { user: { select: { id: true, username: true } } }
-        },
+        curators: { select: { id: true, username: true } },
         _count: {
           select: { contributors: true, releases: true, consumers: true }
         }
@@ -114,7 +112,11 @@ router.get(
     ) {
       return res.status(403).json({ msg: 'Not a member of this community' });
     }
-    res.json(community);
+    // `members` replaces the `consumers[]`-plus-Staff-chip idiom the UI used to
+    // reconstruct a roster from (ADR-0033 §Decision 4). Loaded after the gate so
+    // a 403 costs nothing extra; `_count` stays relation counts, which is what
+    // it always was.
+    res.json({ ...community, members: await listCommunityMembers(id) });
   })
 );
 
@@ -163,7 +165,7 @@ router.get(
   })
 );
 
-// POST /api/communities/:id/members — add user (communities_manage or community staff)
+// POST /api/communities/:id/members — add a consuming member (communities_manage or curator)
 router.post(
   '/:id/members',
   requireAuth,
@@ -175,14 +177,14 @@ router.post(
 
     const community = await prisma.community.findUnique({
       where: { id },
-      include: { staff: { select: { id: true } } }
+      include: { curators: { select: { id: true } } }
     });
     if (!community) return res.status(404).json({ msg: 'Community not found' });
 
     const perms = await loadPermissions(req, res);
     const isAdmin = !!(perms['communities_manage'] || perms['admin']);
-    const isCommunityStaff = community.staff.some((s) => s.id === req.user.id);
-    if (!isAdmin && !isCommunityStaff) {
+    const isCurator = community.curators.some((c) => c.id === req.user.id);
+    if (!isAdmin && !isCurator) {
       return res.status(403).json({ msg: 'Permission denied' });
     }
 
@@ -198,7 +200,7 @@ router.post(
   })
 );
 
-// DELETE /api/communities/:id/members/:userId — remove user (communities_manage or community staff)
+// DELETE /api/communities/:id/members/:userId — remove a consuming member (communities_manage or curator)
 router.delete(
   '/:id/members/:userId',
   requireAuth,
@@ -208,15 +210,32 @@ router.delete(
 
     const community = await prisma.community.findUnique({
       where: { id },
-      include: { staff: { select: { id: true } } }
+      include: { curators: { select: { id: true } } }
     });
     if (!community) return res.status(404).json({ msg: 'Community not found' });
 
     const perms = await loadPermissions(req, res);
     const isAdmin = !!(perms['communities_manage'] || perms['admin']);
-    const isCommunityStaff = community.staff.some((s) => s.id === req.user.id);
-    if (!isAdmin && !isCommunityStaff) {
+    const isCurator = community.curators.some((c) => c.id === req.user.id);
+    if (!isAdmin && !isCurator) {
       return res.status(403).json({ msg: 'Permission denied' });
+    }
+
+    // This route operates on the Consumer link only. When the target also holds
+    // a curator or leader role, refuse rather than partially removing them: no
+    // route strips a role as a side effect of removing a membership
+    // (ADR-0033 §Decision 5). Curators go through DELETE /:id/curators/:userId,
+    // the leader through PUT /:id.
+    const blockingRole =
+      community.leaderId === userId
+        ? 'leader'
+        : community.curators.some((c) => c.id === userId)
+        ? 'curator'
+        : null;
+    if (blockingRole) {
+      return res.status(409).json({
+        msg: `User is the community ${blockingRole}; remove that role first`
+      });
     }
 
     const consumer = await prisma.consumer.findUnique({ where: { userId } });
@@ -230,9 +249,9 @@ router.delete(
   })
 );
 
-// POST /api/communities/:id/staff — add user to community staff (communities_manage or community staff)
+// POST /api/communities/:id/curators — add a curator (communities_manage or curator)
 router.post(
-  '/:id/staff',
+  '/:id/curators',
   requireAuth,
   validateParams(communityIdParamsSchema),
   validate(addMemberSchema),
@@ -242,14 +261,14 @@ router.post(
 
     const community = await prisma.community.findUnique({
       where: { id },
-      include: { staff: { select: { id: true } } }
+      include: { curators: { select: { id: true } } }
     });
     if (!community) return res.status(404).json({ msg: 'Community not found' });
 
     const perms = await loadPermissions(req, res);
     const isAdmin = !!(perms['communities_manage'] || perms['admin']);
-    const isCommunityStaff = community.staff.some((s) => s.id === req.user.id);
-    if (!isAdmin && !isCommunityStaff) {
+    const isCurator = community.curators.some((c) => c.id === req.user.id);
+    if (!isAdmin && !isCurator) {
       return res.status(403).json({ msg: 'Permission denied' });
     }
 
@@ -258,15 +277,15 @@ router.post(
 
     await prisma.community.update({
       where: { id },
-      data: { staff: { connect: { id: userId } } }
+      data: { curators: { connect: { id: userId } } }
     });
     res.status(204).send();
   })
 );
 
-// DELETE /api/communities/:id/staff/:userId — remove from community staff (communities_manage or community staff)
+// DELETE /api/communities/:id/curators/:userId — remove a curator (communities_manage or curator)
 router.delete(
-  '/:id/staff/:userId',
+  '/:id/curators/:userId',
   requireAuth,
   validateParams(memberParamsSchema),
   authHandler(async (req, res) => {
@@ -274,20 +293,20 @@ router.delete(
 
     const community = await prisma.community.findUnique({
       where: { id },
-      include: { staff: { select: { id: true } } }
+      include: { curators: { select: { id: true } } }
     });
     if (!community) return res.status(404).json({ msg: 'Community not found' });
 
     const perms = await loadPermissions(req, res);
     const isAdmin = !!(perms['communities_manage'] || perms['admin']);
-    const isCommunityStaff = community.staff.some((s) => s.id === req.user.id);
-    if (!isAdmin && !isCommunityStaff) {
+    const isCurator = community.curators.some((c) => c.id === req.user.id);
+    if (!isAdmin && !isCurator) {
       return res.status(403).json({ msg: 'Permission denied' });
     }
 
     await prisma.community.update({
       where: { id },
-      data: { staff: { disconnect: { id: userId } } }
+      data: { curators: { disconnect: { id: userId } } }
     });
     res.status(204).send();
   })
@@ -307,7 +326,7 @@ router.post(
       registrationStatus,
       announceVisibility,
       allowDuplicateFormats,
-      staffIds,
+      curatorIds,
       leaderId
     } = parsedBody<CreateCommunityInput>(res);
 
@@ -327,9 +346,9 @@ router.post(
       Comics: '/images/defaults/comics.png'
     };
 
-    // Leader is a superset of staff (ADR-0021): always fold into the staff set.
-    const allStaffIds = [
-      ...(staffIds ?? []),
+    // Leader is a superset of curators (ADR-0021): always fold into the set.
+    const allCuratorIds = [
+      ...(curatorIds ?? []),
       ...(leaderId !== undefined ? [leaderId] : [])
     ];
 
@@ -343,23 +362,19 @@ router.post(
         ...(announceVisibility !== undefined && { announceVisibility }),
         ...(allowDuplicateFormats !== undefined && { allowDuplicateFormats }),
         ...(leaderId !== undefined && { leaderId }),
-        ...(allStaffIds.length && {
-          staff: {
-            connect: [...new Set(allStaffIds)].map((sid) => ({ id: sid }))
+        ...(allCuratorIds.length && {
+          curators: {
+            connect: [...new Set(allCuratorIds)].map((cid) => ({ id: cid }))
           }
         })
       }
     });
 
+    // No Consumer is written for the leader (ADR-0033 §Decision 3). That upsert
+    // existed only so the old `consumer ∪ contributor` checks would pass; the
+    // role union reads `curators` directly, and asserting that a leader consumes
+    // releases may simply be false.
     if (leaderId !== undefined) {
-      await prisma.consumer.upsert({
-        where: { userId: leaderId },
-        create: {
-          userId: leaderId,
-          communities: { connect: { id: community.id } }
-        },
-        update: { communities: { connect: { id: community.id } } }
-      });
       await audit(
         prisma,
         req.user!.id,
@@ -392,7 +407,7 @@ router.put(
       registrationStatus,
       announceVisibility,
       allowDuplicateFormats,
-      staffIds,
+      curatorIds,
       leaderId
     } = parsedBody<UpdateCommunityInput>(res);
 
@@ -402,13 +417,13 @@ router.put(
         return res.status(404).json({ msg: 'Leader user not found' });
     }
 
-    // `staffIds` (when given) replaces the whole staff set, so the new leader
-    // might not be in it — fold them back in to preserve the leader⊇staff
-    // invariant (ADR-0021).
-    const staffConnect =
-      leaderId !== undefined && staffIds !== undefined
-        ? [...new Set([...staffIds, leaderId])]
-        : staffIds;
+    // `curatorIds` (when given) replaces the whole curator set, so the new leader
+    // might not be in it — fold them back in to preserve the leader ⊇ curators
+    // invariant (ADR-0021, narrowed by ADR-0033).
+    const curatorConnect =
+      leaderId !== undefined && curatorIds !== undefined
+        ? [...new Set([...curatorIds, leaderId])]
+        : curatorIds;
 
     const community = await prisma.community.update({
       where: { id },
@@ -420,27 +435,20 @@ router.put(
         ...(announceVisibility !== undefined && { announceVisibility }),
         ...(allowDuplicateFormats !== undefined && { allowDuplicateFormats }),
         ...(leaderId !== undefined && { leaderId }),
-        ...(staffConnect !== undefined && {
-          staff: { set: staffConnect.map((sid: number) => ({ id: sid })) }
+        ...(curatorConnect !== undefined && {
+          curators: { set: curatorConnect.map((cid: number) => ({ id: cid })) }
         }),
-        // Leader given but staff set untouched: connect (don't replace) so the
-        // invariant holds without disturbing existing staff.
+        // Leader given but curator set untouched: connect (don't replace) so the
+        // invariant holds without disturbing existing curators.
         ...(leaderId !== undefined &&
-          staffIds === undefined && {
-            staff: { connect: { id: leaderId } }
+          curatorIds === undefined && {
+            curators: { connect: { id: leaderId } }
           })
       }
     });
 
+    // No Consumer upsert here either — see the create path (ADR-0033 §3).
     if (leaderId !== undefined) {
-      await prisma.consumer.upsert({
-        where: { userId: leaderId },
-        create: {
-          userId: leaderId,
-          communities: { connect: { id: community.id } }
-        },
-        update: { communities: { connect: { id: community.id } } }
-      });
       await audit(
         prisma,
         req.user!.id,

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -43,7 +43,7 @@ export const createCommunitySchema = z
     registrationStatus: registrationStatusEnum,
     announceVisibility: announceVisibilityEnum.optional(),
     allowDuplicateFormats: z.boolean().optional(),
-    staffIds: z.array(z.number().int().positive()).optional(),
+    curatorIds: z.array(z.number().int().positive()).optional(),
     leaderId: z.number().int().positive().optional()
   })
   .refine(
@@ -64,7 +64,7 @@ export const updateCommunitySchema = z.object({
   registrationStatus: registrationStatusEnum.optional(),
   announceVisibility: announceVisibilityEnum.optional(),
   allowDuplicateFormats: z.boolean().optional(),
-  staffIds: z.array(z.number().int().positive()).optional(),
+  curatorIds: z.array(z.number().int().positive()).optional(),
   leaderId: z.number().int().positive().optional()
 });
 


### PR DESCRIPTION
Implements **ADR-0033** (Accepted 2026-07-24). #419 made *access* `consumer ∪ contributor ∪ staff`; the read surface still said membership was consumption. A community staffer with no `Consumer` row could administer a community while being absent from its member roster — the same bug #419 fixed, one layer up.

## Curator (§2)

`Community.staff[]` → `curators[]` (relation `CommunityCurators`), `staffIds` → `curatorIds`, `POST|DELETE /:id/staff` → `/:id/curators`. "Staff" is now reserved site-wide for the Axis-2 rank capability — the collision that cost ADR-0030 a paragraph written solely to keep the two apart.

Relation rename only, so ADR-0001 holds: curator checks stay relation checks paired with an exactly-named rank permission, and no `isCurator()` enters the permission layer.

## Membership is the union (§1, §4)

`GET /:id` gains `members`, each entry carrying the roles that user holds, replacing the `consumers[]`-plus-`Staff`-chip idiom the UI reconstructed.

`listCommunityMembers` sits beside `communityRoleUnion` rather than reusing it literally, and the comment says why: the union is a `CommunityWhereInput` that filters *communities by a user*, while a roster needs *users for one community* — the inverse projection. The arms must stay the same four, so `COMMUNITY_ROLES` plus an agreement test hold them together. That's the ADR-0010 drift risk, made explicit instead of hoped away.

Browse keeps its cheap relation counts — a true union count is a per-row query across a 25-row page, rejected on cost in the ADR.

## No `Consumer` synthesised for the leader (§3)

All three upserts are gone (`communities.ts` ×2, `bootstrap.ts`). ADR-0021's invariant narrows to `leaderId ⟹ user ∈ curators`; the `leaderId` arm stays defensively redundant rather than becoming load-bearing. A leader who also consumes gets a `Consumer` the normal way, through the download grant path.

## 409 instead of a silent downgrade (§5)

`DELETE /:id/members/:userId` refuses when the target holds a curator or leader role, naming the blocking role. Leader wins over curator in the message, since that's the one that has to be reassigned. No route strips a role as a side effect of removing a membership.

## The migration is hand-written

Prisma regenerates an implicit M:N table by dropping and recreating it, which discards every existing curator row. This renames the table and each constraint and index to the names Prisma derives. Verified by introspecting the test DB after `migrate deploy`:

```
tables:      _CommunityCurators          (no _CommunityStaff)
constraints: _CommunityCurators_AB_pkey, _A_fkey, _B_fkey
indexes:     _CommunityCurators_B_index, _CommunityCurators_AB_pkey
```

## Tests

- Unit: the roster reports curator-only, contributor-only and consumer-only members with their roles; an **agreement test** fails if the union and the roster ever disagree on which relations confer membership; a leader whose curator row drifted is still listed, because the union's `leaderId` arm would still match them.
- Route: `members` composes the union; the detail query stops fetching `consumers[]`; 409 for a curator and for the leader; the leader `Consumer` assertions are inverted to `not.toHaveBeenCalled()`.
- Integration: a curator with no `Consumer` row appears in `members`; a leader created with no `Consumer` row appears and the union agrees; `seedDefaultCommunity` is idempotent across the migration and leaves the SysOp a curator and leader but **not** a consumer.
- Full suite green — 1995 unit, plus `communityAccess` / `releaseWorkbench` / `contributions` / `permissions` integration.

## Cross-repo

Contract change rides to **stellar-ui#216**: `staff`/`staffIds` → `curators`/`curatorIds`, the route rename, and the new `members` view. Precedent is ADR-0021's own `ownerId` → `leaderId`, absorbed on an `api:sync`. Pre-alpha, no backfill.

Closes #422. Refs ADR-0033, ADR-0021, ADR-0030, ADR-0001, PRD-08, #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)