### PR TITLE
fix(stats): exclude the reserved System user from totalUsers

### DIFF
--- a/src/integration/staffStats.integration.ts
+++ b/src/integration/staffStats.integration.ts
@@ -1,4 +1,6 @@
 import { truncateAll, seedDefaults, testPrisma } from '../test/dbHelpers';
+import { getSystemStats } from '../modules/stats';
+import { seedSystemUser, SYSTEM_USERNAME } from '../modules/bootstrap';
 
 beforeEach(async () => {
   await truncateAll();
@@ -149,5 +151,36 @@ describe('stats/user-flow DB query', () => {
 
     expect(funnel.length).toBeGreaterThanOrEqual(1);
     expect(funnel.every((f) => typeof f._count === 'number')).toBe(true);
+  });
+});
+
+describe('getSystemStats excludes the reserved System user', () => {
+  it('does not count System in totalUsers', async () => {
+    const before = await getSystemStats();
+    await seedSystemUser(testPrisma);
+    const after = await getSystemStats();
+
+    // The row exists...
+    await expect(
+      testPrisma.user.findUnique({ where: { username: SYSTEM_USERNAME } })
+    ).resolves.not.toBeNull();
+    // ...and is not a member of the site. Seeding machinery must not move the
+    // member count, nor eat a slot against maxUsers.
+    expect(after.totalUsers).toBe(before.totalUsers);
+
+    // A real signup still counts, so the filter is not simply suppressing.
+    await createUser('system-check');
+    const withMember = await getSystemStats();
+    expect(withMember.totalUsers).toBe(before.totalUsers + 1);
+  });
+
+  it('leaves the adjacent counts alone — they already exclude System', async () => {
+    await seedSystemUser(testPrisma);
+    const stats = await getSystemStats();
+
+    // System is `disabled` and never sets lastLogin, so these needed no filter.
+    expect(stats.enabledUsers).toBe(0);
+    expect(stats.activeToday).toBe(0);
+    expect(stats.activeThisMonth).toBe(0);
   });
 });

--- a/src/modules/stats.ts
+++ b/src/modules/stats.ts
@@ -1,5 +1,17 @@
 import { prisma } from '../lib/prisma';
 import { getSettings } from './settings';
+import { SYSTEM_USERNAME } from './bootstrap';
+
+/**
+ * The reserved System user is site machinery, not a member: it owns built-in
+ * fixtures, can never log in, and nobody signed up as it. Counting it inflates
+ * `totalUsers` by one and eats a slot against `maxUsers`.
+ *
+ * Only the total needs this. `enabledUsers` already excludes it (System is
+ * `disabled`), and the active-window counts filter on `lastLogin`, which System
+ * never sets.
+ */
+const EXCLUDE_SYSTEM = { username: { not: SYSTEM_USERNAME } };
 
 export const getSystemStats = async () => {
   const now = new Date();
@@ -26,7 +38,7 @@ export const getSystemStats = async () => {
     contributionDownloadCounts,
     settings
   ] = await Promise.all([
-    prisma.user.count(),
+    prisma.user.count({ where: EXCLUDE_SYSTEM }),
     prisma.user.count({ where: { disabled: false } }),
     prisma.user.count({ where: { lastLogin: { gte: startOfToday } } }),
     prisma.user.count({ where: { lastLogin: { gte: startOfWeek } } }),


### PR DESCRIPTION
`getSystemStats` counted every `users` row, including the reserved System user seeded by `seedSystemUser` — site machinery that owns built-in stylesheet fixtures, can never log in (`disabled` + `rankLocked`, unusable password), and that nobody signed up as. It inflated `totalUsers` by one and ate a slot against `maxUsers`.

## Scope is one line

Only the total needed filtering. Everything adjacent was already correct by construction, and there's now a test recording that rather than leaving it to be re-derived:

| Count | Already excluded System? |
|---|---|
| `enabledUsers` | yes — filters `disabled: false`, System is disabled |
| `activeToday` / `ThisWeek` / `ThisMonth` | yes — filter on `lastLogin`, System never logs in |
| user search (`search.ts`) | yes — filters `disabled: false` |
| **`totalUsers`** | **no — this PR** |

## Why now rather than with the wider stats work

`statsHistory.ts:93` snapshots `stats.totalUsers` into the time series on every capture, so each bucket persists the off-by-one. Existing snapshots stay wrong — pre-alpha, no backfill.

## First of its kind

This is the first System-user exclusion in production code; `SYSTEM_USERNAME` was exported but only the seeder used it. Any later "real members" count should follow this seam.

## Tests

Integration, in `staffStats.integration.ts`. Verified red-capable rather than assumed — with the filter removed the first test fails `Expected: 0, Received: 1`, and passes with it:

- seeding System does not move `totalUsers`, while a real signup still increments it (so the filter isn't just suppressing the count)
- `enabledUsers` / `activeToday` / `activeThisMonth` stay 0 with only System present

🤖 Generated with [Claude Code](https://claude.com/claude-code)