### PR TITLE
fix(test): track background work so truncateAll cannot deadlock

### DIFF
--- a/src/modules/backgroundTasks.spec.ts
+++ b/src/modules/backgroundTasks.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the background-task tracker.
+ */
+
+import {
+  runInBackground,
+  drainBackgroundTasks,
+  pendingBackgroundTaskCount
+} from './backgroundTasks';
+
+const tick = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('runInBackground / drainBackgroundTasks', () => {
+  afterEach(async () => {
+    await drainBackgroundTasks();
+  });
+
+  it('drain waits for a task that settles later', async () => {
+    let done = false;
+    runInBackground(
+      tick(20).then(() => {
+        done = true;
+      })
+    );
+
+    expect(done).toBe(false);
+    await drainBackgroundTasks();
+    expect(done).toBe(true);
+  });
+
+  it('drain waits for tasks registered by a draining task', async () => {
+    // The case the loop exists for: a link check that schedules a recheck. A
+    // single `allSettled` would return before the second task ran, and the
+    // second task holds locks exactly like the first.
+    let inner = false;
+    runInBackground(
+      tick(10).then(() => {
+        runInBackground(
+          tick(10).then(() => {
+            inner = true;
+          })
+        );
+      })
+    );
+
+    await drainBackgroundTasks();
+    expect(inner).toBe(true);
+    expect(pendingBackgroundTaskCount()).toBe(0);
+  });
+
+  it('a rejecting task settles the drain without escaping', async () => {
+    // The call sites attach their own .catch, so a tracked promise is normally
+    // already handled — but the drain must not turn a rejection into a failure
+    // of whatever awaited it.
+    runInBackground(tick(5).then(() => Promise.reject(new Error('boom'))));
+
+    await expect(drainBackgroundTasks()).resolves.toBeUndefined();
+    expect(pendingBackgroundTaskCount()).toBe(0);
+  });
+
+  it('drain on an empty set resolves immediately', async () => {
+    expect(pendingBackgroundTaskCount()).toBe(0);
+    await expect(drainBackgroundTasks()).resolves.toBeUndefined();
+  });
+
+  it('forgets tasks once they settle', async () => {
+    runInBackground(tick(5));
+    expect(pendingBackgroundTaskCount()).toBe(1);
+
+    await drainBackgroundTasks();
+    expect(pendingBackgroundTaskCount()).toBe(0);
+  });
+});

--- a/src/modules/backgroundTasks.ts
+++ b/src/modules/backgroundTasks.ts
@@ -1,0 +1,53 @@
+/**
+ * Tracking for work deliberately started outside the request path.
+ *
+ * Several handlers kick off follow-up work without awaiting it — a ratio-policy
+ * evaluation after a download grant, a link check after a contribution — so a
+ * failure there cannot roll back or slow the response that already succeeded.
+ * That part is intentional and stays.
+ *
+ * What was missing is any handle on the resulting promise. An untracked query
+ * outlives the request that started it, which in tests means it is still holding
+ * row locks when the next test's `truncateAll` starts issuing `TRUNCATE`, and the
+ * two deadlock (40P01, #424). Registering the promise here costs nothing at
+ * runtime and gives tests something to wait on.
+ */
+
+const pending = new Set<Promise<unknown>>();
+
+/**
+ * Runs `p` in the background, tracked.
+ *
+ * Pass a promise that already carries its own error handling — every call site
+ * attaches a `.catch` that logs. This only observes settlement.
+ *
+ * Note the cleanup uses `then(fn, fn)` rather than `finally(fn)`: `finally`
+ * returns a *new* promise that re-rejects when `p` rejects, and nothing handles
+ * that derived promise, so a rejecting task produced an unhandled rejection that
+ * surfaced against whichever test happened to be running. Passing the same
+ * callback as both handlers settles the derived chain either way.
+ */
+export const runInBackground = (p: Promise<unknown>): void => {
+  const forget = (): void => {
+    pending.delete(p);
+  };
+  pending.add(p);
+  void p.then(forget, forget);
+};
+
+/**
+ * Resolves once every tracked task has settled.
+ *
+ * Loops rather than awaiting once: a draining task can register another (a link
+ * check that schedules a recheck), and those late arrivals hold locks just the
+ * same. `allSettled` because a rejected task is still finished — its error is the
+ * caller's business, not the drain's.
+ */
+export const drainBackgroundTasks = async (): Promise<void> => {
+  while (pending.size > 0) {
+    await Promise.allSettled([...pending]);
+  }
+};
+
+/** Number of tasks still in flight. Test/diagnostic use. */
+export const pendingBackgroundTaskCount = (): number => pending.size;

--- a/src/modules/contribution.ts
+++ b/src/modules/contribution.ts
@@ -12,6 +12,7 @@ import { audit } from '../lib/audit';
 import { sizeBytesToNumber } from '../lib/serialize';
 import { getLogger } from './logging';
 import { checkContributionLink } from './linkHealth';
+import { runInBackground } from './backgroundTasks';
 import { assertWithinSizeCap } from './contributionLimits';
 import { resolveTagNames } from './tag';
 import type {
@@ -252,11 +253,13 @@ export const createContributionSubmission = async ({
     });
   });
 
-  checkContributionLink(contribution.id).catch((err) =>
-    log.warn('Initial link check failed', {
-      contributionId: contribution.id,
-      err
-    })
+  runInBackground(
+    checkContributionLink(contribution.id).catch((err) =>
+      log.warn('Initial link check failed', {
+        contributionId: contribution.id,
+        err
+      })
+    )
   );
 
   return {
@@ -358,11 +361,13 @@ export const addContributionToRelease = async ({
       });
     })
     .then((contribution) => {
-      checkContributionLink(contribution.id).catch((err) =>
-        log.warn('Initial link check failed', {
-          contributionId: contribution.id,
-          err
-        })
+      runInBackground(
+        checkContributionLink(contribution.id).catch((err) =>
+          log.warn('Initial link check failed', {
+            contributionId: contribution.id,
+            err
+          })
+        )
       );
       return {
         ...contribution,

--- a/src/modules/downloads.ts
+++ b/src/modules/downloads.ts
@@ -8,6 +8,7 @@ import { AppError } from '../lib/errors';
 import { getLogger } from './logging';
 import { floorSub } from './ratio';
 import { evaluateRatioPolicy } from './ratioPolicy';
+import { runInBackground } from './backgroundTasks';
 
 const log = getLogger('downloads');
 
@@ -192,9 +193,11 @@ export const grantDownloadAccess = async (
 
   // Evaluate ratio policy outside the transaction so a policy error never
   // rolls back an already-committed grant.
-  evaluateRatioPolicy(consumerId).catch((err) => {
-    log.warn('Ratio policy evaluation failed', { consumerId, err });
-  });
+  runInBackground(
+    evaluateRatioPolicy(consumerId).catch((err) => {
+      log.warn('Ratio policy evaluation failed', { consumerId, err });
+    })
+  );
 
   return result;
 };

--- a/src/modules/linkHealth.ts
+++ b/src/modules/linkHealth.ts
@@ -2,6 +2,7 @@ import { LinkHealthStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getLogger } from './logging';
 import { sendSystemMessage } from './pm';
+import { runInBackground } from './backgroundTasks';
 
 const log = getLogger('linkHealth');
 
@@ -255,8 +256,10 @@ export const recordContributionReport = async (
         distinctReporters: distinctReporters.length
       });
       // Kick off a recheck so status can be corrected if the link is actually fine
-      checkContributionLink(contributionId).catch((err) =>
-        log.warn('Post-report link recheck failed', { contributionId, err })
+      runInBackground(
+        checkContributionLink(contributionId).catch((err) =>
+          log.warn('Post-report link recheck failed', { contributionId, err })
+        )
       );
     }
   }

--- a/src/test/dbHelpers.ts
+++ b/src/test/dbHelpers.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { drainBackgroundTasks } from '../modules/backgroundTasks';
 
 const testUrl = process.env.STELLAR_PSQL_URI_TEST!;
 
@@ -14,15 +15,21 @@ export const testPrisma: PrismaClient = new PrismaClient({
 /**
  * Truncates every table (except _prisma_migrations) and resets sequences.
  *
- * Deliberately a per-table loop, NOT a single `TRUNCATE a, b, c … CASCADE`: the
- * batched form takes ACCESS EXCLUSIVE locks on every table at once, which
- * deadlocks (40P01) under CI when a prior test's fire-and-forget query (e.g. the
- * downloads ratio-policy eval) still holds a lock. Truncating one table at a
- * time keeps the lock set per statement small enough to avoid that. The #165
- * flake was setup running slow under load, not this being wrong — the fix is the
- * hook-timeout headroom in devTools.integration.ts, not batching the locks.
+ * Waits for tracked background work first. That drain is what actually keeps
+ * this safe: a query still in flight from the previous test holds row locks, and
+ * truncating underneath it deadlocks (40P01, #424).
+ *
+ * The per-table loop is a leftover mitigation, kept only because it is harmless.
+ * It does NOT bound the lock set, contrary to what this comment used to claim —
+ * the loop runs inside one `DO $$ … $$` block, so it is a single transaction and
+ * every ACCESS EXCLUSIVE lock it takes is held until the block commits, exactly
+ * like the batched `TRUNCATE a, b, c` form. If anything, acquiring them one at a
+ * time widens the window for a cycle, since another connection can take a
+ * conflicting lock on a table the loop has not reached yet. It narrowed the odds
+ * and was mistaken for a fix; the drain above is the fix.
  */
 export const truncateAll = async (): Promise<void> => {
+  await drainBackgroundTasks();
   await testPrisma.$executeRawUnsafe(`
     DO $$ DECLARE r RECORD; BEGIN
       FOR r IN (


### PR DESCRIPTION
Closes #424 — and gets `main` green.

`main` has been red since 2026-07-24, on `e68816d1`, a **docs-only ADR commit**. The `integration` job failed, which gates `publish`, so that commit's image never shipped. One test of 167 failed, and not in an assertion:

```
Raw query failed. Code: `40P01`. ERROR: deadlock detected
  Process 199 waits for AccessExclusiveLock on relation 18019; blocked by 201.
  Process 201 waits for RowShareLock on relation 16560; blocked by 199.
  at truncateAll (src/test/dbHelpers.ts:26:3)
  at Object.<anonymous> (src/integration/downloads.integration.ts:16:3)
```

## Root cause

`grantDownloadAccess` fires the ratio-policy evaluation without awaiting it. Running it outside the transaction is **correct** — a policy error must not roll back an already-committed grant, and that stays. The defect is that nothing held the resulting promise, so the query outlived the test that started it. The next test's `beforeEach(truncateAll)` then issued `TRUNCATE` against tables it still held row locks on, and the two cycled.

Tests run `--runInBand`, so this was never parallel-worker contention. It was one leaked promise inside a single process.

## The fix

A small tracker (`src/modules/backgroundTasks.ts`). Call sites register the promise they have already attached a `.catch` to; `truncateAll` drains before truncating. Fixing it **in the helper rather than per-suite** is what covers all 167 tests instead of just the one that remembers.

Wrapped the three sibling leaks on the request path as well — `contribution.ts` ×2 and `linkHealth.ts` — the same pattern, and the reason `releaseWorkbench.integration.ts:14-19` already carries a `jest.mock` workaround whose comment describes this exact deadlock.

The drain loops rather than awaiting once, because a draining task can register another (a link check that schedules a recheck), and late arrivals hold locks just the same.

### One subtlety the new spec caught

Cleanup uses `then(fn, fn)`, not `finally(fn)`. `finally` returns a *new* promise that re-rejects when the tracked one does, and nothing handled that derived promise — so a rejecting task produced an unhandled rejection that surfaced against whichever test happened to be running next. My first cut had exactly that bug; the "a rejecting task settles the drain without escaping" test failed and pinned it.

## A comment that was actively misleading

`dbHelpers.ts` claimed the per-table loop "keeps the lock set per statement small enough to avoid that." **That is false**, and #424 flags it as having cost time. The loop runs inside a single `DO $$ … $$` block — one transaction — so every `ACCESS EXCLUSIVE` lock it takes is held until the block commits, exactly like the batched `TRUNCATE a, b, c` form it was written to avoid. Acquiring them one at a time arguably *widens* the window, since another connection can take a conflicting lock on a table the loop has not reached yet, which is precisely the shape of the observed cycle. It narrowed the odds and was mistaken for a fix. Comment rewritten to say so.

## Verification

- `typecheck:test` clean.
- Unit suite: **1742 → 1747 passing**, the 5 new tracker tests, no regressions. (14 suites fail identically on pristine `main` locally — `process.exit called with "1"` from missing local env at import; CI's `test` job is green, so they are a local-env artifact, not a baseline break. Verified by stashing every change including untracked files and re-running.)
- Integration suite **not run locally** — no Docker daemon or local Postgres available on this machine. CI's `integration` job is the check that matters here, and since the failure is intermittent I'd suggest re-running that job a few times on this PR before merging rather than trusting one green.

## Related

Refs #165, which mitigated this same untracked-async mechanism by raising `devTools.integration.ts`'s hook timeout 30s → 60s. With the leak closed, that headroom may no longer be load-bearing — not touched here.